### PR TITLE
feat: consider only router root spans in the trace list

### DIFF
--- a/controlplane/clickhouse/migrations/20230825095359_traces_mv.sql
+++ b/controlplane/clickhouse/migrations/20230825095359_traces_mv.sql
@@ -26,8 +26,13 @@ SELECT
 FROM
     cosmo.otel_traces
 WHERE
-    -- only include the root spans
-    empty(ParentSpanId)
+    -- Only include router root spans and spans with operation type.
+    SpanAttributes [ 'wg.router.root_span' ] = 'true' OR
+    -- For backwards compatibility.
+    (mapContains(SpanAttributes, 'wg.operation.type') AND
+         ResourceAttributes [ 'service.name' ] = 'cosmo-router' AND
+         SpanKind = 'SPAN_KIND_SERVER'
+    )
 ORDER BY
     Timestamp DESC;
 

--- a/controlplane/clickhouse/migrations/20230910193138_traces_by_operation_quarter_hourly_mv.sql
+++ b/controlplane/clickhouse/migrations/20230910193138_traces_by_operation_quarter_hourly_mv.sql
@@ -18,8 +18,13 @@ CREATE MATERIALIZED VIEW IF NOT EXISTS cosmo.traces_by_operation_quarter_hourly_
 FROM
     cosmo.otel_traces
 WHERE
-    -- Only include the root spans
-    empty(ParentSpanId)
+    -- Only include router root spans and spans with operation type.
+    SpanAttributes [ 'wg.router.root_span' ] = 'true' OR
+    -- For backwards compatibility.
+    (mapContains(SpanAttributes, 'wg.operation.type') AND
+         ResourceAttributes [ 'service.name' ] = 'cosmo-router' AND
+         SpanKind = 'SPAN_KIND_SERVER'
+    )
 GROUP BY
     Timestamp,
     FederatedGraphID,

--- a/controlplane/clickhouse/migrations/20230910200148_traces_by_client_quarter_hourly_mv.sql
+++ b/controlplane/clickhouse/migrations/20230910200148_traces_by_client_quarter_hourly_mv.sql
@@ -17,7 +17,14 @@ SELECT
     toDateTime(MAX(Timestamp), 'UTC') as LastCalled
 FROM
     cosmo.otel_traces
-WHERE empty(ParentSpanId)
+WHERE
+    -- Only include router root spans and spans with operation type.
+    SpanAttributes [ 'wg.router.root_span' ] = 'true' OR
+    -- For backwards compatibility.
+    (mapContains(SpanAttributes, 'wg.operation.type') AND
+         ResourceAttributes [ 'service.name' ] = 'cosmo-router' AND
+         SpanKind = 'SPAN_KIND_SERVER'
+    )
 GROUP BY
     Timestamp,
     ClientName,

--- a/controlplane/clickhouse/migrations/20230910201357_traces_by_http_status_code_quarter_hourly_mv.sql
+++ b/controlplane/clickhouse/migrations/20230910201357_traces_by_http_status_code_quarter_hourly_mv.sql
@@ -15,7 +15,14 @@ SELECT
     toDateTime(MAX(Timestamp), 'UTC') as LastCalled
 FROM
     cosmo.otel_traces
-WHERE empty(ParentSpanId)
+WHERE
+    -- Only include router root spans and spans with operation type.
+    SpanAttributes [ 'wg.router.root_span' ] = 'true' OR
+    -- For backwards compatibility.
+    (mapContains(SpanAttributes, 'wg.operation.type') AND
+         ResourceAttributes [ 'service.name' ] = 'cosmo-router' AND
+         SpanKind = 'SPAN_KIND_SERVER'
+    )
 GROUP BY
     Timestamp,
     HttpStatusCode,

--- a/controlplane/clickhouse/migrations/20240102205129_subgraph_request_metrics_5_30_mv.sql
+++ b/controlplane/clickhouse/migrations/20240102205129_subgraph_request_metrics_5_30_mv.sql
@@ -19,7 +19,8 @@ SELECT
     mapContains(Attributes, 'wg.subscription') AS IsSubscription
 FROM
     cosmo.otel_metrics_sum
-WHERE ScopeName = 'cosmo.router' AND ScopeVersion = '0.0.1' AND IsMonotonic = true AND MetricName = 'router.http.requests' AND SubgraphID != '' AND OrganizationID != '' AND FederatedGraphID != ''
+WHERE
+    ScopeName = 'cosmo.router' AND ScopeVersion = '0.0.1' AND IsMonotonic = true AND MetricName = 'router.http.requests' AND SubgraphID != '' AND OrganizationID != '' AND FederatedGraphID != ''
 GROUP BY
     SubgraphID,
     FederatedGraphID,

--- a/router/pkg/trace/utils.go
+++ b/router/pkg/trace/utils.go
@@ -34,11 +34,16 @@ func PrefixRequestFilter(prefixes []string) func(r *http.Request) bool {
 }
 
 func CommonRequestFilter(r *http.Request) bool {
-	if r.URL.Path == "/favicon.ico" || r.Method == "OPTIONS" {
+	// Ignore favicon requests
+	if r.URL.Path == "/favicon.ico" {
 		return false
 	}
-	// Ignore websocket connections
-	if r.Header.Get("Upgrade") != "" {
+	// Ignore other methods that aren't part of GraphQL over HTTP
+	if r.Method != "GET" && r.Method != "POST" {
+		return false
+	}
+	// Ignore websocket upgrade requests over GET
+	if r.Method != "GET" && r.Header.Get("Upgrade") != "" {
 		return false
 	}
 	return true

--- a/router/pkg/trace/utils_test.go
+++ b/router/pkg/trace/utils_test.go
@@ -2,6 +2,8 @@ package trace
 
 import (
 	"context"
+	"github.com/stretchr/testify/require"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -57,4 +59,40 @@ func TestTracerFromContext(t *testing.T) {
 
 		traceFn(context.Background(), false)
 	})
+}
+
+func TestCommonRequestFilter(t *testing.T) {
+
+	// Negative test cases
+
+	r, err := http.NewRequest("GET", "http://localhost:8080/favicon.ico", nil)
+	require.NoError(t, err)
+	require.Falsef(t, CommonRequestFilter(r), "ignore favicon requests")
+
+	r, err = http.NewRequest("OPTIONS", "http://localhost:8080", nil)
+	require.NoError(t, err)
+	require.Falsef(t, CommonRequestFilter(r), "ignore OPTIONS requests")
+
+	r, err = http.NewRequest("GET", "http://localhost:8080", nil)
+	r.Header.Set("Upgrade", "websocket")
+	require.NoError(t, err)
+	require.Falsef(t, CommonRequestFilter(r), "ignore websocket upgrades")
+
+	r, err = http.NewRequest("PUT", "http://localhost:8080", nil)
+	require.NoError(t, err)
+	require.Falsef(t, CommonRequestFilter(r), "ignore PUT requests")
+
+	r, err = http.NewRequest("DELETE", "http://localhost:8080", nil)
+	require.NoError(t, err)
+	require.Falsef(t, CommonRequestFilter(r), "ignore DELETE requests")
+
+	// Positive test cases
+
+	r, err = http.NewRequest("GET", "http://localhost:8080", nil)
+	require.NoError(t, err)
+	require.Truef(t, CommonRequestFilter(r), "allow GET requests")
+
+	r, err = http.NewRequest("POST", "http://localhost:8080", nil)
+	require.NoError(t, err)
+	require.Truef(t, CommonRequestFilter(r), "allow POST requests")
 }

--- a/studio/src/components/analytics/trace.tsx
+++ b/studio/src/components/analytics/trace.tsx
@@ -25,7 +25,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "../ui/tooltip";
-import { FiInfo } from "react-icons/fi";
+import { docsBaseURL } from "@/lib/constants";
 
 interface SpanNode extends Span {
   children?: SpanNode[];
@@ -74,7 +74,6 @@ function Node({
   paneWidth: number;
 }) {
   const [showDetails, setShowDetails] = useState(false);
-
   const hasChildren = span.children && span.children.length > 0;
   const parentChildrenCount = parentSpan?.children
     ? parentSpan.children.length
@@ -344,7 +343,7 @@ function Node({
 
 const Trace = ({ spans }: { spans: Span[] }) => {
   const [traceTree, setTraceTree] = useState<SpanNode>();
-
+  const [missingRootSpan, setMissingRootSpan] = useState<boolean>();
   const [globalDuration, setGlobalDuration] = useState(BigInt(0));
   const [globalStartTime, setGlobalStartTime] = useState(BigInt(0));
 
@@ -435,11 +434,20 @@ const Trace = ({ spans }: { spans: Span[] }) => {
         }
       }
 
+      let rootSpan = null;
+
+      // Spans are already sorted by start time
       const rootSpans = spans.filter((span) => !span.parentSpanID);
-      if (rootSpans.length !== 1) {
-        throw new Error("Invalid spans - multiple root spans");
+
+      // check if there is a root span
+      if (rootSpans.length) {
+        rootSpan = rootSpans[0];
+      } else {
+        // if there is no root span, we assume the first span is the root span
+        rootSpan = spans[0];
       }
-      return rootSpans[0];
+
+      return rootSpan;
     };
 
     if (!spans.length) {
@@ -448,6 +456,11 @@ const Trace = ({ spans }: { spans: Span[] }) => {
 
     const tree = buildSpanTree(spans);
     setTraceTree(tree);
+
+    setMissingRootSpan(
+      !!tree.parentSpanID &&
+        !spans.find((span) => tree.parentSpanID === span.spanID),
+    );
 
     setGlobalDuration(gEndTimeNano - gStartTimeNano);
     setGlobalStartTime(gStartTimeNano);
@@ -473,24 +486,72 @@ const Trace = ({ spans }: { spans: Span[] }) => {
             </Tooltip>
           </TooltipProvider>
         </span>
-        <p className="flex items-center gap-x-3">
-          <span className="w-16">Spans</span>: <span>{spans.length}</span>
-        </p>
-        <div className="flex items-start gap-x-3">
-          <span className="w-16 flex-shrink-0">Services</span>:
-          <div className="flex flex-wrap items-center gap-x-3">
-            {detectedService.map((service) => {
-              return (
-                <span key={service.name} className="flex items-center gap-x-2">
-                  <div
-                    className={"h-4 w-4 rounded-sm bg-sky-300"}
-                    style={{ backgroundColor: service.color }}
-                  />
-                  <span>{service.name}</span>
-                </span>
-              );
-            })}
-          </div>
+        <div>
+          <table className="table-auto">
+            <tbody>
+              <tr>
+                <td className="pr-6">Spans</td>
+                <td>
+                  <div className="flex items-center gap-x-3">
+                    <span>:</span>
+                    <span>{spans.length}</span>
+                  </div>
+                </td>
+              </tr>
+              <tr>
+                <td className="pr-6">Services</td>
+                <td>
+                  <div className="flex items-center gap-x-3">
+                    <span>:</span>
+                    <div className="flex flex-wrap gap-x-3">
+                      {detectedService.map((service) => {
+                        return (
+                          <span
+                            key={service.name}
+                            className="flex items-center gap-x-2"
+                          >
+                            <div
+                              className={"h-4 w-4 rounded-sm bg-sky-300"}
+                              style={{ backgroundColor: service.color }}
+                            />
+                            <span>{service.name}</span>
+                          </span>
+                        );
+                      })}
+                    </div>
+                  </div>
+                </td>
+              </tr>
+              <tr>
+                <td className="pr-6">Info</td>
+                <td>
+                  <div className="flex items-center gap-x-3">
+                    <span>:</span>
+                    {missingRootSpan ? (
+                      <div>
+                        <ExclamationTriangleIcon className="inline h-4 w-4 shrink-0 text-orange-600 dark:text-orange-400" />{" "}
+                        This trace has no root span. This can have several
+                        causes.{" "}
+                        <a
+                          target="_blank"
+                          rel="noreferrer"
+                          href={
+                            docsBaseURL +
+                            "/router/open-telemetry#why-is-my-trace-incomplete"
+                          }
+                          className="text-primary"
+                        >
+                          Learn more.
+                        </a>
+                      </div>
+                    ) : (
+                      <span>-</span>
+                    )}
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
         </div>
       </div>
       {traceTree && (


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/wundergraph/cloud/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->

## Motivation and Context

This PR removes the limitation that only traces with a root span are displayed correctly in the Studio. We will also teach the user, when the root span is missing.

![image](https://github.com/wundergraph/cosmo/assets/1764424/61268231-37c2-48af-a2bc-20c275609759)

![image](https://github.com/wundergraph/cosmo/assets/1764424/2cd31cac-503a-4100-981a-8d3d5a1256f3)


<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

## TODO

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
