### PR TITLE
feat(helm): support existing secrets

### DIFF
--- a/helm/cosmo/charts/cdn/CHART.md
+++ b/helm/cosmo/charts/cdn/CHART.md
@@ -17,6 +17,7 @@ WunderGraph Cosmo CDN
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
 | configuration | string | `nil` |  |
 | deploymentStrategy | object | `{}` |  |
+| existingSecret | string | `""` | Existing secret in the same namespace containing the authJwtSecret and s3StorageUrl. The secret keys have to match with current secret. |
 | extraEnvVars | list | `[]` | Allows to set additional environment variables on the container. Useful for global application non-specific settings. |
 | fullnameOverride | string | `""` | String to fully override common.names.fullname template |
 | image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/helm/cosmo/charts/cdn/templates/_helpers.tpl
+++ b/helm/cosmo/charts/cdn/templates/_helpers.tpl
@@ -71,3 +71,15 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+
+{{/*
+Get the name of the secret to use
+*/}}
+{{- define "cdn.secretName" -}}
+{{- if .Values.existingSecret -}}
+    {{- .Values.existingSecret -}}
+{{- else }}
+    {{- printf "%s-secret" (include "cdn.fullname" .) -}}
+{{- end -}}
+{{- end -}}

--- a/helm/cosmo/charts/cdn/templates/deployment.yaml
+++ b/helm/cosmo/charts/cdn/templates/deployment.yaml
@@ -62,13 +62,13 @@ spec:
             - name: S3_STORAGE_URL
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "cdn.fullname" . }}-secret
+                  name: {{ include "cdn.secretName" . }}
                   key: s3StorageUrl
 
             - name: AUTH_JWT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "cdn.fullname" . }}-secret
+                  name: {{ include "cdn.secretName" . }}
                   key: authJwtSecret
 
           ports:

--- a/helm/cosmo/charts/cdn/templates/secret.yaml
+++ b/helm/cosmo/charts/cdn/templates/secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "cdn.fullname" . }}-secret
+  name: {{ include "cdn.secretName" . }}
   annotations:
     # Create secrets before the release
     "helm.sh/hook": pre-install,pre-upgrade

--- a/helm/cosmo/charts/cdn/values.yaml
+++ b/helm/cosmo/charts/cdn/values.yaml
@@ -141,3 +141,6 @@ probes:
 #############################
 
 configuration:
+
+# -- Existing secret in the same namespace containing the authJwtSecret and s3StorageUrl. The secret keys have to match with current secret.
+existingSecret: ""

--- a/helm/cosmo/charts/controlplane/CHART.md
+++ b/helm/cosmo/charts/controlplane/CHART.md
@@ -48,6 +48,7 @@ WunderGraph Cosmo Controlplane
 | configuration.webhookSecret | string | `""` |  |
 | configuration.webhookUrl | string | `""` |  |
 | deploymentStrategy | object | `{}` |  |
+| existingSecret | string | `""` | Existing secret in the same namespace containing the ControlPlane Secrets. The secret keys have to match with current secret. |
 | extraEnvVars | list | `[]` | Allows to set additional environment variables on the container. Useful for global application non-specific settings. |
 | fullnameOverride | string | `""` | String to fully override common.names.fullname template |
 | image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/helm/cosmo/charts/controlplane/templates/_helpers.tpl
+++ b/helm/cosmo/charts/controlplane/templates/_helpers.tpl
@@ -71,3 +71,14 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Get the name of the secret to use
+*/}}
+{{- define "controlplane.secretName" -}}
+{{- if .Values.existingSecret -}}
+    {{- .Values.existingSecret -}}
+{{- else }}
+    {{- printf "%s-secret" (include "controlplane.fullname" .) -}}
+{{- end -}}
+{{- end -}}

--- a/helm/cosmo/charts/controlplane/templates/clickhouse-migration.yaml
+++ b/helm/cosmo/charts/controlplane/templates/clickhouse-migration.yaml
@@ -45,7 +45,7 @@ spec:
             - name: CLICKHOUSE_DSN
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "controlplane.fullname" . }}-secret
+                  name: {{ include "controlplane.secretName" . }}
                   key: clickhouseMigrationDsn
           args:
             - "/app/dist/bin/ch-migrate.js"

--- a/helm/cosmo/charts/controlplane/templates/database-migration.yaml
+++ b/helm/cosmo/charts/controlplane/templates/database-migration.yaml
@@ -40,27 +40,27 @@ spec:
             - name: DB_URL
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "controlplane.fullname" . }}-secret
+                  name: {{ include "controlplane.secretName" . }}
                   key: databaseUrl
             {{- if .Values.configuration.databaseTlsCert }}
             - name: DB_TLS_CERT
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "controlplane.fullname" . }}-secret
+                  name: {{ include "controlplane.secretName" . }}
                   key: databaseTlsCert
             {{- end }}
             {{- if .Values.configuration.databaseTlsCa }}
             - name: DB_TLS_CA
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "controlplane.fullname" . }}-secret
+                  name: {{ include "controlplane.secretName" . }}
                   key: databaseTlsCa
             {{- end }}
             {{- if .Values.configuration.databaseTlsKey }}
             - name: DB_TLS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "controlplane.fullname" . }}-secret
+                  name: {{ include "controlplane.secretName" . }}
                   key: databaseTlsKey
             {{- end }}
           args:

--- a/helm/cosmo/charts/controlplane/templates/deployment.yaml
+++ b/helm/cosmo/charts/controlplane/templates/deployment.yaml
@@ -102,38 +102,38 @@ spec:
             - name: AUTH_JWT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "controlplane.fullname" . }}-secret
+                  name: {{ include "controlplane.secretName" . }}
                   key: jwtSessionSecret
             - name: DB_URL
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "controlplane.fullname" . }}-secret
+                  name: {{ include "controlplane.secretName" . }}
                   key: databaseUrl
             {{- if .Values.configuration.databaseTlsCert }}
             - name: DB_TLS_CERT
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "controlplane.fullname" . }}-secret
+                  name: {{ include "controlplane.secretName" . }}
                   key: databaseTlsCert
             {{- end }}
             {{- if .Values.configuration.databaseTlsCa }}
             - name: DB_TLS_CA
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "controlplane.fullname" . }}-secret
+                  name: {{ include "controlplane.secretName" . }}
                   key: databaseTlsCa
             {{- end }}
             {{- if .Values.configuration.databaseTlsKey }}
             - name: DB_TLS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "controlplane.fullname" . }}-secret
+                  name: {{ include "controlplane.secretName" . }}
                   key: databaseTlsKey
             {{- end }}
             - name: CLICKHOUSE_DSN
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "controlplane.fullname" . }}-secret
+                  name: {{ include "controlplane.secretName" . }}
                   key: clickhouseDsn
             - name: KC_REALM
               valueFrom:
@@ -148,12 +148,12 @@ spec:
             - name: KC_ADMIN_USER
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "controlplane.fullname" . }}-secret
+                  name: {{ include "controlplane.secretName" . }}
                   key: keycloakAdminUser
             - name: KC_ADMIN_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "controlplane.fullname" . }}-secret
+                  name: {{ include "controlplane.secretName" . }}
                   key: keycloakAdminPassword
             - name: KC_API_URL
               valueFrom:
@@ -178,7 +178,7 @@ spec:
             - name: WEBHOOK_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "controlplane.fullname" . }}-secret
+                  name: {{ include "controlplane.secretName" . }}
                   key: webhookSecret
             - name: GITHUB_APP_CLIENT_ID
               valueFrom:
@@ -193,17 +193,17 @@ spec:
             - name: GITHUB_APP_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "controlplane.fullname" . }}-secret
+                  name: {{ include "controlplane.secretName" . }}
                   key: githubAppClientSecret
             - name: GITHUB_APP_PRIVATE_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "controlplane.fullname" . }}-secret
+                  name: {{ include "controlplane.secretName" . }}
                   key: githubAppPrivateKey
             - name: GITHUB_APP_WEBHOOK_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "controlplane.fullname" . }}-secret
+                  name: {{ include "controlplane.secretName" . }}
                   key: githubAppWebhookSecret
             {{- if .Values.configuration.slackAppClientId }}
             - name: SLACK_APP_CLIENT_ID
@@ -216,38 +216,38 @@ spec:
             - name: SLACK_APP_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "controlplane.fullname" . }}-secret
+                  name: {{ include "controlplane.secretName" . }}
                   key: slackAppClientSecret
             {{- end }}
             {{- if .Values.configuration.s3StorageUrl }}
             - name: S3_STORAGE_URL
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "controlplane.fullname" . }}-secret
+                  name: {{ include "controlplane.secretName" . }}
                   key: s3StorageUrl
             {{- end }}
             - name: SMTP_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "controlplane.fullname" . }}-secret
+                  name: {{ include "controlplane.secretName" . }}
                   key: smtpPassword
             - name: SMTP_USERNAME
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "controlplane.fullname" . }}-secret
+                  name: {{ include "controlplane.secretName" . }}
                   key: smtpUsername
             {{- if .Values.configuration.stripeSecretKey }}
             - name: STRIPE_SECRET_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "controlplane.fullname" . }}-secret
+                  name: {{ include "controlplane.secretName" . }}
                   key: stripeSecretKey
             {{- end }}
             {{- if .Values.configuration.stripeWebhookSecret }}
             - name: STRIPE_WEBHOOK_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "controlplane.fullname" . }}-secret
+                  name: {{ include "controlplane.secretName" . }}
                   key: stripeWebhookSecret
             {{- end }}
             {{- if .Values.configuration.defaultBillingPlan }}
@@ -271,35 +271,35 @@ spec:
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "controlplane.fullname" . }}-secret
+                  name: {{ include "controlplane.secretName" . }}
                   key: redisPassword
             {{- end }}
             {{- if .Values.configuration.redisTlsCert }}
             - name: REDIS_TLS_CERT
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "controlplane.fullname" . }}-secret
+                  name: {{ include "controlplane.secretName" . }}
                   key: redisTlsCert
             {{- end }}
             {{- if .Values.configuration.redisTlsCa }}
             - name: REDIS_TLS_CA
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "controlplane.fullname" . }}-secret
+                  name: {{ include "controlplane.secretName" . }}
                   key: redisTlsCa
             {{- end }}
             {{- if .Values.configuration.redisTlsKey }}
             - name: REDIS_TLS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "controlplane.fullname" . }}-secret
+                  name: {{ include "controlplane.secretName" . }}
                   key: redisTlsKey
             {{- end }}
             {{- if .Values.configuration.openAiApiKey }}
             - name: OPENAI_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "controlplane.fullname" . }}-secret
+                  name: {{ include "controlplane.secretName" . }}
                   key: openAiApiKey
             {{- end }}
           ports:

--- a/helm/cosmo/charts/controlplane/templates/organization-seed.yaml
+++ b/helm/cosmo/charts/controlplane/templates/organization-seed.yaml
@@ -54,12 +54,14 @@ spec:
             - name: KC_ADMIN_USER
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "controlplane.fullname" . }}-secret
+                  name: {{ include "controlplane.secretName" . }}
+
                   key: keycloakAdminUser
             - name: KC_ADMIN_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "controlplane.fullname" . }}-secret
+                  name: {{ include "controlplane.secretName" . }}
+
                   key: keycloakAdminPassword
             - name: KC_CLIENT_ID
               valueFrom:
@@ -71,7 +73,8 @@ spec:
             - name: DB_URL
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "controlplane.fullname" . }}-secret
+                  name: {{ include "controlplane.secretName" . }}
+
                   key: databaseUrl
             - name: USER_EMAIL
               value: "{{ .Values.global.seed.userEmail }}"

--- a/helm/cosmo/charts/controlplane/templates/secret.yaml
+++ b/helm/cosmo/charts/controlplane/templates/secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "controlplane.fullname" . }}-secret
+  name: {{ include "controlplane.secretName" . }}
   annotations:
     # Create secrets before the release
     "helm.sh/hook": pre-install,pre-upgrade

--- a/helm/cosmo/charts/controlplane/values.yaml
+++ b/helm/cosmo/charts/controlplane/values.yaml
@@ -188,3 +188,6 @@ configuration:
   # -- The default billing plan, eg `developer@1`
   defaultBillingPlan: ''
   openAiApiKey: ''
+
+# -- Existing secret in the same namespace containing the ControlPlane Secrets. The secret keys have to match with current secret.
+existingSecret: ""

--- a/helm/cosmo/charts/graphqlmetrics/CHART.md
+++ b/helm/cosmo/charts/graphqlmetrics/CHART.md
@@ -19,6 +19,7 @@ WunderGraph Cosmo GraphQL Metrics Collector
 | configuration.listenAddr | string | `"0.0.0.0:4005"` |  |
 | configuration.logLevel | string | `"info"` |  |
 | deploymentStrategy | object | `{}` |  |
+| existingSecret | string | `""` | Existing secret in the same namespace containing the graphqlmetrics Secrets - clickhouseDsn,jwtSecret. The secret keys have to match with current secret. |
 | extraEnvVars | list | `[]` | Allows to set additional environment variables on the container. Useful for global application non-specific settings. |
 | fullnameOverride | string | `""` | String to fully override common.names.fullname template |
 | image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/helm/cosmo/charts/graphqlmetrics/templates/_helpers.tpl
+++ b/helm/cosmo/charts/graphqlmetrics/templates/_helpers.tpl
@@ -71,3 +71,14 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Get the name of the secret to use
+*/}}
+{{- define "graphqlmetrics.secretName" -}}
+{{- if .Values.existingSecret -}}
+    {{- .Values.existingSecret -}}
+{{- else }}
+    {{- printf "%s-secret" (include "graphqlmetrics.fullname" .) -}}
+{{- end -}}
+{{- end -}}

--- a/helm/cosmo/charts/graphqlmetrics/templates/deployment.yaml
+++ b/helm/cosmo/charts/graphqlmetrics/templates/deployment.yaml
@@ -59,12 +59,12 @@ spec:
             - name: CLICKHOUSE_DSN
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "graphqlmetrics.fullname" . }}
+                  name: {{ include "graphqlmetrics.secretName" . }}
                   key: clickhouseDsn
             - name: INGEST_JWT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "graphqlmetrics.fullname" . }}
+                  name: {{ include "graphqlmetrics.secretName" . }}
                   key: jwtSecret
             - name: LISTEN_ADDR
               valueFrom:

--- a/helm/cosmo/charts/graphqlmetrics/templates/secret.yaml
+++ b/helm/cosmo/charts/graphqlmetrics/templates/secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "graphqlmetrics.fullname" . }}
+  name: {{ include "graphqlmetrics.secretName" . }}
   annotations:
     # Support for k14s.io. This annotation will produce a redeployment when the secret changes.
     kapp.k14s.io/versioned: ""

--- a/helm/cosmo/charts/graphqlmetrics/values.yaml
+++ b/helm/cosmo/charts/graphqlmetrics/values.yaml
@@ -135,3 +135,6 @@ configuration:
   clickhouseDsn: "clickhouse://default:changeme@cosmo-clickhouse:9000/cosmo?dial_timeout=15s&compress=lz4"
   logLevel: "info"
   listenAddr: "0.0.0.0:4005"
+
+# -- Existing secret in the same namespace containing the graphqlmetrics Secrets - clickhouseDsn,jwtSecret. The secret keys have to match with current secret.
+existingSecret: ""

--- a/helm/cosmo/charts/otelcollector/CHART.md
+++ b/helm/cosmo/charts/otelcollector/CHART.md
@@ -18,6 +18,7 @@ WunderGraph Cosmo Open Telemetry Collector.
 | configuration.clickhouseDsn | string | `"clickhouse://default:changeme@cosmo-clickhouse:9000/cosmo?dial_timeout=15s&compress=lz4"` |  |
 | deploymentStrategy | object | `{}` |  |
 | existingConfigmap | string | `nil` | The name of the configmap to use for the otelcollector configuration. The key must be "otel-config.yaml". |
+| existingSecret | string | `""` | Existing secret in the same namespace containing the otelcollector Secrets - clickhouseDsn,authJwtSecret. The secret keys have to match with current secret. |
 | extraEnvVars | list | `[]` | Allows to set additional environment variables on the container. Useful for global application non-specific settings. |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/helm/cosmo/charts/otelcollector/templates/_helpers.tpl
+++ b/helm/cosmo/charts/otelcollector/templates/_helpers.tpl
@@ -71,3 +71,14 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Get the name of the secret to use
+*/}}
+{{- define "otelcollector.secretName" -}}
+{{- if .Values.existingSecret -}}
+    {{- .Values.existingSecret -}}
+{{- else }}
+    {{- printf "%s-secret" (include "otelcollector.fullname" .) -}}
+{{- end -}}
+{{- end -}}

--- a/helm/cosmo/charts/otelcollector/templates/deployment.yaml
+++ b/helm/cosmo/charts/otelcollector/templates/deployment.yaml
@@ -62,12 +62,12 @@ spec:
             - name: CLICKHOUSE_ENDPOINT
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "otelcollector.fullname" . }}
+                  name: {{ include "otelcollector.secretName" . }}
                   key: clickhouseDsn
             - name: OTEL_INGEST_JWT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "otelcollector.fullname" . }}
+                  name: {{ include "otelcollector.secretName" . }}
                   key: authJwtSecret
           {{- if .Values.existingConfigmap }}
           volumeMounts:

--- a/helm/cosmo/charts/otelcollector/templates/secret.yaml
+++ b/helm/cosmo/charts/otelcollector/templates/secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "otelcollector.fullname" . }}
+  name: {{ include "otelcollector.secretName" . }}
   annotations:
     # Support for k14s.io. This annotation will produce a redeployment when the secret changes.
     kapp.k14s.io/versioned: ""

--- a/helm/cosmo/charts/otelcollector/values.yaml
+++ b/helm/cosmo/charts/otelcollector/values.yaml
@@ -134,5 +134,8 @@ probes:
 # -- The name of the configmap to use for the otelcollector configuration. The key must be "otel-config.yaml".
 existingConfigmap:
 
+# -- Existing secret in the same namespace containing the otelcollector Secrets - clickhouseDsn,authJwtSecret. The secret keys have to match with current secret.
+existingSecret: ""
+
 configuration:
   clickhouseDsn: "clickhouse://default:changeme@cosmo-clickhouse:9000/cosmo?dial_timeout=15s&compress=lz4"

--- a/helm/cosmo/charts/router/CHART.md
+++ b/helm/cosmo/charts/router/CHART.md
@@ -25,6 +25,7 @@ WunderGraph Cosmo router.
 | configuration.routerConfigPath | string | `""` | A possible to solution could be to use an init container to download the file from a CDN. If set, polling of the config is disabled. |
 | deploymentStrategy | object | `{}` |  |
 | existingConfigmap | string | `""` | If this is set, the commonConfiguration section is ignored. |
+| existingSecret | string | `""` | Existing secret in the same namespace containing the graphApiToken. The secret key has to match with current secret. |
 | extraEnvVars | list | `[]` | Allows to set additional environment variables on the container |
 | extraEnvVarsCM | string | `""` | Name of existing ConfigMap containing extra env vars |
 | extraEnvVarsSecret | string | `""` | Name of existing Secret containing extra env vars |

--- a/helm/cosmo/charts/router/templates/_helpers.tpl
+++ b/helm/cosmo/charts/router/templates/_helpers.tpl
@@ -71,3 +71,14 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Get the name of the secret to use
+*/}}
+{{- define "router.secretName" -}}
+{{- if .Values.existingSecret -}}
+    {{- .Values.existingSecret -}}
+{{- else }}
+    {{- printf "%s-secret" (include "router.fullname" .) -}}
+{{- end -}}
+{{- end -}}

--- a/helm/cosmo/charts/router/templates/deployment.yaml
+++ b/helm/cosmo/charts/router/templates/deployment.yaml
@@ -120,7 +120,7 @@ spec:
             - name: GRAPH_API_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "router.fullname" . }}
+                  name: {{ include "router.secretName" . }}
                   key: graphApiToken
             {{- end }}
           envFrom:

--- a/helm/cosmo/charts/router/templates/secret.yaml
+++ b/helm/cosmo/charts/router/templates/secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "router.fullname" . }}
+  name: {{ include "router.secretName" . }}
   annotations:
     # Support for k14s.io. This annotation will produce a redeployment when the secret changes.
     kapp.k14s.io/versioned: ""

--- a/helm/cosmo/charts/router/values.yaml
+++ b/helm/cosmo/charts/router/values.yaml
@@ -154,6 +154,10 @@ global:
 # -- If this is set, the commonConfiguration section is ignored.
 existingConfigmap: ""
 
+# -- Existing secret in the same namespace containing the graphApiToken. The secret key has to match with current secret.
+existingSecret: ""
+
+# Use this section to pass the graphApiToken or to configure simple settings.
 # -- You can use this to provide the router configuration via yaml. Values here have precedence over the configurations section.
 # -- For a full list of available configuration options, see https://cosmo-docs.wundergraph.com/router/configuration
 commonConfiguration: |-


### PR DESCRIPTION
## Motivation and Context
Support existing secrets to:
*  avoid having sensitive credentials in Cosmo values.yaml.
* Support gitops workflow. ( external-secrets )

This PR closes #453

## TODO

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
