### PR TITLE
feat: allow-list to have fine-grained control over headers

### DIFF
--- a/router-tests/testenv/testenv.go
+++ b/router-tests/testenv/testenv.go
@@ -92,6 +92,7 @@ func Bench(b *testing.B, cfg *Config, f func(b *testing.B, xEnv *Environment)) {
 }
 
 type Config struct {
+	AllowHeaders                       []string
 	Subgraphs                          SubgraphsConfig
 	RouterOptions                      []core.Option
 	OverrideGraphQLPath                string
@@ -627,6 +628,7 @@ func configureRouter(listenerAddr string, testConfig *Config, routerConfig *node
 			ForwardUpgradeHeaders:     true,
 			ForwardUpgradeQueryParams: true,
 			ForwardInitialPayload:     true,
+			AllowHeaders:              testConfig.AllowHeaders,
 		}))
 	}
 	return core.NewRouter(routerOpts...)

--- a/router/pkg/config/config.go
+++ b/router/pkg/config/config.go
@@ -328,6 +328,8 @@ type WebSocketConfiguration struct {
 	ForwardUpgradeQueryParams bool `yaml:"forward_upgrade_query_params" default:"true" envconfig:"WEBSOCKETS_FORWARD_UPGRADE_QUERY_PARAMS"`
 	// ForwardInitialPayload true if the Router should forward the initial payload of a Subscription Request to the Subgraph
 	ForwardInitialPayload bool `yaml:"forward_initial_payload" default:"true" envconfig:"WEBSOCKETS_FORWARD_INITIAL_PAYLOAD"`
+	// AllowHeaders controls the list of headers used when hashing an initial subscription upgrade for a WebSocket connection
+	AllowHeaders []string `yaml:"allow_headers" envconfig:"WEBSOCKETS_ALLOW_HEADERS"`
 }
 
 type AnonymizeIpConfiguration struct {

--- a/router/pkg/config/config.schema.json
+++ b/router/pkg/config/config.schema.json
@@ -144,6 +144,10 @@
           "type": "boolean",
           "default": true,
           "description": "Forward the initial payload in the extensions payload when starting a subscription on a Subgraph. The default value is true."
+        },
+        "allow_headers": {
+          "type": "array",
+          "description": "AllowHeaders controls the list of headers used when hashing an initial subscription upgrade for a WebSocket connection. If unset, all headers are allowed."
         }
       }
     },

--- a/router/pkg/config/fixtures/full.yaml
+++ b/router/pkg/config/fixtures/full.yaml
@@ -242,3 +242,6 @@ websocket:
   forward_initial_payload: true
   forward_upgrade_headers: true
   forward_upgrade_query_params: true
+  allow_headers:
+    - "anexample"
+    - "another"

--- a/router/pkg/config/testdata/config_defaults.json
+++ b/router/pkg/config/testdata/config_defaults.json
@@ -194,7 +194,8 @@
     },
     "ForwardUpgradeHeaders": true,
     "ForwardUpgradeQueryParams": true,
-    "ForwardInitialPayload": true
+    "ForwardInitialPayload": true,
+    "AllowHeaders": []
   },
   "SubgraphErrorPropagation": {
     "Enabled": false,

--- a/router/pkg/config/testdata/config_full.json
+++ b/router/pkg/config/testdata/config_full.json
@@ -299,7 +299,11 @@
     },
     "ForwardUpgradeHeaders": true,
     "ForwardUpgradeQueryParams": true,
-    "ForwardInitialPayload": true
+    "ForwardInitialPayload": true,
+    "AllowHeaders": [
+      "anexample",
+      "another"
+    ]
   },
   "SubgraphErrorPropagation": {
     "Enabled": false,


### PR DESCRIPTION
Adding allow-list to have fine-grained control over headers using a new configuration specifically for WebSocket connections). There are some pre-existing integration tests that are flaky. Let's discuss some approaches to fix this.