### PR TITLE
fix: set response properly as JSON data

### DIFF
--- a/router/internal/wsproto/absinthe.go
+++ b/router/internal/wsproto/absinthe.go
@@ -175,7 +175,7 @@ func (p *absintheWSProtocol) Pong(msg *Message) error {
 }
 
 func (p *absintheWSProtocol) WriteGraphQLData(id string, data json.RawMessage, extensions json.RawMessage) error {
-	payload, err := sjson.SetRawBytes(nil, "result", data)
+	payload, err := sjson.SetBytes(nil, "result", data)
 	if err != nil {
 		return err
 	}

--- a/router/internal/wsproto/absinthe.go
+++ b/router/internal/wsproto/absinthe.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"github.com/tidwall/sjson"
 	"math/big"
 )
 
@@ -174,12 +175,21 @@ func (p *absintheWSProtocol) Pong(msg *Message) error {
 }
 
 func (p *absintheWSProtocol) WriteGraphQLData(id string, data json.RawMessage, extensions json.RawMessage) error {
+	payload, err := sjson.SetRawBytes(nil, "result", data)
+	if err != nil {
+		return err
+	}
+	payload, err = sjson.SetBytes(payload, "subscriptionId", toSubscriptionId(&id))
+	if err != nil {
+		return err
+	}
+
 	return p.conn.WriteJSON(absintheMessage{
 		ID:       &id,
 		Channel:  "1",
 		Protocol: "__absinthe__:control",
 		Type:     absintheMessageEventTypeSubscriptionData,
-		Payload:  json.RawMessage(fmt.Sprintf(`{"result": %s, "subscriptionId": %q}`, string(data), toSubscriptionId(&id))),
+		Payload:  payload,
 	})
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->

## Motivation and Context

Set the data with sjon rather than string concatenation which could result in unexpected behaviour.

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

## TODO

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
