### PR TITLE
fix: allow to start router without graph token but static config

### DIFF
--- a/router/cmd/instance.go
+++ b/router/cmd/instance.go
@@ -45,7 +45,7 @@ func NewRouter(params Params, additionalOptions ...core.Option) (*core.Router, e
 		if err != nil {
 			logger.Fatal("Could not read router config", zap.Error(err), zap.String("path", cfg.RouterConfigPath))
 		}
-	} else {
+	} else if cfg.Graph.Token != "" {
 		routerCDN, err := cdn.NewRouterConfigClient(cfg.CDN.URL, cfg.Graph.Token, cdn.PersistentOperationsOptions{
 			CacheSize: cfg.CDN.CacheSize.Uint64(),
 			Logger:    logger,
@@ -61,7 +61,7 @@ func NewRouter(params Params, additionalOptions ...core.Option) (*core.Router, e
 		)
 	}
 
-	if cfg.RouterRegistration {
+	if cfg.RouterRegistration && cfg.Graph.Token != "" {
 		selfRegister = selfregister.New(cfg.ControlplaneURL, cfg.Graph.Token,
 			selfregister.WithLogger(logger),
 		)

--- a/router/config.yaml
+++ b/router/config.yaml
@@ -4,10 +4,3 @@
 # Please keep this file empty if you don't want to override the defaults.
 
 version: "1"
-
-router_config_path: "./__schemas/config.json"
-
-events:
-  sources:
-    - provider: NATS
-      url: "nats://localhost:4222"

--- a/router/config.yaml
+++ b/router/config.yaml
@@ -4,3 +4,10 @@
 # Please keep this file empty if you don't want to override the defaults.
 
 version: "1"
+
+router_config_path: "./__schemas/config.json"
+
+events:
+  sources:
+    - provider: NATS
+      url: "nats://localhost:4222"

--- a/router/core/operation_parser.go
+++ b/router/core/operation_parser.go
@@ -309,7 +309,7 @@ func (p *OperationParser) parse(ctx context.Context, clientInfo *ClientInfo, bod
 	if len(persistedQuerySha256Hash) > 0 {
 		if p.cdn == nil {
 			return nil, &inputError{
-				message:    "could not resolve persisted query, CDN is not configured",
+				message:    "could not resolve persisted query, feature is not configured",
 				statusCode: http.StatusOK,
 			}
 		}

--- a/router/core/operation_parser.go
+++ b/router/core/operation_parser.go
@@ -307,6 +307,12 @@ func (p *OperationParser) parse(ctx context.Context, clientInfo *ClientInfo, bod
 	}
 
 	if len(persistedQuerySha256Hash) > 0 {
+		if p.cdn == nil {
+			return nil, &inputError{
+				message:    "could not resolve persisted query, CDN is not configured",
+				statusCode: http.StatusOK,
+			}
+		}
 		persistedOperationData, err := p.cdn.PersistedOperation(ctx, clientInfo.Name, persistedQuerySha256Hash)
 		if err != nil {
 			return nil, errors.WithStack(err)

--- a/router/core/router.go
+++ b/router/core/router.go
@@ -319,7 +319,7 @@ func NewRouter(opts ...Option) (*Router, error) {
 	}
 
 	for _, source := range r.eventsConfig.Sources {
-		r.logger.Info("event source", zap.String("provider", source.Provider), zap.String("url", source.URL))
+		r.logger.Info("Event source enabled", zap.String("provider", source.Provider), zap.String("url", source.URL))
 	}
 
 	return r, nil


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/wundergraph/cloud/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->

## Motivation and Context

```
22:04:00 PM WARN No graph token provided. The following features are disabled. Not recommended for Production. {"component": "@wundergraph/router", "service_version": "dev", "features": ["Schema Usage Tracking", "Persistent operations", "Cosmo Cloud Tracing", "Cosmo Cloud Metrics"]}
22:04:00 PM WARN Development mode enabled. This should only be used for testing purposes {"component": "@wundergraph/router", "service_version": "dev"}
22:04:00 PM INFO event source {"component": "@wundergraph/router", "service_version": "dev", "provider": "NATS", "url": "nats://localhost:4222"}
22:04:00 PM INFO Prometheus metrics enabled {"component": "@wundergraph/router", "service_version": "dev", "listen_addr": "0.0.0.0:8088", "endpoint": "/metrics"}
22:04:00 PM INFO Static router config provided. Polling is disabled. Updating router config is only possible by providing a config. {"component": "@wundergraph/router", "service_version": "dev"}
22:04:00 PM WARN Advanced Request Tracing (ART) is enabled in development mode but requires a graph token to work in production. For more information see https://cosmo-docs.wundergraph.com/router/advanced-request-tracing-art {"component": "@wundergraph/router", "service_version": "dev"}
22:04:00 PM INFO Serving GraphQL playground {"component": "@wundergraph/router", "service_version": "dev", "url": "http://0.0.0.0:3002"}
22:04:00 PM INFO GraphQL endpoint {"component": "@wundergraph/router", "service_version": "dev", "method": "POST", "url": "http://0.0.0.0:3002/graphql"}
22:04:00 PM INFO Server listening {"component": "@wundergraph/router", "service_version": "dev", "listen_addr": "0.0.0.0:3002", "playground": true, "introspection": true, "config_version": ""}

```

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
