### PR TITLE
Feat : Allow to rename client headers on propagate to subgraphs

### DIFF
--- a/router/core/header_rule_engine.go
+++ b/router/core/header_rule_engine.go
@@ -2,9 +2,10 @@ package core
 
 import (
 	"fmt"
-	"github.com/wundergraph/cosmo/router/pkg/config"
 	"net/http"
 	"regexp"
+
+	"github.com/wundergraph/cosmo/router/pkg/config"
 
 	nodev1 "github.com/wundergraph/cosmo/router/gen/proto/wg/cosmo/node/v1"
 )
@@ -76,6 +77,17 @@ func (h HeaderRuleEngine) OnOriginRequest(request *http.Request, ctx RequestCont
 	for _, rule := range requestRules {
 		// Forwards the matching client request header to the upstream
 		if rule.Operation == config.HeaderRuleOperationPropagate {
+
+			// Rename the header
+			if rule.Rename != "" {
+				value := ctx.Request().Header.Get(rule.Named)
+				if value != "" {
+					request.Header.Set(rule.Rename, ctx.Request().Header.Get(rule.Named))
+				} else if rule.Default != "" {
+					request.Header.Set(rule.Rename, rule.Default)
+				}
+				continue
+			}
 
 			// Exact match
 			if rule.Named != "" {

--- a/router/pkg/config/config.go
+++ b/router/pkg/config/config.go
@@ -159,6 +159,8 @@ type RequestHeaderRule struct {
 	Matching string `yaml:"matching"`
 	// Named is the exact header name to match
 	Named string `yaml:"named"`
+	// Rename renames the header's key to the provided value
+	Rename string `yaml:"rename,omitempty"`
 	// Default is the default value to set if the header is not present
 	Default string `yaml:"default"`
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->
## WIP
I Added a new field called "rename" to the config and added logic to rename the header only if the rename field is not an empty string.

I need your feedback on the solution I have provided.



## Motivation and Context

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

## TODO

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
