### PR TITLE
feat: display available operation names after pushing an operation

### DIFF
--- a/cli/test/extract-operation-names.test.ts
+++ b/cli/test/extract-operation-names.test.ts
@@ -1,0 +1,38 @@
+import { describe, test, expect } from 'vitest';
+
+import { extractOperationNames } from '../src/commands/operations/commands/push.js';
+
+
+describe('extract operation names', () => {
+    test('parse operations without names', () => {
+        const contents = `query {
+            hello
+        }`;
+        const operationNames = extractOperationNames(contents);
+        expect(operationNames).toEqual([]);
+    });
+    test('parse operations with names', () => {
+        const contents = `query getTaskAndUser {
+            getTask(id: "0x3") {
+              id
+              title
+              completed
+            }
+            queryUser(filter: {username: {eq: "john"}}) {
+              username
+              name
+            }
+          }
+          
+          query completedTasks {
+            queryTask(filter: {completed: true}) {
+              title
+              completed
+            }
+          }
+        `;
+
+        const operationNames = extractOperationNames(contents);
+        expect(operationNames).toEqual(['getTaskAndUser', 'completedTasks']);
+    });
+});


### PR DESCRIPTION
operation names are available in both the JSON and text output. If a persisted
operation has no named operations, the array is empty in JSON and not shown
in the text output.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/wundergraph/cloud/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->

## Motivation and Context

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
