### PR TITLE
feat: ensure TLS and test if mail client is ready

### DIFF
--- a/controlplane/src/core/build-server.ts
+++ b/controlplane/src/core/build-server.ts
@@ -210,6 +210,16 @@ export default async function build(opts: BuildConfig) {
   let mailerClient: Mailer | undefined;
   if (opts.smtpUsername && opts.smtpPassword) {
     mailerClient = new Mailer({ username: opts.smtpUsername, password: opts.smtpPassword });
+    try {
+      const verified = await mailerClient.verifyConnection();
+      if (verified) {
+        log.info('Email client ready to send emails');
+      } else {
+        log.error('Email client failed to verify connection');
+      }
+    } catch (error) {
+      log.error(error, 'Email client could not verify connection');
+    }
   }
 
   const bullWorkers: Worker[] = [];

--- a/controlplane/src/core/services/Mailer.ts
+++ b/controlplane/src/core/services/Mailer.ts
@@ -15,12 +15,22 @@ export default class Mailer {
     this.client = createTransport({
       host: 'smtp.postmarkapp.com',
       port: 587,
+      // true for 465, false for other ports, will still upgrade to StartTLS
       secure: false,
+      requireTLS: true, // Forces the client to use STARTTLS
       auth: {
         user: username,
         pass: password,
       },
     });
+  }
+
+  /**
+   * Verify the connection to the mail server is working.
+   * (Authenticates with the mail server and returns true if successful, false otherwise)
+   */
+  public verifyConnection() {
+    return this.client.verify();
   }
 
   public async sendInviteEmail({


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->

## Motivation and Context

Fix https://linear.app/wundergraph/issue/ENG-4915/controlplane-use-starttls-in-nodemailer

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

## TODO

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
