### PR TITLE
feat(controlplane): use datetime formatted logs

### DIFF
--- a/controlplane/src/core/build-server.ts
+++ b/controlplane/src/core/build-server.ts
@@ -3,7 +3,7 @@ import { fastifyConnectPlugin } from '@connectrpc/connect-fastify';
 import { cors } from '@connectrpc/connect';
 import fastifyCors from '@fastify/cors';
 import { PinoLoggerOptions } from 'fastify/types/logger.js';
-import { pino } from 'pino';
+import { pino, stdTimeFunctions } from 'pino';
 import { compressionBrotli, compressionGzip } from '@connectrpc/connect-node';
 import fastifyGracefulShutdown from 'fastify-graceful-shutdown';
 import routes from './routes.js';
@@ -74,6 +74,7 @@ const developmentLoggerOpts: PinoLoggerOptions = {
 
 export default async function build(opts: BuildConfig) {
   opts.logger = {
+    timestamp: stdTimeFunctions.isoTime,
     formatters: {
       level: (label) => {
         return {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/wundergraph/cloud/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->

## Motivation and Context

The datetime format is much easier to understand

```
{"level":"debug","time":"2023-09-25T18:11:15.230Z","pid":89306,"hostname":"pop-os","msg":"Database connection healthcheck succeeded"}
```

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
