### PR TITLE
Feature/edfs subject validation

### DIFF
--- a/composition/src/errors/errors.ts
+++ b/composition/src/errors/errors.ts
@@ -1169,8 +1169,6 @@ export const invalidEventSubjectTemplateErrorMessage = `The "subject" argument m
 
 export const invalidEventSubjectCharactersErrorMessage = `The "subject" contains invalide characters for subject names.`;
 
-export const invalidFieldDefinitionsNumberErrorMessage = `The "Field definitions" argument must be used with "subject" arguments.`;
-
 export const invalidFieldDefinitionNoArgumentTemplateErrorMessage = `The "Field definition" is defined and should be used in an argument template.`;
 
 export const invalidEventSubjectsItemErrorMessage =

--- a/composition/src/errors/errors.ts
+++ b/composition/src/errors/errors.ts
@@ -1153,7 +1153,15 @@ export function selfImplementationError(typeName: string): Error {
 
 export const invalidEventSubjectErrorMessage = `The "subject" argument must be string with a minimum length of one.`;
 
+export const invalidEventSubjectTemplatePrefixErrorMessage = `The "subject" argument must start with the "args." prefix.`;
+
+export const invalidEventSubjectTemplateArgsLevelErrorMessage = `The "subject" argument must have single level.`;
+
 export const invalidEventSubjectsErrorMessage = `The "subjects" argument must be a list of strings.`;
+
+export const invalidEventSubjectTemplateErrorMessage = `The "subject" argument must be a string or a list of strings.`;
+
+export const invalidEventSubjectCharactersErrorMessage = `The "subject" argument contains invalide characters for subject names.`;
 
 export const invalidEventSubjectsItemErrorMessage =
   `Each item in the "subjects" argument list must be a string with a minimum length of one.` +

--- a/composition/src/errors/errors.ts
+++ b/composition/src/errors/errors.ts
@@ -1161,7 +1161,7 @@ export const invalidEventSubjectsErrorMessage = `The "subjects" argument must be
 
 export const invalidEventSubjectTemplateErrorMessage = `The "subject" argument must be a string or a list of strings.`;
 
-export const invalidEventSubjectCharactersErrorMessage = `The "subject" argument contains invalide characters for subject names.`;
+export const invalidEventSubjectCharactersErrorMessage = `The "subject" contains invalide characters for subject names.`;
 
 export const invalidEventSubjectsItemErrorMessage =
   `Each item in the "subjects" argument list must be a string with a minimum length of one.` +

--- a/composition/src/errors/errors.ts
+++ b/composition/src/errors/errors.ts
@@ -1157,11 +1157,21 @@ export const invalidEventSubjectTemplatePrefixErrorMessage = `The "subject" argu
 
 export const invalidEventSubjectTemplateArgsLevelErrorMessage = `The "subject" argument must have single level.`;
 
+export const invalidEventSubjectTemplateArgsNameNotMatchToFieldArgumentErrorMessage = `The "subject" argument names, e.g., the employeeID of args.employeeID should exist as a field argument; i.e., employeeUpdated(employeeID: ID!).`;
+
+export const invalidFieldDefinitionIsEmptyErrorMessage = 'The "Field definition" arguments are empty.';
+
+export const invalidFieldDefinitionIsNullErrorMessage = `The "Field definition" can't be null.`;
+
 export const invalidEventSubjectsErrorMessage = `The "subjects" argument must be a list of strings.`;
 
 export const invalidEventSubjectTemplateErrorMessage = `The "subject" argument must be a string or a list of strings.`;
 
 export const invalidEventSubjectCharactersErrorMessage = `The "subject" contains invalide characters for subject names.`;
+
+export const invalidFieldDefinitionsNumberErrorMessage = `The "Field definitions" argument must be used with "subject" arguments.`;
+
+export const invalidFieldDefinitionNoArgumentTemplateErrorMessage = `The "Field definition" is defined and should be used in an argument template.`;
 
 export const invalidEventSubjectsItemErrorMessage =
   `Each item in the "subjects" argument list must be a string with a minimum length of one.` +

--- a/composition/src/normalization/normalization-factory.ts
+++ b/composition/src/normalization/normalization-factory.ts
@@ -115,7 +115,6 @@ import {
   invalidFieldDefinitionIsEmptyErrorMessage,
   invalidFieldDefinitionIsNullErrorMessage,
   invalidFieldDefinitionNoArgumentTemplateErrorMessage,
-  invalidFieldDefinitionsNumberErrorMessage,
   noBaseTypeExtensionError,
   noFieldDefinitionsError,
   nonEntityObjectExtensionsEventDrivenErrorMessage,
@@ -310,7 +309,7 @@ export function validateEventSubscribetionSubjects(fieldDefinition: FieldDefinit
   if (fieldDefinition.arguments?.length !== undefined && argsNames.length > 0) {
     for(const argument of fieldDefinition.arguments) {
       if (argsNames.indexOf(argument.name.value) === -1) {
-        errorMessages.push(invalidFieldDefinitionsNumberErrorMessage);
+        errorMessages.push(invalidFieldDefinitionNoArgumentTemplateErrorMessage);
 
         return false;
       };

--- a/composition/src/normalization/normalization-factory.ts
+++ b/composition/src/normalization/normalization-factory.ts
@@ -114,6 +114,7 @@ import {
   invalidEventSubjectTemplateArgsNameNotMatchToFieldArgumentErrorMessage,
   invalidFieldDefinitionIsEmptyErrorMessage,
   invalidFieldDefinitionIsNullErrorMessage,
+  invalidFieldDefinitionNoArgumentTemplateErrorMessage,
   invalidFieldDefinitionsNumberErrorMessage,
   noBaseTypeExtensionError,
   noFieldDefinitionsError,

--- a/composition/src/normalization/normalization-factory.ts
+++ b/composition/src/normalization/normalization-factory.ts
@@ -284,13 +284,13 @@ export function validateEventSubscribetionSubjects(fieldDefinition: FieldDefinit
   const argsNames: Array<string> = [];
 
   for (const value of argumentNodeValue.values) {
-    const val = value.value;
-
-    if (value.kind !== Kind.STRING || val.length < 1) {
+    if (value.kind !== Kind.STRING || value.value.length < 1) {
       errorMessages.push(invalidEventSubjectsItemErrorMessage);
 
       return false;
     }
+
+    const val = value.value;
 
     const regex = /^[a-zA-Z0-9.*>\{\}\s]+$/;
     if (!regex.test(value.value)) {
@@ -307,7 +307,7 @@ export function validateEventSubscribetionSubjects(fieldDefinition: FieldDefinit
   }
 
   if (fieldDefinition.arguments?.length !== undefined && argsNames.length > 0) {
-    for(const argument of fieldDefinition.arguments) {
+    for (const argument of fieldDefinition.arguments) {
       if (argsNames.indexOf(argument.name.value) === -1) {
         errorMessages.push(invalidFieldDefinitionNoArgumentTemplateErrorMessage);
 
@@ -380,10 +380,6 @@ export function getSubjectArgsFieldName(value: string): string {
   }
 
   return res[0].replace(/{{(\s+)?args\./g, '').replace(/(\s+)?}}/g, '');
-}
-
-function validateSubjectStatic(fieldDefinition: FieldDefinitionNode, value: string, errorMessages: string[]): boolean {
-  return true;
 }
 
 export class NormalizationFactory {

--- a/composition/src/normalization/normalization-factory.ts
+++ b/composition/src/normalization/normalization-factory.ts
@@ -291,14 +291,6 @@ export function validateEventSubscribetionSubjects(fieldDefinition: FieldDefinit
     }
 
     const val = value.value;
-
-    const regex = /^[a-zA-Z0-9.*>\{\}\s]+$/;
-    if (!regex.test(value.value)) {
-      errorMessages.push(invalidEventSubjectCharactersErrorMessage);
-
-      return false;
-    }
-
     if (val.includes('{{')) {
       if (!validateSubjectTemplate(fieldDefinition, val, argsNames, errorMessages)) {
         return false;
@@ -326,14 +318,20 @@ export function validateEventSubscribetionSubjects(fieldDefinition: FieldDefinit
 }
 
 function validateSubjectTemplate(fieldDefinition: FieldDefinitionNode, value: string, argsSet: Array<string>, errorMessages: string[]): boolean {
-  if (value.match(/{{(\s+)?args\./g)?.length === undefined) {
+  if (value.match(/{{(\s+)?args\./)?.length === undefined) {
     errorMessages.push(invalidEventSubjectTemplatePrefixErrorMessage);
 
     return false;
   }
 
-  if (value.match(/{{(\s+)?args\.\w+\./g)?.length !== undefined) {
+  if (value.match(/{{(\s+)?args\.\w+\./)?.length !== undefined) {
     errorMessages.push(invalidEventSubjectTemplateArgsLevelErrorMessage);
+
+    return false;
+  }
+
+  if (value.match(/{{(\s+)?args.([a-zA-Z0-9_]+)(\s+)?}}/)?.length === undefined) {
+    errorMessages.push(invalidEventSubjectCharactersErrorMessage);
 
     return false;
   }

--- a/composition/tests/events.test.ts
+++ b/composition/tests/events.test.ts
@@ -549,6 +549,75 @@ describe('events Configuration tests', () => {
       }
     });
 
+    test(`should error field argument can't be defined without argument templetes`, () => {
+      const errors: string[] | undefined = [];
+      const values: ConstListValueNode[] = [{
+        kind: Kind.LIST,
+        values: [
+          {
+            kind: Kind.STRING,
+            value: "entities.me",
+          },
+          {
+            kind: Kind.STRING,
+            value: "entities.*",
+          },
+          {
+            kind: Kind.STRING,
+            value: "entities.>",
+          },
+        ],
+      }];
+
+      const fieldDefinitionNode: FieldDefinitionNode = {
+        name: {
+          value: 'edfs__subscribe',
+          kind: Kind.NAME,
+        },
+        type: {} as NonNullTypeNode,
+        kind: Kind.FIELD_DEFINITION,
+        arguments: [
+          {
+            name: {
+              value: "id",
+              kind: Kind.NAME,
+            },
+            kind: Kind.INPUT_VALUE_DEFINITION,
+            type: {
+              kind: Kind.NON_NULL_TYPE,
+              type: {} as any, // Replace with the actual type definition
+            },
+          },
+          {
+            name: {
+              value: "employeeID",
+              kind: Kind.NAME,
+            },
+            kind: Kind.INPUT_VALUE_DEFINITION,
+            type: {
+              kind: Kind.NON_NULL_TYPE,
+              type: {} as any, // Replace with the actual type definition
+            },
+          },
+        ],
+      };
+
+      for (const value of values) {
+        const errors: string[] | undefined = [];
+        const res = validateEventSubscribetionSubjects(fieldDefinitionNode, value, errors)
+
+        expect(res).toBeDefined();
+        expect(res).toBeFalsy();
+
+        expect(errors).toBeDefined();
+        expect(errors).toHaveLength(1);
+
+        expect(errors![0]).toStrictEqual(
+          invalidFieldDefinitionNoArgumentTemplateErrorMessage,
+        );
+      }
+    });
+
     test(`should error argument template doesn't have field argument`, () => {
       const errors: string[] | undefined = [];
       const values: ConstListValueNode[] = [{
@@ -617,7 +686,7 @@ describe('events Configuration tests', () => {
         expect(errors).toHaveLength(1);
 
         expect(errors![0]).toStrictEqual(
-          invalidFieldDefinitionsNumberErrorMessage,
+          invalidFieldDefinitionNoArgumentTemplateErrorMessage,
         );
       }
     });

--- a/composition/tests/events.test.ts
+++ b/composition/tests/events.test.ts
@@ -29,12 +29,14 @@ import {
   undefinedStreamConfigurationInputErrorMessage,
   unexpectedDirectiveArgumentErrorMessage,
   validateEventSubscribetionSubject,
+  getSubjectArgsFieldName,
 } from '../src';
 import {
   parse,
-  ConstValueNode,
   StringValueNode,
   Kind,
+  FieldDefinitionNode,
+  NonNullTypeNode,
 } from 'graphql';
 import {
   DEFAULT,
@@ -392,7 +394,19 @@ describe('events Configuration tests', () => {
   });
 
   describe('EDFS subject validation tests', () => {
+    test('successfully getSubjectArgsFieldName', () => {
+      const values = new Map<string, string>([
+        ["entities.{{ args.id }}", "id"],
+        ["entities.{{ args.employeeID }}", "employeeID"],
+      ]);
+
+      for (const value of values) {
+        expect(getSubjectArgsFieldName(value[0])).toEqual(value[1]);
+      }
+    });
+
     test('valid subject names', () => {
+      const errors: string[] | undefined = [];
       const values: StringValueNode[] = [
         {
           kind: Kind.STRING,
@@ -416,9 +430,42 @@ describe('events Configuration tests', () => {
         },
       ];
 
+      const fieldDefinitionNode: FieldDefinitionNode = {
+        name: {
+          value: 'edfs__subscribe',
+          kind: Kind.NAME,
+        },
+        type: {}  as NonNullTypeNode,
+        kind: Kind.FIELD_DEFINITION,
+        arguments: [
+          {
+            name: {
+              value: "id",
+              kind: Kind.NAME,
+            },
+            kind: Kind.INPUT_VALUE_DEFINITION,
+            type: {
+              kind: Kind.NON_NULL_TYPE,
+              type: {} as any, // Replace with the actual type definition
+            },
+          },
+          {
+            name: {
+              value: "employeeID",
+              kind: Kind.NAME,
+            },
+            kind: Kind.INPUT_VALUE_DEFINITION,
+            type: {
+              kind: Kind.NON_NULL_TYPE,
+              type: {} as any, // Replace with the actual type definition
+            },
+          },
+        ],
+      };
+
       for (const value of values) {
         const errors: string[] | undefined = [];
-        const res = validateEventSubscribetionSubject(value, errors)
+        const res = validateEventSubscribetionSubject(fieldDefinitionNode, value, errors)
 
         expect(res).toBeDefined();
         expect(res).toBeTruthy();
@@ -444,9 +491,11 @@ describe('events Configuration tests', () => {
         }
       ];
 
+      const fieldDefinitionNode  = {} as FieldDefinitionNode;
+
       for (const value of values) {
         const errors: string[] | undefined = [];
-        const res = validateEventSubscribetionSubject(value, errors)
+        const res = validateEventSubscribetionSubject(fieldDefinitionNode, value, errors)
 
         expect(res).toBeDefined();
         expect(res).toBeFalsy();
@@ -490,9 +539,11 @@ describe('events Configuration tests', () => {
         }
       ];
 
+      const fieldDefinitionNode  = {} as FieldDefinitionNode;
+
       for (const value of values) {
         const errors: string[] | undefined = [];
-        const res = validateEventSubscribetionSubject(value, errors)
+        const res = validateEventSubscribetionSubject(fieldDefinitionNode, value, errors)
 
         expect(res).toBeDefined();
         expect(res).toBeFalsy();

--- a/composition/tests/events.test.ts
+++ b/composition/tests/events.test.ts
@@ -18,6 +18,7 @@ import {
   invalidEventSubjectTemplatePrefixErrorMessage,
   invalidEventSubjectTemplateArgsLevelErrorMessage,
   invalidEventSubjectCharactersErrorMessage,
+  invalidFieldDefinitionNoArgumentTemplateErrorMessage,
   nonEntityObjectExtensionsEventDrivenErrorMessage,
   nonExternalKeyFieldNamesEventDrivenErrorMessage,
   nonKeyFieldNamesEventDrivenErrorMessage,
@@ -28,7 +29,7 @@ import {
   undefinedRequiredArgumentsErrorMessage,
   undefinedStreamConfigurationInputErrorMessage,
   unexpectedDirectiveArgumentErrorMessage,
-  validateEventSubscribetionSubject,
+  validateEventSubscribetionSubjects,
   getSubjectArgsFieldName,
 } from '../src';
 import {
@@ -293,6 +294,7 @@ describe('events Configuration tests', () => {
       expect(errors![0]).toStrictEqual(
         invalidEventDirectiveError(directiveName, rootFieldPath, [
           invalidEventSubjectsItemErrorMessage,
+          invalidFieldDefinitionNoArgumentTemplateErrorMessage,
           invalidEventSourceNameErrorMessage,
         ]),
       );
@@ -465,7 +467,7 @@ describe('events Configuration tests', () => {
 
       for (const value of values) {
         const errors: string[] | undefined = [];
-        const res = validateEventSubscribetionSubject(fieldDefinitionNode, value, errors)
+        const res = validateEventSubscribetionSubjects(fieldDefinitionNode, value, errors)
 
         expect(res).toBeDefined();
         expect(res).toBeTruthy();
@@ -495,7 +497,7 @@ describe('events Configuration tests', () => {
 
       for (const value of values) {
         const errors: string[] | undefined = [];
-        const res = validateEventSubscribetionSubject(fieldDefinitionNode, value, errors)
+        const res = validateEventSubscribetionSubjects(fieldDefinitionNode, value, errors)
 
         expect(res).toBeDefined();
         expect(res).toBeFalsy();
@@ -543,7 +545,7 @@ describe('events Configuration tests', () => {
 
       for (const value of values) {
         const errors: string[] | undefined = [];
-        const res = validateEventSubscribetionSubject(fieldDefinitionNode, value, errors)
+        const res = validateEventSubscribetionSubjects(fieldDefinitionNode, value, errors)
 
         expect(res).toBeDefined();
         expect(res).toBeFalsy();

--- a/composition/tests/events.test.ts
+++ b/composition/tests/events.test.ts
@@ -705,7 +705,7 @@ describe('events Configuration tests', () => {
           },
           {
             kind: Kind.STRING,
-            value: "entities_test.{{ args.id }}",
+            value: "entities.{{ args.id& }}",
           },
         ],
       }];
@@ -1537,7 +1537,7 @@ const invalidSubgraphSubjectCharacters: Subgraph = {
   url: '',
   definitions: parse(`
       type Subscription {
-        employeeUpdated(employeeID: ID!): Employee! @edfs__subscribe(subjects: ["entitiesо.{{ args.employeeID }}"],
+        employeeUpdated(employeeID: ID!): Employee! @edfs__subscribe(subjects: ["entitiesо.{{ args.employee$ID }}"],
         streamConfiguration: { consumerName: "consumer", streamName: "streamName", }
         )
       }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->

## Motivation and Context

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

EDFS Subject validation

1 Template {{ args.id }} validations
2 Static subject separate.with.dots.lowercase validations
3 Nats [wildcard](https://docs.nats.io/reference/faq#does-nats-support-subject-wildcards) entities.* and entities.> validations

## TODO

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
