### PR TITLE
feat(config): support configuration of graphql path

### DIFF
--- a/router/cmd/main.go
+++ b/router/cmd/main.go
@@ -74,6 +74,7 @@ func Main() {
 		core.WithIntrospection(cfg.IntrospectionEnabled),
 		core.WithPlayground(cfg.PlaygroundEnabled),
 		core.WithGraphApiToken(cfg.Graph.Token),
+		core.WithGraphQLPath(cfg.GraphQLPath),
 		core.WithModulesConfig(cfg.Modules),
 		core.WithGracePeriod(cfg.GracePeriod),
 		core.WithHealthCheckPath(cfg.HealthCheckPath),

--- a/router/core/router.go
+++ b/router/core/router.go
@@ -101,7 +101,6 @@ type (
 // Alternatively, use Router.NewTestServer() to create a new Server instance without starting it for testing purposes.
 func NewRouter(opts ...Option) (*Router, error) {
 	r := &Router{}
-	r.graphqlPath = "/graphql"
 
 	for _, opt := range opts {
 		opt(r)
@@ -109,6 +108,11 @@ func NewRouter(opts ...Option) (*Router, error) {
 
 	if r.logger == nil {
 		r.logger = zap.NewNop()
+	}
+
+	// Default value for graphql path
+	if r.graphqlPath == "" {
+		r.graphqlPath = "/graphql"
 	}
 
 	// Default values for trace and metric config

--- a/router/internal/config/config.go
+++ b/router/internal/config/config.go
@@ -145,6 +145,7 @@ type Config struct {
 	HealthCheckPath      string        `yaml:"health_check_path" default:"/health" envconfig:"HEALTH_CHECK_PATH" validate:"uri"`
 	ReadinessCheckPath   string        `yaml:"readiness_check_path" default:"/health/ready" envconfig:"READINESS_CHECK_PATH" validate:"uri"`
 	LivenessCheckPath    string        `yaml:"liveness_check_path" default:"/health/live" envconfig:"LIVENESS_CHECK_PATH" validate:"uri"`
+	GraphQLPath          string        `yaml:"graphql_path" default:"/graphql" envconfig:"GRAPHQL_PATH"`
 
 	ConfigPath       string `default:"config.yaml" envconfig:"CONFIG_PATH" validate:"omitempty,filepath"`
 	RouterConfigPath string `yaml:"router_config_path" envconfig:"ROUTER_CONFIG_PATH" validate:"omitempty,filepath"`


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/wundergraph/cloud/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->

## Motivation and Context

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

Users should be able to modify the path that the gateway uses when serving graphql requests. Currently this path is hardcoded to `/graphql` but similar to the `ListenAddr` it should be possible for the user to change it via configuration. This PR adds support for a new config `GraphQLPath` defined in the yaml and adds it to the configurator code at startup.

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [X] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
