### PR TITLE
fix: alignment of URL button in trace tree view

### DIFF
--- a/studio/src/components/playground/fetch-flow.tsx
+++ b/studio/src/components/playground/fetch-flow.tsx
@@ -180,7 +180,7 @@ const ReactFlowFetchNode = ({ data }: Node<FetchNode>) => {
               <TooltipProvider>
                 <Tooltip>
                   <TooltipTrigger>
-                    <p className="max-w-sm truncate">
+                    <p className="max-w-sm truncate text-left">
                       URL: {data.outputTrace?.request?.url}
                     </p>
                   </TooltipTrigger>


### PR DESCRIPTION
<img width="406" alt="Screenshot 2023-12-15 at 23 04 43" src="https://github.com/wundergraph/cosmo/assets/47415099/24e62c91-dac3-457c-a9b1-eccf51a2cdc5">
