### PR TITLE
fix: support firefox and other browsers by adding user agent to the allowed headers

### DIFF
--- a/controlplane/src/core/build-server.ts
+++ b/controlplane/src/core/build-server.ts
@@ -114,7 +114,7 @@ export default async function build(opts: BuildConfig) {
     // Produce an error if allowedOrigins is undefined
     origin: opts.allowedOrigins || [],
     methods: [...cors.allowedMethods],
-    allowedHeaders: [...cors.allowedHeaders, 'cosmo-org-slug'],
+    allowedHeaders: [...cors.allowedHeaders, 'cosmo-org-slug', 'user-agent'],
     exposedHeaders: [...cors.exposedHeaders, 'Trailer-Response-Id'],
     credentials: true,
     // Let browsers cache CORS information to reduce the number of


### PR DESCRIPTION
- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [x] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
