### PR TITLE
fix: listen port in config

### DIFF
--- a/router/pkg/config/config.schema.json
+++ b/router/pkg/config/config.schema.json
@@ -364,7 +364,7 @@
     "listen_addr": {
       "type": "string",
       "description": "The address on which the router listens for incoming requests. The address is specified as a string with the format 'host:port'.",
-      "default": "localhost:3003",
+      "default": "localhost:3002",
       "format": "hostname-port"
     },
     "controlplane_url": {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/wundergraph/cloud/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->

## Motivation and Context

This is a regression. The correct port is 3002

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

## TODO

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [x] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
