### PR TITLE
fix: improve compose command input

### DIFF
--- a/cli/src/commands/router/commands/compose.ts
+++ b/cli/src/commands/router/commands/compose.ts
@@ -13,7 +13,7 @@ type Config = {
   version: number;
   subgraphs: {
     name: string;
-    routingURL: string;
+    routing_url: string;
     schema?: {
       file: string;
     };
@@ -52,7 +52,7 @@ export default (opts: BaseCommandOptions) => {
       }
 
       const result = await introspectSubgraph({
-        subgraphURL: s.introspection?.url ?? s.routingURL,
+        subgraphURL: s.introspection?.url ?? s.routing_url,
         additionalHeaders: Object.entries(s.introspection?.headers ?? {}).map(([key, value]) => ({
           key,
           value,
@@ -69,7 +69,7 @@ export default (opts: BaseCommandOptions) => {
     const result = composeSubgraphs(
       config.subgraphs.map((s, index) => ({
         name: s.name,
-        url: s.routingURL,
+        url: s.routing_url,
         definitions: parse(sdls[index]),
       })),
     );
@@ -87,7 +87,7 @@ export default (opts: BaseCommandOptions) => {
       federatedSDL: printSchema(result.federationResult.federatedGraphSchema),
       subgraphs: config.subgraphs.map((s, index) => ({
         name: s.name,
-        url: s.routingURL,
+        url: s.routing_url,
         sdl: sdls[index],
       })),
     });


### PR DESCRIPTION
## Motivation and Context

Improves the input file structure for the router compose command

```yaml
version: 1
subgraphs:
  # You can either provide schema file or introspection. File takes precedence
  - name: employees
    routing_url: http://localhost:4001/graphql
    schema:
      file: ./employees.graphql
  - name: family
    routing_url: http://localhost:4002/graphql
    introspection:
      url: http://localhost:4002/graphql
      headers:
        Authorization: 'Bearer YOUR_TOKEN_HERE'
```

- [x] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [x] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
