### PR TITLE
fix: repository and owner slug swapped

### DIFF
--- a/cli/src/commands/subgraph/commands/check.ts
+++ b/cli/src/commands/subgraph/commands/check.ts
@@ -32,7 +32,7 @@ export default (opts: BaseCommandOptions) => {
     let gitInfo: PartialMessage<GitInfo> | undefined;
     const { isPr, commit: commitSha, repository, accountId } = useGitHub();
     if (isPr && commitSha && repository && accountId) {
-      const [repositorySlug, ownerSlug] = repository?.split('/');
+      const [ownerSlug, repositorySlug] = repository?.split('/');
       gitInfo = {
         commitSha,
         accountId,


### PR DESCRIPTION
## Motivation and Context

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [x] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
