### PR TITLE
fix: wait until db is closed in close server hook

### DIFF
--- a/controlplane/src/core/plugins/database.ts
+++ b/controlplane/src/core/plugins/database.ts
@@ -91,10 +91,10 @@ export default fp<DbPluginOptions & DatabaseConnectionConfig>(async function (fa
       throw new Error('Database connection healthcheck failed');
     }
   });
-  fastify.addHook('onClose', () => {
+  fastify.addHook('onClose', async () => {
     fastify.log.debug('Closing database connection ...');
 
-    queryConnection.end({
+    await queryConnection.end({
       timeout: opts.gracefulTimeoutSec ?? 5,
     });
 

--- a/controlplane/src/core/test-util.ts
+++ b/controlplane/src/core/test-util.ts
@@ -33,9 +33,9 @@ export async function beforeAllSetup(): Promise<string> {
 }
 
 export async function afterAllSetup(dbname: string) {
-  const sql = postgres('postgresql://postgres:changeme@localhost:5432/postgres');
-  await sql`DROP DATABASE "${sql.unsafe(dbname)}";`;
-  await sql.end({ timeout: 3 });
+  const sql = postgres('postgresql://postgres:changeme@localhost:5432/postgres', { max: 1 });
+  await sql`DROP DATABASE "${sql.unsafe(dbname)}"`;
+  await sql.end({ timeout: 1 });
 }
 
 export function genID(prefix = 'prefix') {
@@ -95,7 +95,7 @@ export async function seedTest(databaseConnectionUrl: string, userTestData: User
   }
 
   await queryConnection.end({
-    timeout: 3,
+    timeout: 1,
   });
 }
 

--- a/controlplane/vite.config.ts
+++ b/controlplane/vite.config.ts
@@ -1,11 +1,9 @@
-/// <reference types="vitest" />
-
-// Configure Vitest (https://vitest.dev/config/)
-
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
+    // Increase the timeout for integration tests
+    testTimeout: 10_000,
     // Ensure always the CJS version is used otherwise we might conflict with multiple versions of graphql
     alias: [{ find: /^graphql$/, replacement: 'graphql/index.js' }],
   },


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/wundergraph/cloud/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->

## Motivation and Context

On my machine it is not rare, that some tests take longer than 5s. Bootstrapping the server, including migration takes already ~2s.

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

## TODO

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
