### PR TITLE
feat: support per subgraph header rules

### DIFF
--- a/router/internal/config/config.go
+++ b/router/internal/config/config.go
@@ -3,10 +3,11 @@ package config
 import (
 	b64 "encoding/base64"
 	"fmt"
-	"github.com/wundergraph/cosmo/router/internal/logging"
-	"go.uber.org/zap"
 	"os"
 	"time"
+
+	"github.com/wundergraph/cosmo/router/internal/logging"
+	"go.uber.org/zap"
 
 	"github.com/go-playground/validator/v10"
 	"github.com/goccy/go-yaml"
@@ -94,7 +95,8 @@ type BackoffJitterRetry struct {
 
 type HeaderRules struct {
 	// All is a set of rules that apply to all requests
-	All GlobalHeaderRule `yaml:"all"`
+	All       GlobalHeaderRule            `yaml:"all"`
+	Subgraphs map[string]GlobalHeaderRule `yaml:"subgraphs"`
 }
 
 type GlobalHeaderRule struct {


### PR DESCRIPTION
## Motivation and Context
Supports the following in the `config.yaml`:
```yaml
# Header manipulation
headers:
  subgraphs:
    specific-subgraph: # Will only affect this subgraph
      request:
        - op: "propagate"
          named: Subgraph-Secret
         # The value will be replaced with the value of SUBGRAPH_SECRET (or empty string if undefined)
          default: "some-secret"
```

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
