### PR TITLE
feat: enable raw introspection for subgraphs

### DIFF
--- a/cli/src/commands/subgraph/commands/introspect.ts
+++ b/cli/src/commands/subgraph/commands/introspect.ts
@@ -19,7 +19,7 @@ export default (opts: BaseCommandOptions) => {
     'The headers to apply when the subgraph is introspected. This is used for authentication and authorization.The headers are passed in the format <key>=<value> <key>=<value>.Use quotes if there exists space in the key/value.',
   );
   command.option('-o, --out [string]', 'Destination file for the SDL.');
-  command.option('--use-raw-introspection', 'This will use the ');
+  command.option('--use-raw-introspection', 'This will use the standard introspection query.');
   command.action(async (options) => {
     const resp = await introspectSubgraph({
       subgraphURL: options.routingUrl,

--- a/cli/src/commands/subgraph/commands/introspect.ts
+++ b/cli/src/commands/subgraph/commands/introspect.ts
@@ -19,6 +19,7 @@ export default (opts: BaseCommandOptions) => {
     'The headers to apply when the subgraph is introspected. This is used for authentication and authorization.The headers are passed in the format <key>=<value> <key>=<value>.Use quotes if there exists space in the key/value.',
   );
   command.option('-o, --out [string]', 'Destination file for the SDL.');
+  command.option('--use-raw-introspection', 'This will use the ');
   command.action(async (options) => {
     const resp = await introspectSubgraph({
       subgraphURL: options.routingUrl,
@@ -30,6 +31,7 @@ export default (opts: BaseCommandOptions) => {
             value,
           };
         }) || [],
+      rawIntrospection: options.useRawIntrospection,
     });
 
     if (resp.success !== true) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->

## Motivation and Context

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

Allow to introspect subgraphs using standard introspection query.

## TODO

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [x] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
