### PR TITLE
chore: fix command in aws-lambda-router readme

### DIFF
--- a/aws-lambda-router/README.md
+++ b/aws-lambda-router/README.md
@@ -74,13 +74,13 @@ You can find your API Gateway Endpoint URL in the output values displayed after 
 You don't have to build the router yourself. You can download the latest release and follow the instructions below.
 
 1. Download the Lambda Router binary from the official [Router Releases](https://github.com/wundergraph/cosmo/releases?q=aws-lambda-router&expanded=true) page.
-2. Create a .zip archive with the binary and the `router.json` file. You can download the latest `router.json` with [`wgc federated-graph fetch`](https://cosmo-docs.wundergraph.com/cli/federated-graph/fetch).
+2. Create a .zip archive with the binary and the `router.json` file. You can download the latest `router.json` with [`wgc router fetch`](https://cosmo-docs.wundergraph.com/cli/router/fetch).
 
 The .zip archive should look like this:
 ```bash
 .
 └── myFunction.zip/
     ├── bootstrap # Extracted from the Router release archive
-    └── router.json # Downloaded with `wgc federated-graph fetch`
+    └── router.json # Downloaded with `wgc router fetch`
 ```
 3. Deploy the .zip archive to AWS Lambda. You can use SAM CLI or the AWS console. Alternatively, you can use your IaC tool of choice.


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/wundergraph/cloud/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->

## Motivation and Context

There is a typo in the readme file. wgc federated-graph fetch command fetches graphql sdl file, but we need to fetch router.json config file.

btw, contributors guide is not public, so cannot be accessed https://github.com/wundergraph/cloud/blob/main/CONTRIBUTING.md
<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

## TODO

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
