### PR TITLE
fix: remove connect-src CSP policy

### DIFF
--- a/studio/next.config.mjs
+++ b/studio/next.config.mjs
@@ -41,6 +41,8 @@ const lightweightCspHeader = `
 
 /**
  * We can't enforce connect directives yet because the studio can connect to any public router.
+ * @TODO We need to find a way to enforce this without breaking the studio. A possible solution could be to
+ * proxy all requests through an intermediate server to enforce same domain policy.
  */
 const fullCspHeader = `
   default-src 'self' ${process.env.NEXT_PUBLIC_COSMO_STUDIO_URL} ${

--- a/studio/next.config.mjs
+++ b/studio/next.config.mjs
@@ -39,6 +39,9 @@ const lightweightCspHeader = `
   worker-src 'self';
 `;
 
+/**
+ * We can't enforce connect directives yet because the studio can connect to any public router.
+ */
 const fullCspHeader = `
   default-src 'self' ${process.env.NEXT_PUBLIC_COSMO_STUDIO_URL} ${
     process.env.NEXT_PUBLIC_COSMO_CP_URL
@@ -69,23 +72,10 @@ const config = {
             key: debugCSP
                 ? "Content-Security-Policy-Report-Only"
                 : "Content-Security-Policy",
-            value: fullCspHeader.replace(/\n/g, ""),
-          },
-        ],
-      },
-      {
-        // Allow the playground to make requests to the public router that can be hosted on a different domain
-        source: "/(.*)/playground",
-        headers: [
-          {
-            key: debugCSP
-              ? "Content-Security-Policy-Report-Only"
-              : "Content-Security-Policy",
             value: lightweightCspHeader.replace(/\n/g, ""),
           },
         ],
-      },
-
+      }
     ];
   },
 };


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->

## Motivation and Context

We need to find a way to enforce this without breaking the studio. A possible solution could be to proxy all requests through an intermediate server to enforce same domain policy. Setting the CSP header by reading the graphql url could be another way but requires a custom middleware. The proxy approach is easier.

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

## TODO

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
