### PR TITLE
fix: view usage for enums and inputs

### DIFF
--- a/studio/src/components/analytics/field-usage.tsx
+++ b/studio/src/components/analytics/field-usage.tsx
@@ -334,6 +334,7 @@ export const FieldUsageSheet = () => {
 
   const { range, dateRange } = useAnalyticsQueryState();
   const isNamedType = searchParams.get("isNamedType") === "true";
+  const isEnum = searchParams.get("isEnum") === "true";
   const showUsage = searchParams.get("showUsage");
 
   const [type, field] = showUsage?.split(".") ?? [];
@@ -342,8 +343,8 @@ export const FieldUsageSheet = () => {
 
   const { data, error, isLoading, refetch } = useQuery({
     ...getFieldUsage.useQuery({
-      field,
-      typename: isNamedType ? undefined : type,
+      field: isEnum ? undefined : field,
+      typename: isEnum ? field : isNamedType ? undefined : type,
       namedType: isNamedType ? type : undefined,
       graphName: graph?.graph?.name,
       range: range,

--- a/studio/src/pages/[organizationSlug]/graph/[slug]/schema/index.tsx
+++ b/studio/src/pages/[organizationSlug]/graph/[slug]/schema/index.tsx
@@ -109,9 +109,9 @@ const Fields = (props: {
   const hasDetails = props.fields.some(
     (f) => !!f.description || !!f.deprecationReason,
   );
-  const hasUsage = !(
-    ["scalars", "enums", "inputs"] as GraphQLTypeCategory[]
-  ).includes(props.category);
+  const hasUsage = !(["scalars"] as GraphQLTypeCategory[]).includes(
+    props.category,
+  );
 
   const openUsage = (fieldName: string) => {
     const query: Record<string, string> = {};
@@ -119,6 +119,11 @@ const Fields = (props: {
       query.showUsage = fieldName;
     } else {
       query.showUsage = `${router.query.typename || "Query"}.${fieldName}`;
+    }
+
+    if (props.category === "enums") {
+      query.isNamedType = "true";
+      query.isEnum = "true";
     }
 
     router.replace({
@@ -312,7 +317,7 @@ const TypeWrapper = ({ ast }: { ast: GraphQLSchema }) => {
 
   if (category && !typename) {
     const list = getTypesByCategory(ast, category);
-    const hasUsage = category !== "inputs";
+    const hasUsage = true;
 
     const openUsage = (type: string) => {
       router.replace({


### PR DESCRIPTION
## Motivation and Context

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [x] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
