### PR TITLE
fix: create individual metrics per error code

### DIFF
--- a/router-tests/prometheus_test.go
+++ b/router-tests/prometheus_test.go
@@ -503,9 +503,10 @@ func TestPrometheus(t *testing.T) {
 			responseContentLength := findMetricByName(mf, "router_http_requests_error_total")
 			responseContentLengthMetrics := responseContentLength.GetMetric()
 
-			require.Len(t, responseContentLengthMetrics, 2)
+			require.Len(t, responseContentLengthMetrics, 3)
 			require.Len(t, responseContentLengthMetrics[0].Label, 12)
 			require.Len(t, responseContentLengthMetrics[1].Label, 16)
+			require.Len(t, responseContentLengthMetrics[2].Label, 16)
 
 			// Error metric for the subgraph error
 			require.Equal(t, []*io_prometheus_client.LabelPair{
@@ -563,7 +564,7 @@ func TestPrometheus(t *testing.T) {
 				},
 				{
 					Name:  PointerOf("wg_subgraph_error_extended_code"),
-					Value: PointerOf("UNAUTHORIZED,YOUR_ERROR_CODE"),
+					Value: PointerOf("UNAUTHORIZED"),
 				},
 				{
 					Name:  PointerOf("wg_subgraph_id"),
@@ -574,6 +575,74 @@ func TestPrometheus(t *testing.T) {
 					Value: PointerOf("products"),
 				},
 			}, responseContentLengthMetrics[1].Label)
+
+			// Error metric for the subgraph error
+			require.Equal(t, []*io_prometheus_client.LabelPair{
+				{
+					Name:  PointerOf("http_status_code"),
+					Value: PointerOf("403"),
+				},
+				{
+					Name:  PointerOf("otel_scope_name"),
+					Value: PointerOf("cosmo.router.prometheus"),
+				},
+				{
+					Name:  PointerOf("otel_scope_version"),
+					Value: PointerOf("0.0.1"),
+				},
+				{
+					Name:  PointerOf("wg_client_name"),
+					Value: PointerOf("unknown"),
+				},
+				{
+					Name:  PointerOf("wg_client_version"),
+					Value: PointerOf("missing"),
+				},
+				{
+					Name:  PointerOf("wg_component_name"),
+					Value: PointerOf("engine-loader"),
+				},
+				{
+					Name:  PointerOf("wg_federated_graph_id"),
+					Value: PointerOf("graph"),
+				},
+				{
+					Name:  PointerOf("wg_operation_name"),
+					Value: PointerOf("myQuery"),
+				},
+				{
+					Name:  PointerOf("wg_operation_protocol"),
+					Value: PointerOf("http"),
+				},
+				{
+					Name:  PointerOf("wg_operation_type"),
+					Value: PointerOf("query"),
+				},
+				{
+					Name:  PointerOf("wg_router_cluster_name"),
+					Value: PointerOf(""),
+				},
+				{
+					Name:  PointerOf("wg_router_config_version"),
+					Value: PointerOf(""),
+				},
+				{
+					Name:  PointerOf("wg_router_version"),
+					Value: PointerOf("dev"),
+				},
+				{
+					Name:  PointerOf("wg_subgraph_error_extended_code"),
+					Value: PointerOf("YOUR_ERROR_CODE"),
+				},
+				{
+					Name:  PointerOf("wg_subgraph_id"),
+					Value: PointerOf("3"),
+				},
+				{
+					Name:  PointerOf("wg_subgraph_name"),
+					Value: PointerOf("products"),
+				},
+			}, responseContentLengthMetrics[2].Label)
 		})
 	})
 }

--- a/router/core/engine_loader_hooks.go
+++ b/router/core/engine_loader_hooks.go
@@ -136,10 +136,19 @@ func (f *EngineLoaderHooks) OnFinished(ctx context.Context, statusCode int, data
 		slices.Sort(errorCodesAttr)
 
 		if len(errorCodesAttr) > 0 {
+
+			// Create individual metrics for each error code
+			for _, code := range errorCodesAttr {
+				f.metricStore.MeasureRequestError(ctx,
+					// Add only the error code as an attribute
+					append(baseAttributes, rotel.WgSubgraphErrorExtendedCode.String(code))...,
+				)
+			}
+
+			// Add this after the metrics have been created
+			// The list might be used for post-processing
 			baseAttributes = append(baseAttributes, rotel.WgSubgraphErrorExtendedCode.String(strings.Join(errorCodesAttr, ",")))
 		}
-
-		f.metricStore.MeasureRequestError(ctx, baseAttributes...)
 	}
 
 	span.SetAttributes(baseAttributes...)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->

## Motivation and Context

Create a new metric per error code. This will also be exported correctly in prometheus.

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

## TODO

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
