### PR TITLE
fix: crash due to missing explicit type cast

### DIFF
--- a/controlplane/src/core/repositories/FederatedGraphRepository.ts
+++ b/controlplane/src/core/repositories/FederatedGraphRepository.ts
@@ -477,7 +477,7 @@ export class FederatedGraphRepository {
                           sql.raw(
                             `${targetLabelMatchers.labelMatcher.name} && ARRAY[${uniqueLabels.map(
                               (ul) => "'" + joinLabel(ul) + "'",
-                            )}]`,
+                            )}]::TEXT[]`,
                           ),
                         ),
                       ),


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->

## Motivation and Context

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

If the array is empty, I think some postgres version crashes if type isn't explicitly specified. 

## TODO

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [x] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
