### PR TITLE
fix: load monaco from public folder

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -874,6 +874,9 @@ importers:
       autoprefixer:
         specifier: 10.4.14
         version: 10.4.14(postcss@8.4.24)
+      cpy-cli:
+        specifier: ^5.0.0
+        version: 5.0.0
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -9972,6 +9975,11 @@ packages:
     resolution: {integrity: sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==}
     engines: {node: '>=0.10.0'}
 
+  /arrify@3.0.0:
+    resolution: {integrity: sha512-tLkvA81vQG/XqE2mjDkGQHoOINtMHtysSnemrmoGe6PydDPMRbVugqyk4A6V/WDWEfm3l+0d8anA9r8cv/5Jaw==}
+    engines: {node: '>=12'}
+    dev: true
+
   /asn1js@3.0.5:
     resolution: {integrity: sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==}
     engines: {node: '>=12.0.0'}
@@ -11055,6 +11063,38 @@ packages:
       parse-json: 5.2.0
       path-type: 4.0.0
       typescript: 5.3.2
+    dev: true
+
+  /cp-file@10.0.0:
+    resolution: {integrity: sha512-vy2Vi1r2epK5WqxOLnskeKeZkdZvTKfFZQCplE3XWsP+SUJyd5XAUFC9lFgTjjXJF2GMne/UML14iEmkAaDfFg==}
+    engines: {node: '>=14.16'}
+    dependencies:
+      graceful-fs: 4.2.11
+      nested-error-stacks: 2.1.1
+      p-event: 5.0.1
+    dev: true
+
+  /cpy-cli@5.0.0:
+    resolution: {integrity: sha512-fb+DZYbL9KHc0BC4NYqGRrDIJZPXUmjjtqdw4XRRg8iV8dIfghUX/WiL+q4/B/KFTy3sK6jsbUhBaz0/Hxg7IQ==}
+    engines: {node: '>=16'}
+    hasBin: true
+    dependencies:
+      cpy: 10.1.0
+      meow: 12.1.1
+    dev: true
+
+  /cpy@10.1.0:
+    resolution: {integrity: sha512-VC2Gs20JcTyeQob6UViBLnyP0bYHkBh6EiKzot9vi2DmeGlFT9Wd7VG3NBrkNx/jYvFBeyDOMMHdHQhbtKLgHQ==}
+    engines: {node: '>=16'}
+    dependencies:
+      arrify: 3.0.0
+      cp-file: 10.0.0
+      globby: 13.2.2
+      junk: 4.0.1
+      micromatch: 4.0.5
+      nested-error-stacks: 2.1.1
+      p-filter: 3.0.0
+      p-map: 6.0.0
     dev: true
 
   /create-require@1.1.1:
@@ -15446,6 +15486,11 @@ packages:
       object.values: 1.1.6
     dev: true
 
+  /junk@4.0.1:
+    resolution: {integrity: sha512-Qush0uP+G8ZScpGMZvHUiRfI0YBWuB3gVBYlI0v0vvOJt5FLicco+IkP0a50LqTTQhmts/m6tP5SWE+USyIvcQ==}
+    engines: {node: '>=12.20'}
+    dev: true
+
   /just-diff-apply@5.5.0:
     resolution: {integrity: sha512-OYTthRfSh55WOItVqwpefPtNt2VdKsq5AnAK6apdtR6yCH8pr0CmSr710J0Mf+WdQy7K/OzMy7K2MgAfdQURDw==}
     dev: true
@@ -16753,6 +16798,10 @@ packages:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
     dev: true
 
+  /nested-error-stacks@2.1.1:
+    resolution: {integrity: sha512-9iN1ka/9zmX1ZvLV9ewJYEk9h7RyRRtqdK0woXcqohu8EWIerfPUjYJPg0ULy0UqP7cslmdGc8xKDJcojlKiaw==}
+    dev: true
+
   /new-github-release-url@2.0.0:
     resolution: {integrity: sha512-NHDDGYudnvRutt/VhKFlX26IotXe1w0cmkDm6JGquh5bz/bDTw0LufSmH/GxTjEdpHEO+bVKFTwdrcGa/9XlKQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -17267,6 +17316,20 @@ packages:
   /os-tmpdir@1.0.2:
     resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
     engines: {node: '>=0.10.0'}
+
+  /p-event@5.0.1:
+    resolution: {integrity: sha512-dd589iCQ7m1L0bmC5NLlVYfy3TbBEsMUfWx9PyAgPeIcFZ/E2yaTZ4Rz4MiBmmJShviiftHVXOqfnfzJ6kyMrQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      p-timeout: 5.1.0
+    dev: true
+
+  /p-filter@3.0.0:
+    resolution: {integrity: sha512-QtoWLjXAW++uTX67HZQz1dbTpqBfiidsB6VtQUC9iR85S120+s0T5sO6s+B5MLzFcZkrEd/DGMmCjR+f2Qpxwg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      p-map: 5.5.0
+    dev: true
 
   /p-limit@1.3.0:
     resolution: {integrity: sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==}

--- a/studio/.gitignore
+++ b/studio/.gitignore
@@ -37,3 +37,7 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# monaco
+public/monaco-editor/min
+public/monaco-editor

--- a/studio/next.config.mjs
+++ b/studio/next.config.mjs
@@ -30,7 +30,7 @@ const cspHeader = `
   img-src 'self' ${isPreview ? 'https://vercel.live/ https://vercel.com *.pusher.com/ data: blob:' : ''};
   manifest-src 'self';
   media-src 'self';
-  worker-src 'none';
+  worker-src 'self';
 `
 
 /** @type {import("next").NextConfig} */

--- a/studio/package.json
+++ b/studio/package.json
@@ -11,12 +11,14 @@
   ],
   "scripts": {
     "dev": "cross-env FORCE_COLOR=1 next dev",
-    "build": "next build",
+    "build": "pnpm run copy-monaco && next build",
+    "copy-monaco": "rm -rf public/monaco-editor/min && mkdir -p public/monaco-editor/min && cp -r node_modules/monaco-editor/min/vs public/monaco-editor/min",
     "start": "next start",
     "lint": "next lint",
     "test": "vitest run --reporter=default --reporter=hanging-process",
     "lint:fix": "next lint --fix",
     "preinstall": "npx only-allow pnpm",
+    "postinstall": "pnpm run copy-monaco",
     "postversion": "name=\"$(node -p \"var a = require('./package.json');process.stdout.write(a.name);process.exit(0)\")\"; version=\"$(node -p \"var a = require('./package.json');process.stdout.write(a.version);process.exit(0)\")\"; gh workflow run image-release.yml -F name=$name -F workingDirectory=studio -F tag=$version -F dockerContext=."
   },
   "author": {
@@ -125,6 +127,7 @@
     "@types/react-dom": "18.2.6",
     "@vitejs/plugin-react": "^4.2.1",
     "autoprefixer": "10.4.14",
+    "cpy-cli": "^5.0.0",
     "cross-env": "^7.0.3",
     "eslint": "8.43.0",
     "eslint-config-next": "13.4.7",

--- a/studio/src/components/schema/sdl-viewer-monaco.tsx
+++ b/studio/src/components/schema/sdl-viewer-monaco.tsx
@@ -24,7 +24,7 @@ loader.config({
     // Load Monaco Editor from "public" directory
     vs: "/monaco-editor/min/vs",
     // Load Monaco Editor from different CDN
-    // vs: 'https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.43.0/min/vs',
+    // vs: 'https://cdn.jsdelivr.net/npm/monaco-editor@0.43.0/min/vs',
   },
 });
 

--- a/studio/src/components/schema/sdl-viewer-monaco.tsx
+++ b/studio/src/components/schema/sdl-viewer-monaco.tsx
@@ -1,5 +1,5 @@
 import { useResolvedTheme } from "@/hooks/use-resolved-theme";
-import Editor, { DiffEditor, useMonaco } from "@monaco-editor/react";
+import Editor, { DiffEditor, useMonaco, loader } from "@monaco-editor/react";
 import { useEffect, useState } from "react";
 import { schemaViewerDarkTheme } from "./monaco-dark-theme";
 import { Loader } from "@/components/ui/loader";
@@ -7,6 +7,26 @@ import babelPlugin from "prettier/plugins/babel";
 import estreePlugin from "prettier/plugins/estree";
 import graphQLPlugin from "prettier/plugins/graphql";
 import * as prettier from "prettier/standalone";
+
+/*
+ * In order to load the Monaco Editor locally and avoid fetching it from a CDN
+ * (the default CDN is https://cdn.jsdelivr.net), the monaco-editor bundle was
+ * copied into the "public" folder from node_modules, and we called the
+ * loader.config method below to reference it.
+ *
+ * This also avoid specifying the CDN origin in the CSP headers.
+ *
+ * We can also use this method to load the Monaco Editor from a different
+ * CDN like Cloudflare.
+ */
+loader.config({
+  paths: {
+    // Load Monaco Editor from "public" directory
+    vs: "/monaco-editor/min/vs",
+    // Load Monaco Editor from different CDN
+    // vs: 'https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.43.0/min/vs',
+  },
+});
 
 export interface DecorationCollection {
   range: {
@@ -159,7 +179,7 @@ export const SDLViewerMonaco = ({
             },
           });
 
-          const y = editor.getTopForLineNumber(line-5);
+          const y = editor.getTopForLineNumber(line - 5);
           editor.setScrollPosition({ scrollTop: y - 10 });
         }
         editor.createDecorationsCollection(decorations);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->

## Motivation and Context

This will avoid loading monaco from the CDN and therefore makes our CSP policy more strict.

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

## TODO

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
