### PR TITLE
fix: disable epoll for windows to avoid CGO

### DIFF
--- a/router-tests/go.sum
+++ b/router-tests/go.sum
@@ -8,6 +8,7 @@ github.com/MicahParks/keyfunc/v2 v2.1.0/go.mod h1:rW42fi+xgLJ2FRRXAfNx9ZA8WpD4Oe
 github.com/agnivade/levenshtein v1.1.1 h1:QY8M92nrzkmr798gCo3kmMyqXFzdQVpxLlGPRBij0P8=
 github.com/agnivade/levenshtein v1.1.1/go.mod h1:veldBMzWxcCG2ZvUTKD2kJNRdCk5hVbJomOvKkmgYbo=
 github.com/alitto/pond v1.8.3 h1:ydIqygCLVPqIX/USe5EaV/aSRXTRXDEI9JwuDdu+/xs=
+github.com/alitto/pond v1.8.3/go.mod h1:CmvIIGd5jKLasGI3D87qDkQxjzChdKMmnXMg3fG6M6Q=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/andybalholm/brotli v1.0.6 h1:Yf9fFpf49Zrxb9NlQaluyE92/+X7UVHlhMNJN2sxfOI=
@@ -82,10 +83,13 @@ github.com/go-playground/validator/v10 v10.15.5 h1:LEBecTWb/1j5TNY1YYG2RcOUN3R7N
 github.com/go-playground/validator/v10 v10.15.5/go.mod h1:9iXMNT7sEkjXb0I+enO7QXmzG6QCsPWY4zveKFVRSyU=
 github.com/gobwas/httphead v0.0.0-20180130184737-2c6c146eadee/go.mod h1:L0fX3K22YWvt/FAX9NnzrNzcI4wNYi9Yku4O0LKYflo=
 github.com/gobwas/httphead v0.1.0 h1:exrUm0f4YX0L7EBwZHuCF4GDp8aJfVeBrlLQrs6NqWU=
+github.com/gobwas/httphead v0.1.0/go.mod h1:O/RXo79gxV8G+RqlR/otEwx4Q36zl9rqC5u12GKvMCM=
 github.com/gobwas/pool v0.2.0/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6WezmKEw=
 github.com/gobwas/pool v0.2.1 h1:xfeeEhW7pwmX8nuLVlqbzVc7udMDrwetjEv+TZIz1og=
+github.com/gobwas/pool v0.2.1/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6WezmKEw=
 github.com/gobwas/ws v1.0.2/go.mod h1:szmBTxLgaFppYjEmNtny/v3w89xOydFnnZMcgRRu/EM=
 github.com/gobwas/ws v1.3.1 h1:Qi34dfLMWJbiKaNbDVzM9x27nZBjmkaW6i4+Ku+pGVU=
+github.com/gobwas/ws v1.3.1/go.mod h1:hRKAFb8wOxFROYNsT1bqfWnhX+b5MFeJM9r2ZSwg/KY=
 github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
 github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/goccy/go-yaml v1.11.0 h1:n7Z+zx8S9f9KgzG6KtQKf+kwqXZlLNR2F6018Dgau54=
@@ -113,6 +117,7 @@ github.com/google/uuid v1.4.0 h1:MtMxsa51/r9yyhkyLsVeVt0B+BGQZzpQiTQ4eHZ8bc4=
 github.com/google/uuid v1.4.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=
+github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
 github.com/graph-gophers/graphql-go v1.5.0 h1:fDqblo50TEpD0LY7RXk/LFVYEVqo3+tXMNMPSVXA1yc=
 github.com/graph-gophers/graphql-go v1.5.0/go.mod h1:YtmJZDLbF1YYNrlNAuiO5zAStUWc3XZT07iGsVqe1Os=
 github.com/graph-gophers/graphql-transport-ws v0.0.2 h1:DbmSkbIGzj8SvHei6n8Mh9eLQin8PtA8xY9eCzjRpvo=
@@ -274,6 +279,7 @@ github.com/wundergraph/cosmo/demo v0.0.0-20231210173116-4cf620b03fbb/go.mod h1:U
 github.com/wundergraph/cosmo/router v0.0.0-20231210173116-4cf620b03fbb h1:80wThnmhc+wk63zdCsrp5pKzTrvl2LOk6rKV0K4dLcQ=
 github.com/wundergraph/cosmo/router v0.0.0-20231210173116-4cf620b03fbb/go.mod h1:qdH557PGHUBA95ynTxxuGbWkw5fR2X3jF5uiSVU+7Z8=
 github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.2.0.20240110181439-71bf34cedd29 h1:ECO1hqa3nRZgf9eMKzG2vqmqGlnTw2dqtUClTbISUBo=
+github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.2.0.20240110181439-71bf34cedd29/go.mod h1:5yPXLXNnTMg0IvdH2zHLxD9g/6V+aITfRZQUYZyjVK8=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.46.1 h1:aFJWCqJMNjENlcleuuOkGAPH82y0yULBScfXcIEdS24=

--- a/router/core/websocket.go
+++ b/router/core/websocket.go
@@ -411,7 +411,7 @@ func (h *WebsocketHandler) runPoller() {
 		case <-done:
 			return
 		default:
-			connections, err := h.epoll.Wait(8)
+			connections, err := h.epoll.Wait(128)
 			if err != nil {
 				h.logger.Warn("Epoll wait", zap.Error(err))
 				continue

--- a/router/go.mod
+++ b/router/go.mod
@@ -27,7 +27,6 @@ require (
 	github.com/nats-io/nats.go v1.31.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.17.0
-	github.com/smallnest/epoller v1.1.0
 	github.com/stretchr/testify v1.8.4
 	github.com/tidwall/gjson v1.14.4
 	github.com/tidwall/sjson v1.2.5
@@ -50,6 +49,7 @@ require (
 	go.uber.org/zap v1.26.0
 	go.withmatt.com/connect-brotli v0.4.0
 	golang.org/x/sync v0.4.0
+	golang.org/x/sys v0.15.0
 	google.golang.org/grpc v1.59.0
 	google.golang.org/protobuf v1.31.0
 )
@@ -107,7 +107,6 @@ require (
 	golang.org/x/arch v0.4.0 // indirect
 	golang.org/x/crypto v0.16.0 // indirect
 	golang.org/x/net v0.17.0 // indirect
-	golang.org/x/sys v0.15.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20230822172742-b8732ec3820d // indirect

--- a/router/go.sum
+++ b/router/go.sum
@@ -227,8 +227,6 @@ github.com/sergi/go-diff v1.3.1/go.mod h1:aMJSSKb2lpPvRNec0+w3fl7LP9IOFzdc9Pa4NF
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
 github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
-github.com/smallnest/epoller v1.1.0 h1:8x61C2NxUGTUbVEf5PTkVCxxw8qrWchBC9Oa3FJ1IHE=
-github.com/smallnest/epoller v1.1.0/go.mod h1:4sHAHtCdMy9eEmvqjfsDdKXndwQa5TOX6/0fwPSV+Mg=
 github.com/sosodev/duration v1.1.0 h1:kQcaiGbJaIsRqgQy7VGlZrVw1giWO+lDoX3MCPnpVO4=
 github.com/sosodev/duration v1.1.0/go.mod h1:RQIBBX0+fMLc/D9+Jb/fwvVmo0eZvDDEERAikUR6SDg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -325,7 +323,6 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210525143221-35b2ab0089ea/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20221010170243-090e33056c14/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/router/internal/epoller/README.md
+++ b/router/internal/epoller/README.md
@@ -1,0 +1,8 @@
+# Epoller
+
+epoll implementation for connections in Linux, MacOS.
+
+Its target is implementing a simple epoll lib for network connections, so you should see it only contains few methods about net.Conn:
+
+This is a copy of [https://github.com/smallnest/epoller](https://github.com/smallnest/epoller) (v1.2.0) to remove Windows support and avoid the need for CGO.
+On Windows, we handle websocket messages in a separate goroutine, without epoll.

--- a/router/internal/epoller/conn.go
+++ b/router/internal/epoller/conn.go
@@ -1,0 +1,27 @@
+package epoller
+
+import (
+	"net"
+)
+
+// newConnImpl returns a net.Conn with GetFD() method.
+func newConnImpl(in net.Conn) ConnImpl {
+	if ci, ok := in.(ConnImpl); ok {
+		return ci
+	}
+
+	return ConnImpl{
+		Conn: in,
+		fd:   socketFD(in),
+	}
+}
+
+// ConnImpl is a net.Conn with GetFD() method.
+type ConnImpl struct {
+	net.Conn
+	fd int
+}
+
+func (c ConnImpl) GetFD() int {
+	return c.fd
+}

--- a/router/internal/epoller/epoll.go
+++ b/router/internal/epoller/epoll.go
@@ -1,0 +1,35 @@
+package epoller
+
+import (
+	"net"
+	"syscall"
+)
+
+// Poller is the interface for epoll/kqueue poller, special for network connections.
+type Poller interface {
+	// Add adds the connection to poller.
+	Add(conn net.Conn) error
+	// Remove removes the connection from poller. Notice it doesn't call the conn.Close method.
+	Remove(conn net.Conn) error
+	// Wait waits for at most count events and returns the connections.
+	Wait(count int) ([]net.Conn, error)
+	// Close closes the poller. If closeConns is true, it will close all the connections.
+	Close(closeConns bool) error
+}
+
+func socketFD(conn net.Conn) int {
+	if con, ok := conn.(syscall.Conn); ok {
+		raw, err := con.SyscallConn()
+		if err != nil {
+			return 0
+		}
+		sfd := 0
+		raw.Control(func(fd uintptr) {
+			sfd = int(fd)
+		})
+		return sfd
+	} else if con, ok := conn.(ConnImpl); ok {
+		return con.fd
+	}
+	return 0
+}

--- a/router/internal/epoller/epoll_bsd.go
+++ b/router/internal/epoller/epoll_bsd.go
@@ -1,0 +1,160 @@
+//go:build darwin || netbsd || freebsd || openbsd || dragonfly
+// +build darwin netbsd freebsd openbsd dragonfly
+
+package epoller
+
+import (
+	"errors"
+	"net"
+	"sync"
+	"syscall"
+)
+
+var _ Poller = (*Epoll)(nil)
+
+// Epoll is a epoll based poller.
+type Epoll struct {
+	fd int
+	ts syscall.Timespec
+
+	connBufferSize int
+	mu             *sync.RWMutex
+	changes        []syscall.Kevent_t
+	conns          map[int]net.Conn
+	connbuf        []net.Conn
+}
+
+// NewPoller creates a new poller instance.
+func NewPoller(connBufferSize int) (*Epoll, error) {
+	return newPollerWithBuffer(connBufferSize)
+}
+
+// newPollerWithBuffer creates a new poller instance with buffer size.
+func newPollerWithBuffer(count int) (*Epoll, error) {
+	p, err := syscall.Kqueue()
+	if err != nil {
+		panic(err)
+	}
+	_, err = syscall.Kevent(p, []syscall.Kevent_t{{
+		Ident:  0,
+		Filter: syscall.EVFILT_USER,
+		Flags:  syscall.EV_ADD | syscall.EV_CLEAR,
+	}}, nil, nil)
+	if err != nil {
+		panic(err)
+	}
+
+	return &Epoll{
+		fd:             p,
+		ts:             syscall.NsecToTimespec(1e9),
+		connBufferSize: count,
+		mu:             &sync.RWMutex{},
+		conns:          make(map[int]net.Conn),
+		connbuf:        make([]net.Conn, count, count),
+	}, nil
+}
+
+// Close closes the poller.
+func (e *Epoll) Close(closeConns bool) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if closeConns {
+		for _, conn := range e.conns {
+			conn.Close()
+		}
+	}
+
+	e.conns = nil
+	e.changes = nil
+	e.connbuf = e.connbuf[:0]
+
+	return syscall.Close(e.fd)
+}
+
+// Add adds a network connection to the poller.
+func (e *Epoll) Add(conn net.Conn) error {
+	conn = newConnImpl(conn)
+	fd := socketFD(conn)
+	if e := syscall.SetNonblock(int(fd), true); e != nil {
+		return errors.New("udev: unix.SetNonblock failed")
+	}
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	e.changes = append(e.changes,
+		syscall.Kevent_t{
+			Ident: uint64(fd), Flags: syscall.EV_ADD | syscall.EV_EOF, Filter: syscall.EVFILT_READ,
+		},
+	)
+
+	e.conns[fd] = conn
+
+	return nil
+}
+
+// Remove removes a connection from the poller.
+// If close is true, the connection will be closed.
+func (e *Epoll) Remove(conn net.Conn) error {
+	fd := socketFD(conn)
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if len(e.changes) <= 1 {
+		e.changes = nil
+	} else {
+		changes := make([]syscall.Kevent_t, 0, len(e.changes)-1)
+		ident := uint64(fd)
+		for _, ke := range e.changes {
+			if ke.Ident != ident {
+				changes = append(changes, ke)
+			}
+		}
+		e.changes = changes
+	}
+
+	delete(e.conns, fd)
+
+	return nil
+}
+
+// Wait waits for events and returns the connections.
+func (e *Epoll) Wait(count int) ([]net.Conn, error) {
+	events := make([]syscall.Kevent_t, count)
+
+	e.mu.RLock()
+	changes := e.changes
+	e.mu.RUnlock()
+
+retry:
+	n, err := syscall.Kevent(e.fd, changes, events, &e.ts)
+	if err != nil {
+		if err == syscall.EINTR {
+			goto retry
+		}
+		return nil, err
+	}
+
+	var conns []net.Conn
+	if e.connBufferSize == 0 {
+		conns = make([]net.Conn, 0, n)
+	} else {
+		conns = e.connbuf[:0]
+	}
+
+	e.mu.RLock()
+	for i := 0; i < n; i++ {
+		conn := e.conns[int(events[i].Ident)]
+		if conn != nil {
+			if (events[i].Flags & syscall.EV_EOF) == syscall.EV_EOF {
+				conn.Close()
+			}
+			conns = append(conns, conn)
+		}
+	}
+	e.mu.RUnlock()
+
+	return conns, nil
+}

--- a/router/internal/epoller/epoll_linux.go
+++ b/router/internal/epoller/epoll_linux.go
@@ -1,0 +1,130 @@
+//go:build linux
+// +build linux
+
+package epoller
+
+import (
+	"errors"
+	"net"
+	"sync"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+var _ Poller = (*Epoll)(nil)
+
+// Epoll is an epoll based poller.
+type Epoll struct {
+	fd int
+
+	connBufferSize int
+	lock           *sync.RWMutex
+	conns          map[int]net.Conn
+	connbuf        []net.Conn
+}
+
+// NewPoller creates a new epoll poller.
+func NewPoller(connBufferSize int) (*Epoll, error) {
+	return newPollerWithBuffer(connBufferSize)
+}
+
+// newPollerWithBuffer creates a new epoll poller with a buffer.
+func newPollerWithBuffer(count int) (*Epoll, error) {
+	fd, err := unix.EpollCreate1(0)
+	if err != nil {
+		return nil, err
+	}
+	return &Epoll{
+		fd:             fd,
+		connBufferSize: count,
+		lock:           &sync.RWMutex{},
+		conns:          make(map[int]net.Conn),
+		connbuf:        make([]net.Conn, count),
+	}, nil
+}
+
+// Close closes the poller. If closeConns is true, it will close all the connections.
+func (e *Epoll) Close(closeConns bool) error {
+	e.lock.Lock()
+	defer e.lock.Unlock()
+
+	if closeConns {
+		for _, conn := range e.conns {
+			conn.Close()
+		}
+	}
+
+	e.conns = nil
+	e.connbuf = e.connbuf[:0]
+
+	return unix.Close(e.fd)
+}
+
+// Add adds a connection to the poller.
+func (e *Epoll) Add(conn net.Conn) error {
+	conn = newConnImpl(conn)
+	fd := socketFD(conn)
+	if e := syscall.SetNonblock(int(fd), true); e != nil {
+		return errors.New("udev: unix.SetNonblock failed")
+	}
+
+	e.lock.Lock()
+	defer e.lock.Unlock()
+
+	err := unix.EpollCtl(e.fd, syscall.EPOLL_CTL_ADD, fd, &unix.EpollEvent{Events: unix.POLLIN | unix.POLLHUP, Fd: int32(fd)})
+	if err != nil {
+		return err
+	}
+	e.conns[fd] = conn
+	return nil
+}
+
+// Remove removes a connection from the poller.
+func (e *Epoll) Remove(conn net.Conn) error {
+	fd := socketFD(conn)
+	err := unix.EpollCtl(e.fd, syscall.EPOLL_CTL_DEL, fd, nil)
+	if err != nil {
+		return err
+	}
+	e.lock.Lock()
+	defer e.lock.Unlock()
+	delete(e.conns, fd)
+
+	return nil
+}
+
+// Wait waits for at most count events and returns the connections.
+func (e *Epoll) Wait(count int) ([]net.Conn, error) {
+	events := make([]unix.EpollEvent, count)
+
+retry:
+	n, err := unix.EpollWait(e.fd, events, -1)
+	if err != nil {
+		if err == unix.EINTR {
+			goto retry
+		}
+		return nil, err
+	}
+
+	var conns []net.Conn
+	if e.connBufferSize == 0 {
+		conns = make([]net.Conn, 0, n)
+	} else {
+		conns = e.connbuf[:0]
+	}
+	e.lock.RLock()
+	for i := 0; i < n; i++ {
+		conn := e.conns[int(events[i].Fd)]
+		if conn != nil {
+			if (events[i].Events & unix.POLLHUP) == unix.POLLHUP {
+				conn.Close()
+			}
+
+			conns = append(conns, conn)
+		}
+	}
+	e.lock.RUnlock()
+
+	return conns, nil
+}

--- a/router/internal/epoller/epoll_test.go
+++ b/router/internal/epoller/epoll_test.go
@@ -1,0 +1,170 @@
+package epoller
+
+import (
+	"errors"
+	"io"
+	"log"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPoller(t *testing.T) {
+	// connections
+	num := 10
+	// msg per connection
+	msgPerConn := 10
+
+	poller, err := NewPoller(0)
+	require.NoError(t, err)
+
+	// start server
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+
+			poller.Add(conn)
+		}
+	}()
+
+	// create num connections and send msgPerConn messages per connection
+	for i := 0; i < num; i++ {
+		go func() {
+			conn, err := net.Dial("tcp", ln.Addr().String())
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			time.Sleep(time.Second)
+			for i := 0; i < msgPerConn; i++ {
+				n, err := conn.Write([]byte("hello world"))
+				if err != nil {
+					t.Error(err)
+				}
+				if n != len("hello world") {
+					t.Errorf("expect to write %d bytes but got %d bytes", len("hello world"), n)
+				}
+			}
+			conn.Close()
+		}()
+	}
+
+	// read those num * msgPerConn messages, and each message (hello world) contains 11 bytes.
+	done := make(chan struct{})
+	errs := make(chan error)
+	var total int
+	var count int
+
+	expected := num * msgPerConn * len("hello world")
+	go func(errs chan error) {
+		for {
+			conns, err := poller.Wait(128)
+			if err != nil {
+				t.Log(err)
+				errs <- err // fatal errors (i.e t.Fatal()) must be reported in the main test goroutine
+				return
+			}
+			if len(conns) == 0 {
+				continue
+			}
+			count++
+			buf := make([]byte, 1024)
+			for _, conn := range conns {
+				n, err := conn.Read(buf)
+				if err != nil {
+					if err == io.EOF || errors.Is(err, net.ErrClosed) {
+						poller.Remove(conn)
+						conn.Close()
+					} else {
+						t.Error(err)
+					}
+				}
+				total += n
+			}
+
+			if total == expected {
+				break
+			}
+		}
+
+		t.Logf("read all %d bytes, count: %d", total, count)
+		close(done)
+	}(errs)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+	case err := <-errs:
+		t.Fatal(err)
+	}
+
+	if total != expected {
+		t.Fatalf("epoller does not work. expect %d bytes but got %d bytes", expected, total)
+	}
+}
+
+type netPoller struct {
+	Poller   Poller
+	WriteReq chan uint64
+}
+
+func TestPoller_growstack(t *testing.T) {
+	var nps []netPoller
+	for i := 0; i < 2; i++ {
+		poller, err := NewPoller(128)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		// the following line cause goroutine stack grow and copy local variables to new allocated stack and switch to new stack
+		// but runtime.adjustpointers will check whether pointers bigger than runtime.minLegalPointer(4096) or throw a panic
+		// fatal error: invalid pointer found on stack (runtime/stack.go:599@go1.14.3)
+		// since NewEpoller return A pointer created by CreateIoCompletionPort may less than 4096
+		np := netPoller{
+			Poller:   poller,
+			WriteReq: make(chan uint64, 1000000),
+		}
+
+		nps = append(nps, np)
+	}
+
+	poller := nps[0].Poller
+	// start server
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer ln.Close()
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+
+			poller.Add(conn)
+		}
+	}()
+
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	time.Sleep(200 * time.Millisecond)
+	for i := 0; i < 100; i++ {
+		conn.Write([]byte("hello world"))
+	}
+	conn.Close()
+}

--- a/router/internal/epoller/epoll_unsupported.go
+++ b/router/internal/epoller/epoll_unsupported.go
@@ -1,0 +1,11 @@
+//go:build windows
+// +build windows
+
+package epoller
+
+import "errors"
+
+// NewPoller creates a new epoll poller.
+func NewPoller(connBufferSize int) (Poller, error) {
+	return nil, errors.New("epoll is not supported on windows")
+}

--- a/router/internal/epoller/fd_test.go
+++ b/router/internal/epoller/fd_test.go
@@ -1,0 +1,55 @@
+package epoller
+
+import (
+	"net"
+	"reflect"
+	"runtime"
+	"syscall"
+	"testing"
+)
+
+func reflectSocketFDAsUint(conn net.Conn) uint64 {
+	tcpConn := reflect.Indirect(reflect.ValueOf(conn)).FieldByName("conn")
+	fdVal := tcpConn.FieldByName("fd")
+	pfdVal := reflect.Indirect(fdVal).FieldByName("pfd")
+
+	return pfdVal.FieldByName("Sysfd").Uint()
+}
+
+func rawSocketFD(conn net.Conn) uint64 {
+	if con, ok := conn.(syscall.Conn); ok {
+		raw, err := con.SyscallConn()
+		if err != nil {
+			return 0
+		}
+		sfd := uint64(0)
+		raw.Control(func(fd uintptr) {
+			sfd = uint64(fd)
+		})
+		return sfd
+	}
+	return 0
+}
+
+func BenchmarkSocketFdReflect(b *testing.B) {
+	var con, _ = net.Dial(`udp`, "8.8.8.8:53")
+	fd := uint64(0)
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		fd = reflectSocketFDAsUint(con)
+	}
+	runtime.KeepAlive(fd)
+}
+
+func BenchmarkSocketFdRaw(b *testing.B) {
+	con, _ := net.Dial(`udp`, "8.8.8.8:53")
+	fd := uint64(0)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		fd = rawSocketFD(con)
+	}
+	runtime.KeepAlive(fd)
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/wundergraph/cloud/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->

## Motivation and Context

I saw that our build broke because https://github.com/smallnest/epoller requires CGO on windows. The dependency on CGO is not worth it. We can reevaluate it once users reporting about performance issues on Windows.

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
