### PR TITLE
feat: Follow prometheus naming convention when converting metrics

### DIFF
--- a/otelcollector/Dockerfile
+++ b/otelcollector/Dockerfile
@@ -21,4 +21,4 @@ RUN /otelcol --version
 
 
 ENTRYPOINT ["/otelcol"]
-CMD ["--config", "/etc/otel-config.yaml" ]
+CMD ["--config", "/etc/otel-config.yaml", "--feature-gates=pkg.translator.prometheus.NormalizeName"]


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/wundergraph/cloud/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->

## Motivation and Context

This PR enabled a feature gate to follow the Prometheus naming convention when converting OTLP metrics.

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
