### PR TITLE
feat: allow to update admission url

### DIFF
--- a/cli/src/commands/federated-graph/commands/create.ts
+++ b/cli/src/commands/federated-graph/commands/create.ts
@@ -27,7 +27,7 @@ export default (opts: BaseCommandOptions) => {
   );
   command.option(
     '--admission-webhook-url <url>',
-    'The admission webhook url. This is the url that the controlplane will use to implement admission control for the federated graph. This is optional.',
+    'The admission webhook url. This is the url that the controlplane will use to implement admission control for the federated graph.',
     [],
   );
   command.option('--readme <path-to-readme>', 'The markdown file which describes the federated graph.');

--- a/cli/src/commands/federated-graph/commands/update.ts
+++ b/cli/src/commands/federated-graph/commands/update.ts
@@ -23,8 +23,17 @@ export default (opts: BaseCommandOptions) => {
     'The label matcher is used to select the subgraphs to federate. The labels are passed in the format <key>=<value> <key>=<value>. They are separated by spaces and grouped using comma. Example: --label-matcher team=A,team=B env=prod',
   );
   command.option(
+    '--admission-webhook-url <url>',
+    'The admission webhook url. This is the url that the controlplane will use to implement admission control for the federated graph.',
+    [],
+  );
+  command.option(
     '--unset-label-matchers',
     'This will remove all label matchers. It will not add new label matchers if both this and --label-matchers option is passed.',
+  );
+  command.option(
+    '--unset-admission-webhook-url',
+    'This will remove the admission webhook url. It will not add new admission webhook url if both this and --admission-webhook-url option is passed.',
   );
   command.option('--readme <path-to-readme>', 'The markdown file which describes the subgraph.');
   command.action(async (name, options) => {
@@ -48,6 +57,7 @@ export default (opts: BaseCommandOptions) => {
         routingUrl: options.routingUrl,
         labelMatchers: options.labelMatcher,
         unsetLabelMatchers: options.unsetLabelMatchers,
+        unsetAdmissionWebhookUrl: options.unsetAdmissionWebhookUrl,
         readme: readmeFile ? await readFile(readmeFile, 'utf8') : undefined,
       },
       {

--- a/cli/src/commands/federated-graph/commands/update.ts
+++ b/cli/src/commands/federated-graph/commands/update.ts
@@ -56,6 +56,7 @@ export default (opts: BaseCommandOptions) => {
         namespace: options.namespace,
         routingUrl: options.routingUrl,
         labelMatchers: options.labelMatcher,
+        admissionWebhookURL: options.admissionWebhookUrl,
         unsetLabelMatchers: options.unsetLabelMatchers,
         unsetAdmissionWebhookUrl: options.unsetAdmissionWebhookUrl,
         readme: readmeFile ? await readFile(readmeFile, 'utf8') : undefined,

--- a/cli/src/commands/federated-graph/commands/update.ts
+++ b/cli/src/commands/federated-graph/commands/update.ts
@@ -23,18 +23,15 @@ export default (opts: BaseCommandOptions) => {
     'The label matcher is used to select the subgraphs to federate. The labels are passed in the format <key>=<value> <key>=<value>. They are separated by spaces and grouped using comma. Example: --label-matcher team=A,team=B env=prod',
   );
   command.option(
-    '--admission-webhook-url <url>',
-    'The admission webhook url. This is the url that the controlplane will use to implement admission control for the federated graph.',
-    [],
-  );
-  command.option(
     '--unset-label-matchers',
     'This will remove all label matchers. It will not add new label matchers if both this and --label-matchers option is passed.',
   );
   command.option(
-    '--unset-admission-webhook-url',
-    'This will remove the admission webhook url. It will not add new admission webhook url if both this and --admission-webhook-url option is passed.',
+    '--admission-webhook-url <url>',
+    'The admission webhook url. This is the url that the controlplane will use to implement admission control for the federated graph.',
+    [],
   );
+
   command.option('--readme <path-to-readme>', 'The markdown file which describes the subgraph.');
   command.action(async (name, options) => {
     let readmeFile;
@@ -58,7 +55,6 @@ export default (opts: BaseCommandOptions) => {
         labelMatchers: options.labelMatcher,
         admissionWebhookURL: options.admissionWebhookUrl,
         unsetLabelMatchers: options.unsetLabelMatchers,
-        unsetAdmissionWebhookUrl: options.unsetAdmissionWebhookUrl,
         readme: readmeFile ? await readFile(readmeFile, 'utf8') : undefined,
       },
       {

--- a/cli/src/commands/subgraph/commands/create.ts
+++ b/cli/src/commands/subgraph/commands/create.ts
@@ -26,10 +26,6 @@ export default (opts: BaseCommandOptions) => {
     'The labels to apply to the subgraph. The labels are passed in the format <key>=<value> <key>=<value>.',
   );
   command.option(
-    '--header [headers...]',
-    'The headers to apply when the subgraph is introspected. This is used for authentication and authorization.',
-  );
-  command.option(
     '--subscription-url [url]',
     'The url used for subscriptions. If empty, it defaults to same url used for routing.',
   );
@@ -58,7 +54,6 @@ export default (opts: BaseCommandOptions) => {
         namespace: options.namespace,
         labels: options.label ? options.label.map((label: string) => splitLabel(label)) : [],
         routingUrl: options.routingUrl,
-        headers: options.header,
         // If the argument is provided but the URL is not, clear it
         subscriptionUrl: options.subscriptionUrl === true ? '' : options.subscriptionUrl,
         subscriptionProtocol: options.subscriptionProtocol

--- a/cli/src/commands/subgraph/commands/publish.ts
+++ b/cli/src/commands/subgraph/commands/publish.ts
@@ -35,11 +35,6 @@ export default (opts: BaseCommandOptions) => {
     'This will remove all labels. It will not add new labels if both this and --labels option is passed.',
   );
   command.option(
-    '--header [headers...]',
-    'The headers to apply when the subgraph is introspected. This is used for authentication and authorization.',
-    [],
-  );
-  command.option(
     '--subscription-url [url]',
     'The url used for subscriptions. If empty, it defaults to same url used for routing.',
   );
@@ -86,7 +81,6 @@ export default (opts: BaseCommandOptions) => {
         schema,
         // Optional when subgraph does not exist yet
         routingUrl: options.routingUrl,
-        headers: options.header,
         subscriptionUrl: options.subscriptionUrl,
         subscriptionProtocol: options.subscriptionProtocol
           ? parseGraphQLSubscriptionProtocol(options.subscriptionProtocol)

--- a/connect/src/wg/cosmo/platform/v1/platform_pb.ts
+++ b/connect/src/wg/cosmo/platform/v1/platform_pb.ts
@@ -3837,6 +3837,11 @@ export class UpdateFederatedGraphRequest extends Message<UpdateFederatedGraphReq
    */
   admissionWebhookURL?: string;
 
+  /**
+   * @generated from field: optional bool unset_admission_webhook_url = 8;
+   */
+  unsetAdmissionWebhookUrl?: boolean;
+
   constructor(data?: PartialMessage<UpdateFederatedGraphRequest>) {
     super();
     proto3.util.initPartial(data, this);
@@ -3852,6 +3857,7 @@ export class UpdateFederatedGraphRequest extends Message<UpdateFederatedGraphReq
     { no: 5, name: "namespace", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 6, name: "unset_label_matchers", kind: "scalar", T: 8 /* ScalarType.BOOL */, opt: true },
     { no: 7, name: "admissionWebhookURL", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
+    { no: 8, name: "unset_admission_webhook_url", kind: "scalar", T: 8 /* ScalarType.BOOL */, opt: true },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): UpdateFederatedGraphRequest {

--- a/connect/src/wg/cosmo/platform/v1/platform_pb.ts
+++ b/connect/src/wg/cosmo/platform/v1/platform_pb.ts
@@ -3837,11 +3837,6 @@ export class UpdateFederatedGraphRequest extends Message<UpdateFederatedGraphReq
    */
   admissionWebhookURL?: string;
 
-  /**
-   * @generated from field: optional bool unset_admission_webhook_url = 8;
-   */
-  unsetAdmissionWebhookUrl?: boolean;
-
   constructor(data?: PartialMessage<UpdateFederatedGraphRequest>) {
     super();
     proto3.util.initPartial(data, this);
@@ -3857,7 +3852,6 @@ export class UpdateFederatedGraphRequest extends Message<UpdateFederatedGraphReq
     { no: 5, name: "namespace", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 6, name: "unset_label_matchers", kind: "scalar", T: 8 /* ScalarType.BOOL */, opt: true },
     { no: 7, name: "admissionWebhookURL", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
-    { no: 8, name: "unset_admission_webhook_url", kind: "scalar", T: 8 /* ScalarType.BOOL */, opt: true },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): UpdateFederatedGraphRequest {

--- a/connect/src/wg/cosmo/platform/v1/platform_pb.ts
+++ b/connect/src/wg/cosmo/platform/v1/platform_pb.ts
@@ -460,13 +460,6 @@ export class PublishFederatedSubgraphRequest extends Message<PublishFederatedSub
   labels: Label[] = [];
 
   /**
-   * The headers are the headers which will be used to route the requests to the subgraph.
-   *
-   * @generated from field: repeated string headers = 5;
-   */
-  headers: string[] = [];
-
-  /**
    * The subscription protocol to use when subscribing to this subgraph
    *
    * @generated from field: optional wg.cosmo.common.GraphQLSubscriptionProtocol subscription_protocol = 6;
@@ -506,7 +499,6 @@ export class PublishFederatedSubgraphRequest extends Message<PublishFederatedSub
     { no: 2, name: "schema", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 3, name: "routing_url", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
     { no: 4, name: "labels", kind: "message", T: Label, repeated: true },
-    { no: 5, name: "headers", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },
     { no: 6, name: "subscription_protocol", kind: "enum", T: proto3.getEnumType(GraphQLSubscriptionProtocol), opt: true },
     { no: 7, name: "subscription_url", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
     { no: 8, name: "namespace", kind: "scalar", T: 9 /* ScalarType.STRING */ },
@@ -855,13 +847,6 @@ export class CreateFederatedSubgraphRequest extends Message<CreateFederatedSubgr
   labels: Label[] = [];
 
   /**
-   * headers are the headers which will be used to route the requests to the subgraph.
-   *
-   * @generated from field: repeated string headers = 4;
-   */
-  headers: string[] = [];
-
-  /**
    * subscription protocol to use when subscribing to this subgraph
    *
    * @generated from field: optional wg.cosmo.common.GraphQLSubscriptionProtocol subscription_protocol = 5;
@@ -898,7 +883,6 @@ export class CreateFederatedSubgraphRequest extends Message<CreateFederatedSubgr
     { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 2, name: "routing_url", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 3, name: "labels", kind: "message", T: Label, repeated: true },
-    { no: 4, name: "headers", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },
     { no: 5, name: "subscription_protocol", kind: "enum", T: proto3.getEnumType(GraphQLSubscriptionProtocol), opt: true },
     { no: 6, name: "subscription_url", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
     { no: 7, name: "readme", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },

--- a/controlplane/src/core/bufservices/PlatformService.ts
+++ b/controlplane/src/core/bufservices/PlatformService.ts
@@ -2584,7 +2584,8 @@ export default function (opts: RouterOptions): Partial<ServiceImpl<typeof Platfo
           readme: req.readme,
           blobStorage: opts.blobStorage,
           namespaceId: federatedGraph.namespaceId,
-          unsetLabelMatchers: req.unsetLabelMatchers ?? false,
+          unsetLabelMatchers: req.unsetLabelMatchers,
+          unsetAdmissionWebhookURL: req.unsetAdmissionWebhookUrl,
           admissionConfig: {
             cdnBaseUrl: opts.cdnBaseUrl,
             jwtSecret: opts.admissionWebhookJWTSecret,

--- a/controlplane/src/core/bufservices/PlatformService.ts
+++ b/controlplane/src/core/bufservices/PlatformService.ts
@@ -2585,6 +2585,7 @@ export default function (opts: RouterOptions): Partial<ServiceImpl<typeof Platfo
           blobStorage: opts.blobStorage,
           namespaceId: federatedGraph.namespaceId,
           unsetLabelMatchers: req.unsetLabelMatchers,
+          admissionWebhookURL: req.admissionWebhookURL,
           unsetAdmissionWebhookURL: req.unsetAdmissionWebhookUrl,
           admissionConfig: {
             cdnBaseUrl: opts.cdnBaseUrl,

--- a/controlplane/src/core/bufservices/PlatformService.ts
+++ b/controlplane/src/core/bufservices/PlatformService.ts
@@ -848,7 +848,7 @@ export default function (opts: RouterOptions): Partial<ServiceImpl<typeof Platfo
           };
         }
 
-        if (req.admissionWebhookURL && !isValidUrl(req.routingUrl)) {
+        if (req.admissionWebhookURL && !isValidUrl(req.admissionWebhookURL)) {
           return {
             response: {
               code: EnumStatusCode.ERR,
@@ -2573,6 +2573,17 @@ export default function (opts: RouterOptions): Partial<ServiceImpl<typeof Platfo
           };
         }
 
+        if (req.admissionWebhookURL && !isValidUrl(req.admissionWebhookURL)) {
+          return {
+            response: {
+              code: EnumStatusCode.ERR,
+              details: `Admission Webhook URL is not a valid URL`,
+            },
+            compositionErrors: [],
+            deploymentErrors: [],
+          };
+        }
+
         const deploymentErrors: PlainMessage<DeploymentError>[] = [];
         let compositionErrors: PlainMessage<CompositionError>[] = [];
 
@@ -2586,7 +2597,6 @@ export default function (opts: RouterOptions): Partial<ServiceImpl<typeof Platfo
           namespaceId: federatedGraph.namespaceId,
           unsetLabelMatchers: req.unsetLabelMatchers,
           admissionWebhookURL: req.admissionWebhookURL,
-          unsetAdmissionWebhookURL: req.unsetAdmissionWebhookUrl,
           admissionConfig: {
             cdnBaseUrl: opts.cdnBaseUrl,
             jwtSecret: opts.admissionWebhookJWTSecret,
@@ -2714,7 +2724,7 @@ export default function (opts: RouterOptions): Partial<ServiceImpl<typeof Platfo
           };
         }
 
-        // check if the user is authorized to perform the action
+        // Check if the user is authorized to perform the action
         await opts.authorizer.authorize({
           db: opts.db,
           graph: {
@@ -2726,6 +2736,7 @@ export default function (opts: RouterOptions): Partial<ServiceImpl<typeof Platfo
           authContext,
         });
 
+        // When un-setting the url, the url can be empty string
         if (req.subscriptionUrl && !isValidUrl(req.subscriptionUrl)) {
           return {
             response: {

--- a/controlplane/src/core/repositories/FederatedGraphRepository.ts
+++ b/controlplane/src/core/repositories/FederatedGraphRepository.ts
@@ -180,32 +180,26 @@ export class FederatedGraphRepository {
         throw new Error(`Federated graph not found`);
       }
 
-      // update routing URL when changed
+      // Update routing URL when changed. (Is required)
       if (routingUrl && federatedGraph.routingUrl !== routingUrl) {
         await tx.update(federatedGraphs).set({ routingUrl }).where(eq(federatedGraphs.id, federatedGraph.id)).execute();
       }
 
-      // update admission webhook URL when changed
-      if (data.unsetAdmissionWebhookURL) {
+      // Update admission webhook URL when changed. (Is optional)
+      if (admissionWebhookURL !== undefined && federatedGraph.admissionWebhookURL !== admissionWebhookURL) {
         await tx
           .update(federatedGraphs)
-          .set({ admissionWebhookURL: null })
-          .where(eq(federatedGraphs.id, federatedGraph.id))
-          .execute();
-      } else if (admissionWebhookURL && federatedGraph.admissionWebhookURL !== admissionWebhookURL) {
-        await tx
-          .update(federatedGraphs)
-          .set({ admissionWebhookURL })
+          .set({ admissionWebhookURL: admissionWebhookURL || null })
           .where(eq(federatedGraphs.id, federatedGraph.id))
           .execute();
       }
 
-      // update the readme of the fed graph
-      if (data.readme) {
+      // Update the readme of the fed graph. (Is optional)
+      if (data.readme !== undefined) {
         await targetRepo.updateReadmeOfTarget({ id: data.targetId, readme: data.readme });
       }
 
-      // update label matchers
+      // Update label matchers (Is optional)
       if (data.labelMatchers.length > 0 || data.unsetLabelMatchers) {
         const labelMatchers = data.unsetLabelMatchers ? [] : normalizeLabelMatchers(data.labelMatchers);
 

--- a/controlplane/src/core/repositories/FederatedGraphRepository.ts
+++ b/controlplane/src/core/repositories/FederatedGraphRepository.ts
@@ -159,7 +159,8 @@ export class FederatedGraphRepository {
     readme?: string;
     blobStorage: BlobStorage;
     namespaceId: string;
-    unsetLabelMatchers: boolean;
+    unsetLabelMatchers?: boolean;
+    unsetAdmissionWebhookURL?: boolean;
     admissionWebhookURL?: string;
     admissionConfig: {
       jwtSecret: string;
@@ -185,8 +186,13 @@ export class FederatedGraphRepository {
       }
 
       // update admission webhook URL when changed
-      // if undefined, it means the user wants to remove the admission webhook
-      if (admissionWebhookURL !== undefined && federatedGraph.admissionWebhookURL !== admissionWebhookURL) {
+      if (data.unsetAdmissionWebhookURL) {
+        await tx
+          .update(federatedGraphs)
+          .set({ admissionWebhookURL: null })
+          .where(eq(federatedGraphs.id, federatedGraph.id))
+          .execute();
+      } else if (admissionWebhookURL && federatedGraph.admissionWebhookURL !== admissionWebhookURL) {
         await tx
           .update(federatedGraphs)
           .set({ admissionWebhookURL })

--- a/controlplane/src/core/repositories/SubgraphRepository.ts
+++ b/controlplane/src/core/repositories/SubgraphRepository.ts
@@ -220,24 +220,25 @@ export class SubgraphRepository {
           .execute();
       }
 
-      if (data.subscriptionUrl && data.subscriptionUrl !== subgraph.subscriptionUrl) {
+      if (data.subscriptionUrl !== undefined && data.subscriptionUrl !== subgraph.subscriptionUrl) {
         subgraphChanged = true;
         const url = normalizeURL(data.subscriptionUrl);
         await tx
           .update(subgraphs)
           .set({
-            subscriptionUrl: url,
+            subscriptionUrl: url || null,
           })
           .where(eq(subgraphs.id, subgraph.id))
           .execute();
       }
 
-      if (data.subscriptionProtocol && data.subscriptionProtocol !== subgraph.subscriptionProtocol) {
+      if (data.subscriptionProtocol !== undefined && data.subscriptionProtocol !== subgraph.subscriptionProtocol) {
         subgraphChanged = true;
         await tx
           .update(subgraphs)
           .set({
-            subscriptionProtocol: data.subscriptionProtocol,
+            // ws is the default protocol
+            subscriptionProtocol: data.subscriptionProtocol || 'ws',
           })
           .where(eq(subgraphs.id, subgraph.id))
           .execute();
@@ -349,7 +350,7 @@ export class SubgraphRepository {
       }
 
       // update the readme of the subgraph
-      if (data.readme) {
+      if (data.readme !== undefined) {
         await targetRepo.updateReadmeOfTarget({ id: data.targetId, readme: data.readme });
       }
     });

--- a/controlplane/src/core/services/AdmissionWebhookController.ts
+++ b/controlplane/src/core/services/AdmissionWebhookController.ts
@@ -92,9 +92,6 @@ export class AdmissionWebhookController {
               `Config validation has failed. /validate-config handler responded with: StatusCode: ${err.response.status}. Error: ${err.response.data.error}`,
             );
           }
-          throw new AdmissionError(
-            `Non-200 status code from /validate-config handler received: StatusCode: ${err.response?.status}`,
-          );
         }
         throw new AdmissionError(
           `Unable to reach admission webhook handler on ${url}. Make sure the URL is correct and the service is running.`,

--- a/controlplane/src/core/services/AdmissionWebhookController.ts
+++ b/controlplane/src/core/services/AdmissionWebhookController.ts
@@ -86,12 +86,10 @@ export class AdmissionWebhookController {
       );
 
       if (err instanceof AxiosError) {
-        if (err.response?.status !== 200) {
-          if (err.response?.data?.error) {
-            throw new AdmissionError(
-              `Config validation has failed. /validate-config handler responded with: StatusCode: ${err.response.status}. Error: ${err.response.data.error}`,
-            );
-          }
+        if (err.response?.status !== 200 && err.response?.data?.error) {
+          throw new AdmissionError(
+            `Config validation has failed. /validate-config handler responded with: StatusCode: ${err.response.status}. Error: ${err.response.data.error}`,
+          );
         }
         throw new AdmissionError(
           `Unable to reach admission webhook handler on ${url}. Make sure the URL is correct and the service is running.`,

--- a/controlplane/test/subgraph.test.ts
+++ b/controlplane/test/subgraph.test.ts
@@ -124,7 +124,6 @@ describe('Subgraph', (ctx) => {
       routingUrl: 'http://localhost:3001',
       subscriptionUrl: 'http://localhost:3001',
       subscriptionProtocol: GraphQLSubscriptionProtocol.GRAPHQL_SUBSCRIPTION_PROTOCOL_SSE,
-      headers: [],
     });
     expect(publishSubgraphResp.response?.code).toBe(EnumStatusCode.OK);
 

--- a/package.json
+++ b/package.json
@@ -48,6 +48,9 @@
     "@bufbuild/protoc-gen-es": "^1.4.1",
     "@commitlint/cli": "17.6.6",
     "@commitlint/config-conventional": "17.6.6",
+    "@connectrpc/connect-query": "^0.6.0",
+    "@connectrpc/protoc-gen-connect-es": "^1.1.3",
+    "@connectrpc/protoc-gen-connect-query": "^0.6.0",
     "@lerna-lite/cli": "2.5.1",
     "@lerna-lite/publish": "2.5.1",
     "@lerna-lite/version": "2.5.1",
@@ -55,9 +58,7 @@
     "husky": "^8.0.3",
     "lint-staged": "^12.5.0",
     "prettier": "^3.0.3",
-    "@connectrpc/protoc-gen-connect-es": "^1.1.3",
-    "@connectrpc/connect-query": "^0.6.0",
-    "@connectrpc/protoc-gen-connect-query": "^0.6.0"
+    "vitest": "1.4.0"
   },
   "packageManager": "pnpm@8.7.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       prettier:
         specifier: ^3.0.3
         version: 3.0.3
+      vitest:
+        specifier: 1.4.0
+        version: 1.4.0(@types/node@20.11.26)
 
   admission-server:
     dependencies:

--- a/proto/wg/cosmo/platform/v1/platform.proto
+++ b/proto/wg/cosmo/platform/v1/platform.proto
@@ -33,8 +33,6 @@ message PublishFederatedSubgraphRequest {
   optional string routing_url = 3;
   // The labels are the labels of the services which will form the federated graph. If the proposed is not valid, the service will be rejected.
   repeated Label labels = 4;
-  // The headers are the headers which will be used to route the requests to the subgraph. (Not used anymore)
-  repeated string headers = 5 [deprecated = true];
   // The subscription protocol to use when subscribing to this subgraph
   optional wg.cosmo.common.GraphQLSubscriptionProtocol subscription_protocol = 6;
   // The url used for subscriptions
@@ -97,8 +95,6 @@ message CreateFederatedSubgraphRequest {
   string routing_url = 2;
   // labels are the labels of the services which will form the federated graph. If the proposed is not valid, the service will be rejected.
   repeated Label labels = 3;
-  // headers are the headers which will be used to route the requests to the subgraph. (Not used anymore)
-  repeated string headers = 4 [deprecated = true];
   // subscription protocol to use when subscribing to this subgraph
   optional wg.cosmo.common.GraphQLSubscriptionProtocol subscription_protocol = 5;
     // url used for subscriptions

--- a/proto/wg/cosmo/platform/v1/platform.proto
+++ b/proto/wg/cosmo/platform/v1/platform.proto
@@ -33,8 +33,8 @@ message PublishFederatedSubgraphRequest {
   optional string routing_url = 3;
   // The labels are the labels of the services which will form the federated graph. If the proposed is not valid, the service will be rejected.
   repeated Label labels = 4;
-  // The headers are the headers which will be used to route the requests to the subgraph.
-  repeated string headers = 5;
+  // The headers are the headers which will be used to route the requests to the subgraph. (Not used anymore)
+  repeated string headers = 5 [deprecated = true];
   // The subscription protocol to use when subscribing to this subgraph
   optional wg.cosmo.common.GraphQLSubscriptionProtocol subscription_protocol = 6;
   // The url used for subscriptions
@@ -97,8 +97,8 @@ message CreateFederatedSubgraphRequest {
   string routing_url = 2;
   // labels are the labels of the services which will form the federated graph. If the proposed is not valid, the service will be rejected.
   repeated Label labels = 3;
-  // headers are the headers which will be used to route the requests to the subgraph.
-  repeated string headers = 4;
+  // headers are the headers which will be used to route the requests to the subgraph. (Not used anymore)
+  repeated string headers = 4 [deprecated = true];
   // subscription protocol to use when subscribing to this subgraph
   optional wg.cosmo.common.GraphQLSubscriptionProtocol subscription_protocol = 5;
     // url used for subscriptions
@@ -489,7 +489,6 @@ message UpdateFederatedGraphRequest {
   string namespace = 5;
   optional bool unset_label_matchers = 6;
   optional string admissionWebhookURL = 7;
-  optional bool unset_admission_webhook_url = 8;
 }
 
 message UpdateFederatedGraphResponse {

--- a/proto/wg/cosmo/platform/v1/platform.proto
+++ b/proto/wg/cosmo/platform/v1/platform.proto
@@ -489,6 +489,7 @@ message UpdateFederatedGraphRequest {
   string namespace = 5;
   optional bool unset_label_matchers = 6;
   optional string admissionWebhookURL = 7;
+  optional bool unset_admission_webhook_url = 8;
 }
 
 message UpdateFederatedGraphResponse {

--- a/shared/src/utils/util.ts
+++ b/shared/src/utils/util.ts
@@ -1,3 +1,5 @@
+import { SubscriptionProtocol } from '../router-config/builder.js';
+
 export function delay(t: number) {
   return new Promise((resolve) => setTimeout(resolve, t));
 }
@@ -49,7 +51,7 @@ export function isValidUrl(url: string) {
   }
 }
 
-export function isValidSubscriptionProtocol(protocol: string) {
+export function isValidSubscriptionProtocol(protocol: SubscriptionProtocol) {
   switch (protocol) {
     case 'sse':
     case 'sse_post':

--- a/shared/src/utils/util.ts
+++ b/shared/src/utils/util.ts
@@ -48,3 +48,16 @@ export function isValidUrl(url: string) {
     return false;
   }
 }
+
+export function isValidSubscriptionProtocol(protocol: string) {
+  switch (protocol) {
+    case 'sse':
+    case 'sse_post':
+    case 'ws': {
+      return true;
+    }
+    default: {
+      return false;
+    }
+  }
+}

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,0 +1,1 @@
+export default ['controlplane', 'shared', 'cli', 'composition'];


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->

## Motivation and Context

- Allow to update admission url.
- Allow to unset several other flags with an empty value
- Cleanup flag handling.
- Remove unused header option from commands and proto in a backwards compatible way
- Add vitest.workspace.yaml for vscode debugging support (Upgrade the vscode plugin to the latest pre-release version)

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

## TODO

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
