### PR TITLE
test: improve router test suite performance

### DIFF
--- a/demo/pkg/subgraphs/employees/subgraph/schema.resolvers.go
+++ b/demo/pkg/subgraphs/employees/subgraph/schema.resolvers.go
@@ -6,7 +6,6 @@ package subgraph
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/wundergraph/cosmo/demo/pkg/subgraphs/employees/subgraph/generated"
@@ -104,7 +103,6 @@ func (r *subscriptionResolver) CurrentTime(ctx context.Context) (<-chan *model.T
 		for {
 			// In our example we'll send the current time every second.
 			time.Sleep(1 * time.Second)
-			fmt.Println("Tick")
 
 			currentTime := time.Now()
 			t := &model.Time{
@@ -117,7 +115,6 @@ func (r *subscriptionResolver) CurrentTime(ctx context.Context) (<-chan *model.T
 			// This avoids goroutine getting blocked forever or panicking,
 			select {
 			case <-ctx.Done(): // This runs when context gets cancelled. Subscription closes.
-				fmt.Println("Subscription Closed")
 				// Handle deregistration of the channel here. `close(ch)`
 				return // Remember to return to end the routine.
 

--- a/router-tests/authentication_test.go
+++ b/router-tests/authentication_test.go
@@ -49,9 +49,11 @@ func assertHasGraphQLErrors(t *testing.T, rr *httptest.ResponseRecorder) {
 }
 
 func TestAuthentication(t *testing.T) {
+	t.Parallel()
 	server, jwksServer := setupServerWithJWKS(t, nil, false)
 
 	t.Run("no token", func(t *testing.T) {
+		t.Parallel()
 		// Operations without token should work succeed
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("POST", "/graphql", strings.NewReader(employeesQuery))
@@ -62,6 +64,7 @@ func TestAuthentication(t *testing.T) {
 	})
 
 	t.Run("invalid token", func(t *testing.T) {
+		t.Parallel()
 		// Operations with an invalid token should fail
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("POST", "/graphql", strings.NewReader(employeesQuery))
@@ -74,6 +77,7 @@ func TestAuthentication(t *testing.T) {
 	})
 
 	t.Run("valid token", func(t *testing.T) {
+		t.Parallel()
 		// Operations with an token should succeed
 		token, err := jwksServer.Token(nil)
 		require.NoError(t, err)
@@ -89,6 +93,8 @@ func TestAuthentication(t *testing.T) {
 }
 
 func TestAuthenticationWithCustomHeaders(t *testing.T) {
+	t.Parallel()
+
 	const (
 		headerName        = "X-My-Header"
 		headerValuePrefix = "Token"
@@ -122,9 +128,11 @@ func TestAuthenticationWithCustomHeaders(t *testing.T) {
 }
 
 func TestAuthorization(t *testing.T) {
+	t.Parallel()
 	server, jwksServer := setupServerWithJWKS(t, nil, true)
 
 	t.Run("no token", func(t *testing.T) {
+		t.Parallel()
 		// Operations without token should fail
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("POST", "/graphql", strings.NewReader(employeesQuery))
@@ -135,6 +143,7 @@ func TestAuthorization(t *testing.T) {
 	})
 
 	t.Run("invalid token", func(t *testing.T) {
+		t.Parallel()
 		// Operations with an invalid token should fail
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("POST", "/graphql", strings.NewReader(employeesQuery))
@@ -147,6 +156,7 @@ func TestAuthorization(t *testing.T) {
 	})
 
 	t.Run("valid token", func(t *testing.T) {
+		t.Parallel()
 		// Operations with an token should succeed
 		token, err := jwksServer.Token(nil)
 		require.NoError(t, err)
@@ -162,6 +172,7 @@ func TestAuthorization(t *testing.T) {
 }
 
 func TestAuthenticationMultipleProviders(t *testing.T) {
+	t.Parallel()
 	authServer1, err := jwks.NewServer()
 	require.NoError(t, err)
 	t.Cleanup(authServer1.Close)
@@ -190,6 +201,7 @@ func TestAuthenticationMultipleProviders(t *testing.T) {
 	server := setupServer(t, core.WithAccessController(accessController))
 
 	t.Run("authenticate with first provider", func(t *testing.T) {
+		t.Parallel()
 		for _, prefix := range authenticator1HeaderValuePrefixes {
 			prefix := prefix
 			t.Run("prefix "+prefix, func(t *testing.T) {
@@ -207,6 +219,7 @@ func TestAuthenticationMultipleProviders(t *testing.T) {
 	})
 
 	t.Run("authenticate with second provider", func(t *testing.T) {
+		t.Parallel()
 		for _, prefix := range authenticator2HeaderValuePrefixes {
 			prefix := prefix
 			t.Run("prefix "+prefix, func(t *testing.T) {
@@ -224,6 +237,7 @@ func TestAuthenticationMultipleProviders(t *testing.T) {
 	})
 
 	t.Run("invalid token", func(t *testing.T) {
+		t.Parallel()
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("POST", "/graphql", strings.NewReader(employeesQuery))
 		req.Header.Set("Authorization", "Bearer invalid")

--- a/router-tests/headers_test.go
+++ b/router-tests/headers_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestForwardHeaders(t *testing.T) {
+	t.Parallel()
 	const (
 		// Make sure you copy these to the struct tag in the subscription test
 		headerNameInGlobalRule   = "foo"

--- a/router-tests/singleflight_test.go
+++ b/router-tests/singleflight_test.go
@@ -1,0 +1,169 @@
+package integration_test
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/wundergraph/cosmo/router/config"
+	"github.com/wundergraph/cosmo/router/core"
+	"go.uber.org/atomic"
+)
+
+type customTransport struct {
+	delay        time.Duration
+	requestCount atomic.Int64
+	baseRT       http.RoundTripper
+}
+
+func (c *customTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	c.requestCount.Inc()
+	if c.delay > 0 {
+		time.Sleep(c.delay)
+	}
+	return c.baseRT.RoundTrip(r)
+}
+
+func TestSingleFlight(t *testing.T) {
+	t.Parallel()
+	var (
+		numOfOperations = 10
+		wg              sync.WaitGroup
+	)
+	transport := &customTransport{
+		baseRT: http.DefaultTransport,
+		delay:  time.Millisecond * 10,
+	}
+	server := setupServer(t, core.WithCustomRoundTripper(transport))
+	wg.Add(numOfOperations)
+	trigger := make(chan struct{})
+	for i := 0; i < numOfOperations; i++ {
+		go func() {
+			defer wg.Done()
+			<-trigger
+			result := sendData(server, "/graphql", []byte(`{"query":"{ employees { id } }"}`))
+			assert.Equal(t, http.StatusOK, result.Result().StatusCode)
+			assert.Equal(t, `{"data":{"employees":[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5},{"id":7},{"id":8},{"id":9},{"id":10},{"id":11},{"id":12}]}}`, result.Body.String())
+		}()
+	}
+	close(trigger)
+	wg.Wait()
+	// We expect that the number of requests is less than the number of operations
+	assert.NotEqual(t, int64(numOfOperations), transport.requestCount.Load())
+	t.Logf("Number of origin requests: %d", transport.requestCount.Load())
+}
+
+func TestSingleFlightMutations(t *testing.T) {
+	t.Parallel()
+	var (
+		numOfOperations = 5
+		wg              sync.WaitGroup
+	)
+	transport := &customTransport{
+		baseRT: http.DefaultTransport,
+		delay:  time.Millisecond * 10,
+	}
+	server := setupServer(t, core.WithCustomRoundTripper(transport))
+	wg.Add(numOfOperations)
+	trigger := make(chan struct{})
+	for i := 0; i < numOfOperations; i++ {
+		go func() {
+			defer wg.Done()
+			<-trigger
+			result := sendData(server, "/graphql", []byte(`{"query":"mutation { updateEmployeeTag(id: 1, tag: \"test\") { id tag } }"}`))
+			assert.Equal(t, http.StatusOK, result.Result().StatusCode)
+			assert.Equal(t, `{"data":{"updateEmployeeTag":{"id":1,"tag":"test"}}}`, result.Body.String())
+		}()
+	}
+	close(trigger)
+	wg.Wait()
+	// As this is a mutation, we expect that the number of requests is equal to the number of operations
+	assert.Equal(t, int64(numOfOperations), transport.requestCount.Load())
+}
+
+func TestSingleFlightDifferentHeaders(t *testing.T) {
+	t.Parallel()
+	var (
+		numOfOperations = 10
+		wg              sync.WaitGroup
+	)
+	transport := &customTransport{
+		baseRT: http.DefaultTransport,
+		delay:  time.Millisecond * 10,
+	}
+	server := setupServer(t,
+		core.WithCustomRoundTripper(transport),
+		core.WithHeaderRules(config.HeaderRules{
+			All: config.GlobalHeaderRule{
+				Request: []config.RequestHeaderRule{
+					{
+						Named:     "Authorization",
+						Operation: config.HeaderRuleOperationPropagate,
+					},
+				},
+			},
+		}),
+	)
+	wg.Add(numOfOperations)
+	for i := 0; i < numOfOperations; i++ {
+		go func(num int) {
+			defer wg.Done()
+			result := sendDataWithHeader(server, "/graphql", []byte(`{"query":"{ employees { id } }"}`), http.Header{
+				"Authorization": []string{fmt.Sprintf("Bearer test-%d", num)},
+			})
+			assert.Equal(t, http.StatusOK, result.Result().StatusCode)
+			assert.Equal(t, `{"data":{"employees":[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5},{"id":7},{"id":8},{"id":9},{"id":10},{"id":11},{"id":12}]}}`, result.Body.String())
+		}(i)
+	}
+	wg.Wait()
+	// As the Authorization header is propagated, and the value is different for each request,
+	// we expect that the number of requests is equal to the number of operations
+	assert.Equal(t, int64(numOfOperations), transport.requestCount.Load())
+}
+
+func TestSingleFlightSameHeaders(t *testing.T) {
+	t.Parallel()
+	var (
+		numOfOperations = 10
+		wg              sync.WaitGroup
+	)
+	transport := &customTransport{
+		baseRT: http.DefaultTransport,
+		delay:  time.Millisecond * 10,
+	}
+	server := setupServer(t,
+		core.WithCustomRoundTripper(transport),
+		core.WithHeaderRules(config.HeaderRules{
+			All: config.GlobalHeaderRule{
+				Request: []config.RequestHeaderRule{
+					{
+						Named:     "Authorization",
+						Operation: config.HeaderRuleOperationPropagate,
+					},
+				},
+			},
+		}),
+	)
+	wg.Add(numOfOperations)
+	trigger := make(chan struct{})
+	for i := 0; i < numOfOperations; i++ {
+		go func() {
+			defer wg.Done()
+			<-trigger
+			result := sendDataWithHeader(server, "/graphql", []byte(`{"query":"{ employees { id } }"}`), http.Header{
+				"Authorization": []string{"Bearer test"},
+			})
+			assert.Equal(t, http.StatusOK, result.Result().StatusCode)
+			assert.Equal(t, `{"data":{"employees":[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5},{"id":7},{"id":8},{"id":9},{"id":10},{"id":11},{"id":12}]}}`, result.Body.String())
+		}()
+	}
+	close(trigger)
+	wg.Wait()
+	// As the Authorization header is propagated, and the value is the same for each request,
+	// we expect that the number of requests is less than the number of operations
+	assert.NotEqual(t, int64(numOfOperations), transport.requestCount.Load())
+	t.Logf("Number of origin requests: %d", transport.requestCount.Load())
+}

--- a/router-tests/subgraph_errors_test.go
+++ b/router-tests/subgraph_errors_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestSubgraphReturnsSuccessfully(t *testing.T) {
+	t.Parallel()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		response := []byte(fmt.Sprintf(`{"data":{"hello": "%s"}}`, "John Doe"))
@@ -74,6 +75,7 @@ func TestSubgraphReturnsSuccessfully(t *testing.T) {
 }
 
 func TestSubgraphReturnsGraphQLErrorWithNullData(t *testing.T) {
+	t.Parallel()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		response := []byte(`{"errors":[{"message":"Something went wrong"}],"data":null}`)
@@ -135,6 +137,7 @@ func TestSubgraphReturnsGraphQLErrorWithNullData(t *testing.T) {
 }
 
 func TestSubgraphReturnsGraphQLErrorWithMissingData(t *testing.T) {
+	t.Parallel()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		response := []byte(`{"errors":[{"message":"Something went wrong"}]}`)
@@ -196,6 +199,7 @@ func TestSubgraphReturnsGraphQLErrorWithMissingData(t *testing.T) {
 }
 
 func TestSubgraphReturnsHttpError(t *testing.T) {
+	t.Parallel()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
- Make most tests parallel
- Avoid generating the same configuration multiple times
- Make timings more tighter when possible, to make the tests not spend
so much time waiting

This reduces the runtime for the whole testsuite from ~180s to ~18s

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/wundergraph/cloud/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->

## Motivation and Context

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
