### PR TITLE
fix: fix default value for `extraEnvVars` in values for `router`

### DIFF
--- a/helm/cosmo/charts/router/README.md
+++ b/helm/cosmo/charts/router/README.md
@@ -26,7 +26,7 @@ This is the official Helm Chart for the WunderGraph Cosmo Router.
 | deploymentStrategy | object | `{}` |  |
 | existingConfigmap | string | `""` | If this is set, the commonConfiguration section is ignored. |
 | existingSecret | string | `""` | Existing secret in the same namespace containing the graphApiToken. The secret key has to match with current secret. |
-| extraEnvVars | string | `nil` | Allows to set additional environment / runtime variables on the container. Useful for global application non-specific settings. |
+| extraEnvVars | list | `[]` | Allows to set additional environment / runtime variables on the container. Useful for global application non-specific settings. |
 | extraEnvVarsCM | string | `""` | Name of existing ConfigMap containing extra env vars |
 | extraEnvVarsSecret | string | `""` | Name of existing Secret containing extra env vars |
 | extraVolumeMounts | list | `[]` | Optionally specify extra list of additional volumeMounts for Router container's |

--- a/helm/cosmo/charts/router/values.yaml
+++ b/helm/cosmo/charts/router/values.yaml
@@ -22,7 +22,7 @@ nameOverride: ""
 fullnameOverride: ""
 
 # -- Allows to set additional environment / runtime variables on the container. Useful for global application non-specific settings.
-extraEnvVars:
+extraEnvVars: []
   # Recommended for production to mitigate the risk of OOM kills. Requires Go 1.19+.
   # Keep the value lower than the maximum memory limit you set. E.g. if you have 3GB memory limit, set this to 2750MiB.
 #  - name: GOMEMLIMIT


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->

## Motivation and Context

Fix typo in default values and docs for the chart of router

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

## TODO

- [ ] Tests or benchmark included - N/A
- [x] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [x] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
