### PR TITLE
fix: change 'scopes' keyword to 'scope'

### DIFF
--- a/router-tests/authentication_test.go
+++ b/router-tests/authentication_test.go
@@ -166,7 +166,7 @@ func TestAuthentication(t *testing.T) {
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			// Operations with a token should succeed
 			token, err := authServer.Token(map[string]any{
-				"scopes": "read:employee read:private",
+				"scope": "read:employee read:private",
 			})
 			require.NoError(t, err)
 			header := http.Header{
@@ -193,7 +193,7 @@ func TestAuthentication(t *testing.T) {
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			// Operations with an token should succeed
 			token, err := authServer.Token(map[string]any{
-				"scopes": "read:employee",
+				"scope": "read:employee",
 			})
 			require.NoError(t, err)
 			header := http.Header{
@@ -223,7 +223,7 @@ func TestAuthentication(t *testing.T) {
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			// Operations with a token should succeed
 			token, err := authServer.Token(map[string]any{
-				"scopes": "read:employee",
+				"scope": "read:employee",
 			})
 			require.NoError(t, err)
 			header := http.Header{
@@ -328,7 +328,7 @@ func TestAuthentication(t *testing.T) {
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			// Operations with a token should succeed
 			token, err := authServer.Token(map[string]any{
-				"scopes": "read:all",
+				"scope": "read:all",
 			})
 			require.NoError(t, err)
 			header := http.Header{
@@ -355,7 +355,7 @@ func TestAuthentication(t *testing.T) {
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			// Operations with a token should succeed
 			token, err := authServer.Token(map[string]any{
-				"scopes": "read:employee read:private read:all",
+				"scope": "read:employee read:private read:all",
 			})
 			require.NoError(t, err)
 			header := http.Header{
@@ -382,7 +382,7 @@ func TestAuthentication(t *testing.T) {
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			// Operations with a token should succeed
 			token, err := authServer.Token(map[string]any{
-				"scopes": "read:fact read:miscellaneous",
+				"scope": "read:fact read:miscellaneous",
 			})
 			require.NoError(t, err)
 			header := http.Header{
@@ -495,7 +495,7 @@ func TestAuthentication(t *testing.T) {
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			token, err := authServer.Token(map[string]any{
-				"scopes": "write:fact read:miscellaneous read:all",
+				"scope": "write:fact read:miscellaneous read:all",
 			})
 			require.NoError(t, err)
 			header := http.Header{
@@ -522,7 +522,7 @@ func TestAuthentication(t *testing.T) {
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			token, err := authServer.Token(map[string]any{
-				"scopes": "write:fact read:miscellaneous",
+				"scope": "write:fact read:miscellaneous",
 			})
 			require.NoError(t, err)
 			header := http.Header{
@@ -549,7 +549,7 @@ func TestAuthentication(t *testing.T) {
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			token, err := authServer.Token(map[string]any{
-				"scopes": "read:miscellaneous read:all",
+				"scope": "read:miscellaneous read:all",
 			})
 			require.NoError(t, err)
 			header := http.Header{
@@ -579,7 +579,7 @@ func TestAuthentication(t *testing.T) {
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			token, err := authServer.Token(map[string]any{
-				"scopes": "read:miscellaneous read:all",
+				"scope": "read:miscellaneous read:all",
 			})
 			require.NoError(t, err)
 			header := http.Header{

--- a/router/pkg/authentication/authentication.go
+++ b/router/pkg/authentication/authentication.go
@@ -56,7 +56,7 @@ func (a *authentication) Scopes() []string {
 	if a == nil {
 		return nil
 	}
-	scopes, ok := a.claims["scopes"].(string)
+	scopes, ok := a.claims["scope"].(string)
 	if !ok {
 		return nil
 	}


### PR DESCRIPTION
## Motivation and Context

A lot of details about this problem is outlined in #645 .  This relatively trivial change fixes what appears to be a typo: the `scopes` keyword gleaned from the JWT token payload should be `scope` according to [RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693#name-scope-scopes-claim).

Closes #645

## TODO

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
