### PR TITLE
fix: add handlers to the custom transport / throw error on invalid cfg path

### DIFF
--- a/router/core/transport.go
+++ b/router/core/transport.go
@@ -124,6 +124,10 @@ func (t TransportFactory) RoundTripper(transport http.RoundTripper, enableStream
 		t.retryOptions,
 	)
 
+	tp.preHandlers = t.preHandlers
+	tp.postHandlers = t.postHandlers
+	tp.logger = t.logger
+
 	return tp
 }
 

--- a/router/internal/config/config.go
+++ b/router/internal/config/config.go
@@ -187,7 +187,7 @@ func LoadConfig(envOverride string) (*Config, error) {
 	configBytes, err := os.ReadFile(c.ConfigPath)
 	if err != nil {
 		if configPathOverride {
-			return nil, fmt.Errorf("config file %s could not be found: %w", c.ConfigPath, err)
+			return nil, fmt.Errorf("could not read custom config file %s: %w", c.ConfigPath, err)
 		} else {
 			logger.Info("Default config file could not be found",
 				zap.String("configPath", defaultConfigPath),

--- a/router/internal/config/config.go
+++ b/router/internal/config/config.go
@@ -180,6 +180,7 @@ func LoadConfig(envOverride string) (*Config, error) {
 		c.ConfigPath = defaultConfigPath
 	}
 
+	// Configuration from environment variables. We don't have the config here.
 	logLevel, err := logging.ZapLogLevelFromString(c.LogLevel)
 	logger := logging.New(!c.JSONLog, c.LogLevel == "debug", logLevel).
 		With(zap.String("component", "@wundergraph/router"))

--- a/router/internal/config/config.go
+++ b/router/internal/config/config.go
@@ -186,6 +186,7 @@ func LoadConfig(envOverride string) (*Config, error) {
 	logger := logging.New(!c.JSONLog, c.LogLevel == "debug", logLevel).
 		With(zap.String("component", "@wundergraph/router"))
 
+	// Custom config path can only be supported through environment variable
 	configBytes, err := os.ReadFile(c.ConfigPath)
 	if err != nil {
 		if configPathOverride {

--- a/router/internal/config/config.go
+++ b/router/internal/config/config.go
@@ -189,7 +189,7 @@ func LoadConfig(envOverride string) (*Config, error) {
 		if configPathOverride {
 			return nil, fmt.Errorf("could not read custom config file %s: %w", c.ConfigPath, err)
 		} else {
-			logger.Info("Default config file could not be found",
+			logger.Info("Default config file is not loaded",
 				zap.String("configPath", defaultConfigPath),
 				zap.Error(err),
 			)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/wundergraph/cloud/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->

## Motivation and Context

From now on when the user passes a custom config path and the file cannot be found an error is thrown and the server exits.
I have fixed #81 as well. I'll make this clear in the release notes as well.

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
