### PR TITLE
fix: database creation in clickhouse

### DIFF
--- a/helm/cosmo/values.full.yaml
+++ b/helm/cosmo/values.full.yaml
@@ -221,8 +221,14 @@ clickhouse:
     username: 'default'
     password: 'changeme'
   initdbScripts:
-    db-init.sql: |
-      CREATE DATABASE cosmo;
+    db-init.sh: |
+      #!/bin/bash
+      set -e
+
+      clickhouse-client --user $CLICKHOUSE_ADMIN_USER --password $CLICKHOUSE_ADMIN_PASSWORD -n <<-EOSQL
+        CREATE DATABASE IF NOT EXISTS cosmo;
+      EOSQL
+
 
 # Postgres for the Cosmo Controlplane
 # https://artifacthub.io/packages/helm/bitnami/postgresql


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->

## Motivation and Context

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

Fixes https://github.com/wundergraph/cosmo/issues/566

Currently database in clickhouse is not being created because sql files are not allowed in `initdbScripts`:


```
│ clickhouse 13:33:50.27 WARN  ==> Skipping /docker-entrypoint-initdb.d/db-init.sql, supported formats are: .sh                                    
```

## TODO

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
