### PR TITLE
feat: improve subgraph error handling

### DIFF
--- a/demo/pkg/subgraphs/employees/subgraph/employees.go
+++ b/demo/pkg/subgraphs/employees/subgraph/employees.go
@@ -1,9 +1,14 @@
 package subgraph
 
 import (
-	"github.com/wundergraph/cosmo/demo/pkg/subgraphs/employees/subgraph/model"
 	"slices"
+
+	"github.com/wundergraph/cosmo/demo/pkg/subgraphs/employees/subgraph/model"
 )
+
+func strPtr(s string) *string {
+	return &s
+}
 
 var employees = []*model.Employee{
 	{
@@ -18,7 +23,7 @@ var employees = []*model.Employee{
 			EngineerType: model.EngineerTypeBackend,
 			Title:        []string{"Founder", "CEO"},
 		},
-		Notes: "Jens notes resolved by employees",
+		Notes: strPtr("Jens notes resolved by employees"),
 	},
 	{
 		Details: &model.Details{
@@ -32,7 +37,7 @@ var employees = []*model.Employee{
 			EngineerType: model.EngineerTypeFullstack,
 			Title:        []string{"Co-founder", "Tech Lead"},
 		},
-		Notes: "Dustin notes resolved by employees",
+		Notes: strPtr("Dustin notes resolved by employees"),
 	},
 	{
 		Details: &model.Details{
@@ -45,7 +50,7 @@ var employees = []*model.Employee{
 			Departments: []model.Department{model.DepartmentMarketing},
 			Title:       []string{"Co-founder", "Head of Growth"},
 		},
-		Notes: "Stefan notes resolved by employees",
+		Notes: strPtr("Stefan notes resolved by employees"),
 	},
 	{
 		Details: &model.Details{
@@ -61,7 +66,7 @@ var employees = []*model.Employee{
 			},
 			Title: []string{"Co-founder", "COO"},
 		},
-		Notes: "Björn notes resolved by employees",
+		Notes: strPtr("Björn notes resolved by employees"),
 	},
 	{
 		ID: 5,
@@ -75,7 +80,7 @@ var employees = []*model.Employee{
 			EngineerType: model.EngineerTypeBackend,
 			Title:        []string{"Senior GO Engineer"},
 		},
-		Notes: "Serigy notes resolved by employees",
+		Notes: strPtr("Serigy notes resolved by employees"),
 	},
 	{
 		Details: &model.Details{
@@ -89,7 +94,7 @@ var employees = []*model.Employee{
 			EngineerType: model.EngineerTypeFullstack,
 			Title:        []string{"Software Engineer"},
 		},
-		Notes: "Suvij notes resolved by employees",
+		Notes: strPtr("Suvij notes resolved by employees"),
 	},
 	{
 		Details: &model.Details{
@@ -103,7 +108,7 @@ var employees = []*model.Employee{
 			EngineerType: model.EngineerTypeFullstack,
 			Title:        []string{"Software Engineer"},
 		},
-		Notes: "Nithin notes resolved by employees",
+		Notes: strPtr("Nithin notes resolved by employees"),
 	},
 	{
 		Details: &model.Details{
@@ -117,7 +122,7 @@ var employees = []*model.Employee{
 			EngineerType: model.EngineerTypeBackend,
 			Title:        []string{"Senior Backend Engineer"},
 		},
-		Notes: "Alberto notes resolved by employees",
+		Notes: strPtr("Alberto notes resolved by employees"),
 	},
 	{
 		Details: &model.Details{
@@ -131,7 +136,7 @@ var employees = []*model.Employee{
 			EngineerType: model.EngineerTypeFrontend,
 			Title:        []string{"Senior Frontend Engineer"},
 		},
-		Notes: "Eelco notes resolved by employees",
+		Notes: strPtr("Eelco notes resolved by employees"),
 	},
 	{
 		Details: &model.Details{
@@ -147,7 +152,7 @@ var employees = []*model.Employee{
 			},
 			Title: []string{"Accounting & Finance"},
 		},
-		Notes: "Alexandra notes resolved by employees",
+		Notes: strPtr("Alexandra notes resolved by employees"),
 	},
 	{
 		Details: &model.Details{
@@ -161,7 +166,7 @@ var employees = []*model.Employee{
 			EngineerType: model.EngineerTypeFullstack,
 			Title:        []string{"Software Engineer"},
 		},
-		Notes: "David notes resolved by employees",
+		Notes: strPtr("David notes resolved by employees"),
 	},
 }
 

--- a/demo/pkg/subgraphs/employees/subgraph/generated/generated.go
+++ b/demo/pkg/subgraphs/employees/subgraph/generated/generated.go
@@ -687,7 +687,7 @@ type Employee implements Identifiable @key(fields: "id") {
   id: Int!
   tag: String!
   role: RoleType!
-  notes: String!
+  notes: String
 }
 
 type Time {
@@ -1566,14 +1566,11 @@ func (ec *executionContext) _Employee_notes(ctx context.Context, field graphql.C
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Employee_notes(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -5163,9 +5160,6 @@ func (ec *executionContext) _Employee(ctx context.Context, sel ast.SelectionSet,
 			}
 		case "notes":
 			out.Values[i] = ec._Employee_notes(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/demo/pkg/subgraphs/employees/subgraph/model/models_gen.go
+++ b/demo/pkg/subgraphs/employees/subgraph/model/models_gen.go
@@ -72,7 +72,7 @@ type Employee struct {
 	ID      int      `json:"id"`
 	Tag     string   `json:"tag"`
 	Role    RoleType `json:"role"`
-	Notes   string   `json:"notes"`
+	Notes   *string  `json:"notes,omitempty"`
 }
 
 func (Employee) IsIdentifiable() {}

--- a/demo/pkg/subgraphs/employees/subgraph/schema.graphqls
+++ b/demo/pkg/subgraphs/employees/subgraph/schema.graphqls
@@ -81,7 +81,7 @@ type Employee implements Identifiable @key(fields: "id") {
   id: Int!
   tag: String!
   role: RoleType!
-  notes: String!
+  notes: String
 }
 
 type Time {

--- a/demo/pkg/subgraphs/products/subgraph/employees.go
+++ b/demo/pkg/subgraphs/products/subgraph/employees.go
@@ -2,6 +2,10 @@ package subgraph
 
 import "github.com/wundergraph/cosmo/demo/pkg/subgraphs/products/subgraph/model"
 
+func strPtr(s string) *string {
+	return &s
+}
+
 var employees = []*model.Employee{
 	{
 		ID: 1,
@@ -12,7 +16,7 @@ var employees = []*model.Employee{
 			model.ProductNameMarketing,
 			model.ProductNameSdk,
 		},
-		Notes: "Jens notes resolved by products",
+		Notes: strPtr("Jens notes resolved by products"),
 	},
 	{
 		ID: 2,
@@ -20,7 +24,7 @@ var employees = []*model.Employee{
 			model.ProductNameCosmo,
 			model.ProductNameSdk,
 		},
-		Notes: "Dustin notes resolved by products",
+		Notes: strPtr("Dustin notes resolved by products"),
 	},
 	{
 		ID: 3,
@@ -28,7 +32,7 @@ var employees = []*model.Employee{
 			model.ProductNameConsultancy,
 			model.ProductNameMarketing,
 		},
-		Notes: "Stefan notes resolved by products",
+		Notes: strPtr("Stefan notes resolved by products"),
 	},
 	{
 		ID: 4,
@@ -37,7 +41,7 @@ var employees = []*model.Employee{
 			model.ProductNameHumanResources,
 			model.ProductNameMarketing,
 		},
-		Notes: "Björn notes resolved by products",
+		Notes: strPtr("Björn notes resolved by products"),
 	},
 	{
 		ID: 5,
@@ -45,7 +49,7 @@ var employees = []*model.Employee{
 			model.ProductNameEngine,
 			model.ProductNameSdk,
 		},
-		Notes: "Sergiy notes resolved by products",
+		Notes: strPtr("Sergiy notes resolved by products"),
 	},
 	{
 		ID: 7,
@@ -53,7 +57,7 @@ var employees = []*model.Employee{
 			model.ProductNameCosmo,
 			model.ProductNameSdk,
 		},
-		Notes: "Suvij notes resolved by products",
+		Notes: strPtr("Suvij notes resolved by products"),
 	},
 	{
 		ID: 8,
@@ -61,7 +65,7 @@ var employees = []*model.Employee{
 			model.ProductNameCosmo,
 			model.ProductNameSdk,
 		},
-		Notes: "Nithin notes resolved by products",
+		Notes: strPtr("Nithin notes resolved by products"),
 	},
 	{
 		ID: 9,
@@ -71,7 +75,7 @@ var employees = []*model.Employee{
 			model.ProductNameEngine,
 			model.ProductNameSdk,
 		},
-		Notes: "Alberto notes resolved by products",
+		Notes: strPtr("Alberto notes resolved by products"),
 	},
 	{
 		ID: 10,
@@ -80,14 +84,14 @@ var employees = []*model.Employee{
 			model.ProductNameCosmo,
 			model.ProductNameSdk,
 		},
-		Notes: "Eelco notes resolved by products",
+		Notes: strPtr("Eelco notes resolved by products"),
 	},
 	{
 		ID: 11,
 		Products: []model.ProductName{
 			model.ProductNameFinance,
 		},
-		Notes: "Alexandra notes resolved by products",
+		Notes: strPtr("Alexandra notes resolved by products"),
 	},
 	{
 		ID: 12,
@@ -97,6 +101,6 @@ var employees = []*model.Employee{
 			model.ProductNameEngine,
 			model.ProductNameSdk,
 		},
-		Notes: "David notes resolved by products",
+		Notes: strPtr("David notes resolved by products"),
 	},
 }

--- a/demo/pkg/subgraphs/products/subgraph/generated/generated.go
+++ b/demo/pkg/subgraphs/products/subgraph/generated/generated.go
@@ -378,7 +378,7 @@ enum ProductName {
 type Employee @key(fields: "id") {
   id: Int!
   products: [ProductName!]!
-  notes: String! @override(from: "employees")
+  notes: String @override(from: "employees")
 }
 
 union Products = Consultancy | Cosmo | Documentation
@@ -1052,14 +1052,11 @@ func (ec *executionContext) _Employee_notes(ctx context.Context, field graphql.C
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Employee_notes(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -3642,9 +3639,6 @@ func (ec *executionContext) _Employee(ctx context.Context, sel ast.SelectionSet,
 			}
 		case "notes":
 			out.Values[i] = ec._Employee_notes(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/demo/pkg/subgraphs/products/subgraph/model/models_gen.go
+++ b/demo/pkg/subgraphs/products/subgraph/model/models_gen.go
@@ -41,7 +41,7 @@ func (Documentation) IsProducts() {}
 type Employee struct {
 	ID       int           `json:"id"`
 	Products []ProductName `json:"products"`
-	Notes    string        `json:"notes"`
+	Notes    *string       `json:"notes,omitempty"`
 }
 
 func (Employee) IsEntity() {}

--- a/demo/pkg/subgraphs/products/subgraph/schema.graphqls
+++ b/demo/pkg/subgraphs/products/subgraph/schema.graphqls
@@ -19,7 +19,7 @@ enum ProductName {
 type Employee @key(fields: "id") {
   id: Int!
   products: [ProductName!]!
-  notes: String! @override(from: "employees")
+  notes: String @override(from: "employees")
 }
 
 union Products = Consultancy | Cosmo | Documentation

--- a/router-tests/singleflight_test.go
+++ b/router-tests/singleflight_test.go
@@ -16,7 +16,7 @@ import (
 type customTransport struct {
 	delay        time.Duration
 	requestCount atomic.Int64
-	baseRT       http.RoundTripper
+	roundTrip    func(r *http.Request) (*http.Response, error)
 }
 
 func (c *customTransport) RoundTrip(r *http.Request) (*http.Response, error) {
@@ -24,7 +24,7 @@ func (c *customTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 	if c.delay > 0 {
 		time.Sleep(c.delay)
 	}
-	return c.baseRT.RoundTrip(r)
+	return c.roundTrip(r)
 }
 
 func TestSingleFlight(t *testing.T) {
@@ -34,8 +34,10 @@ func TestSingleFlight(t *testing.T) {
 		wg              sync.WaitGroup
 	)
 	transport := &customTransport{
-		baseRT: http.DefaultTransport,
-		delay:  time.Millisecond * 10,
+		delay: time.Millisecond * 10,
+		roundTrip: func(r *http.Request) (*http.Response, error) {
+			return http.DefaultTransport.RoundTrip(r)
+		},
 	}
 	server := setupServer(t, core.WithCustomRoundTripper(transport))
 	wg.Add(numOfOperations)
@@ -63,8 +65,10 @@ func TestSingleFlightMutations(t *testing.T) {
 		wg              sync.WaitGroup
 	)
 	transport := &customTransport{
-		baseRT: http.DefaultTransport,
-		delay:  time.Millisecond * 10,
+		delay: time.Millisecond * 10,
+		roundTrip: func(r *http.Request) (*http.Response, error) {
+			return http.DefaultTransport.RoundTrip(r)
+		},
 	}
 	server := setupServer(t, core.WithCustomRoundTripper(transport))
 	wg.Add(numOfOperations)
@@ -91,8 +95,10 @@ func TestSingleFlightDifferentHeaders(t *testing.T) {
 		wg              sync.WaitGroup
 	)
 	transport := &customTransport{
-		baseRT: http.DefaultTransport,
-		delay:  time.Millisecond * 10,
+		delay: time.Millisecond * 10,
+		roundTrip: func(r *http.Request) (*http.Response, error) {
+			return http.DefaultTransport.RoundTrip(r)
+		},
 	}
 	server := setupServer(t,
 		core.WithCustomRoundTripper(transport),
@@ -131,8 +137,10 @@ func TestSingleFlightSameHeaders(t *testing.T) {
 		wg              sync.WaitGroup
 	)
 	transport := &customTransport{
-		baseRT: http.DefaultTransport,
-		delay:  time.Millisecond * 10,
+		delay: time.Millisecond * 10,
+		roundTrip: func(r *http.Request) (*http.Response, error) {
+			return http.DefaultTransport.RoundTrip(r)
+		},
 	}
 	server := setupServer(t,
 		core.WithCustomRoundTripper(transport),

--- a/router/go.mod
+++ b/router/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/stretchr/testify v1.8.4
 	github.com/tidwall/gjson v1.14.4
 	github.com/tidwall/sjson v1.2.5
-	github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.2.0.20231215114324-a36c2926669a
+	github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.2.0.20231218140341-92f315e1731b
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.45.0
 	go.opentelemetry.io/otel v1.19.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v0.42.0

--- a/router/go.sum
+++ b/router/go.sum
@@ -244,6 +244,8 @@ github.com/vektah/gqlparser/v2 v2.5.10 h1:6zSM4azXC9u4Nxy5YmdmGu4uKamfwsdKTwp5zs
 github.com/vektah/gqlparser/v2 v2.5.10/go.mod h1:1rCcfwB2ekJofmluGWXMSEnPMZgbxzwj6FaZ/4OT8Cc=
 github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.2.0.20231215114324-a36c2926669a h1:VpCaFhZ1oqFgOu1UoXr4H04daQb4PoexJLP6PDHtkno=
 github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.2.0.20231215114324-a36c2926669a/go.mod h1:P6rgQN3OgjqJ6wUw1lN1U3LREFDW3jy0NFyJdBr4THE=
+github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.2.0.20231218140341-92f315e1731b h1:mO+tQdC01nS/57a7PdaoArw+6gxA5Dz21COfu4iUVtM=
+github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.2.0.20231218140341-92f315e1731b/go.mod h1:hXjJPrZ+oyWMEG8Cqzt6cmCNCW8D8RAieoctDtR8fgg=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.45.0 h1:x8Z78aZx8cOF0+Kkazoc7lwUNMGy0LrzEMxTm4BbTxg=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.45.0/go.mod h1:62CPTSry9QZtOaSsE3tOzhx6LzDhHnXJ6xHeMNNiM6Q=
 go.opentelemetry.io/otel v1.19.0 h1:MuS/TNf4/j4IXsZuJegVzI1cwut7Qc00344rgH7p8bs=


### PR DESCRIPTION
Doesn't swallow subgraph errors anymore. Collects them and wraps them as a multi-error which is then appended to the trace span to surface subgraph issues, e.g. in Prometheus.