### PR TITLE
chore: persist @inaccessible fields in the federated schema

### DIFF
--- a/composition/src/schema-building/utils.ts
+++ b/composition/src/schema-building/utils.ts
@@ -1403,6 +1403,10 @@ function extractPersistedDirectives(
       persistedDirectivesData.directives.set(directiveName, directiveNodes);
       continue;
     }
+    // Only add one instance of the @inaccessible directive
+    if (directiveName === INACCESSIBLE) {
+      continue;
+    }
     existingDirectives.push(...directiveNodes);
   }
   return persistedDirectivesData;

--- a/composition/tests/inaccessible.test.ts
+++ b/composition/tests/inaccessible.test.ts
@@ -19,7 +19,7 @@ import {
 } from './utils/utils';
 
 describe('@inaccessible tests', () => {
-  test('that inaccessible fields are not included in the federated graph', () => {
+  test('that inaccessible fields are persisted in the federated graph', () => {
     const { errors, federationResult } = federateSubgraphs([subgraphA, subgraphB]);
     expect(errors).toBeUndefined();
     expect(schemaToSortedNormalizedString(federationResult!.federatedGraphSchema)).toBe(
@@ -29,6 +29,7 @@ describe('@inaccessible tests', () => {
       type Entity {
         age: Int!
         id: ID!
+        name: String! @inaccessible
       }
       
       type Query {
@@ -74,10 +75,12 @@ describe('@inaccessible tests', () => {
           `
       type Entity implements Interface {
         id: ID!
+        name: String! @inaccessible
       }
       
       interface Interface {
         id: ID!
+        name: String! @inaccessible
       }
       
       type Query {
@@ -105,6 +108,7 @@ describe('@inaccessible tests', () => {
       
       interface Interface {
         id: ID!
+        name: String @inaccessible
       }
       
       type Query {
@@ -175,7 +179,7 @@ describe('@inaccessible tests', () => {
     expect(errors![0]).toStrictEqual(allFieldDefinitionsAreInaccessibleError('interface', 'Interface'));
   });
 
-  test('that an error is returned if all fields defined on an extended interface are declared', () => {
+  test('that an error is returned if all fields defined on an extended interface are declared @inaccessible', () => {
     const { errors } = federateSubgraphs([subgraphA, subgraphL]);
     expect(errors).toBeDefined();
     expect(errors![0]).toStrictEqual(allFieldDefinitionsAreInaccessibleError('interface', 'Interface'));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->

## Motivation and Context

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

## TODO

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
