### PR TITLE
fix: fix the expansion of selectors in the istio-gateway template for the router helm chart

### DIFF
--- a/helm/cosmo/charts/router/templates/istio-gateway.yaml
+++ b/helm/cosmo/charts/router/templates/istio-gateway.yaml
@@ -13,7 +13,8 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  selector: {{ .Values.istioGateway.selector }}
+  selector:
+    {{- toYaml .Values.istioGateway.selector | nindent 4 }}
   servers:
   {{- range .Values.istioGateway.hosts }}
   - hosts:


### PR DESCRIPTION
Fix the expansion of selectors in the istio-gateway template for the router helm chart, it was previously inlining it to the text representation of a Go map (my bad 😬 )

## Motivation and Context

Supporting istio gateway for the router helm chart.

## TODO

- [x] Tests or benchmark included
- [x] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [x] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
