### PR TITLE
feat: add istioGateway and VirtualService to router helm chart

### DIFF
--- a/helm/cosmo/charts/router/README.md
+++ b/helm/cosmo/charts/router/README.md
@@ -40,12 +40,14 @@ This is the official Helm Chart for the WunderGraph Cosmo Router.
 | imagePullSecrets | list | `[]` |  |
 | ingress.hosts | string | `nil` |  |
 | ingress.tls | list | `[]` |  |
-| istioGateway | object | `{"annotations":{},"hosts":[],"selector":{}}` | Requires Istio v1.5 or greater |
+| istioGateway | object | `{"annotations":{},"enabled":false,"hosts":[],"selector":{}}` | Requires Istio v1.5 or greater |
 | istioGateway.annotations | object | `{}` | Annotations for the Gateway |
+| istioGateway.enabled | bool | `false` | enable the istioGateway - often used in conjunction with istioVirtualService to expose services via an istio gateway deployment |
 | istioGateway.hosts | list | `[]` | List of hosts that the gateway can serve |
 | istioGateway.selector | object | `{}` | Selectors for the Gateway deployment |
-| istioVirtualService | object | `{"annotations":{}}` | Requires Istio v1.5 or greater |
+| istioVirtualService | object | `{"annotations":{},"enabled":false}` | Requires Istio v1.5 or greater |
 | istioVirtualService.annotations | object | `{}` | Annotations for the VirtualService |
+| istioVirtualService.enabled | bool | `false` | enable an Istio VirtualService |
 | nameOverride | string | `""` | String to partially override common.names.fullname template (will maintain the release name) |
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |

--- a/helm/cosmo/charts/router/README.md
+++ b/helm/cosmo/charts/router/README.md
@@ -40,6 +40,12 @@ This is the official Helm Chart for the WunderGraph Cosmo Router.
 | imagePullSecrets | list | `[]` |  |
 | ingress.hosts | string | `nil` |  |
 | ingress.tls | list | `[]` |  |
+| istioGateway | object | `{"annotations":{},"hosts":[],"selector":{}}` | Requires Istio v1.5 or greater |
+| istioGateway.annotations | object | `{}` | Annotations for the Gateway |
+| istioGateway.hosts | list | `[]` | List of hosts that the gateway can serve |
+| istioGateway.selector | object | `{}` | Selectors for the Gateway deployment |
+| istioVirtualService | object | `{"annotations":{}}` | Requires Istio v1.5 or greater |
+| istioVirtualService.annotations | object | `{}` | Annotations for the VirtualService |
 | nameOverride | string | `""` | String to partially override common.names.fullname template (will maintain the release name) |
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |

--- a/helm/cosmo/charts/router/templates/gateway.yaml
+++ b/helm/cosmo/charts/router/templates/gateway.yaml
@@ -1,0 +1,64 @@
+{{- if .Values.istioGateway -}}
+{{- if .Values.istioGateway.enabled -}}
+{{- $fullName := include "router.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: networking.istio.io/v1beta1
+kind: Gateway
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "router.labels" . | nindent 4 }}
+  {{- with .Values.istioGateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    app: {{ .Values.istioGateway.gatewayName }}
+  servers:
+  {{- range .Values.istioGateway.hosts }}
+  - hosts:
+    - {{ .host | quote }}
+    port:
+      name: http
+      number: 80
+      protocol: HTTP
+    tls:
+      httpsRedirect: true
+  - hosts:
+    - {{ .host | quote }}
+    port:
+      name: https
+      number: 443
+      protocol: HTTPS
+    tls:
+      credentialName: {{ .credentialName }}
+      mode: SIMPLE
+  {{- end}}
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "router.labels" . | nindent 4 }}
+  {{- with .Values.istioGateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  gateways:
+  - {{ $fullName }}
+  hosts:
+  - '*'
+  http:
+  - match:
+    - uri:
+        prefix: /
+    route:
+    - destination:
+        host: {{ $fullName }}
+        port:
+          number: {{ $svcPort }}
+{{- end }}
+{{- end }}

--- a/helm/cosmo/charts/router/templates/istio-gateway.yaml
+++ b/helm/cosmo/charts/router/templates/istio-gateway.yaml
@@ -13,8 +13,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  selector:
-    app: {{ .Values.istioGateway.gatewayName }}
+  selector: {{ .Values.istioGateway.selector }}
   servers:
   {{- range .Values.istioGateway.hosts }}
   - hosts:
@@ -35,30 +34,5 @@ spec:
       credentialName: {{ .credentialName }}
       mode: SIMPLE
   {{- end}}
----
-apiVersion: networking.istio.io/v1beta1
-kind: VirtualService
-metadata:
-  name: {{ $fullName }}
-  labels:
-    {{- include "router.labels" . | nindent 4 }}
-  {{- with .Values.istioGateway.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-spec:
-  gateways:
-  - {{ $fullName }}
-  hosts:
-  - '*'
-  http:
-  - match:
-    - uri:
-        prefix: /
-    route:
-    - destination:
-        host: {{ $fullName }}
-        port:
-          number: {{ $svcPort }}
 {{- end }}
 {{- end }}

--- a/helm/cosmo/charts/router/templates/istio-virtual-service.yaml
+++ b/helm/cosmo/charts/router/templates/istio-virtual-service.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.istioVirtualService -}}
+{{- if .Values.istioVirtualService.enabled -}}
+{{- $fullName := include "router.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "router.labels" . | nindent 4 }}
+  {{- with .Values.istioVirtualService.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  gateways:
+  - {{ $fullName }}
+  hosts:
+  - '*'
+  http:
+  - match:
+    - uri:
+        prefix: /
+    route:
+    - destination:
+        host: {{ $fullName }}
+        port:
+          number: {{ $svcPort }}
+{{- end }}
+{{- end }}

--- a/helm/cosmo/charts/router/values.yaml
+++ b/helm/cosmo/charts/router/values.yaml
@@ -87,7 +87,8 @@ ingress:
 # -- Sets the [istio gateway](https://istio.io/latest/docs/reference/config/networking/gateway/) load balancer to expose the virtual service
 # -- Requires Istio v1.5 or greater
 istioGateway:
-  # enabled: true
+  # -- enable the istioGateway - often used in conjunction with istioVirtualService to expose services via an istio gateway deployment
+  enabled: false
   # -- Selectors for the Gateway deployment
   selector: {}
   # -- Annotations for the Gateway
@@ -102,7 +103,8 @@ istioGateway:
 # -- Sets the [virtual service](https://istio.io/latest/docs/reference/config/networking/virtual-service/) to route a Gateway to the router
 # -- Requires Istio v1.5 or greater
 istioVirtualService:
-  # enabled: true
+  # -- enable an Istio VirtualService
+  enabled: false
   # -- Annotations for the VirtualService
   annotations: {}
 

--- a/helm/cosmo/charts/router/values.yaml
+++ b/helm/cosmo/charts/router/values.yaml
@@ -84,6 +84,13 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+istioGateway:
+  # enabled: true
+  # gatewayName: istio-ingress
+  # hosts:
+  #   - host: router.wundergraph.local
+  #     credentialName: istio-ingressgateway-certs
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little

--- a/helm/cosmo/charts/router/values.yaml
+++ b/helm/cosmo/charts/router/values.yaml
@@ -84,12 +84,27 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+# -- Sets the [istio gateway](https://istio.io/latest/docs/reference/config/networking/gateway/) load balancer to expose the virtual service
+# -- Requires Istio v1.5 or greater
 istioGateway:
   # enabled: true
-  # gatewayName: istio-ingress
-  # hosts:
-  #   - host: router.wundergraph.local
-  #     credentialName: istio-ingressgateway-certs
+  # -- Selectors for the Gateway deployment
+  selector: {}
+  # -- Annotations for the Gateway
+  annotations: {}
+  # -- List of hosts that the gateway can serve
+  hosts: []
+    # -- Hostname the Gateway can serve
+    # - host: router.wundergraph.local
+    # -- The name of the secret that holds the TLS certs including the CA certificates
+    #   credentialName: istio-ingressgateway-certs
+
+# -- Sets the [virtual service](https://istio.io/latest/docs/reference/config/networking/virtual-service/) to route a Gateway to the router
+# -- Requires Istio v1.5 or greater
+istioVirtualService:
+  # enabled: true
+  # -- Annotations for the VirtualService
+  annotations: {}
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
## Motivation and Context

We use Istio and `istioGateway`/`VirtualService` rather than an ingress. We also don't have any plans to support the newer `ingressGateway`. This should provide the necessary resources to create the `istioGateway` and `VirtualService` (disabled by default).

## TODO

- [x] Tests or benchmark included
- [x] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [x] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
