### PR TITLE
fix: omit invalid group filters

### DIFF
--- a/controlplane/src/core/repositories/analytics/AnalyticsRequestViewRepository.ts
+++ b/controlplane/src/core/repositories/analytics/AnalyticsRequestViewRepository.ts
@@ -640,7 +640,9 @@ export class AnalyticsRequestViewRepository {
         return filters.filter((f) => f.field !== 'p95');
       }
       case AnalyticsViewGroupName.OperationName: {
-        return filters.filter((f) => !['durationInNano', 'clientName', 'statusMessages'].includes(f.field));
+        return filters.filter(
+          (f) => !['durationInNano', 'clientName', 'clientVersion', 'statusMessages'].includes(f.field),
+        );
       }
       case AnalyticsViewGroupName.Client: {
         return filters.filter((f) => ['clientName', 'p95', 'clientVersion'].includes(f.field));


### PR DESCRIPTION
## Motivation and Context

Client version was missing in the blacklist of grouped filters

## TODO

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [x] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
