### PR TITLE
fix: url overflow in federated graph card

### DIFF
--- a/studio/src/components/federatedgraphs-cards.tsx
+++ b/studio/src/components/federatedgraphs-cards.tsx
@@ -597,16 +597,22 @@ const GraphCard = ({ graph }: { graph: FederatedGraph }) => {
 
         <div className="mt-3 flex flex-1 flex-col items-start px-6">
           <div className="text-base font-semibold">{graph.name}</div>
-          <p
-            className={cn(
-              "mb-5 truncate pt-1 text-xs text-gray-500 dark:text-gray-400",
-              {
-                italic: !graph.routingURL,
-              },
-            )}
-          >
-            {parsedURL()}
-          </p>
+          <Tooltip delayDuration={100}>
+            <TooltipTrigger asChild>
+              <p
+                className={cn(
+                  "mb-5 w-full truncate pt-1 text-xs text-gray-500 dark:text-gray-400",
+                  {
+                    italic: !graph.routingURL,
+                  },
+                )}
+              >
+                {parsedURL()}
+              </p>
+            </TooltipTrigger>
+            <TooltipContent>{parsedURL()}</TooltipContent>
+          </Tooltip>
+
           <div className="mb-3 flex flex-wrap items-center gap-x-5">
             <div className="flex items-center gap-x-2">
               {graph.supportsFederation ? (


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->

## Motivation and Context

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

Lengthy urls were not being truncated.

## TODO

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [x] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
