### PR TITLE
fix(controlplane): replace weburl if is domain

### DIFF
--- a/controlplane/src/core/auth-utils.ts
+++ b/controlplane/src/core/auth-utils.ts
@@ -1,3 +1,4 @@
+import * as net from 'node:net';
 import { FastifyReply, FastifyRequest } from 'fastify';
 import cookie from 'cookie';
 import axios from 'axios';
@@ -51,7 +52,9 @@ export default class AuthUtils {
     private opts: AuthUtilsOptions,
   ) {
     this.webUrl = new URL(opts.webBaseUrl);
-    this.webDomain = this.webUrl.hostname.replace(/^[^.]+\./g, '');
+    this.webDomain = net.isIPv4(this.webUrl.hostname)
+      ? this.webUrl.hostname
+      : this.webUrl.hostname.replace(/^[^.]+\./g, '');
     this.secureCookie = this.webUrl.protocol === 'https:';
   }
 


### PR DESCRIPTION
## Motivation and Context

When I tried to use wundergraph on my local system, I configured it using an ip from my test lan. When I logged in the sessions were never written to the db. Investigating further I found the replace in AuthUtils which I tried to fix.

## TODO

- [X] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [X] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
