### PR TITLE
fix: cli reading incorrect github sha

### DIFF
--- a/cli/src/github.ts
+++ b/cli/src/github.ts
@@ -2,56 +2,34 @@ import { readFileSync } from 'node:fs';
 
 // https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
 
-export function parseBranch(branch: any) {
-  return branch ? /^(?:refs\/heads\/)?(?<branch>.+)$/i.exec(branch)?.[1] : undefined;
-}
-
-const getPrEvent = () => {
+function getLatestPRCommit(): string | undefined {
   try {
     const event = process.env.GITHUB_EVENT_PATH
       ? JSON.parse(readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8'))
       : undefined;
 
     if (event && event.pull_request) {
-      return {
-        branch: event.pull_request.base ? parseBranch(event.pull_request.base.ref) : undefined,
-        pr: event.pull_request.number,
-      };
+      return event.pull_request.head.sha;
     }
   } catch {
-    // Noop
+    return undefined;
   }
-
-  return { pr: undefined, branch: undefined };
-};
-
-const getPrNumber = () => {
-  const event = process.env.GITHUB_EVENT_PATH
-    ? JSON.parse(readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8'))
-    : undefined;
-
-  return event && event.pull_request ? event.pull_request.number : undefined;
-};
+}
 
 export function useGitHub() {
   const isPr =
     process.env.GITHUB_EVENT_NAME === 'pull_request' || process.env.GITHUB_EVENT_NAME === 'pull_request_target';
-  const branch = parseBranch(
-    process.env.GITHUB_EVENT_NAME === 'pull_request_target'
-      ? `refs/pull/${getPrNumber()}/merge`
-      : process.env.GITHUB_REF,
-  );
+
+  const commit = getLatestPRCommit();
 
   return {
-    commit: process.env.GITHUB_SHA,
-    build: process.env.GITHUB_RUN_ID,
     isPr,
-    branch,
-    prBranch: isPr ? branch : undefined,
+    commit,
+    build: process.env.GITHUB_RUN_ID,
+    branch: process.env.GITHUB_HEAD_REF,
     repository: process.env.GITHUB_REPOSITORY,
     accountId: process.env.GITHUB_REPOSITORY_OWNER_ID,
     repositoryId: process.env.GITHUB_REPOSITORY_ID,
     root: process.env.GITHUB_WORKSPACE,
-    ...(isPr ? getPrEvent() : undefined),
   };
 }


### PR DESCRIPTION
## Motivation and Context

GitHub ref and commit from env will be different as mentioned [here](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request) so we need to read it from event json. Also cleaned up the file

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [x] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
