### PR TITLE
feat: show link to studio page on subgraph check

### DIFF
--- a/cli/src/commands/subgraph/commands/check.ts
+++ b/cli/src/commands/subgraph/commands/check.ts
@@ -8,7 +8,7 @@ import { Command, program } from 'commander';
 import logSymbols from 'log-symbols';
 import { resolve } from 'pathe';
 import pc from 'picocolors';
-import { baseHeaders } from '../../../core/config.js';
+import { baseHeaders, config } from '../../../core/config.js';
 import { BaseCommandOptions } from '../../../core/types/types.js';
 import { useGitHub } from '../../../github.js';
 
@@ -103,6 +103,11 @@ export default (opts: BaseCommandOptions) => {
     let success = false;
     let finalStatement = '';
 
+    let studioCheckDestination = '';
+    if (resp.checkId && resp.checkedFederatedGraphs.length > 0) {
+      studioCheckDestination = `Open in studio: ${config.webURL}/${resp.checkedFederatedGraphs[0].organizationSlug}/${resp.checkedFederatedGraphs[0].namespace}/graph/${resp.checkedFederatedGraphs[0].name}/checks/${resp.checkId}`;
+    }
+
     switch (resp.response?.code) {
       case EnumStatusCode.OK: {
         if (
@@ -110,7 +115,7 @@ export default (opts: BaseCommandOptions) => {
           resp.breakingChanges.length === 0 &&
           resp.compositionErrors.length === 0
         ) {
-          console.log('\nDetected no changes.\n');
+          console.log(`\nDetected no changes.\n${studioCheckDestination}\n`);
 
           success = true;
 
@@ -188,13 +193,20 @@ export default (opts: BaseCommandOptions) => {
         }
 
         if (success) {
-          console.log('\n' + logSymbols.success + pc.green(` Schema check passed. ${finalStatement}`) + '\n');
+          console.log(
+            '\n' +
+              logSymbols.success +
+              pc.green(` Schema check passed. ${finalStatement}`) +
+              '\n' +
+              studioCheckDestination +
+              '\n',
+          );
         } else {
           program.error(
             '\n' +
               logSymbols.error +
               pc.red(
-                ` Schema check failed. ${finalStatement}\nSee https://cosmo-docs.wundergraph.com/studio/schema-checks for more information on resolving operation check errors.`,
+                ` Schema check failed. ${finalStatement}\nSee https://cosmo-docs.wundergraph.com/studio/schema-checks for more information on resolving operation check errors.\n${studioCheckDestination}\n`,
               ) +
               '\n',
           );

--- a/connect/src/wg/cosmo/platform/v1/platform_pb.ts
+++ b/connect/src/wg/cosmo/platform/v1/platform_pb.ts
@@ -1140,6 +1140,61 @@ export class CheckOperationUsageStats extends Message<CheckOperationUsageStats> 
 }
 
 /**
+ * @generated from message wg.cosmo.platform.v1.CheckedFederatedGraphs
+ */
+export class CheckedFederatedGraphs extends Message<CheckedFederatedGraphs> {
+  /**
+   * @generated from field: string id = 1;
+   */
+  id = "";
+
+  /**
+   * @generated from field: string name = 2;
+   */
+  name = "";
+
+  /**
+   * @generated from field: string namespace = 3;
+   */
+  namespace = "";
+
+  /**
+   * @generated from field: string organization_slug = 4;
+   */
+  organizationSlug = "";
+
+  constructor(data?: PartialMessage<CheckedFederatedGraphs>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "wg.cosmo.platform.v1.CheckedFederatedGraphs";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 3, name: "namespace", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 4, name: "organization_slug", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): CheckedFederatedGraphs {
+    return new CheckedFederatedGraphs().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): CheckedFederatedGraphs {
+    return new CheckedFederatedGraphs().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): CheckedFederatedGraphs {
+    return new CheckedFederatedGraphs().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: CheckedFederatedGraphs | PlainMessage<CheckedFederatedGraphs> | undefined, b: CheckedFederatedGraphs | PlainMessage<CheckedFederatedGraphs> | undefined): boolean {
+    return proto3.util.equals(CheckedFederatedGraphs, a, b);
+  }
+}
+
+/**
  * @generated from message wg.cosmo.platform.v1.CheckSubgraphSchemaResponse
  */
 export class CheckSubgraphSchemaResponse extends Message<CheckSubgraphSchemaResponse> {
@@ -1171,6 +1226,16 @@ export class CheckSubgraphSchemaResponse extends Message<CheckSubgraphSchemaResp
    */
   operationUsageStats?: CheckOperationUsageStats;
 
+  /**
+   * @generated from field: string check_id = 6;
+   */
+  checkId = "";
+
+  /**
+   * @generated from field: repeated wg.cosmo.platform.v1.CheckedFederatedGraphs checked_federated_graphs = 7;
+   */
+  checkedFederatedGraphs: CheckedFederatedGraphs[] = [];
+
   constructor(data?: PartialMessage<CheckSubgraphSchemaResponse>) {
     super();
     proto3.util.initPartial(data, this);
@@ -1184,6 +1249,8 @@ export class CheckSubgraphSchemaResponse extends Message<CheckSubgraphSchemaResp
     { no: 3, name: "nonBreakingChanges", kind: "message", T: SchemaChange, repeated: true },
     { no: 4, name: "compositionErrors", kind: "message", T: CompositionError, repeated: true },
     { no: 5, name: "operationUsageStats", kind: "message", T: CheckOperationUsageStats },
+    { no: 6, name: "check_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 7, name: "checked_federated_graphs", kind: "message", T: CheckedFederatedGraphs, repeated: true },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): CheckSubgraphSchemaResponse {

--- a/controlplane/src/core/bufservices/PlatformService.ts
+++ b/controlplane/src/core/bufservices/PlatformService.ts
@@ -1038,6 +1038,8 @@ export default function (opts: RouterOptions): Partial<ServiceImpl<typeof Platfo
             breakingChanges: [],
             nonBreakingChanges: [],
             compositionErrors: [],
+            checkId: '',
+            checkedFederatedGraphs: [],
           };
         }
 
@@ -1051,6 +1053,8 @@ export default function (opts: RouterOptions): Partial<ServiceImpl<typeof Platfo
             breakingChanges: [],
             nonBreakingChanges: [],
             compositionErrors: [],
+            checkId: '',
+            checkedFederatedGraphs: [],
           };
         }
 
@@ -1065,6 +1069,8 @@ export default function (opts: RouterOptions): Partial<ServiceImpl<typeof Platfo
             breakingChanges: [],
             nonBreakingChanges: [],
             compositionErrors: [],
+            checkId: '',
+            checkedFederatedGraphs: [],
           };
         }
 
@@ -1087,6 +1093,8 @@ export default function (opts: RouterOptions): Partial<ServiceImpl<typeof Platfo
             breakingChanges: [],
             nonBreakingChanges: [],
             compositionErrors: [],
+            checkId: schemaCheckID,
+            checkedFederatedGraphs: [],
           };
         }
 
@@ -1216,6 +1224,13 @@ export default function (opts: RouterOptions): Partial<ServiceImpl<typeof Platfo
           nonBreakingChanges: schemaChanges.nonBreakingChanges,
           operationUsageStats: isInspectable ? collectOperationUsageStats(inspectedOperations) : undefined,
           compositionErrors,
+          checkId: schemaCheckID,
+          checkedFederatedGraphs: result.compositions.map((c) => ({
+            id: c.id,
+            name: c.name,
+            namespace: c.namespace,
+            organizationSlug: authContext.organizationSlug,
+          })),
         };
       });
     },

--- a/proto/wg/cosmo/platform/v1/platform.proto
+++ b/proto/wg/cosmo/platform/v1/platform.proto
@@ -136,6 +136,13 @@ message CheckOperationUsageStats {
   uint32 safeOperations = 4;
 }
 
+message CheckedFederatedGraphs {
+  string id = 1;
+  string name = 2;
+  string namespace = 3;
+  string organization_slug = 4;
+}
+
 message CheckSubgraphSchemaResponse {
   Response response = 1;
   repeated SchemaChange breakingChanges = 2;
@@ -144,6 +151,8 @@ message CheckSubgraphSchemaResponse {
   // Contains the operation usage stats for the operations that are impacted by the schema changes.
   // Can be undefined when the schema changes are not inspectable by real traffic breaking change detection.
   CheckOperationUsageStats operationUsageStats = 5;
+  string check_id = 6;
+  repeated CheckedFederatedGraphs checked_federated_graphs = 7;
 }
 
 message FixSubgraphSchemaResponse {


### PR DESCRIPTION
## Motivation and Context

Shows the link to studio page for the check in output.

## TODO

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [x] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
