### PR TITLE
feat: standalone binary distributions for `wgc`

### DIFF
--- a/cli/.eslintrc
+++ b/cli/.eslintrc
@@ -1,8 +1,6 @@
 {
   "extends": ["eslint-config-unjs", "plugin:require-extensions/recommended"],
-  "plugins": [
-        "require-extensions"
-  ],
+  "plugins": ["require-extensions"],
   "rules": {
     "space-before-function-paren": 0,
     "arrow-parens": 0,
@@ -23,6 +21,7 @@
     "@typescript-eslint/no-non-null-assertion": 0,
     "unicorn/expiring-todo-comments": 0,
     "no-useless-constructor": 0,
-    "unicorn/no-process-exit": 0
+    "unicorn/no-process-exit": 0,
+    "unicorn/prefer-top-level-await": 0
   }
 }

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,8 +1,15 @@
 # Change Log
+
 Binaries are attached to the github release otherwise all images can be found [here](https://github.com/orgs/wundergraph/packages?repo_name=cosmo)
 
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## [0.54.0](https://github.com/wundergraph/cosmo/compare/wgc@0.53.3...wgc@0.54.0) (2024-05-16)
+
+### Features
+
+- standalone binary distributions (macos, linux, & win) of wgc with vercel/pkg (@samjcombs)
 
 ## [0.53.3](https://github.com/wundergraph/cosmo/compare/wgc@0.53.2...wgc@0.53.3) (2024-05-14)
 
@@ -20,31 +27,31 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-* support inaccessible and add foundation for contracts ([#764](https://github.com/wundergraph/cosmo/issues/764)) ([08a7db2](https://github.com/wundergraph/cosmo/commit/08a7db222ce1763ffe8062d3792c41e0c54b4224)) (@Aenimus)
+- support inaccessible and add foundation for contracts ([#764](https://github.com/wundergraph/cosmo/issues/764)) ([08a7db2](https://github.com/wundergraph/cosmo/commit/08a7db222ce1763ffe8062d3792c41e0c54b4224)) (@Aenimus)
 
 ## [0.52.1](https://github.com/wundergraph/cosmo/compare/wgc@0.52.0...wgc@0.52.1) (2024-04-30)
 
 ### Bug Fixes
 
-* add fetch-schema command to replace the old functionality of the fetch cmd ([#760](https://github.com/wundergraph/cosmo/issues/760)) ([fc3f5c6](https://github.com/wundergraph/cosmo/commit/fc3f5c65b9322c0573a9c8f72dee5ae096debe9a)) (@JivusAyrus)
+- add fetch-schema command to replace the old functionality of the fetch cmd ([#760](https://github.com/wundergraph/cosmo/issues/760)) ([fc3f5c6](https://github.com/wundergraph/cosmo/commit/fc3f5c65b9322c0573a9c8f72dee5ae096debe9a)) (@JivusAyrus)
 
 # [0.52.0](https://github.com/wundergraph/cosmo/compare/wgc@0.51.5...wgc@0.52.0) (2024-04-26)
 
 ### Features
 
-* add apollo compatibility mode in wgc federated-graph fetch command ([#742](https://github.com/wundergraph/cosmo/issues/742)) ([ecd73ab](https://github.com/wundergraph/cosmo/commit/ecd73ab91e1c8289008cae1062220826884d26e8)) (@JivusAyrus)
+- add apollo compatibility mode in wgc federated-graph fetch command ([#742](https://github.com/wundergraph/cosmo/issues/742)) ([ecd73ab](https://github.com/wundergraph/cosmo/commit/ecd73ab91e1c8289008cae1062220826884d26e8)) (@JivusAyrus)
 
 ## [0.51.5](https://github.com/wundergraph/cosmo/compare/wgc@0.51.4...wgc@0.51.5) (2024-04-23)
 
 ### Bug Fixes
 
-* upgrade deps to cover CVEs ([#750](https://github.com/wundergraph/cosmo/issues/750)) ([e261beb](https://github.com/wundergraph/cosmo/commit/e261beb8375ca41eb8a2fa4b3223d202c3bb7460)) (@StarpTech)
+- upgrade deps to cover CVEs ([#750](https://github.com/wundergraph/cosmo/issues/750)) ([e261beb](https://github.com/wundergraph/cosmo/commit/e261beb8375ca41eb8a2fa4b3223d202c3bb7460)) (@StarpTech)
 
 ## [0.51.4](https://github.com/wundergraph/cosmo/compare/wgc@0.51.3...wgc@0.51.4) (2024-04-23)
 
 ### Reverts
 
-* Revert "chore(release): Publish [skip ci]" ([feaf2ef](https://github.com/wundergraph/cosmo/commit/feaf2ef49321388daff7c4d9f4558cdda78b5744)) (@StarpTech)
+- Revert "chore(release): Publish [skip ci]" ([feaf2ef](https://github.com/wundergraph/cosmo/commit/feaf2ef49321388daff7c4d9f4558cdda78b5744)) (@StarpTech)
 
 ## [0.51.3](https://github.com/wundergraph/cosmo/compare/wgc@0.51.2...wgc@0.51.3) (2024-04-17)
 
@@ -54,7 +61,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-* inform users if there is nothing new to publish ([#710](https://github.com/wundergraph/cosmo/issues/710)) ([faf01fc](https://github.com/wundergraph/cosmo/commit/faf01fc9e398ef70873abeec8eee06e797cbabf3)) (@JivusAyrus)
+- inform users if there is nothing new to publish ([#710](https://github.com/wundergraph/cosmo/issues/710)) ([faf01fc](https://github.com/wundergraph/cosmo/commit/faf01fc9e398ef70873abeec8eee06e797cbabf3)) (@JivusAyrus)
 
 ## [0.51.1](https://github.com/wundergraph/cosmo/compare/wgc@0.51.0...wgc@0.51.1) (2024-04-11)
 
@@ -64,7 +71,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-* enable raw introspection for subgraphs ([#721](https://github.com/wundergraph/cosmo/issues/721)) ([bd6668f](https://github.com/wundergraph/cosmo/commit/bd6668ffbbcf156468f0876e3ae79db23201eb36)) (@thisisnithin)
+- enable raw introspection for subgraphs ([#721](https://github.com/wundergraph/cosmo/issues/721)) ([bd6668f](https://github.com/wundergraph/cosmo/commit/bd6668ffbbcf156468f0876e3ae79db23201eb36)) (@thisisnithin)
 
 ## [0.50.4](https://github.com/wundergraph/cosmo/compare/wgc@0.50.3...wgc@0.50.4) (2024-04-10)
 
@@ -78,23 +85,23 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-* provide default subscription protocol for composition-go ([#702](https://github.com/wundergraph/cosmo/issues/702)) ([53140ea](https://github.com/wundergraph/cosmo/commit/53140eabcc960bd95626837da308c86674aeb8a4)) (@Aenimus)
+- provide default subscription protocol for composition-go ([#702](https://github.com/wundergraph/cosmo/issues/702)) ([53140ea](https://github.com/wundergraph/cosmo/commit/53140eabcc960bd95626837da308c86674aeb8a4)) (@Aenimus)
 
 ## [0.50.1](https://github.com/wundergraph/cosmo/compare/wgc@0.50.0...wgc@0.50.1) (2024-04-04)
 
 ### Bug Fixes
 
-* don't enforce org slug when using API key ([#688](https://github.com/wundergraph/cosmo/issues/688)) ([f5f7b4e](https://github.com/wundergraph/cosmo/commit/f5f7b4e5237d0d3a91a60c1878c0bf89dd721bee)) (@StarpTech)
+- don't enforce org slug when using API key ([#688](https://github.com/wundergraph/cosmo/issues/688)) ([f5f7b4e](https://github.com/wundergraph/cosmo/commit/f5f7b4e5237d0d3a91a60c1878c0bf89dd721bee)) (@StarpTech)
 
 # [0.50.0](https://github.com/wundergraph/cosmo/compare/wgc@0.49.1...wgc@0.50.0) (2024-04-03)
 
 ### Features
 
-* use offline token, refresh token implementation ([#686](https://github.com/wundergraph/cosmo/issues/686)) ([4429319](https://github.com/wundergraph/cosmo/commit/442931935e979f53b0b093fbad217a2c91807f8e)) (@)
+- use offline token, refresh token implementation ([#686](https://github.com/wundergraph/cosmo/issues/686)) ([4429319](https://github.com/wundergraph/cosmo/commit/442931935e979f53b0b093fbad217a2c91807f8e)) (@)
 
 ### Features
 
-* use offline token, refresh token implementation ([#686](https://github.com/wundergraph/cosmo/issues/686)) ([4429319](https://github.com/wundergraph/cosmo/commit/442931935e979f53b0b093fbad217a2c91807f8e)) (@StarpTech)
+- use offline token, refresh token implementation ([#686](https://github.com/wundergraph/cosmo/issues/686)) ([4429319](https://github.com/wundergraph/cosmo/commit/442931935e979f53b0b093fbad217a2c91807f8e)) (@StarpTech)
 
 ## [0.49.1](https://github.com/wundergraph/cosmo/compare/wgc@0.49.0...wgc@0.49.1) (2024-03-21)
 
@@ -104,23 +111,23 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-* show warning when both auth methods are used ([#654](https://github.com/wundergraph/cosmo/issues/654)) ([0ee7d3c](https://github.com/wundergraph/cosmo/commit/0ee7d3ce3ed1d3dbd2c6558492cf96d05fa453b9)) (@StarpTech)
+- show warning when both auth methods are used ([#654](https://github.com/wundergraph/cosmo/issues/654)) ([0ee7d3c](https://github.com/wundergraph/cosmo/commit/0ee7d3ce3ed1d3dbd2c6558492cf96d05fa453b9)) (@StarpTech)
 
 # [0.48.0](https://github.com/wundergraph/cosmo/compare/wgc@0.47.0...wgc@0.48.0) (2024-03-20)
 
 ### Features
 
-* monograph support ([#623](https://github.com/wundergraph/cosmo/issues/623)) ([a255f74](https://github.com/wundergraph/cosmo/commit/a255f747d63454e1219760b729d99e4778d56dda)) (@thisisnithin)
+- monograph support ([#623](https://github.com/wundergraph/cosmo/issues/623)) ([a255f74](https://github.com/wundergraph/cosmo/commit/a255f747d63454e1219760b729d99e4778d56dda)) (@thisisnithin)
 
 # [0.47.0](https://github.com/wundergraph/cosmo/compare/wgc@0.46.1...wgc@0.47.0) (2024-03-18)
 
 ### Bug Fixes
 
-* raw output not being a valid json ([#642](https://github.com/wundergraph/cosmo/issues/642)) ([a690338](https://github.com/wundergraph/cosmo/commit/a690338d0a152d76fdc408e272b5b57299752ab2)) (@thisisnithin)
+- raw output not being a valid json ([#642](https://github.com/wundergraph/cosmo/issues/642)) ([a690338](https://github.com/wundergraph/cosmo/commit/a690338d0a152d76fdc408e272b5b57299752ab2)) (@thisisnithin)
 
 ### Features
 
-* allow to update admission url ([#638](https://github.com/wundergraph/cosmo/issues/638)) ([c7f7ee6](https://github.com/wundergraph/cosmo/commit/c7f7ee65f7716d463fb0bf96cf386e54ba5f8b73)) (@StarpTech)
+- allow to update admission url ([#638](https://github.com/wundergraph/cosmo/issues/638)) ([c7f7ee6](https://github.com/wundergraph/cosmo/commit/c7f7ee65f7716d463fb0bf96cf386e54ba5f8b73)) (@StarpTech)
 
 ## [0.46.1](https://github.com/wundergraph/cosmo/compare/wgc@0.46.0...wgc@0.46.1) (2024-03-16)
 
@@ -130,7 +137,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-* router config signature validation through custom admission webhooks ([#628](https://github.com/wundergraph/cosmo/issues/628)) ([384fd7e](https://github.com/wundergraph/cosmo/commit/384fd7e3372479e96fccc4fc771dc4e9f9c84754)) (@StarpTech)
+- router config signature validation through custom admission webhooks ([#628](https://github.com/wundergraph/cosmo/issues/628)) ([384fd7e](https://github.com/wundergraph/cosmo/commit/384fd7e3372479e96fccc4fc771dc4e9f9c84754)) (@StarpTech)
 
 ## [0.45.1](https://github.com/wundergraph/cosmo/compare/wgc@0.45.0...wgc@0.45.1) (2024-03-13)
 
@@ -140,13 +147,13 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-* add configurable schema linting ([#596](https://github.com/wundergraph/cosmo/issues/596)) ([c662485](https://github.com/wundergraph/cosmo/commit/c66248529c5bc13e795725c82ba50dbad79451ae)) (@JivusAyrus)
+- add configurable schema linting ([#596](https://github.com/wundergraph/cosmo/issues/596)) ([c662485](https://github.com/wundergraph/cosmo/commit/c66248529c5bc13e795725c82ba50dbad79451ae)) (@JivusAyrus)
 
 ## [0.44.2](https://github.com/wundergraph/cosmo/compare/wgc@0.44.1...wgc@0.44.2) (2024-03-08)
 
 ### Bug Fixes
 
-* handle empty files in the cli itself ([#593](https://github.com/wundergraph/cosmo/issues/593)) ([de08e24](https://github.com/wundergraph/cosmo/commit/de08e24e63bc0083d3b86c417cb1bd282891c60b)) (@JivusAyrus)
+- handle empty files in the cli itself ([#593](https://github.com/wundergraph/cosmo/issues/593)) ([de08e24](https://github.com/wundergraph/cosmo/commit/de08e24e63bc0083d3b86c417cb1bd282891c60b)) (@JivusAyrus)
 
 ## [0.44.1](https://github.com/wundergraph/cosmo/compare/wgc@0.44.0...wgc@0.44.1) (2024-03-06)
 
@@ -156,8 +163,8 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-* **cli:** new command to fetch latest published subgraph SDL ([#575](https://github.com/wundergraph/cosmo/issues/575)) ([09a0ab5](https://github.com/wundergraph/cosmo/commit/09a0ab54cccae6f46c1e585cf12fa9321f44e9ed)) (@StarpTech)
-* show link to studio page on subgraph check ([#578](https://github.com/wundergraph/cosmo/issues/578)) ([701d81c](https://github.com/wundergraph/cosmo/commit/701d81c764b12bb1a2ec308634e69aaffb9e7e3e)) (@thisisnithin)
+- **cli:** new command to fetch latest published subgraph SDL ([#575](https://github.com/wundergraph/cosmo/issues/575)) ([09a0ab5](https://github.com/wundergraph/cosmo/commit/09a0ab54cccae6f46c1e585cf12fa9321f44e9ed)) (@StarpTech)
+- show link to studio page on subgraph check ([#578](https://github.com/wundergraph/cosmo/issues/578)) ([701d81c](https://github.com/wundergraph/cosmo/commit/701d81c764b12bb1a2ec308634e69aaffb9e7e3e)) (@thisisnithin)
 
 ## [0.43.2](https://github.com/wundergraph/cosmo/compare/wgc@0.43.1...wgc@0.43.2) (2024-02-23)
 
@@ -167,14 +174,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-* **cli:** ensure to exit with 1 in error cases ([#568](https://github.com/wundergraph/cosmo/issues/568)) ([ae1d254](https://github.com/wundergraph/cosmo/commit/ae1d254995ada8fc72d5906e9e9e06779c49d7dd)) (@StarpTech)
+- **cli:** ensure to exit with 1 in error cases ([#568](https://github.com/wundergraph/cosmo/issues/568)) ([ae1d254](https://github.com/wundergraph/cosmo/commit/ae1d254995ada8fc72d5906e9e9e06779c49d7dd)) (@StarpTech)
 
 # [0.43.0](https://github.com/wundergraph/cosmo/compare/wgc@0.42.2...wgc@0.43.0) (2024-02-21)
 
 ### Features
 
-* handle exceptions gracefully ([#563](https://github.com/wundergraph/cosmo/issues/563)) ([5a8776d](https://github.com/wundergraph/cosmo/commit/5a8776d7e7e5510a7295268410918bdb0df95154)) (@thisisnithin)
-* version update check ([#562](https://github.com/wundergraph/cosmo/issues/562)) ([f4646b4](https://github.com/wundergraph/cosmo/commit/f4646b42433baf6a45c63e82f8d4192eac3146dc)) (@thisisnithin)
+- handle exceptions gracefully ([#563](https://github.com/wundergraph/cosmo/issues/563)) ([5a8776d](https://github.com/wundergraph/cosmo/commit/5a8776d7e7e5510a7295268410918bdb0df95154)) (@thisisnithin)
+- version update check ([#562](https://github.com/wundergraph/cosmo/issues/562)) ([f4646b4](https://github.com/wundergraph/cosmo/commit/f4646b42433baf6a45c63e82f8d4192eac3146dc)) (@thisisnithin)
 
 ## [0.42.2](https://github.com/wundergraph/cosmo/compare/wgc@0.42.1...wgc@0.42.2) (2024-02-20)
 
@@ -188,19 +195,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-* support empty labels and label matchers ([#555](https://github.com/wundergraph/cosmo/issues/555)) ([8bb857c](https://github.com/wundergraph/cosmo/commit/8bb857c94f8165676b2ca5101c199f3bc0648d10)) (@thisisnithin)
+- support empty labels and label matchers ([#555](https://github.com/wundergraph/cosmo/issues/555)) ([8bb857c](https://github.com/wundergraph/cosmo/commit/8bb857c94f8165676b2ca5101c199f3bc0648d10)) (@thisisnithin)
 
 ## [0.41.1](https://github.com/wundergraph/cosmo/compare/wgc@0.41.0...wgc@0.41.1) (2024-02-19)
 
 ### Bug Fixes
 
-* don't expose token on wgc list command ([#550](https://github.com/wundergraph/cosmo/issues/550)) ([357ffae](https://github.com/wundergraph/cosmo/commit/357ffae4362c3c37dc955d40363da40cd985bf3f)) (@StarpTech)
+- don't expose token on wgc list command ([#550](https://github.com/wundergraph/cosmo/issues/550)) ([357ffae](https://github.com/wundergraph/cosmo/commit/357ffae4362c3c37dc955d40363da40cd985bf3f)) (@StarpTech)
 
 # [0.41.0](https://github.com/wundergraph/cosmo/compare/wgc@0.40.6...wgc@0.41.0) (2024-02-16)
 
 ### Features
 
-* operation check overrides ([#516](https://github.com/wundergraph/cosmo/issues/516)) ([651ff8e](https://github.com/wundergraph/cosmo/commit/651ff8ed88cd542d56cf11d11086f659fc3f5d4e)) (@thisisnithin)
+- operation check overrides ([#516](https://github.com/wundergraph/cosmo/issues/516)) ([651ff8e](https://github.com/wundergraph/cosmo/commit/651ff8ed88cd542d56cf11d11086f659fc3f5d4e)) (@thisisnithin)
 
 ## [0.40.6](https://github.com/wundergraph/cosmo/compare/wgc@0.40.5...wgc@0.40.6) (2024-02-13)
 
@@ -214,7 +221,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-* update subscription protocol ([#517](https://github.com/wundergraph/cosmo/issues/517)) ([5f21022](https://github.com/wundergraph/cosmo/commit/5f210225f2bbe81bd396151dd3e33d2c9074d6df)) (@thisisnithin)
+- update subscription protocol ([#517](https://github.com/wundergraph/cosmo/issues/517)) ([5f21022](https://github.com/wundergraph/cosmo/commit/5f210225f2bbe81bd396151dd3e33d2c9074d6df)) (@thisisnithin)
 
 ## [0.40.3](https://github.com/wundergraph/cosmo/compare/wgc@0.40.2...wgc@0.40.3) (2024-02-06)
 
@@ -228,19 +235,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-* cli tables ui ([#482](https://github.com/wundergraph/cosmo/issues/482)) ([a1dcdb3](https://github.com/wundergraph/cosmo/commit/a1dcdb3772f2c1bda2795cefd19e698de29b579b)) (@JivusAyrus)
+- cli tables ui ([#482](https://github.com/wundergraph/cosmo/issues/482)) ([a1dcdb3](https://github.com/wundergraph/cosmo/commit/a1dcdb3772f2c1bda2795cefd19e698de29b579b)) (@JivusAyrus)
 
 # [0.40.0](https://github.com/wundergraph/cosmo/compare/wgc@0.39.2...wgc@0.40.0) (2024-02-01)
 
 ### Features
 
-* integrate S3 when executing "getLatestValidRouterConfig" from the CLI ([#467](https://github.com/wundergraph/cosmo/issues/467)) ([90b7c8e](https://github.com/wundergraph/cosmo/commit/90b7c8ed01bdd659183c87cc2d94946ab20fe073)) (@JivusAyrus)
+- integrate S3 when executing "getLatestValidRouterConfig" from the CLI ([#467](https://github.com/wundergraph/cosmo/issues/467)) ([90b7c8e](https://github.com/wundergraph/cosmo/commit/90b7c8ed01bdd659183c87cc2d94946ab20fe073)) (@JivusAyrus)
 
 ## [0.39.2](https://github.com/wundergraph/cosmo/compare/wgc@0.39.1...wgc@0.39.2) (2024-01-31)
 
 ### Bug Fixes
 
-* validate routing urls ([#470](https://github.com/wundergraph/cosmo/issues/470)) ([166d9ef](https://github.com/wundergraph/cosmo/commit/166d9efb53f5554b1dcbd49f7dd334f6cc1e4a87)) (@JivusAyrus)
+- validate routing urls ([#470](https://github.com/wundergraph/cosmo/issues/470)) ([166d9ef](https://github.com/wundergraph/cosmo/commit/166d9efb53f5554b1dcbd49f7dd334f6cc1e4a87)) (@JivusAyrus)
 
 ## [0.39.1](https://github.com/wundergraph/cosmo/compare/wgc@0.39.0...wgc@0.39.1) (2024-01-30)
 
@@ -250,7 +257,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-* implement authorization directives ([#448](https://github.com/wundergraph/cosmo/issues/448)) ([181d89d](https://github.com/wundergraph/cosmo/commit/181d89d8e7dbf8eb23cddfa0b6c91c840a2986b0)) (@Aenimus)
+- implement authorization directives ([#448](https://github.com/wundergraph/cosmo/issues/448)) ([181d89d](https://github.com/wundergraph/cosmo/commit/181d89d8e7dbf8eb23cddfa0b6c91c840a2986b0)) (@Aenimus)
 
 ## [0.38.2](https://github.com/wundergraph/cosmo/compare/wgc@0.38.1...wgc@0.38.2) (2024-01-29)
 
@@ -260,13 +267,13 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-* remove typo in move option ([#459](https://github.com/wundergraph/cosmo/issues/459)) ([71397df](https://github.com/wundergraph/cosmo/commit/71397dfaa85f2ffc23be14871299dc35f0a3d38f)) (@StarpTech)
+- remove typo in move option ([#459](https://github.com/wundergraph/cosmo/issues/459)) ([71397df](https://github.com/wundergraph/cosmo/commit/71397dfaa85f2ffc23be14871299dc35f0a3d38f)) (@StarpTech)
 
 # [0.38.0](https://github.com/wundergraph/cosmo/compare/wgc@0.37.4...wgc@0.38.0) (2024-01-26)
 
 ### Features
 
-* namespaces ([#447](https://github.com/wundergraph/cosmo/issues/447)) ([bbe5258](https://github.com/wundergraph/cosmo/commit/bbe5258c5e764c52947f831d3a7f1a2f93c267d4)) (@thisisnithin)
+- namespaces ([#447](https://github.com/wundergraph/cosmo/issues/447)) ([bbe5258](https://github.com/wundergraph/cosmo/commit/bbe5258c5e764c52947f831d3a7f1a2f93c267d4)) (@thisisnithin)
 
 ## [0.37.4](https://github.com/wundergraph/cosmo/compare/wgc@0.37.3...wgc@0.37.4) (2024-01-26)
 
@@ -288,7 +295,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-* provide router config over cdn ([#411](https://github.com/wundergraph/cosmo/issues/411)) ([f04ac84](https://github.com/wundergraph/cosmo/commit/f04ac84d2f6c155409f7db69e7646c04047e32b5)) (@JivusAyrus)
+- provide router config over cdn ([#411](https://github.com/wundergraph/cosmo/issues/411)) ([f04ac84](https://github.com/wundergraph/cosmo/commit/f04ac84d2f6c155409f7db69e7646c04047e32b5)) (@JivusAyrus)
 
 ## [0.36.5](https://github.com/wundergraph/cosmo/compare/wgc@0.36.4...wgc@0.36.5) (2024-01-09)
 
@@ -314,7 +321,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-* add readme for subgraphs and federated graphs ([#384](https://github.com/wundergraph/cosmo/issues/384)) ([260ffac](https://github.com/wundergraph/cosmo/commit/260ffac99d5c81b82991d1261b937cf4fa344949)) (@JivusAyrus)
+- add readme for subgraphs and federated graphs ([#384](https://github.com/wundergraph/cosmo/issues/384)) ([260ffac](https://github.com/wundergraph/cosmo/commit/260ffac99d5c81b82991d1261b937cf4fa344949)) (@JivusAyrus)
 
 ## [0.35.5](https://github.com/wundergraph/cosmo/compare/wgc@0.35.4...wgc@0.35.5) (2023-12-19)
 
@@ -340,7 +347,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-* add rbac for subgraphs and federated graphs ([#351](https://github.com/wundergraph/cosmo/issues/351)) ([72e39bc](https://github.com/wundergraph/cosmo/commit/72e39bc1ff914831499c0625e443ab2ec0af135c)) (@JivusAyrus)
+- add rbac for subgraphs and federated graphs ([#351](https://github.com/wundergraph/cosmo/issues/351)) ([72e39bc](https://github.com/wundergraph/cosmo/commit/72e39bc1ff914831499c0625e443ab2ec0af135c)) (@JivusAyrus)
 
 ## [0.34.2](https://github.com/wundergraph/cosmo/compare/wgc@0.34.1...wgc@0.34.2) (2023-12-09)
 
@@ -350,13 +357,13 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-* do not require login for download-binary ([#342](https://github.com/wundergraph/cosmo/issues/342)) ([78f894a](https://github.com/wundergraph/cosmo/commit/78f894a4f770e4657574b7bbd10137650d49dfc1)) (@Aenimus)
+- do not require login for download-binary ([#342](https://github.com/wundergraph/cosmo/issues/342)) ([78f894a](https://github.com/wundergraph/cosmo/commit/78f894a4f770e4657574b7bbd10137650d49dfc1)) (@Aenimus)
 
 # [0.34.0](https://github.com/wundergraph/cosmo/compare/wgc@0.33.1...wgc@0.34.0) (2023-12-05)
 
 ### Features
 
-* implement wgc router download-binary ([#339](https://github.com/wundergraph/cosmo/issues/339)) ([5de5b4e](https://github.com/wundergraph/cosmo/commit/5de5b4e9aedf79143543fe56f99034510f5e8f43)) (@Aenimus)
+- implement wgc router download-binary ([#339](https://github.com/wundergraph/cosmo/issues/339)) ([5de5b4e](https://github.com/wundergraph/cosmo/commit/5de5b4e9aedf79143543fe56f99034510f5e8f43)) (@Aenimus)
 
 ## [0.33.1](https://github.com/wundergraph/cosmo/compare/wgc@0.33.0...wgc@0.33.1) (2023-12-04)
 
@@ -366,7 +373,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-* persist ops from playground and view all client ops ([#323](https://github.com/wundergraph/cosmo/issues/323)) ([042d7db](https://github.com/wundergraph/cosmo/commit/042d7db00dbf2945a6be2b30e31d7851befc407b)) (@thisisnithin)
+- persist ops from playground and view all client ops ([#323](https://github.com/wundergraph/cosmo/issues/323)) ([042d7db](https://github.com/wundergraph/cosmo/commit/042d7db00dbf2945a6be2b30e31d7851befc407b)) (@thisisnithin)
 
 ## [0.32.2](https://github.com/wundergraph/cosmo/compare/wgc@0.32.1...wgc@0.32.2) (2023-11-30)
 
@@ -380,7 +387,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-* accept custom operation IDs for persisted operations ([#302](https://github.com/wundergraph/cosmo/issues/302)) ([a535a62](https://github.com/wundergraph/cosmo/commit/a535a62bb7f70d2e58d1a04066fb74e78d932653)) (@fiam)
+- accept custom operation IDs for persisted operations ([#302](https://github.com/wundergraph/cosmo/issues/302)) ([a535a62](https://github.com/wundergraph/cosmo/commit/a535a62bb7f70d2e58d1a04066fb74e78d932653)) (@fiam)
 
 ## [0.31.1](https://github.com/wundergraph/cosmo/compare/wgc@0.31.0...wgc@0.31.1) (2023-11-28)
 
@@ -390,25 +397,25 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-* add support for outputting pushed operations as JSON ([#294](https://github.com/wundergraph/cosmo/issues/294)) ([98d188d](https://github.com/wundergraph/cosmo/commit/98d188db01ee494de1e8a4d5a2cb9f571582045c)) (@fiam)
+- add support for outputting pushed operations as JSON ([#294](https://github.com/wundergraph/cosmo/issues/294)) ([98d188d](https://github.com/wundergraph/cosmo/commit/98d188db01ee494de1e8a4d5a2cb9f571582045c)) (@fiam)
 
 ## [0.30.1](https://github.com/wundergraph/cosmo/compare/wgc@0.30.0...wgc@0.30.1) (2023-11-23)
 
 ### Bug Fixes
 
-* import files with extension in new commands ([#289](https://github.com/wundergraph/cosmo/issues/289)) ([3e337de](https://github.com/wundergraph/cosmo/commit/3e337de5929a81f6076b5057d0796819da2a7811)) (@fiam)
+- import files with extension in new commands ([#289](https://github.com/wundergraph/cosmo/issues/289)) ([3e337de](https://github.com/wundergraph/cosmo/commit/3e337de5929a81f6076b5057d0796819da2a7811)) (@fiam)
 
 # [0.30.0](https://github.com/wundergraph/cosmo/compare/wgc@0.28.2...wgc@0.30.0) (2023-11-23)
 
 ### Features
 
-* add support for persisted operations ([#249](https://github.com/wundergraph/cosmo/issues/249)) ([a9ad47f](https://github.com/wundergraph/cosmo/commit/a9ad47ff5cf7db6bccf774e168b1d1ce3ee7bcdd)) (@fiam)
+- add support for persisted operations ([#249](https://github.com/wundergraph/cosmo/issues/249)) ([a9ad47f](https://github.com/wundergraph/cosmo/commit/a9ad47ff5cf7db6bccf774e168b1d1ce3ee7bcdd)) (@fiam)
 
 # [0.29.0](https://github.com/wundergraph/cosmo/compare/wgc@0.28.2...wgc@0.29.0) (2023-11-23)
 
 ### Features
 
-* add support for persisted operations ([#249](https://github.com/wundergraph/cosmo/issues/249)) ([a9ad47f](https://github.com/wundergraph/cosmo/commit/a9ad47ff5cf7db6bccf774e168b1d1ce3ee7bcdd)) (@fiam)
+- add support for persisted operations ([#249](https://github.com/wundergraph/cosmo/issues/249)) ([a9ad47f](https://github.com/wundergraph/cosmo/commit/a9ad47ff5cf7db6bccf774e168b1d1ce3ee7bcdd)) (@fiam)
 
 ## [0.28.2](https://github.com/wundergraph/cosmo/compare/wgc@0.28.1...wgc@0.28.2) (2023-11-20)
 
@@ -422,19 +429,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-* consider input and argument usage for breaking change detection ([#255](https://github.com/wundergraph/cosmo/issues/255)) ([e10ac40](https://github.com/wundergraph/cosmo/commit/e10ac401f543f5540b5ada8f80533ddfbd0bc728)) (@jensneuse)
+- consider input and argument usage for breaking change detection ([#255](https://github.com/wundergraph/cosmo/issues/255)) ([e10ac40](https://github.com/wundergraph/cosmo/commit/e10ac401f543f5540b5ada8f80533ddfbd0bc728)) (@jensneuse)
 
 # [0.27.0](https://github.com/wundergraph/cosmo/compare/wgc@0.26.0...wgc@0.27.0) (2023-11-15)
 
 ### Features
 
-* add check for deleted subgraphs ([#258](https://github.com/wundergraph/cosmo/issues/258)) ([ba87fe5](https://github.com/wundergraph/cosmo/commit/ba87fe51631ece9c2efaea6350dc93590f1846c5)) (@Pagebakers)
+- add check for deleted subgraphs ([#258](https://github.com/wundergraph/cosmo/issues/258)) ([ba87fe5](https://github.com/wundergraph/cosmo/commit/ba87fe51631ece9c2efaea6350dc93590f1846c5)) (@Pagebakers)
 
 # [0.26.0](https://github.com/wundergraph/cosmo/compare/wgc@0.25.2...wgc@0.26.0) (2023-11-10)
 
 ### Features
 
-* implement [@override](https://github.com/override) ([#246](https://github.com/wundergraph/cosmo/issues/246)) ([b6d0448](https://github.com/wundergraph/cosmo/commit/b6d044861e918f7c82931e1d5374fc7f6fc01daa)) (@Aenimus)
+- implement [@override](https://github.com/override) ([#246](https://github.com/wundergraph/cosmo/issues/246)) ([b6d0448](https://github.com/wundergraph/cosmo/commit/b6d044861e918f7c82931e1d5374fc7f6fc01daa)) (@Aenimus)
 
 ## [0.25.2](https://github.com/wundergraph/cosmo/compare/wgc@0.25.1...wgc@0.25.2) (2023-11-09)
 
@@ -448,13 +455,13 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-* upgrade to stable connect & react-query 5 ([#231](https://github.com/wundergraph/cosmo/issues/231)) ([0c434eb](https://github.com/wundergraph/cosmo/commit/0c434eb41b357f596d19607cd2c8572f6a9899a1)) (@StarpTech)
+- upgrade to stable connect & react-query 5 ([#231](https://github.com/wundergraph/cosmo/issues/231)) ([0c434eb](https://github.com/wundergraph/cosmo/commit/0c434eb41b357f596d19607cd2c8572f6a9899a1)) (@StarpTech)
 
 # [0.24.0](https://github.com/wundergraph/cosmo/compare/wgc@0.23.1...wgc@0.24.0) (2023-11-03)
 
 ### Features
 
-* operation checks (breaking change detection) ([#214](https://github.com/wundergraph/cosmo/issues/214)) ([0935413](https://github.com/wundergraph/cosmo/commit/093541305866327c5c44637603621e4a8053640d)) (@StarpTech)
+- operation checks (breaking change detection) ([#214](https://github.com/wundergraph/cosmo/issues/214)) ([0935413](https://github.com/wundergraph/cosmo/commit/093541305866327c5c44637603621e4a8053640d)) (@StarpTech)
 
 ## [0.23.1](https://github.com/wundergraph/cosmo/compare/wgc@0.23.0...wgc@0.23.1) (2023-10-26)
 
@@ -464,26 +471,26 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-* schema field level usage analytics ([#174](https://github.com/wundergraph/cosmo/issues/174)) ([4f257a7](https://github.com/wundergraph/cosmo/commit/4f257a71984e991be2304b09a083c69da65200d2)) (@StarpTech)
+- schema field level usage analytics ([#174](https://github.com/wundergraph/cosmo/issues/174)) ([4f257a7](https://github.com/wundergraph/cosmo/commit/4f257a71984e991be2304b09a083c69da65200d2)) (@StarpTech)
 
 # [0.22.0](https://github.com/wundergraph/cosmo/compare/wgc@0.21.0...wgc@0.22.0) (2023-10-23)
 
 ### Features
 
-* allow to upsert a subgraph on publish ([#196](https://github.com/wundergraph/cosmo/issues/196)) ([27a1630](https://github.com/wundergraph/cosmo/commit/27a1630574e817412a6d5fb2b304da645a31d481)) (@StarpTech)
+- allow to upsert a subgraph on publish ([#196](https://github.com/wundergraph/cosmo/issues/196)) ([27a1630](https://github.com/wundergraph/cosmo/commit/27a1630574e817412a6d5fb2b304da645a31d481)) (@StarpTech)
 
 # [0.21.0](https://github.com/wundergraph/cosmo/compare/wgc@0.20.2...wgc@0.21.0) (2023-10-20)
 
 ### Features
 
-* add support for subscriptions ([#185](https://github.com/wundergraph/cosmo/issues/185)) ([5a78aa0](https://github.com/wundergraph/cosmo/commit/5a78aa01f60ac4184ac69b0bd72aa1ce467bff93)) (@fiam)
-* auto ignore schema errors for check command if github is integrated ([#184](https://github.com/wundergraph/cosmo/issues/184)) ([05d1b4a](https://github.com/wundergraph/cosmo/commit/05d1b4a4fcb836013c8db49796c174eba0c96744)) (@thisisnithin)
+- add support for subscriptions ([#185](https://github.com/wundergraph/cosmo/issues/185)) ([5a78aa0](https://github.com/wundergraph/cosmo/commit/5a78aa01f60ac4184ac69b0bd72aa1ce467bff93)) (@fiam)
+- auto ignore schema errors for check command if github is integrated ([#184](https://github.com/wundergraph/cosmo/issues/184)) ([05d1b4a](https://github.com/wundergraph/cosmo/commit/05d1b4a4fcb836013c8db49796c174eba0c96744)) (@thisisnithin)
 
 ## [0.20.2](https://github.com/wundergraph/cosmo/compare/wgc@0.20.1...wgc@0.20.2) (2023-10-16)
 
 ### Bug Fixes
 
-* allow absolute paths for the wgc compose output file ([#187](https://github.com/wundergraph/cosmo/issues/187)) ([7cc8b7f](https://github.com/wundergraph/cosmo/commit/7cc8b7f72722e15f67a2a24a8c19ec1d5f916b80)) (@fiam)
+- allow absolute paths for the wgc compose output file ([#187](https://github.com/wundergraph/cosmo/issues/187)) ([7cc8b7f](https://github.com/wundergraph/cosmo/commit/7cc8b7f72722e15f67a2a24a8c19ec1d5f916b80)) (@fiam)
 
 ## [0.20.1](https://github.com/wundergraph/cosmo/compare/wgc@0.20.0...wgc@0.20.1) (2023-10-13)
 
@@ -493,50 +500,50 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-* use metric data for dashboard stats ([#169](https://github.com/wundergraph/cosmo/issues/169)) ([e25fe32](https://github.com/wundergraph/cosmo/commit/e25fe32cdc053d658b0b0cdcd819b039be3341e6)) (@StarpTech)
+- use metric data for dashboard stats ([#169](https://github.com/wundergraph/cosmo/issues/169)) ([e25fe32](https://github.com/wundergraph/cosmo/commit/e25fe32cdc053d658b0b0cdcd819b039be3341e6)) (@StarpTech)
 
 ## [0.19.3](https://github.com/wundergraph/cosmo/compare/wgc@0.19.2...wgc@0.19.3) (2023-10-06)
 
 ### Bug Fixes
 
-* repository and owner slug swapped ([#166](https://github.com/wundergraph/cosmo/issues/166)) ([1b61193](https://github.com/wundergraph/cosmo/commit/1b61193751992ee81e80a7712aeb9b9c69d3045a)) (@thisisnithin)
+- repository and owner slug swapped ([#166](https://github.com/wundergraph/cosmo/issues/166)) ([1b61193](https://github.com/wundergraph/cosmo/commit/1b61193751992ee81e80a7712aeb9b9c69d3045a)) (@thisisnithin)
 
 ## [0.19.2](https://github.com/wundergraph/cosmo/compare/wgc@0.19.1...wgc@0.19.2) (2023-10-06)
 
 ### Bug Fixes
 
-* cli reading incorrect github sha ([#162](https://github.com/wundergraph/cosmo/issues/162)) ([89de9a5](https://github.com/wundergraph/cosmo/commit/89de9a5435f7538a275f5931cd5a473b065cae04)) (@thisisnithin)
+- cli reading incorrect github sha ([#162](https://github.com/wundergraph/cosmo/issues/162)) ([89de9a5](https://github.com/wundergraph/cosmo/commit/89de9a5435f7538a275f5931cd5a473b065cae04)) (@thisisnithin)
 
 ## [0.19.1](https://github.com/wundergraph/cosmo/compare/wgc@0.19.0...wgc@0.19.1) (2023-10-06)
 
 ### Bug Fixes
 
-* update local demo script and fix the create router token cmd ([#151](https://github.com/wundergraph/cosmo/issues/151)) ([b305cfb](https://github.com/wundergraph/cosmo/commit/b305cfb4710316f6ebb63e1b8f40362b06e38c42)) (@JivusAyrus)
+- update local demo script and fix the create router token cmd ([#151](https://github.com/wundergraph/cosmo/issues/151)) ([b305cfb](https://github.com/wundergraph/cosmo/commit/b305cfb4710316f6ebb63e1b8f40362b06e38c42)) (@JivusAyrus)
 
 # [0.19.0](https://github.com/wundergraph/cosmo/compare/wgc@0.18.0...wgc@0.19.0) (2023-10-05)
 
 ### Features
 
-* implement list and delete router tokens ([#146](https://github.com/wundergraph/cosmo/issues/146)) ([72543f7](https://github.com/wundergraph/cosmo/commit/72543f796c66d155782cd90bc4828803fbb971c7)) (@JivusAyrus)
+- implement list and delete router tokens ([#146](https://github.com/wundergraph/cosmo/issues/146)) ([72543f7](https://github.com/wundergraph/cosmo/commit/72543f796c66d155782cd90bc4828803fbb971c7)) (@JivusAyrus)
 
 # [0.18.0](https://github.com/wundergraph/cosmo/compare/wgc@0.17.0...wgc@0.18.0) (2023-10-04)
 
 ### Features
 
-* github app integration ([#140](https://github.com/wundergraph/cosmo/issues/140)) ([783a1f9](https://github.com/wundergraph/cosmo/commit/783a1f9c3f42284d1bf6cfa0d8fd46971724500a)) (@thisisnithin)
-* handle multiple orgs in the cli ([#145](https://github.com/wundergraph/cosmo/issues/145)) ([77234c9](https://github.com/wundergraph/cosmo/commit/77234c979e117473bf8429c0cd0e4d4c888eb81d)) (@JivusAyrus)
+- github app integration ([#140](https://github.com/wundergraph/cosmo/issues/140)) ([783a1f9](https://github.com/wundergraph/cosmo/commit/783a1f9c3f42284d1bf6cfa0d8fd46971724500a)) (@thisisnithin)
+- handle multiple orgs in the cli ([#145](https://github.com/wundergraph/cosmo/issues/145)) ([77234c9](https://github.com/wundergraph/cosmo/commit/77234c979e117473bf8429c0cd0e4d4c888eb81d)) (@JivusAyrus)
 
 # [0.17.0](https://github.com/wundergraph/cosmo/compare/wgc@0.16.0...wgc@0.17.0) (2023-09-29)
 
 ### Features
 
-* improve trail version banner and handle trial version expiry ([#138](https://github.com/wundergraph/cosmo/issues/138)) ([0ecb2d1](https://github.com/wundergraph/cosmo/commit/0ecb2d150d9f9906631168aa0f588d2ca64ab590)) (@JivusAyrus)
+- improve trail version banner and handle trial version expiry ([#138](https://github.com/wundergraph/cosmo/issues/138)) ([0ecb2d1](https://github.com/wundergraph/cosmo/commit/0ecb2d150d9f9906631168aa0f588d2ca64ab590)) (@JivusAyrus)
 
 # [0.16.0](https://github.com/wundergraph/cosmo/compare/wgc@0.15.1...wgc@0.16.0) (2023-09-27)
 
 ### Features
 
-* output file option for cli commands ([#121](https://github.com/wundergraph/cosmo/issues/121)) ([329023e](https://github.com/wundergraph/cosmo/commit/329023e1b3e518020dd2948220d64960783d3577)) (@thisisnithin)
+- output file option for cli commands ([#121](https://github.com/wundergraph/cosmo/issues/121)) ([329023e](https://github.com/wundergraph/cosmo/commit/329023e1b3e518020dd2948220d64960783d3577)) (@thisisnithin)
 
 ## [0.15.1](https://github.com/wundergraph/cosmo/compare/wgc@0.15.0...wgc@0.15.1) (2023-09-26)
 
@@ -546,7 +553,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-* implement get changelog cli command ([#117](https://github.com/wundergraph/cosmo/issues/117)) ([ffaad09](https://github.com/wundergraph/cosmo/commit/ffaad093a212a6340263c4223452fb9edfec7570)) (@thisisnithin)
+- implement get changelog cli command ([#117](https://github.com/wundergraph/cosmo/issues/117)) ([ffaad09](https://github.com/wundergraph/cosmo/commit/ffaad093a212a6340263c4223452fb9edfec7570)) (@thisisnithin)
 
 ## [0.14.1](https://github.com/wundergraph/cosmo/compare/wgc@0.14.0...wgc@0.14.1) (2023-09-25)
 
@@ -556,23 +563,23 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-* add logout command ([#106](https://github.com/wundergraph/cosmo/issues/106)) ([1f965a9](https://github.com/wundergraph/cosmo/commit/1f965a97e4c53d067b428ed6f7e22b39be28c788)) (@JivusAyrus)
+- add logout command ([#106](https://github.com/wundergraph/cosmo/issues/106)) ([1f965a9](https://github.com/wundergraph/cosmo/commit/1f965a97e4c53d067b428ed6f7e22b39be28c788)) (@JivusAyrus)
 
 # [0.13.0](https://github.com/wundergraph/cosmo/compare/wgc@0.12.0...wgc@0.13.0) (2023-09-21)
 
 ### Bug Fixes
 
-* update realm json and modify config ([#101](https://github.com/wundergraph/cosmo/issues/101)) ([73d8d8d](https://github.com/wundergraph/cosmo/commit/73d8d8d8330b9fd85bba2c9d437cda72f4363d88)) (@JivusAyrus)
+- update realm json and modify config ([#101](https://github.com/wundergraph/cosmo/issues/101)) ([73d8d8d](https://github.com/wundergraph/cosmo/commit/73d8d8d8330b9fd85bba2c9d437cda72f4363d88)) (@JivusAyrus)
 
 ### Features
 
-* add login command ([#95](https://github.com/wundergraph/cosmo/issues/95)) ([e9da8c3](https://github.com/wundergraph/cosmo/commit/e9da8c3c9e018029e0aef06d3b3b823732812a47)) (@JivusAyrus)
+- add login command ([#95](https://github.com/wundergraph/cosmo/issues/95)) ([e9da8c3](https://github.com/wundergraph/cosmo/commit/e9da8c3c9e018029e0aef06d3b3b823732812a47)) (@JivusAyrus)
 
 # [0.12.0](https://github.com/wundergraph/cosmo/compare/wgc@0.11.3...wgc@0.12.0) (2023-09-20)
 
 ### Features
 
-* store subgraphs in router config ([#61](https://github.com/wundergraph/cosmo/issues/61)) ([de7b132](https://github.com/wundergraph/cosmo/commit/de7b13244755acd49c38ff1e6c537234ab506960)) (@thisisnithin)
+- store subgraphs in router config ([#61](https://github.com/wundergraph/cosmo/issues/61)) ([de7b132](https://github.com/wundergraph/cosmo/commit/de7b13244755acd49c38ff1e6c537234ab506960)) (@thisisnithin)
 
 ## [0.11.3](https://github.com/wundergraph/cosmo/compare/wgc@0.11.2...wgc@0.11.3) (2023-09-19)
 
@@ -586,13 +593,13 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-* use relative path to read subgraph schema ([#75](https://github.com/wundergraph/cosmo/issues/75)) ([26a145f](https://github.com/wundergraph/cosmo/commit/26a145f5412d753f710a273d78be0b7dcb4d5a23)) (@devsergiy)
+- use relative path to read subgraph schema ([#75](https://github.com/wundergraph/cosmo/issues/75)) ([26a145f](https://github.com/wundergraph/cosmo/commit/26a145f5412d753f710a273d78be0b7dcb4d5a23)) (@devsergiy)
 
 # [0.11.0](https://github.com/wundergraph/cosmo/compare/wgc@0.10.2...wgc@0.11.0) (2023-09-16)
 
 ### Features
 
-* only generate node api for router ([#76](https://github.com/wundergraph/cosmo/issues/76)) ([9307648](https://github.com/wundergraph/cosmo/commit/93076481437030fa6e348dccbc74591f91878f57)) (@StarpTech)
+- only generate node api for router ([#76](https://github.com/wundergraph/cosmo/issues/76)) ([9307648](https://github.com/wundergraph/cosmo/commit/93076481437030fa6e348dccbc74591f91878f57)) (@StarpTech)
 
 ## [0.10.2](https://github.com/wundergraph/cosmo/compare/wgc@0.10.1...wgc@0.10.2) (2023-09-15)
 
@@ -606,11 +613,11 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-* improve compose command input ([#58](https://github.com/wundergraph/cosmo/issues/58)) ([4430f85](https://github.com/wundergraph/cosmo/commit/4430f85615a3fb4bd0cbc41e6919981556927ab5)) (@thisisnithin)
+- improve compose command input ([#58](https://github.com/wundergraph/cosmo/issues/58)) ([4430f85](https://github.com/wundergraph/cosmo/commit/4430f85615a3fb4bd0cbc41e6919981556927ab5)) (@thisisnithin)
 
 ### Features
 
-* migrate from cli-table to cli-table3 ([#41](https://github.com/wundergraph/cosmo/issues/41)) ([d21bbd9](https://github.com/wundergraph/cosmo/commit/d21bbd935f17ff35d03a2a2cb43ad1fedf815906)) (@JivusAyrus)
+- migrate from cli-table to cli-table3 ([#41](https://github.com/wundergraph/cosmo/issues/41)) ([d21bbd9](https://github.com/wundergraph/cosmo/commit/d21bbd935f17ff35d03a2a2cb43ad1fedf815906)) (@JivusAyrus)
 
 ## [0.9.1](https://github.com/wundergraph/cosmo/compare/wgc@0.9.0...wgc@0.9.1) (2023-09-11)
 
@@ -620,9 +627,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-* add introspect subgraph command ([#44](https://github.com/wundergraph/cosmo/issues/44)) ([bf376cd](https://github.com/wundergraph/cosmo/commit/bf376cd75382b16659efb670ea54494f691328aa)) (@JivusAyrus)
-* introspect subgraphs in cli ([#53](https://github.com/wundergraph/cosmo/issues/53)) ([2bd9f95](https://github.com/wundergraph/cosmo/commit/2bd9f95cd3ac13e878a12ab526d575c9b1daf248)) (@JivusAyrus)
-* router compose command ([#54](https://github.com/wundergraph/cosmo/issues/54)) ([109313a](https://github.com/wundergraph/cosmo/commit/109313a54d730e143d2b182fb7a72e7dd4386317)) (@thisisnithin)
+- add introspect subgraph command ([#44](https://github.com/wundergraph/cosmo/issues/44)) ([bf376cd](https://github.com/wundergraph/cosmo/commit/bf376cd75382b16659efb670ea54494f691328aa)) (@JivusAyrus)
+- introspect subgraphs in cli ([#53](https://github.com/wundergraph/cosmo/issues/53)) ([2bd9f95](https://github.com/wundergraph/cosmo/commit/2bd9f95cd3ac13e878a12ab526d575c9b1daf248)) (@JivusAyrus)
+- router compose command ([#54](https://github.com/wundergraph/cosmo/issues/54)) ([109313a](https://github.com/wundergraph/cosmo/commit/109313a54d730e143d2b182fb7a72e7dd4386317)) (@thisisnithin)
 
 ## [0.8.3](https://github.com/wundergraph/cosmo/compare/wgc@0.8.2...wgc@0.8.3) (2023-09-08)
 
@@ -640,15 +647,15 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-* add federatedGraph and subgraph list command ([#34](https://github.com/wundergraph/cosmo/issues/34)) ([d235307](https://github.com/wundergraph/cosmo/commit/d2353070bd3fa29ccbd4ccf571964482532fae0a)) (@JivusAyrus)
-* implement whoami cli command ([#33](https://github.com/wundergraph/cosmo/issues/33)) ([c920b25](https://github.com/wundergraph/cosmo/commit/c920b25ff4dc31cf9788b1590e3c89e4a33a3ac0)) (@StarpTech)
-* move to new connectrpc packages ([#32](https://github.com/wundergraph/cosmo/issues/32)) ([4c8423b](https://github.com/wundergraph/cosmo/commit/4c8423bf377b63af6a42a42d7d5fc1ce2db1f09e)) (@StarpTech)
+- add federatedGraph and subgraph list command ([#34](https://github.com/wundergraph/cosmo/issues/34)) ([d235307](https://github.com/wundergraph/cosmo/commit/d2353070bd3fa29ccbd4ccf571964482532fae0a)) (@JivusAyrus)
+- implement whoami cli command ([#33](https://github.com/wundergraph/cosmo/issues/33)) ([c920b25](https://github.com/wundergraph/cosmo/commit/c920b25ff4dc31cf9788b1590e3c89e4a33a3ac0)) (@StarpTech)
+- move to new connectrpc packages ([#32](https://github.com/wundergraph/cosmo/issues/32)) ([4c8423b](https://github.com/wundergraph/cosmo/commit/4c8423bf377b63af6a42a42d7d5fc1ce2db1f09e)) (@StarpTech)
 
 # [0.7.0](https://github.com/wundergraph/cosmo/compare/wgc@0.6.5...wgc@0.7.0) (2023-09-02)
 
 ### Features
 
-* add prometheus ([#31](https://github.com/wundergraph/cosmo/issues/31)) ([d318c73](https://github.com/wundergraph/cosmo/commit/d318c7331d77d21d0246344d76fbe0fc6b617174)) (@StarpTech)
+- add prometheus ([#31](https://github.com/wundergraph/cosmo/issues/31)) ([d318c73](https://github.com/wundergraph/cosmo/commit/d318c7331d77d21d0246344d76fbe0fc6b617174)) (@StarpTech)
 
 ## [0.6.5](https://github.com/wundergraph/cosmo/compare/wgc@0.6.4...wgc@0.6.5) (2023-08-31)
 
@@ -658,7 +665,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-* throw auth error inside try, allow to customize k8s probes, use … ([#24](https://github.com/wundergraph/cosmo/issues/24)) ([2d5695b](https://github.com/wundergraph/cosmo/commit/2d5695b95adad9b2fd8a6cacbc2dd2a1c2cb9bd6)) (@StarpTech)
+- throw auth error inside try, allow to customize k8s probes, use … ([#24](https://github.com/wundergraph/cosmo/issues/24)) ([2d5695b](https://github.com/wundergraph/cosmo/commit/2d5695b95adad9b2fd8a6cacbc2dd2a1c2cb9bd6)) (@StarpTech)
 
 ## [0.6.3](https://github.com/wundergraph/cosmo/compare/wgc@0.6.2...wgc@0.6.3) (2023-08-29)
 
@@ -668,7 +675,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-* improvements ([#18](https://github.com/wundergraph/cosmo/issues/18)) ([fdf2b29](https://github.com/wundergraph/cosmo/commit/fdf2b290ec57e502d8011e29e06a067d32afdf18)) (@JivusAyrus)
+- improvements ([#18](https://github.com/wundergraph/cosmo/issues/18)) ([fdf2b29](https://github.com/wundergraph/cosmo/commit/fdf2b290ec57e502d8011e29e06a067d32afdf18)) (@JivusAyrus)
 
 ## [0.6.1](https://github.com/wundergraph/cosmo/compare/wgc@0.6.0...wgc@0.6.1) (2023-08-28)
 
@@ -678,7 +685,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-* prepare release pipeline ([#1](https://github.com/wundergraph/cosmo/issues/1)) ([747aa47](https://github.com/wundergraph/cosmo/commit/747aa47d5e965d1b74862fbb5598bafb2fa05ee2)) (@StarpTech)
+- prepare release pipeline ([#1](https://github.com/wundergraph/cosmo/issues/1)) ([747aa47](https://github.com/wundergraph/cosmo/commit/747aa47d5e965d1b74862fbb5598bafb2fa05ee2)) (@StarpTech)
 
 ## [0.5.2](https://github.com/wundergraph/cosmo/compare/wgc@0.4.0...wgc@0.5.2) (2023-08-24)
 
@@ -692,28 +699,28 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-* prepare release pipeline ([#1](https://github.com/wundergraph/cosmo/issues/1)) ([747aa47](https://github.com/wundergraph/cosmo/commit/747aa47d5e965d1b74862fbb5598bafb2fa05ee2)) (@StarpTech)
+- prepare release pipeline ([#1](https://github.com/wundergraph/cosmo/issues/1)) ([747aa47](https://github.com/wundergraph/cosmo/commit/747aa47d5e965d1b74862fbb5598bafb2fa05ee2)) (@StarpTech)
 
 # 0.4.0 (2023-08-24)
 
 ### Features
 
-* prepare release pipeline ([#1](https://github.com/wundergraph/cosmo/issues/1)) ([747aa47](https://github.com/wundergraph/cosmo/commit/747aa47d5e965d1b74862fbb5598bafb2fa05ee2)) (@StarpTech)
+- prepare release pipeline ([#1](https://github.com/wundergraph/cosmo/issues/1)) ([747aa47](https://github.com/wundergraph/cosmo/commit/747aa47d5e965d1b74862fbb5598bafb2fa05ee2)) (@StarpTech)
 
 # 0.3.0 (2023-08-24)
 
 ### Features
 
-* prepare release pipeline ([#1](https://github.com/wundergraph/cosmo/issues/1)) ([747aa47](https://github.com/wundergraph/cosmo/commit/747aa47d5e965d1b74862fbb5598bafb2fa05ee2)) (@StarpTech)
+- prepare release pipeline ([#1](https://github.com/wundergraph/cosmo/issues/1)) ([747aa47](https://github.com/wundergraph/cosmo/commit/747aa47d5e965d1b74862fbb5598bafb2fa05ee2)) (@StarpTech)
 
 # 0.2.0 (2023-08-24)
 
 ### Features
 
-* prepare release pipeline ([#1](https://github.com/wundergraph/cosmo/issues/1)) ([747aa47](https://github.com/wundergraph/cosmo/commit/747aa47d5e965d1b74862fbb5598bafb2fa05ee2)) (@StarpTech)
+- prepare release pipeline ([#1](https://github.com/wundergraph/cosmo/issues/1)) ([747aa47](https://github.com/wundergraph/cosmo/commit/747aa47d5e965d1b74862fbb5598bafb2fa05ee2)) (@StarpTech)
 
 # 0.1.0 (2023-08-24)
 
 ### Features
 
-* prepare release pipeline ([#1](https://github.com/wundergraph/cosmo/issues/1)) ([747aa47](https://github.com/wundergraph/cosmo/commit/747aa47d5e965d1b74862fbb5598bafb2fa05ee2)) (@StarpTech)
+- prepare release pipeline ([#1](https://github.com/wundergraph/cosmo/issues/1)) ([747aa47](https://github.com/wundergraph/cosmo/commit/747aa47d5e965d1b74862fbb5598bafb2fa05ee2)) (@StarpTech)

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wgc",
-  "version": "0.53.3",
+  "version": "0.54.0",
   "description": "The official CLI tool to manage the GraphQL Federation Platform Cosmo",
   "type": "module",
   "main": "dist/index.js",
@@ -20,6 +20,7 @@
   },
   "scripts": {
     "build": "del dist && tsc",
+    "build:binaries": "./scripts/build-binaries.sh",
     "wgc": "tsx src/index.ts",
     "test": "pnpm lint && vitest run",
     "coverage": "vitest run --coverage",

--- a/cli/package.json
+++ b/cli/package.json
@@ -61,6 +61,10 @@
     "picocolors": "^1.0.0"
   },
   "devDependencies": {
+    "@rollup/plugin-commonjs": "^25.0.7",
+    "@rollup/plugin-json": "^6.1.0",
+    "@rollup/plugin-node-resolve": "^15.2.3",
+    "@rollup/plugin-typescript": "^11.1.6",
     "@types/cli-progress": "^3.11.5",
     "@types/cli-table": "^0.3.1",
     "@types/decompress": "^4.2.7",
@@ -71,7 +75,9 @@
     "eslint": "^8.52.0",
     "eslint-config-unjs": "^0.2.1",
     "eslint-plugin-require-extensions": "^0.1.3",
+    "pkg": "^5.8.1",
     "prettier": "^3.0.3",
+    "rollup": "^4.17.2",
     "tsx": "^4.7.1",
     "typescript": "^5.2.2",
     "vitest": "^1.5.0"

--- a/cli/rollup.config.js
+++ b/cli/rollup.config.js
@@ -1,0 +1,13 @@
+import resolve from '@rollup/plugin-node-resolve';
+import typescript from '@rollup/plugin-typescript';
+import commonjs from '@rollup/plugin-commonjs';
+import json from '@rollup/plugin-json';
+
+export default {
+  input: 'src/index.ts',
+  output: {
+    format: 'cjs',
+    file: 'dist/bundle.cjs',
+  },
+  plugins: [resolve({ exportConditions: ['node'] }), typescript(), commonjs(), json()],
+};

--- a/cli/scripts/build-binaries.sh
+++ b/cli/scripts/build-binaries.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+
+echo " 📦  Building wcg binaries..."
+del dist/bundle.cjs 
+del dist/bin
+
+# vercel/pkg doesnt support es modules so we need to transpile to cjs
+# see ../rollup.config.js
+rollup -c
+
+pkg dist/bundle.cjs -t node16-macos,node16-linux,node16-win --out-path dist/bin
+
+cd dist/bin
+
+mkdir macos linux win
+mv bundle-macos macos/wcg
+mv bundle-linux linux/wcg
+mv bundle-win.exe win/wcg.exe
+
+echo " 📦  Building wcg binaries... Done"

--- a/cli/scripts/install.ps1
+++ b/cli/scripts/install.ps1
@@ -1,0 +1,24 @@
+Write-Host "Installing wgc...
+
+__      ____ _  ___
+\ \ /\ / / _` |/ __|
+ \ V  V / (_| | (__
+  \_/\_/ \__, |\___|
+         |___/
+"
+
+$OS = $env:OS
+$URL = ""
+
+if ($OS -eq "Windows_NT") {
+    $URL = "https://github.com/wundegraph/cosmo/releases/latest/download/wgc-windows.exe"
+} else {
+    Write-Host "Unsupported OS: $OS"
+    exit 1
+}
+
+Invoke-WebRequest -Uri $URL -OutFile $env:ProgramFiles\wgc\wgc.exe
+chmod +x $env:ProgramFiles\wgc\wgc.exe
+
+Write-Host "wgc installed successfully!"
+chmod +x wgc.exe

--- a/cli/scripts/install.sh
+++ b/cli/scripts/install.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -e
+
+echo "Installing wgc...   
+
+__      ____ _  ___   
+\ \ /\ / / _\` |/ __|  
+ \ V  V / (_| | (__   
+  \_/\_/ \__, |\___|  
+         |___/        
+"
+
+OS=$(uname -s)
+URL=""
+
+case "$OS" in
+    Linux)
+        URL="https://github.com/wundegraph/cosmo/releases/latest/download/wgc-linux"
+        ;;
+    Darwin)
+        URL="https://github.com/wundegraph/cosmo/releases/latest/download/wgc-mac"
+        ;;
+    CYGWIN*|MINGW32*|MSYS*|MINGW*)
+        URL="https://github.com/wundegraph/cosmo/releases/latest/download/wgc-windows.exe"
+        ;;
+    *)
+        echo "Unsupported OS: $OS"
+        exit 1
+        ;;
+esac
+
+curl -L -o /usr/local/bin/wgc $URL
+chmod +x /usr/local/bin/wgc
+
+echo "wgc installed successfully!"
+

--- a/cli/src/core/config.ts
+++ b/cli/src/core/config.ts
@@ -1,15 +1,11 @@
 import { readFileSync } from 'node:fs';
-import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import pc from 'picocolors';
 import yaml from 'js-yaml';
 import envPaths from 'env-paths';
 
-const info = JSON.parse(
-  await readFile(new URL('../../package.json', import.meta.url), {
-    encoding: 'utf8',
-  }),
-);
+const packageJsonPath = path.join(process.cwd(), 'package.json');
+const info = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
 
 const paths = envPaths('cosmo', { suffix: '' });
 export const configDir = paths.config;

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -8,7 +8,9 @@ import program from './commands/index.js';
 dotenv.config();
 
 try {
-  await program.parseAsync(process.argv);
+  (async () => {
+    await program.parseAsync(process.argv);
+  })();
 } catch (e) {
   console.log('');
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,7 +20,7 @@ importers:
         version: 1.4.1(@bufbuild/protobuf@1.4.1)
       '@commitlint/cli':
         specifier: 19.2.1
-        version: 19.2.1(@types/node@20.3.1)(typescript@5.1.3)
+        version: 19.2.1(@types/node@20.11.26)(typescript@5.3.2)
       '@commitlint/config-conventional':
         specifier: 19.1.0
         version: 19.1.0
@@ -35,13 +35,13 @@ importers:
         version: 0.6.0(@bufbuild/protoc-gen-es@1.4.1)
       '@lerna-lite/cli':
         specifier: 3.3.1
-        version: 3.3.1(@lerna-lite/publish@3.3.1)(@lerna-lite/version@3.3.1)(typescript@5.1.3)
+        version: 3.3.1(@lerna-lite/publish@3.3.1)(@lerna-lite/version@3.3.1)(typescript@5.3.2)
       '@lerna-lite/publish':
         specifier: 3.3.1
-        version: 3.3.1(typescript@5.1.3)
+        version: 3.3.1(typescript@5.3.2)
       '@lerna-lite/version':
         specifier: 3.3.1
-        version: 3.3.1(@lerna-lite/publish@3.3.1)(typescript@5.1.3)
+        version: 3.3.1(@lerna-lite/publish@3.3.1)(typescript@5.3.2)
       del-cli:
         specifier: ^5.1.0
         version: 5.1.0
@@ -56,7 +56,7 @@ importers:
         version: 3.0.3
       vitest:
         specifier: ^1.5.0
-        version: 1.5.0(@types/node@20.3.1)
+        version: 1.5.0(@types/node@20.11.26)
 
   admission-server:
     dependencies:
@@ -214,6 +214,18 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0
     devDependencies:
+      '@rollup/plugin-commonjs':
+        specifier: ^25.0.7
+        version: 25.0.7(rollup@4.17.2)
+      '@rollup/plugin-json':
+        specifier: ^6.1.0
+        version: 6.1.0(rollup@4.17.2)
+      '@rollup/plugin-node-resolve':
+        specifier: ^15.2.3
+        version: 15.2.3(rollup@4.17.2)
+      '@rollup/plugin-typescript':
+        specifier: ^11.1.6
+        version: 11.1.6(rollup@4.17.2)(typescript@5.2.2)
       '@types/cli-progress':
         specifier: ^3.11.5
         version: 3.11.5
@@ -244,9 +256,15 @@ importers:
       eslint-plugin-require-extensions:
         specifier: ^0.1.3
         version: 0.1.3(eslint@8.52.0)
+      pkg:
+        specifier: ^5.8.1
+        version: 5.8.1
       prettier:
         specifier: ^3.0.3
         version: 3.0.3
+      rollup:
+        specifier: ^4.17.2
+        version: 4.17.2
       tsx:
         specifier: ^4.7.1
         version: 4.7.1
@@ -1635,6 +1653,15 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@babel/generator@7.18.2:
+    resolution: {integrity: sha512-W1lG5vUwFvfMd8HVXqdfbuG7RuaSrTCCD8cl8fP8wOivdbtbIg2Db3IWUcgvfxKbbn6ZBGYRW/Zk1MIwK49mgw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.23.6
+      '@jridgewell/gen-mapping': 0.3.3
+      jsesc: 2.5.2
+    dev: true
+
   /@babel/generator@7.23.6:
     resolution: {integrity: sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==}
     engines: {node: '>=6.9.0'}
@@ -1745,6 +1772,14 @@ packages:
       chalk: 2.4.2
       js-tokens: 4.0.0
 
+  /@babel/parser@7.18.4:
+    resolution: {integrity: sha512-FDge0dFazETFcxGw/EXzOkN8uJp0PC7Qbm+Pe9T+av2zlBpOgunFHkQPPn+eRuClU73JF+98D531UgayY89tow==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+    dependencies:
+      '@babel/types': 7.23.6
+    dev: true
+
   /@babel/parser@7.23.6:
     resolution: {integrity: sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==}
     engines: {node: '>=6.0.0'}
@@ -1819,6 +1854,15 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
+
+  /@babel/types@7.19.0:
+    resolution: {integrity: sha512-YuGopBq3ke25BVSiS6fgF49Ul9gH1x70Bcr6bqRLjWCkcX8Hre1/5+z+IiWOIerRMSSEfGZVB9z9kyq7wVs9YA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-string-parser': 7.23.4
+      '@babel/helper-validator-identifier': 7.22.20
+      to-fast-properties: 2.0.0
+    dev: true
 
   /@babel/types@7.23.4:
     resolution: {integrity: sha512-7uIFwVYpoplT5jp/kVv6EF93VaJ8H+Yn5IczYiaAi98ajzjfoZfslet/e0sLh+wVBjb2qqIut1b0S26VSafsSQ==}
@@ -3056,14 +3100,14 @@ packages:
     dev: false
     optional: true
 
-  /@commitlint/cli@19.2.1(@types/node@20.3.1)(typescript@5.1.3):
+  /@commitlint/cli@19.2.1(@types/node@20.11.26)(typescript@5.3.2):
     resolution: {integrity: sha512-cbkYUJsLqRomccNxvoJTyv5yn0bSy05BBizVyIcLACkRbVUqYorC351Diw/XFSWC/GtpwiwT2eOvQgFZa374bg==}
     engines: {node: '>=v18'}
     hasBin: true
     dependencies:
       '@commitlint/format': 19.0.3
       '@commitlint/lint': 19.1.0
-      '@commitlint/load': 19.2.0(@types/node@20.3.1)(typescript@5.1.3)
+      '@commitlint/load': 19.2.0(@types/node@20.11.26)(typescript@5.3.2)
       '@commitlint/read': 19.2.1
       '@commitlint/types': 19.0.3
       execa: 8.0.1
@@ -3132,7 +3176,7 @@ packages:
       '@commitlint/types': 19.0.3
     dev: true
 
-  /@commitlint/load@19.2.0(@types/node@20.3.1)(typescript@5.1.3):
+  /@commitlint/load@19.2.0(@types/node@20.11.26)(typescript@5.3.2):
     resolution: {integrity: sha512-XvxxLJTKqZojCxaBQ7u92qQLFMMZc4+p9qrIq/9kJDy8DOrEa7P1yx7Tjdc2u2JxIalqT4KOGraVgCE7eCYJyQ==}
     engines: {node: '>=v18'}
     dependencies:
@@ -3141,8 +3185,8 @@ packages:
       '@commitlint/resolve-extends': 19.1.0
       '@commitlint/types': 19.0.3
       chalk: 5.3.0
-      cosmiconfig: 9.0.0(typescript@5.1.3)
-      cosmiconfig-typescript-loader: 5.0.0(@types/node@20.3.1)(cosmiconfig@9.0.0)(typescript@5.1.3)
+      cosmiconfig: 9.0.0(typescript@5.3.2)
+      cosmiconfig-typescript-loader: 5.0.0(@types/node@20.11.26)(cosmiconfig@9.0.0)(typescript@5.3.2)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
@@ -5269,7 +5313,7 @@ packages:
       url-template: 3.1.0
     dev: false
 
-  /@lerna-lite/cli@3.3.1(@lerna-lite/publish@3.3.1)(@lerna-lite/version@3.3.1)(typescript@5.1.3):
+  /@lerna-lite/cli@3.3.1(@lerna-lite/publish@3.3.1)(@lerna-lite/version@3.3.1)(typescript@5.3.2):
     resolution: {integrity: sha512-tniFllcJtrR6SinS1AnDMzviZmnR1fInyIX1HZCIaDiiSz1O3FAM+QmrrFfSHl5HRaPpVGEPMP9KexTKZE+Csw==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -5294,10 +5338,10 @@ packages:
       '@lerna-lite/watch':
         optional: true
     dependencies:
-      '@lerna-lite/core': 3.3.1(typescript@5.1.3)
-      '@lerna-lite/init': 3.3.1(typescript@5.1.3)
-      '@lerna-lite/publish': 3.3.1(typescript@5.1.3)
-      '@lerna-lite/version': 3.3.1(@lerna-lite/publish@3.3.1)(typescript@5.1.3)
+      '@lerna-lite/core': 3.3.1(typescript@5.3.2)
+      '@lerna-lite/init': 3.3.1(typescript@5.3.2)
+      '@lerna-lite/publish': 3.3.1(typescript@5.3.2)
+      '@lerna-lite/version': 3.3.1(@lerna-lite/publish@3.3.1)(typescript@5.3.2)
       dedent: 1.5.1
       dotenv: 16.4.5
       import-local: 3.1.0
@@ -5311,7 +5355,7 @@ packages:
       - typescript
     dev: true
 
-  /@lerna-lite/core@3.3.1(typescript@5.1.3):
+  /@lerna-lite/core@3.3.1(typescript@5.3.2):
     resolution: {integrity: sha512-YkYVaHzdRqOFKtCZcWfRVg44lu1OXErzx9xKruKYjX6qHfUr0zqyNVm6tbzWGy9wPdU4VWw77KKzG+gtIEcGjA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     dependencies:
@@ -5319,7 +5363,7 @@ packages:
       chalk: 5.3.0
       clone-deep: 4.0.1
       config-chain: 1.1.13
-      cosmiconfig: 9.0.0(typescript@5.1.3)
+      cosmiconfig: 9.0.0(typescript@5.3.2)
       dedent: 1.5.1
       execa: 8.0.1
       fs-extra: 11.2.0
@@ -5348,11 +5392,11 @@ packages:
       - typescript
     dev: true
 
-  /@lerna-lite/init@3.3.1(typescript@5.1.3):
+  /@lerna-lite/init@3.3.1(typescript@5.3.2):
     resolution: {integrity: sha512-dYTEfwz4xv43BeILWjWxijhpTcKtHqIQEx1QVEmzOVJu6lbpATkbFYQ5DO4BXElyx/5hjNLHptKnDIen9T5Peg==}
     engines: {node: ^18.0.0 || >=20.0.0}
     dependencies:
-      '@lerna-lite/core': 3.3.1(typescript@5.1.3)
+      '@lerna-lite/core': 3.3.1(typescript@5.3.2)
       fs-extra: 11.2.0
       p-map: 7.0.1
       write-json-file: 5.0.0
@@ -5363,13 +5407,13 @@ packages:
       - typescript
     dev: true
 
-  /@lerna-lite/publish@3.3.1(typescript@5.1.3):
+  /@lerna-lite/publish@3.3.1(typescript@5.3.2):
     resolution: {integrity: sha512-NmuO+nZ09S1QP+iigr4MrdROfOSL17bscoVKVsiBL5pHwX11lv6UyqRdpDDcG9UbExfRtyeDEFy37GfpPpD0iQ==}
     engines: {node: ^18.0.0 || >=20.0.0}
     dependencies:
-      '@lerna-lite/cli': 3.3.1(@lerna-lite/publish@3.3.1)(@lerna-lite/version@3.3.1)(typescript@5.1.3)
-      '@lerna-lite/core': 3.3.1(typescript@5.1.3)
-      '@lerna-lite/version': 3.3.1(@lerna-lite/publish@3.3.1)(typescript@5.1.3)
+      '@lerna-lite/cli': 3.3.1(@lerna-lite/publish@3.3.1)(@lerna-lite/version@3.3.1)(typescript@5.3.2)
+      '@lerna-lite/core': 3.3.1(typescript@5.3.2)
+      '@lerna-lite/version': 3.3.1(@lerna-lite/publish@3.3.1)(typescript@5.3.2)
       '@npmcli/arborist': 7.4.0
       byte-size: 8.1.1
       chalk: 5.3.0
@@ -5404,12 +5448,12 @@ packages:
       - typescript
     dev: true
 
-  /@lerna-lite/version@3.3.1(@lerna-lite/publish@3.3.1)(typescript@5.1.3):
+  /@lerna-lite/version@3.3.1(@lerna-lite/publish@3.3.1)(typescript@5.3.2):
     resolution: {integrity: sha512-0Kes5H0H8+tZSTLMTf5ArZTIijROSwgvJsnd5o7z6XvYZM8cq9ED63tpzgX9GKXyqnjZH4mlHpcQr5lpmABJFA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     dependencies:
-      '@lerna-lite/cli': 3.3.1(@lerna-lite/publish@3.3.1)(@lerna-lite/version@3.3.1)(typescript@5.1.3)
-      '@lerna-lite/core': 3.3.1(typescript@5.1.3)
+      '@lerna-lite/cli': 3.3.1(@lerna-lite/publish@3.3.1)(@lerna-lite/version@3.3.1)(typescript@5.3.2)
+      '@lerna-lite/core': 3.3.1(typescript@5.3.2)
       '@octokit/plugin-enterprise-rest': 6.0.1
       '@octokit/rest': 20.0.2
       chalk: 5.3.0
@@ -7760,11 +7804,102 @@ packages:
     resolution: {integrity: sha512-l3YHBLAol6d/IKnB9LhpD0cEZWAoe3eFKUyTYWmFmCO2Q/WOckxLQAUyMZWwZV2M/m3+4vgRoaolFqaII82/TA==}
     dev: false
 
+  /@rollup/plugin-commonjs@25.0.7(rollup@4.17.2):
+    resolution: {integrity: sha512-nEvcR+LRjEjsaSsc4x3XZfCCvZIaSMenZu/OiwOKGN2UhQpAYI7ru7czFvyWbErlpoGjnSX3D5Ch5FcMA3kRWQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^2.68.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@rollup/pluginutils': 5.1.0(rollup@4.17.2)
+      commondir: 1.0.1
+      estree-walker: 2.0.2
+      glob: 8.1.0
+      is-reference: 1.2.1
+      magic-string: 0.30.5
+      rollup: 4.17.2
+    dev: true
+
+  /@rollup/plugin-json@6.1.0(rollup@4.17.2):
+    resolution: {integrity: sha512-EGI2te5ENk1coGeADSIwZ7G2Q8CJS2sF120T7jLw4xFw9n7wIOXHo+kIYRAoVpJAN+kmqZSoO3Fp4JtoNF4ReA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@rollup/pluginutils': 5.1.0(rollup@4.17.2)
+      rollup: 4.17.2
+    dev: true
+
+  /@rollup/plugin-node-resolve@15.2.3(rollup@4.17.2):
+    resolution: {integrity: sha512-j/lym8nf5E21LwBT4Df1VD6hRO2L2iwUeUmP7litikRsVp1H6NWx20NEp0Y7su+7XGc476GnXXc4kFeZNGmaSQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^2.78.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@rollup/pluginutils': 5.1.0(rollup@4.17.2)
+      '@types/resolve': 1.20.2
+      deepmerge: 4.3.1
+      is-builtin-module: 3.2.1
+      is-module: 1.0.0
+      resolve: 1.22.2
+      rollup: 4.17.2
+    dev: true
+
+  /@rollup/plugin-typescript@11.1.6(rollup@4.17.2)(typescript@5.2.2):
+    resolution: {integrity: sha512-R92yOmIACgYdJ7dJ97p4K69I8gg6IEHt8M7dUBxN3W6nrO8uUxX5ixl0yU/N3aZTi8WhPuICvOHXQvF6FaykAA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^2.14.0||^3.0.0||^4.0.0
+      tslib: '*'
+      typescript: '>=3.7.0'
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+      tslib:
+        optional: true
+    dependencies:
+      '@rollup/pluginutils': 5.1.0(rollup@4.17.2)
+      resolve: 1.22.2
+      rollup: 4.17.2
+      typescript: 5.2.2
+    dev: true
+
+  /@rollup/pluginutils@5.1.0(rollup@4.17.2):
+    resolution: {integrity: sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@types/estree': 1.0.5
+      estree-walker: 2.0.2
+      picomatch: 2.3.1
+      rollup: 4.17.2
+    dev: true
+
   /@rollup/rollup-android-arm-eabi@4.16.2:
     resolution: {integrity: sha512-VGodkwtEuZ+ENPz/CpDSl091koMv8ao5jHVMbG1vNK+sbx/48/wVzP84M5xSfDAC69mAKKoEkSo+ym9bXYRK9w==}
     cpu: [arm]
     os: [android]
     requiresBuild: true
+    optional: true
+
+  /@rollup/rollup-android-arm-eabi@4.17.2:
+    resolution: {integrity: sha512-NM0jFxY8bB8QLkoKxIQeObCaDlJKewVlIEkuyYKm5An1tdVZ966w2+MPQ2l8LBZLjR+SgyV+nRkTIunzOYBMLQ==}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@rollup/rollup-android-arm-eabi@4.9.5:
@@ -7782,6 +7917,14 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@rollup/rollup-android-arm64@4.17.2:
+    resolution: {integrity: sha512-yeX/Usk7daNIVwkq2uGoq2BYJKZY1JfyLTaHO/jaiSwi/lsf8fTFoQW/n6IdAsx5tx+iotu2zCJwz8MxI6D/Bw==}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@rollup/rollup-android-arm64@4.9.5:
     resolution: {integrity: sha512-f14d7uhAMtsCGjAYwZGv6TwuS3IFaM4ZnGMUn3aCBgkcHAYErhV1Ad97WzBvS2o0aaDv4mVz+syiN0ElMyfBPg==}
     cpu: [arm64]
@@ -7795,6 +7938,14 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
+    optional: true
+
+  /@rollup/rollup-darwin-arm64@4.17.2:
+    resolution: {integrity: sha512-kcMLpE6uCwls023+kknm71ug7MZOrtXo+y5p/tsg6jltpDtgQY1Eq5sGfHcQfb+lfuKwhBmEURDga9N0ol4YPw==}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@rollup/rollup-darwin-arm64@4.9.5:
@@ -7812,6 +7963,14 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@rollup/rollup-darwin-x64@4.17.2:
+    resolution: {integrity: sha512-AtKwD0VEx0zWkL0ZjixEkp5tbNLzX+FCqGG1SvOu993HnSz4qDI6S4kGzubrEJAljpVkhRSlg5bzpV//E6ysTQ==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@rollup/rollup-darwin-x64@4.9.5:
     resolution: {integrity: sha512-UmElV1OY2m/1KEEqTlIjieKfVwRg0Zwg4PLgNf0s3glAHXBN99KLpw5A5lrSYCa1Kp63czTpVll2MAqbZYIHoA==}
     cpu: [x64]
@@ -7825,6 +7984,14 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
+    optional: true
+
+  /@rollup/rollup-linux-arm-gnueabihf@4.17.2:
+    resolution: {integrity: sha512-3reX2fUHqN7sffBNqmEyMQVj/CKhIHZd4y631duy0hZqI8Qoqf6lTtmAKvJFYa6bhU95B1D0WgzHkmTg33In0A==}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@rollup/rollup-linux-arm-gnueabihf@4.9.5:
@@ -7842,11 +8009,27 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@rollup/rollup-linux-arm-musleabihf@4.17.2:
+    resolution: {integrity: sha512-uSqpsp91mheRgw96xtyAGP9FW5ChctTFEoXP0r5FAzj/3ZRv3Uxjtc7taRQSaQM/q85KEKjKsZuiZM3GyUivRg==}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@rollup/rollup-linux-arm64-gnu@4.16.2:
     resolution: {integrity: sha512-UN7VAXLyeyGbCQWiOtQN7BqmjTDw1ON2Oos4lfk0YR7yNhFEJWZiwGtvj9Ay4lsT/ueT04sh80Sg2MlWVVZ+Ug==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    optional: true
+
+  /@rollup/rollup-linux-arm64-gnu@4.17.2:
+    resolution: {integrity: sha512-EMMPHkiCRtE8Wdk3Qhtciq6BndLtstqZIroHiiGzB3C5LDJmIZcSzVtLRbwuXuUft1Cnv+9fxuDtDxz3k3EW2A==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@rollup/rollup-linux-arm64-gnu@4.9.5:
@@ -7864,6 +8047,14 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@rollup/rollup-linux-arm64-musl@4.17.2:
+    resolution: {integrity: sha512-NMPylUUZ1i0z/xJUIx6VUhISZDRT+uTWpBcjdv0/zkp7b/bQDF+NfnfdzuTiB1G6HTodgoFa93hp0O1xl+/UbA==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@rollup/rollup-linux-arm64-musl@4.9.5:
     resolution: {integrity: sha512-QaKFVOzzST2xzY4MAmiDmURagWLFh+zZtttuEnuNn19AiZ0T3fhPyjPPGwLNdiDT82ZE91hnfJsUiDwF9DClIQ==}
     cpu: [arm64]
@@ -7879,11 +8070,27 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@rollup/rollup-linux-powerpc64le-gnu@4.17.2:
+    resolution: {integrity: sha512-T19My13y8uYXPw/L/k0JYaX1fJKFT/PWdXiHr8mTbXWxjVF1t+8Xl31DgBBvEKclw+1b00Chg0hxE2O7bTG7GQ==}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@rollup/rollup-linux-riscv64-gnu@4.16.2:
     resolution: {integrity: sha512-ohkPt0lKoCU0s4B6twro2aft+QROPdUiWwOjPNTzwTsBK5w+2+iT9kySdtOdq0gzWJAdiqsV4NFtXOwGZmIsHA==}
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
+    optional: true
+
+  /@rollup/rollup-linux-riscv64-gnu@4.17.2:
+    resolution: {integrity: sha512-BOaNfthf3X3fOWAB+IJ9kxTgPmMqPPH5f5k2DcCsRrBIbWnaJCgX2ll77dV1TdSy9SaXTR5iDXRL8n7AnoP5cg==}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@rollup/rollup-linux-riscv64-gnu@4.9.5:
@@ -7901,11 +8108,27 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@rollup/rollup-linux-s390x-gnu@4.17.2:
+    resolution: {integrity: sha512-W0UP/x7bnn3xN2eYMql2T/+wpASLE5SjObXILTMPUBDB/Fg/FxC+gX4nvCfPBCbNhz51C+HcqQp2qQ4u25ok6g==}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@rollup/rollup-linux-x64-gnu@4.16.2:
     resolution: {integrity: sha512-oc5/SlITI/Vj/qL4UM+lXN7MERpiy1HEOnrE+SegXwzf7WP9bzmZd6+MDljCEZTdSY84CpvUv9Rq7bCaftn1+g==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
+    optional: true
+
+  /@rollup/rollup-linux-x64-gnu@4.17.2:
+    resolution: {integrity: sha512-Hy7pLwByUOuyaFC6mAr7m+oMC+V7qyifzs/nW2OJfC8H4hbCzOX07Ov0VFk/zP3kBsELWNFi7rJtgbKYsav9QQ==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@rollup/rollup-linux-x64-gnu@4.9.5:
@@ -7923,6 +8146,14 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@rollup/rollup-linux-x64-musl@4.17.2:
+    resolution: {integrity: sha512-h1+yTWeYbRdAyJ/jMiVw0l6fOOm/0D1vNLui9iPuqgRGnXA0u21gAqOyB5iHjlM9MMfNOm9RHCQ7zLIzT0x11Q==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@rollup/rollup-linux-x64-musl@4.9.5:
     resolution: {integrity: sha512-ezyFUOwldYpj7AbkwyW9AJ203peub81CaAIVvckdkyH8EvhEIoKzaMFJj0G4qYJ5sw3BpqhFrsCc30t54HV8vg==}
     cpu: [x64]
@@ -7936,6 +8167,14 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
+    optional: true
+
+  /@rollup/rollup-win32-arm64-msvc@4.17.2:
+    resolution: {integrity: sha512-tmdtXMfKAjy5+IQsVtDiCfqbynAQE/TQRpWdVataHmhMb9DCoJxp9vLcCBjEQWMiUYxO1QprH/HbY9ragCEFLA==}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@rollup/rollup-win32-arm64-msvc@4.9.5:
@@ -7953,6 +8192,14 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@rollup/rollup-win32-ia32-msvc@4.17.2:
+    resolution: {integrity: sha512-7II/QCSTAHuE5vdZaQEwJq2ZACkBpQDOmQsE6D6XUbnBHW8IAhm4eTufL6msLJorzrHDFv3CF8oCA/hSIRuZeQ==}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@rollup/rollup-win32-ia32-msvc@4.9.5:
     resolution: {integrity: sha512-AiqiLkb9KSf7Lj/o1U3SEP9Zn+5NuVKgFdRIZkvd4N0+bYrTOovVd0+LmYCPQGbocT4kvFyK+LXCDiXPBF3fyA==}
     cpu: [ia32]
@@ -7966,6 +8213,14 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
+    optional: true
+
+  /@rollup/rollup-win32-x64-msvc@4.17.2:
+    resolution: {integrity: sha512-TGGO7v7qOq4CYmSBVEYpI1Y5xDuCEnbVC5Vth8mOsW0gDSzxNrVERPc790IGHsrT2dQSimgMr9Ub3Y1Jci5/8w==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@rollup/rollup-win32-x64-msvc@4.9.5:
@@ -9434,6 +9689,10 @@ packages:
       '@types/scheduler': 0.16.3
       csstype: 3.1.2
 
+  /@types/resolve@1.20.2:
+    resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
+    dev: true
+
   /@types/scheduler@0.16.3:
     resolution: {integrity: sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==}
 
@@ -10285,6 +10544,11 @@ packages:
   /asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
+  /at-least-node@1.0.0:
+    resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
+    engines: {node: '>= 4.0.0'}
+    dev: true
+
   /atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
@@ -10804,6 +11068,10 @@ packages:
     optionalDependencies:
       fsevents: 2.3.3
 
+  /chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+    dev: true
+
   /chownr@2.0.0:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
     engines: {node: '>=10'}
@@ -10929,6 +11197,14 @@ packages:
   /client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
     dev: false
+
+  /cliui@7.0.4:
+    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+    dev: true
 
   /cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -11078,6 +11354,10 @@ packages:
     resolution: {integrity: sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==}
     dev: true
 
+  /commondir@1.0.1:
+    resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
+    dev: true
+
   /compare-func@2.0.0:
     resolution: {integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==}
     dependencies:
@@ -11219,9 +11499,8 @@ packages:
 
   /core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
-    dev: false
 
-  /cosmiconfig-typescript-loader@5.0.0(@types/node@20.3.1)(cosmiconfig@9.0.0)(typescript@5.1.3):
+  /cosmiconfig-typescript-loader@5.0.0(@types/node@20.11.26)(cosmiconfig@9.0.0)(typescript@5.3.2):
     resolution: {integrity: sha512-+8cK7jRAReYkMwMiG+bxhcNKiHJDM6bR9FD/nGBXOWdMLuYawjF5cGrtLilJ+LGd3ZjCXnJjR5DkfWPoIVlqJA==}
     engines: {node: '>=v16'}
     peerDependencies:
@@ -11229,10 +11508,10 @@ packages:
       cosmiconfig: '>=8.2'
       typescript: '>=4'
     dependencies:
-      '@types/node': 20.3.1
-      cosmiconfig: 9.0.0(typescript@5.1.3)
+      '@types/node': 20.11.26
+      cosmiconfig: 9.0.0(typescript@5.3.2)
       jiti: 1.19.1
-      typescript: 5.1.3
+      typescript: 5.3.2
     dev: true
 
   /cosmiconfig@7.1.0:
@@ -11256,7 +11535,7 @@ packages:
       path-type: 4.0.0
     dev: false
 
-  /cosmiconfig@9.0.0(typescript@5.1.3):
+  /cosmiconfig@9.0.0(typescript@5.3.2):
     resolution: {integrity: sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -11269,7 +11548,7 @@ packages:
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       parse-json: 5.2.0
-      typescript: 5.1.3
+      typescript: 5.3.2
     dev: true
 
   /cp-file@10.0.0:
@@ -11615,6 +11894,13 @@ packages:
       character-entities: 2.0.2
     dev: false
 
+  /decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+    dependencies:
+      mimic-response: 3.1.0
+    dev: true
+
   /decompress-tar@4.1.1:
     resolution: {integrity: sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==}
     engines: {node: '>=4'}
@@ -11707,6 +11993,11 @@ packages:
       which-typed-array: 1.1.13
     dev: true
 
+  /deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
+    dev: true
+
   /deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -11718,7 +12009,6 @@ packages:
   /deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
-    dev: false
 
   /default-browser-id@3.0.0:
     resolution: {integrity: sha512-OZ1y3y0SqSICtE8DE4S8YOE9UZOJ8wO16fKWVP5J1Qz42kV9jcnMVFrEE/noXb/ss3Q4pZIH79kxofzyNNtUNA==}
@@ -11850,6 +12140,11 @@ packages:
   /detect-indent@7.0.1:
     resolution: {integrity: sha512-Mc7QhQ8s+cLrnUfU/Ji94vG/r8M26m8f++vyres4ZoojaRDpZ1eSIh/EpzLNwlWuvzSZ3UbDFspjFvTDXe6e/g==}
     engines: {node: '>=12.20'}
+    dev: true
+
+  /detect-libc@2.0.3:
+    resolution: {integrity: sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==}
+    engines: {node: '>=8'}
     dev: true
 
   /detect-node-es@1.1.0:
@@ -13697,6 +13992,10 @@ packages:
     resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
     dev: false
 
+  /estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+    dev: true
+
   /estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
     dependencies:
@@ -13783,6 +14082,11 @@ packages:
       signal-exit: 4.1.0
       strip-final-newline: 3.0.0
 
+  /expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+    dev: true
+
   /exponential-backoff@3.1.1:
     resolution: {integrity: sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==}
     dev: true
@@ -13849,7 +14153,6 @@ packages:
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.5
-    dev: true
 
   /fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
@@ -14195,18 +14498,34 @@ packages:
       tslib: 2.4.0
     dev: false
 
+  /from2@2.3.0:
+    resolution: {integrity: sha512-OMcX/4IC/uqEPVgGeyfN22LJk6AZrMkRZHxcHBMBvHScDGgwTm2GT2Wkgtocyd3JfZffjj2kYUDXXII0Fk9W0g==}
+    dependencies:
+      inherits: 2.0.4
+      readable-stream: 2.3.8
+    dev: true
+
   /from@0.1.7:
     resolution: {integrity: sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==}
     dev: true
 
   /fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
-    dev: false
 
   /fs-extra@11.2.0:
     resolution: {integrity: sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==}
     engines: {node: '>=14.14'}
     dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.1.0
+      universalify: 2.0.0
+    dev: true
+
+  /fs-extra@9.1.0:
+    resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
+    engines: {node: '>=10'}
+    dependencies:
+      at-least-node: 1.0.0
       graceful-fs: 4.2.11
       jsonfile: 6.1.0
       universalify: 2.0.0
@@ -14408,6 +14727,10 @@ packages:
       git-up: 7.0.0
     dev: true
 
+  /github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
+    dev: true
+
   /glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -14504,7 +14827,7 @@ packages:
     dependencies:
       array-union: 2.1.0
       dir-glob: 3.0.1
-      fast-glob: 3.3.1
+      fast-glob: 3.3.2
       ignore: 5.2.4
       merge2: 1.4.1
       slash: 3.0.0
@@ -15152,6 +15475,14 @@ packages:
     engines: {node: '>=12'}
     dev: false
 
+  /into-stream@6.0.0:
+    resolution: {integrity: sha512-XHbaOAvP+uFKUFsOgoNPRjLkwB+I22JFPFe5OjTkQ0nwgj6+pSjb4NmB6VMxaPshLiOf+zcpOCBQuLwC1KHhZA==}
+    engines: {node: '>=10'}
+    dependencies:
+      from2: 2.3.0
+      p-is-promise: 3.0.0
+    dev: true
+
   /invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
     dependencies:
@@ -15262,6 +15593,12 @@ packages:
     dependencies:
       has: 1.0.3
 
+  /is-core-module@2.9.0:
+    resolution: {integrity: sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==}
+    dependencies:
+      has: 1.0.3
+    dev: true
+
   /is-date-object@1.0.5:
     resolution: {integrity: sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==}
     engines: {node: '>= 0.4'}
@@ -15337,6 +15674,10 @@ packages:
     resolution: {integrity: sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==}
     dev: true
 
+  /is-module@1.0.0:
+    resolution: {integrity: sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==}
+    dev: true
+
   /is-natural-number@4.0.1:
     resolution: {integrity: sha512-Y4LTamMe0DDQIIAlaer9eKebAlDSV6huy+TWhJVPlzZh2o4tRP5SQWFlLn5N0To4mDD22/qdOq+veo1cSISLgQ==}
     dev: false
@@ -15410,6 +15751,12 @@ packages:
 
   /is-promise@2.2.2:
     resolution: {integrity: sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==}
+    dev: true
+
+  /is-reference@1.2.1:
+    resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
+    dependencies:
+      '@types/estree': 1.0.5
     dev: true
 
   /is-regex@1.1.4:
@@ -15535,7 +15882,6 @@ packages:
 
   /isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
-    dev: false
 
   /isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
@@ -16813,6 +17159,11 @@ packages:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
     engines: {node: '>=12'}
 
+  /mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+    dev: true
+
   /min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
@@ -16934,6 +17285,10 @@ packages:
       yallist: 4.0.0
     dev: true
 
+  /mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+    dev: true
+
   /mkdirp@1.0.4:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
     engines: {node: '>=10'}
@@ -17037,6 +17392,13 @@ packages:
       yargs: 17.7.2
     dev: true
 
+  /multistream@4.1.0:
+    resolution: {integrity: sha512-J1XDiAmmNpRCBfIWJv+n0ymC4ABcf/Pl+5YvC5B/D2f/2+8PtHvCNxMPKiQcZyi922Hq69J2YOpb1pTywfifyw==}
+    dependencies:
+      once: 1.4.0
+      readable-stream: 3.6.2
+    dev: true
+
   /mute-stream@1.0.0:
     resolution: {integrity: sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -17052,6 +17414,10 @@ packages:
     resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  /napi-build-utils@1.0.2:
+    resolution: {integrity: sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==}
+    dev: true
 
   /natural-compare-lite@1.4.0:
     resolution: {integrity: sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==}
@@ -17142,6 +17508,13 @@ packages:
       tslib: 2.6.2
     dev: false
 
+  /node-abi@3.62.0:
+    resolution: {integrity: sha512-CPMcGa+y33xuL1E0TcNIu4YyaZCxnnvkVaEXrsosR3FxN+fV8xvb7Mzpb7IgKler10qeMkE6+Dp8qJhpzdq35g==}
+    engines: {node: '>=10'}
+    dependencies:
+      semver: 7.6.0
+    dev: true
+
   /node-abort-controller@3.1.1:
     resolution: {integrity: sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==}
     dev: false
@@ -17164,7 +17537,6 @@ packages:
         optional: true
     dependencies:
       whatwg-url: 5.0.0
-    dev: false
 
   /node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
@@ -17610,6 +17982,11 @@ packages:
       p-map: 5.5.0
     dev: true
 
+  /p-is-promise@3.0.0:
+    resolution: {integrity: sha512-Wo8VsW4IRQSKVXsJCn7TomUaVtyfjVDn3nUP7kE967BQk0CwFpdbZs0X0uk5sW9mkBa9eNM7hCMaG93WUAwxYQ==}
+    engines: {node: '>=8'}
+    dev: true
+
   /p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
     engines: {node: '>=6'}
@@ -18018,12 +18395,57 @@ packages:
       find-up: 4.1.0
     dev: true
 
+  /pkg-fetch@3.4.2:
+    resolution: {integrity: sha512-0+uijmzYcnhC0hStDjm/cl2VYdrmVVBpe7Q8k9YBojxmR5tG8mvR9/nooQq3QSXiQqORDVOTY3XqMEqJVIzkHA==}
+    hasBin: true
+    dependencies:
+      chalk: 4.1.2
+      fs-extra: 9.1.0
+      https-proxy-agent: 5.0.1
+      node-fetch: 2.6.13
+      progress: 2.0.3
+      semver: 7.6.0
+      tar-fs: 2.1.1
+      yargs: 16.2.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: true
+
   /pkg-types@1.0.3:
     resolution: {integrity: sha512-nN7pYi0AQqJnoLPC9eHFQ8AcyaixBUOwvqc5TDnIKCMEE6I0y8P7OKA7fPexsXGCGxQDl/cmrLAp26LhcwxZ4A==}
     dependencies:
       jsonc-parser: 3.2.0
       mlly: 1.5.0
       pathe: 1.1.2
+
+  /pkg@5.8.1:
+    resolution: {integrity: sha512-CjBWtFStCfIiT4Bde9QpJy0KeH19jCfwZRJqHFDFXfhUklCx8JoFmMj3wgnEYIwGmZVNkhsStPHEOnrtrQhEXA==}
+    hasBin: true
+    peerDependencies:
+      node-notifier: '>=9.0.1'
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+    dependencies:
+      '@babel/generator': 7.18.2
+      '@babel/parser': 7.18.4
+      '@babel/types': 7.19.0
+      chalk: 4.1.2
+      fs-extra: 9.1.0
+      globby: 11.1.0
+      into-stream: 6.0.0
+      is-core-module: 2.9.0
+      minimist: 1.2.8
+      multistream: 4.1.0
+      pkg-fetch: 3.4.2
+      prebuild-install: 7.1.1
+      resolve: 1.22.2
+      stream-meter: 1.0.4
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: true
 
   /pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
@@ -18140,6 +18562,25 @@ packages:
     engines: {node: '>=12'}
     dev: false
 
+  /prebuild-install@7.1.1:
+    resolution: {integrity: sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      detect-libc: 2.0.3
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 1.0.2
+      node-abi: 3.62.0
+      pump: 3.0.0
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.1
+      tunnel-agent: 0.6.0
+    dev: true
+
   /prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -18254,7 +18695,6 @@ packages:
 
   /process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
-    dev: false
 
   /process-warning@2.2.0:
     resolution: {integrity: sha512-/1WZ8+VQjR6avWOgHeEPd7SDQmFQ1B5mC1eRXsCm5TarlNmx/wCsa5GEaxGm05BORRtyG/Ex/3xq3TuRvq57qg==}
@@ -18267,6 +18707,11 @@ packages:
   /process@0.11.10:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
+
+  /progress@2.0.3:
+    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
+    engines: {node: '>=0.4.0'}
+    dev: true
 
   /promise-all-reject-late@1.0.1:
     resolution: {integrity: sha512-vuf0Lf0lOxyQREH7GDIOUMLS7kz+gs8i6B+Yi8dC68a2sychGrHTJYghMBD6k7eUcH0H5P73EckCA48xijWqXw==}
@@ -18547,6 +18992,16 @@ packages:
       iconv-lite: 0.4.24
       unpipe: 1.0.0
     dev: false
+
+  /rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
+    dev: true
 
   /react-clientside-effect@1.2.6(react@18.2.0):
     resolution: {integrity: sha512-XGGGRQAKY+q25Lz9a/4EPqom7WRjz3z9R2k4jhVKA/puQFH/5Nt27vFZYql4m4NVNdUvX8PS3O7r/Zzm7cjUlg==}
@@ -18936,7 +19391,6 @@ packages:
       safe-buffer: 5.1.2
       string_decoder: 1.1.1
       util-deprecate: 1.0.2
-    dev: false
 
   /readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
@@ -19222,6 +19676,32 @@ packages:
       '@rollup/rollup-win32-x64-msvc': 4.16.2
       fsevents: 2.3.3
 
+  /rollup@4.17.2:
+    resolution: {integrity: sha512-/9ClTJPByC0U4zNLowV1tMBe8yMEAxewtR3cUNX5BoEpGH3dQEWpJLr6CLp0fPdYRF/fzVOgvDb1zXuakwF5kQ==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+    dependencies:
+      '@types/estree': 1.0.5
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.17.2
+      '@rollup/rollup-android-arm64': 4.17.2
+      '@rollup/rollup-darwin-arm64': 4.17.2
+      '@rollup/rollup-darwin-x64': 4.17.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.17.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.17.2
+      '@rollup/rollup-linux-arm64-gnu': 4.17.2
+      '@rollup/rollup-linux-arm64-musl': 4.17.2
+      '@rollup/rollup-linux-powerpc64le-gnu': 4.17.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.17.2
+      '@rollup/rollup-linux-s390x-gnu': 4.17.2
+      '@rollup/rollup-linux-x64-gnu': 4.17.2
+      '@rollup/rollup-linux-x64-musl': 4.17.2
+      '@rollup/rollup-win32-arm64-msvc': 4.17.2
+      '@rollup/rollup-win32-ia32-msvc': 4.17.2
+      '@rollup/rollup-win32-x64-msvc': 4.17.2
+      fsevents: 2.3.3
+    dev: true
+
   /rollup@4.9.5:
     resolution: {integrity: sha512-E4vQW0H/mbNMw2yLSqJyjtkHY9dslf/p0zuT1xehNRqUTBOFMqEjguDvqhXr7N7r/4ttb2jr4T41d3dncmIgbQ==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -19285,7 +19765,6 @@ packages:
 
   /safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
-    dev: false
 
   /safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
@@ -19472,6 +19951,18 @@ packages:
       '@sigstore/verify': 1.1.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+    dev: true
+
+  /simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
     dev: true
 
   /sisteransi@1.0.5:
@@ -19703,6 +20194,12 @@ packages:
       stream-chain: 2.2.5
     dev: false
 
+  /stream-meter@1.0.4:
+    resolution: {integrity: sha512-4sOEtrbgFotXwnEuzzsQBYEV1elAeFSO8rSGeTwabuX1RRn/kEq9JVH7I0MRBhKVRR0sJkr0M0QCH7yOLf9fhQ==}
+    dependencies:
+      readable-stream: 2.3.8
+    dev: true
+
   /streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
@@ -19788,7 +20285,6 @@ packages:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
     dependencies:
       safe-buffer: 5.1.2
-    dev: false
 
   /string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
@@ -19845,6 +20341,11 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       min-indent: 1.0.1
+    dev: true
+
+  /strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
     dev: true
 
   /strip-json-comments@3.1.1:
@@ -20028,6 +20529,15 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
+  /tar-fs@2.1.1:
+    resolution: {integrity: sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==}
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.0
+      tar-stream: 2.2.0
+    dev: true
+
   /tar-stream@1.6.2:
     resolution: {integrity: sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==}
     engines: {node: '>= 0.8.0'}
@@ -20040,6 +20550,17 @@ packages:
       to-buffer: 1.1.1
       xtend: 4.0.2
     dev: false
+
+  /tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.4
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+    dev: true
 
   /tar@6.2.0:
     resolution: {integrity: sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==}
@@ -20186,7 +20707,6 @@ packages:
 
   /tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
-    dev: false
 
   /tr46@1.0.1:
     resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
@@ -20397,6 +20917,12 @@ packages:
       make-fetch-happen: 13.0.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+    dependencies:
+      safe-buffer: 5.2.1
     dev: true
 
   /type-check@0.4.0:
@@ -21030,7 +21556,7 @@ packages:
       '@types/node': 20.3.1
       esbuild: 0.20.2
       postcss: 8.4.38
-      rollup: 4.16.2
+      rollup: 4.17.2
     optionalDependencies:
       fsevents: 2.3.3
     dev: true
@@ -21308,7 +21834,6 @@ packages:
 
   /webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-    dev: false
 
   /webidl-conversions@4.0.2:
     resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
@@ -21344,7 +21869,6 @@ packages:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
-    dev: false
 
   /whatwg-url@7.1.0:
     resolution: {integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==}
@@ -21567,6 +22091,19 @@ packages:
   /yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
+    dev: true
+
+  /yargs@16.2.0:
+    resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==}
+    engines: {node: '>=10'}
+    dependencies:
+      cliui: 7.0.4
+      escalade: 3.1.1
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 20.2.9
     dev: true
 
   /yargs@17.7.2:


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->

## Motivation and Context

In enterprise settings, installing a cli via npm globally isnt always possible.  Potential blockers include: 
- complete lack of familiarity with npm ecosystem (android, ios app teams, service teams, etc)
- conflicts with existing node ecosystem (perhaps teams are forced to use node14 or otherwise have conflicting dependencies)

Generally it is industry standard to offer cli tools in standalone binaries.  

## Details

Implementation is using [vercel/pkg](https://github.com/vercel/pkg) to produce the binaries. 

While there are a few options for modern node binary distribution ([deno](https://docs.deno.com/runtime/manual/tools/compiler), [bun](https://bun.sh/docs/bundler/executables), [node-22](https://nodejs.org/api/single-executable-applications.html)), `pkg` allows for easy export of cross-platform node16 binaries without fundamentally altering the runtime. 

NOTICE: `pkg` is deprecated as of early 2024 as the maintainer couldnt keep up with the ecosystem.  Case in point, `pkg` offers no [support for es6 modules](https://github.com/vercel/pkg/issues/1291).   

Luckily, there is a [workaround](https://github.com/vercel/pkg/issues/1291#issuecomment-1733514629). 

The workaround involves using [rollup](https://github.com/rollup/rollup) to bundle the output into a single `.cjs` file.  

Rollup [doesn't seem to support top-level await](https://github.com/rollup/rollup/issues/3623) so I [made IIFEs out of of the two top-level awaits](https://github.com/wundergraph/cosmo/commit/553302028b71fe60a5b72508882fea4deb251027) in the in the package. 

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

## TODO

- [ ] **Update stub URLS in install scripts with real release locations**
- [ ] **Develop github workflow to build binaries in CI/CD pipeline**
- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
