### PR TITLE
feat: implement backoff jitter retry mechanism

### DIFF
--- a/router/cmd/main.go
+++ b/router/cmd/main.go
@@ -82,9 +82,10 @@ func Main() {
 		core.WithHeaderRules(cfg.Headers),
 		core.WithStaticRouterConfig(routerConfig),
 		core.WithRetryOptions(
-			cfg.TrafficShaping.All.Retry.BackoffJitter.MaxAttempts,
-			cfg.TrafficShaping.All.Retry.BackoffJitter.MaxDuration,
-			cfg.TrafficShaping.All.Retry.BackoffJitter.Interval,
+			cfg.TrafficShaping.All.BackoffJitterRetry.Enabled,
+			cfg.TrafficShaping.All.BackoffJitterRetry.MaxAttempts,
+			cfg.TrafficShaping.All.BackoffJitterRetry.MaxDuration,
+			cfg.TrafficShaping.All.BackoffJitterRetry.Interval,
 		),
 		core.WithCors(&cors.Config{
 			AllowOrigins:     cfg.CORS.AllowOrigins,

--- a/router/cmd/main.go
+++ b/router/cmd/main.go
@@ -54,7 +54,7 @@ func Main() {
 		controlplane.WithFederatedGraph(cfg.Graph.Name),
 		controlplane.WithLogger(logger),
 		controlplane.WithGraphApiToken(cfg.Graph.Token),
-		controlplane.WithPollInterval(time.Duration(cfg.PollIntervalSeconds)*time.Second),
+		controlplane.WithPollInterval(cfg.PollInterval),
 	)
 
 	var routerConfig *nodev1.RouterConfig
@@ -75,18 +75,23 @@ func Main() {
 		core.WithPlayground(cfg.PlaygroundEnabled),
 		core.WithGraphApiToken(cfg.Graph.Token),
 		core.WithModulesConfig(cfg.Modules),
-		core.WithGracePeriod(time.Duration(cfg.GracePeriodSeconds)*time.Second),
+		core.WithGracePeriod(cfg.GracePeriod),
 		core.WithHealthCheckPath(cfg.HealthCheckPath),
 		core.WithLivenessCheckPath(cfg.LivenessCheckPath),
 		core.WithReadinessCheckPath(cfg.ReadinessCheckPath),
 		core.WithHeaderRules(cfg.Headers),
 		core.WithStaticRouterConfig(routerConfig),
+		core.WithRetryOptions(
+			cfg.TrafficShaping.All.Retry.BackoffJitter.MaxAttempts,
+			cfg.TrafficShaping.All.Retry.BackoffJitter.MaxDuration,
+			cfg.TrafficShaping.All.Retry.BackoffJitter.Interval,
+		),
 		core.WithCors(&cors.Config{
 			AllowOrigins:     cfg.CORS.AllowOrigins,
 			AllowMethods:     cfg.CORS.AllowMethods,
 			AllowCredentials: cfg.CORS.AllowCredentials,
 			AllowHeaders:     cfg.CORS.AllowHeaders,
-			MaxAge:           time.Duration(cfg.CORS.MaxAgeMinutes) * time.Minute,
+			MaxAge:           cfg.CORS.MaxAge,
 		}),
 		core.WithTracing(&trace.Config{
 			Enabled:       cfg.Telemetry.Tracing.Enabled,
@@ -94,7 +99,7 @@ func Main() {
 			Endpoint:      cfg.Telemetry.Endpoint,
 			Sampler:       cfg.Telemetry.Tracing.Config.SamplingRate,
 			Batcher:       trace.KindOtlpHttp,
-			BatchTimeout:  time.Duration(cfg.Telemetry.Tracing.Config.BatchTimeoutSeconds) * time.Second,
+			BatchTimeout:  cfg.Telemetry.Tracing.Config.BatchTimeout,
 			ExportTimeout: 30 * time.Second,
 			OtlpHeaders:   cfg.Telemetry.Headers,
 			OtlpHttpPath:  "/v1/traces",
@@ -127,11 +132,10 @@ func Main() {
 
 	<-ctx.Done()
 
-	shutdownDelayDuration := time.Duration(cfg.ShutdownDelaySeconds) * time.Second
-	logger.Info("Graceful shutdown ...", zap.String("shutdownDelay", shutdownDelayDuration.String()))
+	logger.Info("Graceful shutdown ...", zap.String("shutdownDelay", cfg.ShutdownDelay.String()))
 
 	// enforce a maximum shutdown delay
-	ctx, cancel := context.WithTimeout(context.Background(), shutdownDelayDuration)
+	ctx, cancel := context.WithTimeout(context.Background(), cfg.ShutdownDelay)
 	defer cancel()
 
 	if err := router.Shutdown(ctx); err != nil {

--- a/router/core/context.go
+++ b/router/core/context.go
@@ -93,7 +93,7 @@ type requestContext struct {
 	// request is the original request received by the router.
 	request *http.Request
 	// operation is the GraphQL operation context
-	operation OperationContext
+	operation *operationContext
 	// sendError returns the most recent error occurred while trying to make the origin request.
 	sendError error
 }
@@ -110,7 +110,7 @@ func (c *requestContext) Request() *http.Request {
 	return c.request
 }
 
-func WithRequestContext(ctx context.Context, operation RequestContext) context.Context {
+func withRequestContext(ctx context.Context, operation *requestContext) context.Context {
 	return context.WithValue(ctx, requestContextKey, operation)
 }
 
@@ -327,4 +327,13 @@ func getOperationContext(ctx context.Context) *operationContext {
 		return nil
 	}
 	return op.(*operationContext)
+}
+
+// isMutationRequest returns true if the current request is a mutation request
+func isMutationRequest(ctx context.Context) bool {
+	op := getRequestContext(ctx)
+	if op == nil {
+		return false
+	}
+	return op.Operation().Type() == "mutation"
 }

--- a/router/core/executor.go
+++ b/router/core/executor.go
@@ -25,8 +25,7 @@ type ExecutorConfigurationBuilder struct {
 	transport     *http.Transport
 	logger        *zap.Logger
 
-	preHandlers  []TransportPreHandler
-	postHandlers []TransportPostHandler
+	transportOptions *TransportOptions
 }
 
 type Executor struct {
@@ -104,13 +103,13 @@ func (b *ExecutorConfigurationBuilder) buildPlannerConfiguration(routerCfg *node
 	// the plan config is what the engine uses to turn a GraphQL Request into an execution plan
 	// the plan config is stateful as it carries connection pools and other things
 	loader := NewLoader(NewDefaultFactoryResolver(
-		NewTransport(b.preHandlers, b.postHandlers),
+		NewTransport(b.transportOptions),
 		b.transport,
 		b.logger,
 	))
 
 	// this generates the plan config using the data source factories from the config package
-	planConfig, err := loader.Load(routerCfg.EngineConfig, b.baseURL)
+	planConfig, err := loader.Load(routerCfg.EngineConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load configuration: %w", err)
 	}

--- a/router/core/router.go
+++ b/router/core/router.go
@@ -141,6 +141,10 @@ func NewRouter(opts ...Option) (*Router, error) {
 
 	// Default values for retry options
 
+	if r.maxRetryCount == 0 {
+		r.maxRetryCount = 5
+	}
+
 	if r.retryInterval == 0 {
 		r.retryInterval = 5 * time.Second
 	}

--- a/router/core/transport.go
+++ b/router/core/transport.go
@@ -3,9 +3,11 @@ package core
 import (
 	"fmt"
 	"github.com/wundergraph/cosmo/router/internal/otel"
+	"github.com/wundergraph/cosmo/router/internal/retrytransport"
 	"github.com/wundergraph/cosmo/router/internal/trace"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	otrace "go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
 	"net/http"
 	"net/url"
 	"time"
@@ -18,11 +20,12 @@ type CustomTransport struct {
 	roundTripper http.RoundTripper
 	preHandlers  []TransportPreHandler
 	postHandlers []TransportPostHandler
+	logger       *zap.Logger
 }
 
-func NewCustomTransport(originalTransport http.RoundTripper) *CustomTransport {
+func NewCustomTransport(logger *zap.Logger, roundTripper http.RoundTripper, retryOptions retrytransport.RetryOptions) *CustomTransport {
 	return &CustomTransport{
-		roundTripper: originalTransport,
+		roundTripper: retrytransport.NewRetryHTTPTransport(roundTripper, retryOptions, logger),
 	}
 }
 
@@ -69,19 +72,31 @@ type TransportFactory struct {
 	customTransport *CustomTransport
 	preHandlers     []TransportPreHandler
 	postHandlers    []TransportPostHandler
+	retryOptions    retrytransport.RetryOptions
+	logger          *zap.Logger
 }
 
 var _ ApiTransportFactory = TransportFactory{}
 
-func NewTransport(preHandlers []TransportPreHandler, postHandlers []TransportPostHandler) *TransportFactory {
+type TransportOptions struct {
+	preHandlers  []TransportPreHandler
+	postHandlers []TransportPostHandler
+	retryOptions retrytransport.RetryOptions
+	logger       *zap.Logger
+}
+
+func NewTransport(opts *TransportOptions) *TransportFactory {
 	return &TransportFactory{
-		preHandlers:  preHandlers,
-		postHandlers: postHandlers,
+		preHandlers:  opts.preHandlers,
+		postHandlers: opts.postHandlers,
+		logger:       opts.logger,
+		retryOptions: opts.retryOptions,
 	}
 }
 
-func (t TransportFactory) RoundTripper(transport *http.Transport, enableStreamingMode bool) http.RoundTripper {
+func (t TransportFactory) RoundTripper(transport http.RoundTripper, enableStreamingMode bool) http.RoundTripper {
 	tp := NewCustomTransport(
+		t.logger,
 		trace.NewTransport(
 			transport,
 			[]otelhttp.Option{
@@ -99,10 +114,8 @@ func (t TransportFactory) RoundTripper(transport *http.Transport, enableStreamin
 				}
 			}),
 		),
+		t.retryOptions,
 	)
-
-	tp.preHandlers = t.preHandlers
-	tp.postHandlers = t.postHandlers
 
 	return tp
 }

--- a/router/core/transport.go
+++ b/router/core/transport.go
@@ -24,8 +24,15 @@ type CustomTransport struct {
 }
 
 func NewCustomTransport(logger *zap.Logger, roundTripper http.RoundTripper, retryOptions retrytransport.RetryOptions) *CustomTransport {
+
+	if retryOptions.Enabled {
+		return &CustomTransport{
+			roundTripper: retrytransport.NewRetryHTTPTransport(roundTripper, retryOptions, logger),
+		}
+	}
+
 	return &CustomTransport{
-		roundTripper: retrytransport.NewRetryHTTPTransport(roundTripper, retryOptions, logger),
+		roundTripper: roundTripper,
 	}
 }
 

--- a/router/go.mod
+++ b/router/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/bufbuild/connect-go v1.9.0
 	github.com/buger/jsonparser v1.1.1
 	github.com/cespare/xxhash/v2 v2.2.0
+	github.com/cloudflare/backoff v0.0.0-20161212185259-647f3cdfc87a
 	github.com/dgraph-io/ristretto v0.1.1
 	github.com/go-chi/chi v1.5.4
 	github.com/go-playground/validator/v10 v10.15.3
@@ -36,12 +37,9 @@ require (
 )
 
 require (
-	code.cloudfoundry.org/lager/v3 v3.0.2 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bytedance/sonic v1.9.2 // indirect
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
-	github.com/cloudflare/backoff v0.0.0-20161212185259-647f3cdfc87a // indirect
-	github.com/concourse/retryhttp v1.2.4 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/evanphx/json-patch v0.5.2 // indirect
@@ -53,11 +51,8 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
-	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
-	github.com/gojek/heimdall v5.0.2+incompatible // indirect
 	github.com/golang/glog v1.1.1 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
-	github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
@@ -69,8 +64,6 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
-	github.com/onsi/ginkgo/v2 v2.9.2 // indirect
-	github.com/openzipkin/zipkin-go v0.4.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.9 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
@@ -79,7 +72,6 @@ require (
 	github.com/prometheus/procfs v0.9.0 // indirect
 	github.com/r3labs/sse/v2 v2.8.1 // indirect
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.0 // indirect
-	github.com/sethgrid/pester v1.2.0 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect
@@ -95,7 +87,6 @@ require (
 	golang.org/x/net v0.12.0 // indirect
 	golang.org/x/sys v0.12.0 // indirect
 	golang.org/x/text v0.11.0 // indirect
-	golang.org/x/tools v0.7.0 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1 // indirect
 	gopkg.in/cenkalti/backoff.v1 v1.1.0 // indirect

--- a/router/go.mod
+++ b/router/go.mod
@@ -36,9 +36,12 @@ require (
 )
 
 require (
+	code.cloudfoundry.org/lager/v3 v3.0.2 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bytedance/sonic v1.9.2 // indirect
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
+	github.com/cloudflare/backoff v0.0.0-20161212185259-647f3cdfc87a // indirect
+	github.com/concourse/retryhttp v1.2.4 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/evanphx/json-patch v0.5.2 // indirect
@@ -50,8 +53,11 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
+	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
+	github.com/gojek/heimdall v5.0.2+incompatible // indirect
 	github.com/golang/glog v1.1.1 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
@@ -63,6 +69,8 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
+	github.com/onsi/ginkgo/v2 v2.9.2 // indirect
+	github.com/openzipkin/zipkin-go v0.4.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.9 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
@@ -71,6 +79,7 @@ require (
 	github.com/prometheus/procfs v0.9.0 // indirect
 	github.com/r3labs/sse/v2 v2.8.1 // indirect
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.0 // indirect
+	github.com/sethgrid/pester v1.2.0 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect
@@ -86,6 +95,7 @@ require (
 	golang.org/x/net v0.12.0 // indirect
 	golang.org/x/sys v0.12.0 // indirect
 	golang.org/x/text v0.11.0 // indirect
+	golang.org/x/tools v0.7.0 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1 // indirect
 	gopkg.in/cenkalti/backoff.v1 v1.1.0 // indirect

--- a/router/go.sum
+++ b/router/go.sum
@@ -30,9 +30,6 @@ cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0Zeo
 cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohlUTyfDhBk=
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
-code.cloudfoundry.org/lager v1.1.1-0.20230321195817-3d52f427a2d2 h1:/XzZDmyGGMbVARg2I8/gooQHUZrnbFjLN6blLWxdcXU=
-code.cloudfoundry.org/lager/v3 v3.0.2 h1:H0dcQY+814G1Ea0e5K/AMaMpcr+Pe5Iv+AALJEwrP9U=
-code.cloudfoundry.org/lager/v3 v3.0.2/go.mod h1:zA6tOIWhr5uZUez+PGpdfBHDWQOfhOrr0cgKDagZPwk=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/99designs/gqlgen v0.17.22 h1:TOcrF8t0T3I0za9JD3CB6ehq7dDEMjR9Onikf8Lc/04=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
@@ -73,8 +70,6 @@ github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
-github.com/concourse/retryhttp v1.2.4 h1:eo1DhK3ZaW7lWm846Y9R8/91LpETTWA6/YtBhxabclY=
-github.com/concourse/retryhttp v1.2.4/go.mod h1:OdmoHwj4SdbCWGnoHMvar5lcsLVQNpUkOI3uLgLBS8Q=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -127,8 +122,6 @@ github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91
 github.com/go-playground/validator/v10 v10.2.0/go.mod h1:uOYAAleCW8F/7oMFd6aG0GOhaH6EGOAJShg8Id5JGkI=
 github.com/go-playground/validator/v10 v10.15.3 h1:S+sSpunYjNPDuXkWbK+x+bA7iXiW296KG4dL3X7xUZo=
 github.com/go-playground/validator/v10 v10.15.3/go.mod h1:9iXMNT7sEkjXb0I+enO7QXmzG6QCsPWY4zveKFVRSyU=
-github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
-github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572/go.mod h1:9Pwr4B2jHnOSGXyyzV8ROjYa2ojvAY6HCGYYfMoC3Ls=
 github.com/gobwas/httphead v0.0.0-20180130184737-2c6c146eadee h1:s+21KNqlpePfkah2I+gwHF8xmJWRjooY+5248k6m4A0=
 github.com/gobwas/httphead v0.0.0-20180130184737-2c6c146eadee/go.mod h1:L0fX3K22YWvt/FAX9NnzrNzcI4wNYi9Yku4O0LKYflo=
 github.com/gobwas/pool v0.2.0 h1:QEmUOlnSjWtnpRGHF3SauEiOsy82Cup83Vf2LcMlnc8=
@@ -138,8 +131,6 @@ github.com/gobwas/ws v1.0.4 h1:5eXU1CZhpQdq5kXbKb+sECH5Ia5KiO6CYzIzdlVx6Bs=
 github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
 github.com/goccy/go-yaml v1.11.0 h1:n7Z+zx8S9f9KgzG6KtQKf+kwqXZlLNR2F6018Dgau54=
 github.com/goccy/go-yaml v1.11.0/go.mod h1:H+mJrWtjPTJAHvRbV09MCK9xYwODM+wRTVFFTWckfng=
-github.com/gojek/heimdall v5.0.2+incompatible h1:S9IJNuRErtH5MZ7Aps10haoTAoxy9Q0E0bYIjJZT7Vg=
-github.com/gojek/heimdall v5.0.2+incompatible/go.mod h1:caFYHVXyKSrgUJgtgHM+KJZGyI1wWxghxu7aFPLVfI8=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=
 github.com/golang/glog v1.1.1 h1:jxpi2eWoU84wbX9iIEyAeeoac3FLuifZpY9tcNUD9kw=
@@ -195,8 +186,6 @@ github.com/google/pprof v0.0.0-20200212024743-f11f1df84d12/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200430221834-fc25d7d30c6d/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
-github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38 h1:yAJXTCF9TqKcTiHJAE8dj7HMvPfh66eeA2JYW7eFpSE=
-github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
@@ -216,7 +205,6 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
-github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/jensneuse/abstractlogger v0.0.4 h1:sa4EH8fhWk3zlTDbSncaWKfwxYM8tYSlQ054ETLyyQY=
 github.com/jensneuse/abstractlogger v0.0.4/go.mod h1:6WuamOHuykJk8zED/R0LNiLhWR6C7FIAo43ocUEB3mo=
 github.com/jensneuse/byte-template v0.0.0-20200214152254-4f3cf06e5c68 h1:E80wOd3IFQcoBxLkAUpUQ3BoGrZ4DxhQdP21+HH1s6A=
@@ -264,10 +252,6 @@ github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJ
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
-github.com/onsi/ginkgo/v2 v2.9.2 h1:BA2GMJOtfGAfagzYtrAlufIP0lq6QERkFmHLMLPwFSU=
-github.com/onsi/ginkgo/v2 v2.9.2/go.mod h1:WHcJJG2dIlcCqVfBAwUCrJxSPFb6v4azBwgxeMeDuts=
-github.com/openzipkin/zipkin-go v0.4.1 h1:kNd/ST2yLLWhaWrkgchya40TJabe8Hioj9udfPcEO5A=
-github.com/openzipkin/zipkin-go v0.4.1/go.mod h1:qY0VqDSN1pOBN94dBc6w2GJlWLiovAyg7Qt6/I9HecM=
 github.com/pelletier/go-toml/v2 v2.0.9 h1:uH2qQXheeefCCkuBBSLi7jCiSmj3VRh2+Goq2N7Xxu0=
 github.com/pelletier/go-toml/v2 v2.0.9/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdUvyaeZurnPPDc=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -293,8 +277,6 @@ github.com/santhosh-tekuri/jsonschema/v5 v5.3.0 h1:uIkTLo0AGRc8l7h5l9r+GcYi9qfVP
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.0/go.mod h1:FKdcjfQW6rpZSnxxUvEA5H/cDPdvJ/SZJQLWWXWGrZ0=
 github.com/sebdah/goldie/v2 v2.5.3 h1:9ES/mNN+HNUbNWpVAlrzuZ7jE+Nrczbj8uFRjM7624Y=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
-github.com/sethgrid/pester v1.2.0 h1:adC9RS29rRUef3rIKWPOuP1Jm3/MmB6ke+OhE5giENI=
-github.com/sethgrid/pester v1.2.0/go.mod h1:hEUINb4RqvDxtoCaU0BNT/HV4ig5kfgOasrf1xcvr0A=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
@@ -307,7 +289,6 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
@@ -560,8 +541,6 @@ golang.org/x/tools v0.0.0-20200618134242-20370b0cb4b2/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20200729194436-6467de6f59a7/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200804011535-6c149bb5ef0d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
-golang.org/x/tools v0.7.0 h1:W4OVu8VVOaIO0yzWMNdepAulS7YfoS3Zabrm8DOXXU4=
-golang.org/x/tools v0.7.0/go.mod h1:4pg6aUX35JBAogB10C9AtvVL+qowtN4pT3CGSQex14s=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/router/go.sum
+++ b/router/go.sum
@@ -30,6 +30,9 @@ cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0Zeo
 cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohlUTyfDhBk=
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
+code.cloudfoundry.org/lager v1.1.1-0.20230321195817-3d52f427a2d2 h1:/XzZDmyGGMbVARg2I8/gooQHUZrnbFjLN6blLWxdcXU=
+code.cloudfoundry.org/lager/v3 v3.0.2 h1:H0dcQY+814G1Ea0e5K/AMaMpcr+Pe5Iv+AALJEwrP9U=
+code.cloudfoundry.org/lager/v3 v3.0.2/go.mod h1:zA6tOIWhr5uZUez+PGpdfBHDWQOfhOrr0cgKDagZPwk=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/99designs/gqlgen v0.17.22 h1:TOcrF8t0T3I0za9JD3CB6ehq7dDEMjR9Onikf8Lc/04=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
@@ -61,6 +64,8 @@ github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWR
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/cloudflare/backoff v0.0.0-20161212185259-647f3cdfc87a h1:8d1CEOF1xldesKds5tRG3tExBsMOgWYownMHNCsev54=
+github.com/cloudflare/backoff v0.0.0-20161212185259-647f3cdfc87a/go.mod h1:rzgs2ZOiguV6/NpiDgADjRLPNyZlApIWxKpkT+X8SdY=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=
@@ -68,6 +73,8 @@ github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
+github.com/concourse/retryhttp v1.2.4 h1:eo1DhK3ZaW7lWm846Y9R8/91LpETTWA6/YtBhxabclY=
+github.com/concourse/retryhttp v1.2.4/go.mod h1:OdmoHwj4SdbCWGnoHMvar5lcsLVQNpUkOI3uLgLBS8Q=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -120,6 +127,8 @@ github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91
 github.com/go-playground/validator/v10 v10.2.0/go.mod h1:uOYAAleCW8F/7oMFd6aG0GOhaH6EGOAJShg8Id5JGkI=
 github.com/go-playground/validator/v10 v10.15.3 h1:S+sSpunYjNPDuXkWbK+x+bA7iXiW296KG4dL3X7xUZo=
 github.com/go-playground/validator/v10 v10.15.3/go.mod h1:9iXMNT7sEkjXb0I+enO7QXmzG6QCsPWY4zveKFVRSyU=
+github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
+github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572/go.mod h1:9Pwr4B2jHnOSGXyyzV8ROjYa2ojvAY6HCGYYfMoC3Ls=
 github.com/gobwas/httphead v0.0.0-20180130184737-2c6c146eadee h1:s+21KNqlpePfkah2I+gwHF8xmJWRjooY+5248k6m4A0=
 github.com/gobwas/httphead v0.0.0-20180130184737-2c6c146eadee/go.mod h1:L0fX3K22YWvt/FAX9NnzrNzcI4wNYi9Yku4O0LKYflo=
 github.com/gobwas/pool v0.2.0 h1:QEmUOlnSjWtnpRGHF3SauEiOsy82Cup83Vf2LcMlnc8=
@@ -129,6 +138,8 @@ github.com/gobwas/ws v1.0.4 h1:5eXU1CZhpQdq5kXbKb+sECH5Ia5KiO6CYzIzdlVx6Bs=
 github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
 github.com/goccy/go-yaml v1.11.0 h1:n7Z+zx8S9f9KgzG6KtQKf+kwqXZlLNR2F6018Dgau54=
 github.com/goccy/go-yaml v1.11.0/go.mod h1:H+mJrWtjPTJAHvRbV09MCK9xYwODM+wRTVFFTWckfng=
+github.com/gojek/heimdall v5.0.2+incompatible h1:S9IJNuRErtH5MZ7Aps10haoTAoxy9Q0E0bYIjJZT7Vg=
+github.com/gojek/heimdall v5.0.2+incompatible/go.mod h1:caFYHVXyKSrgUJgtgHM+KJZGyI1wWxghxu7aFPLVfI8=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=
 github.com/golang/glog v1.1.1 h1:jxpi2eWoU84wbX9iIEyAeeoac3FLuifZpY9tcNUD9kw=
@@ -184,6 +195,8 @@ github.com/google/pprof v0.0.0-20200212024743-f11f1df84d12/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200430221834-fc25d7d30c6d/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
+github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38 h1:yAJXTCF9TqKcTiHJAE8dj7HMvPfh66eeA2JYW7eFpSE=
+github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
@@ -203,6 +216,7 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/jensneuse/abstractlogger v0.0.4 h1:sa4EH8fhWk3zlTDbSncaWKfwxYM8tYSlQ054ETLyyQY=
 github.com/jensneuse/abstractlogger v0.0.4/go.mod h1:6WuamOHuykJk8zED/R0LNiLhWR6C7FIAo43ocUEB3mo=
 github.com/jensneuse/byte-template v0.0.0-20200214152254-4f3cf06e5c68 h1:E80wOd3IFQcoBxLkAUpUQ3BoGrZ4DxhQdP21+HH1s6A=
@@ -250,6 +264,10 @@ github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJ
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
+github.com/onsi/ginkgo/v2 v2.9.2 h1:BA2GMJOtfGAfagzYtrAlufIP0lq6QERkFmHLMLPwFSU=
+github.com/onsi/ginkgo/v2 v2.9.2/go.mod h1:WHcJJG2dIlcCqVfBAwUCrJxSPFb6v4azBwgxeMeDuts=
+github.com/openzipkin/zipkin-go v0.4.1 h1:kNd/ST2yLLWhaWrkgchya40TJabe8Hioj9udfPcEO5A=
+github.com/openzipkin/zipkin-go v0.4.1/go.mod h1:qY0VqDSN1pOBN94dBc6w2GJlWLiovAyg7Qt6/I9HecM=
 github.com/pelletier/go-toml/v2 v2.0.9 h1:uH2qQXheeefCCkuBBSLi7jCiSmj3VRh2+Goq2N7Xxu0=
 github.com/pelletier/go-toml/v2 v2.0.9/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdUvyaeZurnPPDc=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -275,6 +293,8 @@ github.com/santhosh-tekuri/jsonschema/v5 v5.3.0 h1:uIkTLo0AGRc8l7h5l9r+GcYi9qfVP
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.0/go.mod h1:FKdcjfQW6rpZSnxxUvEA5H/cDPdvJ/SZJQLWWXWGrZ0=
 github.com/sebdah/goldie/v2 v2.5.3 h1:9ES/mNN+HNUbNWpVAlrzuZ7jE+Nrczbj8uFRjM7624Y=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
+github.com/sethgrid/pester v1.2.0 h1:adC9RS29rRUef3rIKWPOuP1Jm3/MmB6ke+OhE5giENI=
+github.com/sethgrid/pester v1.2.0/go.mod h1:hEUINb4RqvDxtoCaU0BNT/HV4ig5kfgOasrf1xcvr0A=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
@@ -287,6 +307,7 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
@@ -539,6 +560,8 @@ golang.org/x/tools v0.0.0-20200618134242-20370b0cb4b2/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20200729194436-6467de6f59a7/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200804011535-6c149bb5ef0d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
+golang.org/x/tools v0.7.0 h1:W4OVu8VVOaIO0yzWMNdepAulS7YfoS3Zabrm8DOXXU4=
+golang.org/x/tools v0.7.0/go.mod h1:4pg6aUX35JBAogB10C9AtvVL+qowtN4pT3CGSQex14s=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/router/internal/config/config.go
+++ b/router/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	b64 "encoding/base64"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/go-playground/validator/v10"
 	"github.com/goccy/go-yaml"
@@ -32,8 +33,8 @@ type Graph struct {
 type Tracing struct {
 	Enabled bool `yaml:"enabled" default:"true" envconfig:"TRACING_ENABLED"`
 	Config  struct {
-		BatchTimeoutSeconds int     `yaml:"batch_timeout_seconds" default:"10" envconfig:"TRACING_BATCH_TIMEOUT_SECONDS"`
-		SamplingRate        float64 `yaml:"sampling_rate" default:"1" validate:"min=0,max=1" envconfig:"TRACING_SAMPLING_RATE"`
+		BatchTimeout time.Duration `yaml:"batch_timeout" default:"10s" envconfig:"TRACING_BATCH_TIMEOUT"`
+		SamplingRate float64       `yaml:"sampling_rate" default:"1" validate:"min=0,max=1" envconfig:"TRACING_SAMPLING_RATE"`
 	} `yaml:"config"`
 }
 
@@ -62,11 +63,30 @@ type OpenTelemetry struct {
 }
 
 type CORS struct {
-	AllowOrigins     []string `yaml:"allow_origins" default:"*" envconfig:"CORS_ALLOW_ORIGINS"`
-	AllowMethods     []string `yaml:"allow_methods" default:"HEAD,GET,POST" envconfig:"CORS_ALLOW_METHODS"`
-	AllowHeaders     []string `yaml:"allow_headers" default:"Origin,Content-Length,Content-Type" envconfig:"CORS_ALLOW_HEADERS"`
-	AllowCredentials bool     `yaml:"allow_credentials" default:"true" envconfig:"CORS_ALLOW_CREDENTIALS"`
-	MaxAgeMinutes    int      `yaml:"max_age_minutes" default:"5" validate:"min=5" envconfig:"CORS_MAX_AGE_MINUTES"`
+	AllowOrigins     []string      `yaml:"allow_origins" default:"*" envconfig:"CORS_ALLOW_ORIGINS"`
+	AllowMethods     []string      `yaml:"allow_methods" default:"HEAD,GET,POST" envconfig:"CORS_ALLOW_METHODS"`
+	AllowHeaders     []string      `yaml:"allow_headers" default:"Origin,Content-Length,Content-Type" envconfig:"CORS_ALLOW_HEADERS"`
+	AllowCredentials bool          `yaml:"allow_credentials" default:"true" envconfig:"CORS_ALLOW_CREDENTIALS"`
+	MaxAge           time.Duration `yaml:"max_age" default:"5m" validate:"min=5m" envconfig:"CORS_MAX_AGE"`
+}
+
+type TrafficShapingRules struct {
+	// All is a set of rules that apply to all requests
+	All GlobalTrafficShapingRule `yaml:"all"`
+}
+
+type GlobalTrafficShapingRule struct {
+	Retry TrafficShapingRetry `yaml:"retry"`
+}
+
+type TrafficShapingRetry struct {
+	BackoffJitter LinearJitterOptions `yaml:"backoff_jitter"`
+}
+
+type LinearJitterOptions struct {
+	MaxAttempts int           `yaml:"max_attempts" default:"5" validate:"min=1"`
+	MaxDuration time.Duration `yaml:"max_duration" default:"20s"`
+	Interval    time.Duration `yaml:"interval" default:"5s"`
 }
 
 type HeaderRules struct {
@@ -111,21 +131,22 @@ type Config struct {
 	Telemetry OpenTelemetry `yaml:"telemetry"`
 	CORS      CORS          `yaml:"cors"`
 
-	Modules map[string]interface{} `yaml:"modules"`
-	Headers HeaderRules            `yaml:"headers"`
+	Modules        map[string]interface{} `yaml:"modules"`
+	Headers        HeaderRules            `yaml:"headers"`
+	TrafficShaping TrafficShapingRules    `yaml:"traffic_shaping"`
 
-	ListenAddr           string `yaml:"listen_addr" default:"localhost:3002" validate:"hostname_port" envconfig:"LISTEN_ADDR"`
-	ControlplaneURL      string `yaml:"controlplane_url" validate:"required" default:"https://cosmo-cp.wundergraph.com" envconfig:"CONTROLPLANE_URL" validate:"uri"`
-	PlaygroundEnabled    bool   `yaml:"playground_enabled" default:"true" envconfig:"PLAYGROUND_ENABLED"`
-	IntrospectionEnabled bool   `yaml:"introspection_enabled" default:"true" envconfig:"INTROSPECTION_ENABLED"`
-	LogLevel             string `yaml:"log_level" default:"info" envconfig:"LOG_LEVEL" validate:"oneof=debug info warning error fatal panic"`
-	JSONLog              bool   `yaml:"json_log" default:"true" envconfig:"JSON_LOG"`
-	ShutdownDelaySeconds int    `yaml:"shutdown_delay_seconds" default:"30" validate:"min=5" envconfig:"SHUTDOWN_DELAY_SECONDS"`
-	GracePeriodSeconds   int    `yaml:"grace_period_seconds" default:"20" envconfig:"GRACE_PERIOD_SECONDS"`
-	PollIntervalSeconds  int    `yaml:"poll_interval_seconds" default:"10" validate:"min=5" envconfig:"POLL_INTERVAL_SECONDS"`
-	HealthCheckPath      string `yaml:"health_check_path" default:"/health" envconfig:"HEALTH_CHECK_PATH" validate:"uri"`
-	ReadinessCheckPath   string `yaml:"readiness_check_path" default:"/health/ready" envconfig:"READINESS_CHECK_PATH" validate:"uri"`
-	LivenessCheckPath    string `yaml:"liveness_check_path" default:"/health/live" envconfig:"LIVENESS_CHECK_PATH" validate:"uri"`
+	ListenAddr           string        `yaml:"listen_addr" default:"localhost:3002" validate:"hostname_port" envconfig:"LISTEN_ADDR"`
+	ControlplaneURL      string        `yaml:"controlplane_url" validate:"required" default:"https://cosmo-cp.wundergraph.com" envconfig:"CONTROLPLANE_URL" validate:"uri"`
+	PlaygroundEnabled    bool          `yaml:"playground_enabled" default:"true" envconfig:"PLAYGROUND_ENABLED"`
+	IntrospectionEnabled bool          `yaml:"introspection_enabled" default:"true" envconfig:"INTROSPECTION_ENABLED"`
+	LogLevel             string        `yaml:"log_level" default:"info" envconfig:"LOG_LEVEL" validate:"oneof=debug info warning error fatal panic"`
+	JSONLog              bool          `yaml:"json_log" default:"true" envconfig:"JSON_LOG"`
+	ShutdownDelay        time.Duration `yaml:"shutdown_delay" default:"30s" validate:"min=5s" envconfig:"SHUTDOWN_DELAY"`
+	GracePeriod          time.Duration `yaml:"grace_period" default:"20s" envconfig:"GRACE_PERIOD"`
+	PollInterval         time.Duration `yaml:"poll_interval" default:"10s" validate:"min=5s" envconfig:"POLL_INTERVAL"`
+	HealthCheckPath      string        `yaml:"health_check_path" default:"/health" envconfig:"HEALTH_CHECK_PATH" validate:"uri"`
+	ReadinessCheckPath   string        `yaml:"readiness_check_path" default:"/health/ready" envconfig:"READINESS_CHECK_PATH" validate:"uri"`
+	LivenessCheckPath    string        `yaml:"liveness_check_path" default:"/health/live" envconfig:"LIVENESS_CHECK_PATH" validate:"uri"`
 
 	ConfigPath       string `default:"config.yaml" envconfig:"CONFIG_PATH" validate:"omitempty,filepath"`
 	RouterConfigPath string `yaml:"router_config_path" envconfig:"ROUTER_CONFIG_PATH" validate:"omitempty,filepath"`

--- a/router/internal/config/config.go
+++ b/router/internal/config/config.go
@@ -72,21 +72,18 @@ type CORS struct {
 
 type TrafficShapingRules struct {
 	// All is a set of rules that apply to all requests
-	All GlobalTrafficShapingRule `yaml:"all"`
+	All GlobalSubgraphRequestRule `yaml:"all"`
 }
 
-type GlobalTrafficShapingRule struct {
-	Retry TrafficShapingRetry `yaml:"retry"`
+type GlobalSubgraphRequestRule struct {
+	BackoffJitterRetry BackoffJitterRetry `yaml:"retry"`
 }
 
-type TrafficShapingRetry struct {
-	BackoffJitter LinearJitterOptions `yaml:"backoff_jitter"`
-}
-
-type LinearJitterOptions struct {
+type BackoffJitterRetry struct {
+	Enabled     bool          `yaml:"enabled" default:"true" envconfig:"RETRY_ENABLED"`
 	MaxAttempts int           `yaml:"max_attempts" default:"5" validate:"min=1"`
-	MaxDuration time.Duration `yaml:"max_duration" default:"20s"`
-	Interval    time.Duration `yaml:"interval" default:"5s"`
+	MaxDuration time.Duration `yaml:"max_duration" default:"20s" validate:"min=1s"`
+	Interval    time.Duration `yaml:"interval" default:"3s" validate:"min=100ms"`
 }
 
 type HeaderRules struct {

--- a/router/internal/config/config.go
+++ b/router/internal/config/config.go
@@ -33,8 +33,8 @@ type Graph struct {
 type Tracing struct {
 	Enabled bool `yaml:"enabled" default:"true" envconfig:"TRACING_ENABLED"`
 	Config  struct {
-		BatchTimeout time.Duration `yaml:"batch_timeout" default:"10s" envconfig:"TRACING_BATCH_TIMEOUT"`
-		SamplingRate float64       `yaml:"sampling_rate" default:"1" validate:"min=0,max=1" envconfig:"TRACING_SAMPLING_RATE"`
+		BatchTimeout time.Duration `yaml:"batch_timeout" default:"10s" validate:"required,min=5s,max=120s" envconfig:"TRACING_BATCH_TIMEOUT"`
+		SamplingRate float64       `yaml:"sampling_rate" default:"1" validate:"required,min=0,max=1" envconfig:"TRACING_SAMPLING_RATE"`
 	} `yaml:"config"`
 }
 
@@ -67,7 +67,7 @@ type CORS struct {
 	AllowMethods     []string      `yaml:"allow_methods" default:"HEAD,GET,POST" envconfig:"CORS_ALLOW_METHODS"`
 	AllowHeaders     []string      `yaml:"allow_headers" default:"Origin,Content-Length,Content-Type" envconfig:"CORS_ALLOW_HEADERS"`
 	AllowCredentials bool          `yaml:"allow_credentials" default:"true" envconfig:"CORS_ALLOW_CREDENTIALS"`
-	MaxAge           time.Duration `yaml:"max_age" default:"5m" validate:"min=5m" envconfig:"CORS_MAX_AGE"`
+	MaxAge           time.Duration `yaml:"max_age" default:"5m" validate:"required,min=5m" envconfig:"CORS_MAX_AGE"`
 }
 
 type TrafficShapingRules struct {
@@ -81,9 +81,10 @@ type GlobalSubgraphRequestRule struct {
 
 type BackoffJitterRetry struct {
 	Enabled     bool          `yaml:"enabled" default:"true" envconfig:"RETRY_ENABLED"`
-	MaxAttempts int           `yaml:"max_attempts" default:"5" validate:"min=1"`
-	MaxDuration time.Duration `yaml:"max_duration" default:"20s" validate:"min=1s"`
-	Interval    time.Duration `yaml:"interval" default:"3s" validate:"min=100ms"`
+	Algorithm   string        `yaml:"algorithm" default:"backoff_jitter" validate:"oneof=backoff_jitter"`
+	MaxAttempts int           `yaml:"max_attempts" default:"5" validate:"required,min=1,required_if=Algorithm backoff_jitter"`
+	MaxDuration time.Duration `yaml:"max_duration" default:"10s" validate:"required,min=1s,required_if=Algorithm backoff_jitter"`
+	Interval    time.Duration `yaml:"interval" default:"3s" validate:"required,min=100ms,required_if=Algorithm backoff_jitter"`
 }
 
 type HeaderRules struct {
@@ -138,9 +139,9 @@ type Config struct {
 	IntrospectionEnabled bool          `yaml:"introspection_enabled" default:"true" envconfig:"INTROSPECTION_ENABLED"`
 	LogLevel             string        `yaml:"log_level" default:"info" envconfig:"LOG_LEVEL" validate:"oneof=debug info warning error fatal panic"`
 	JSONLog              bool          `yaml:"json_log" default:"true" envconfig:"JSON_LOG"`
-	ShutdownDelay        time.Duration `yaml:"shutdown_delay" default:"30s" validate:"min=5s" envconfig:"SHUTDOWN_DELAY"`
-	GracePeriod          time.Duration `yaml:"grace_period" default:"20s" envconfig:"GRACE_PERIOD"`
-	PollInterval         time.Duration `yaml:"poll_interval" default:"10s" validate:"min=5s" envconfig:"POLL_INTERVAL"`
+	ShutdownDelay        time.Duration `yaml:"shutdown_delay" default:"30s" validate:"required,min=5s" envconfig:"SHUTDOWN_DELAY"`
+	GracePeriod          time.Duration `yaml:"grace_period" default:"20s" validate:"required" envconfig:"GRACE_PERIOD"`
+	PollInterval         time.Duration `yaml:"poll_interval" default:"10s" validate:"required,min=5s" envconfig:"POLL_INTERVAL"`
 	HealthCheckPath      string        `yaml:"health_check_path" default:"/health" envconfig:"HEALTH_CHECK_PATH" validate:"uri"`
 	ReadinessCheckPath   string        `yaml:"readiness_check_path" default:"/health/ready" envconfig:"READINESS_CHECK_PATH" validate:"uri"`
 	LivenessCheckPath    string        `yaml:"liveness_check_path" default:"/health/live" envconfig:"LIVENESS_CHECK_PATH" validate:"uri"`

--- a/router/internal/retrytransport/retry_transport.go
+++ b/router/internal/retrytransport/retry_transport.go
@@ -1,0 +1,105 @@
+package retrytransport
+
+import (
+	"errors"
+	"github.com/cloudflare/backoff"
+	"go.uber.org/zap"
+	"net/http"
+	"strings"
+	"syscall"
+	"time"
+)
+
+var defaultRetryableErrors = []error{
+	syscall.ECONNREFUSED, // "connection refused"
+	syscall.ECONNRESET,   // "connection reset by peer"
+	syscall.ETIMEDOUT,    // "operation timed out"
+	errors.New("i/o timeout"),
+	errors.New("no such host"),
+	errors.New("handshake failure"),
+	errors.New("handshake timeout"),
+	errors.New("timeout awaiting response headers"),
+	errors.New("unexpected EOF"),
+	errors.New("unexpected EOF reading trailer"),
+}
+
+type RetryOptions struct {
+	MaxRetryCount int
+	Interval      time.Duration
+	MaxDuration   time.Duration
+	OnRetry       func(count int, req *http.Request, resp *http.Response, err error)
+	ShouldRetry   func(err error, req *http.Request, resp *http.Response) bool
+}
+
+type RetryHTTPTransport struct {
+	RoundTripper http.RoundTripper
+	RetryOptions RetryOptions
+	Logger       *zap.Logger
+}
+
+func NewRetryHTTPTransport(roundTripper http.RoundTripper, retryOptions RetryOptions, logger *zap.Logger) *RetryHTTPTransport {
+	return &RetryHTTPTransport{
+		RoundTripper: roundTripper,
+		RetryOptions: retryOptions,
+		Logger:       logger,
+	}
+}
+
+func (rt *RetryHTTPTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+
+	resp, err := rt.RoundTripper.RoundTrip(req)
+
+	b := backoff.New(rt.RetryOptions.MaxDuration, rt.RetryOptions.Interval)
+	defer b.Reset()
+
+	// Retry logic
+	retries := 0
+	for rt.RetryOptions.ShouldRetry(err, req, resp) && retries < rt.RetryOptions.MaxRetryCount {
+		if rt.RetryOptions.OnRetry != nil {
+			rt.RetryOptions.OnRetry(retries, req, resp, err)
+		}
+
+		retries++
+
+		// Wait for the specified backoff period
+		sleepDuration := b.Duration()
+
+		rt.Logger.Info("Retrying request", zap.Int("retry", retries), zap.String("url", req.URL.String()), zap.Duration("sleep", sleepDuration))
+
+		// Wait for the specified backoff period
+		time.Sleep(sleepDuration)
+
+		// Retry the request
+		resp, err = rt.RoundTripper.RoundTrip(req)
+
+	}
+
+	return resp, err
+}
+
+func IsRetryableError(err error, resp *http.Response) bool {
+
+	if resp != nil {
+		// HTTP
+		if resp.StatusCode == http.StatusBadGateway ||
+			resp.StatusCode == http.StatusServiceUnavailable ||
+			resp.StatusCode == http.StatusGatewayTimeout ||
+			resp.StatusCode == http.StatusTooManyRequests {
+			return true
+		}
+	}
+
+	if err != nil {
+		// Network
+		s := err.Error()
+		for _, retryableError := range defaultRetryableErrors {
+			if strings.HasSuffix(
+				strings.ToLower(s),
+				strings.ToLower(retryableError.Error())) {
+				return true
+			}
+		}
+	}
+
+	return false
+}

--- a/router/internal/retrytransport/retry_transport_test.go
+++ b/router/internal/retrytransport/retry_transport_test.go
@@ -1,0 +1,121 @@
+package retrytransport
+
+import (
+	"errors"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	"net/http"
+	"net/http/httptest"
+	"syscall"
+	"testing"
+	"time"
+)
+
+type MockTransport struct {
+	roundTripper http.RoundTripper
+	handler      func(req *http.Request) (*http.Response, error)
+}
+
+func (dt *MockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return dt.handler(req)
+}
+
+func TestRetryOnHTTP5xx(t *testing.T) {
+
+	logger := zap.NewNop()
+	retries := 0
+
+	tr := RetryHTTPTransport{
+		RoundTripper: &MockTransport{
+			handler: func(req *http.Request) (*http.Response, error) {
+				if retries == 0 {
+					return &http.Response{
+						StatusCode: http.StatusBadGateway,
+					}, nil
+				} else if retries == 1 {
+					return &http.Response{
+						StatusCode: http.StatusServiceUnavailable,
+					}, nil
+				} else if retries == 2 {
+					return &http.Response{
+						StatusCode: http.StatusGatewayTimeout,
+					}, nil
+				}
+
+				return &http.Response{
+					StatusCode: http.StatusOK,
+				}, nil
+			},
+		},
+		RetryOptions: RetryOptions{
+			MaxRetryCount: 3,
+			MinDuration:   1 * time.Millisecond,
+			MaxDuration:   10 * time.Millisecond,
+			ShouldRetry: func(err error, req *http.Request, resp *http.Response) bool {
+				return IsRetryableError(err, resp)
+			},
+			OnRetry: func(count int, req *http.Request, resp *http.Response, err error) {
+				retries++
+			},
+		},
+		Logger: logger,
+	}
+
+	req := httptest.NewRequest("GET", "http://localhost:3000/graphql", nil)
+
+	resp, err := tr.RoundTrip(req)
+	assert.Nil(t, err)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	assert.Equal(t, 3, retries)
+
+}
+
+func TestRetryOnNetErrors(t *testing.T) {
+
+	logger := zap.NewNop()
+	retries := 0
+
+	tr := RetryHTTPTransport{
+		RoundTripper: &MockTransport{
+			handler: func(req *http.Request) (*http.Response, error) {
+				if retries == 0 {
+					return nil, syscall.ECONNREFUSED
+				} else if retries == 1 {
+					return nil, syscall.ECONNRESET
+				} else if retries == 2 {
+					return nil, syscall.ETIMEDOUT
+				} else if retries == 3 {
+					return nil, errors.New("i/o timeout")
+				}
+
+				return &http.Response{
+					StatusCode: http.StatusOK,
+				}, nil
+			},
+		},
+		RetryOptions: RetryOptions{
+			MaxRetryCount: 4,
+			MinDuration:   1 * time.Millisecond,
+			MaxDuration:   10 * time.Millisecond,
+			ShouldRetry: func(err error, req *http.Request, resp *http.Response) bool {
+				return IsRetryableError(err, resp)
+			},
+			OnRetry: func(count int, req *http.Request, resp *http.Response, err error) {
+				retries++
+			},
+		},
+		Logger: logger,
+	}
+
+	req := httptest.NewRequest("GET", "http://localhost:3000/graphql", nil)
+
+	resp, err := tr.RoundTrip(req)
+	assert.Nil(t, err)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	assert.Equal(t, 4, retries)
+
+}

--- a/router/internal/retrytransport/retry_transport_test.go
+++ b/router/internal/retrytransport/retry_transport_test.go
@@ -49,7 +49,7 @@ func TestRetryOnHTTP5xx(t *testing.T) {
 		},
 		RetryOptions: RetryOptions{
 			MaxRetryCount: 3,
-			MinDuration:   1 * time.Millisecond,
+			Interval:      1 * time.Millisecond,
 			MaxDuration:   10 * time.Millisecond,
 			ShouldRetry: func(err error, req *http.Request, resp *http.Response) bool {
 				return IsRetryableError(err, resp)
@@ -97,7 +97,7 @@ func TestRetryOnNetErrors(t *testing.T) {
 		},
 		RetryOptions: RetryOptions{
 			MaxRetryCount: 4,
-			MinDuration:   1 * time.Millisecond,
+			Interval:      1 * time.Millisecond,
 			MaxDuration:   10 * time.Millisecond,
 			ShouldRetry: func(err error, req *http.Request, resp *http.Response) bool {
 				return IsRetryableError(err, resp)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/wundergraph/cloud/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->

## Motivation and Context

Implements backoff jitter retry for query operations
https://cosmo-docs.wundergraph.com/~/changes/VKKWOoLA1Kg0m70D5CDW/router/traffic-shaping

Introduce a breaking change where delays, and timeouts are parsed as Go duration (10s, 100ms) instead of suffixing all environment variables and config properties with _seconds)

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
