### PR TITLE
fix: provide more specific error messages when operation planning fails

### DIFF
--- a/router-tests/integration_test.go
+++ b/router-tests/integration_test.go
@@ -701,3 +701,19 @@ func FuzzQuery(f *testing.F) {
 		}
 	})
 }
+
+func TestPlannerErrorMessage(t *testing.T) {
+	server := setupServer(t)
+	// Error message should contain the invalid argument name instead of a
+	// generic planning error message
+	rr := sendData(server, []byte(`{"query":"{  employee(id:3, does_not_exist: 42) { id } }"}`))
+	if rr.Code != http.StatusOK {
+		t.Error("unexpected status code", rr.Code)
+	}
+	var resp graphqlErrorResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	require.Len(t, resp.Errors, 1)
+	assert.Equal(t, `Unknown argument "does_not_exist" on field "Query.employee".`, resp.Errors[0].Message)
+}

--- a/router-tests/websocket_test.go
+++ b/router-tests/websocket_test.go
@@ -162,6 +162,10 @@ func TestSubscriptionOverWebsocket(t *testing.T) {
 	conn.SetReadDeadline(time.Time{})
 }
 
+type graphqlErrorResponse struct {
+	Errors []graphqlError `json:"errors"`
+}
+
 type graphqlError struct {
 	Message string `json:"message"`
 }

--- a/router/core/graphql_handler.go
+++ b/router/core/graphql_handler.go
@@ -25,7 +25,6 @@ import (
 )
 
 var (
-	errMsgOperationParseFailed = errors.New("failed to parse operation")
 	errCouldNotResolveResponse = errors.New("could not resolve response")
 	errServerTimeout           = errors.New("server timeout")
 	errServerCanceled          = errors.New("server canceled")

--- a/router/core/operation_planner.go
+++ b/router/core/operation_planner.go
@@ -53,7 +53,7 @@ func (p *OperationPlanner) preparePlan(requestOperationName []byte, requestOpera
 	// create and postprocess the plan
 	preparedPlan := planner.Plan(&doc, p.executor.Definition, unsafebytes.BytesToString(requestOperationName), &report)
 	if report.HasErrors() {
-		return planWithMetaData{}, errors.Join(errMsgOperationParseFailed, report)
+		return planWithMetaData{}, &reportError{report: &report}
 	}
 	post := postprocess.DefaultProcessor()
 	post.Process(preparedPlan)


### PR DESCRIPTION
Instead of returning a generic message via HTTP/ws, use the error report
as returned by the engine.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/wundergraph/cloud/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->

## Motivation and Context

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
