### PR TITLE
fix: unset admission webhook using empty string

### DIFF
--- a/connect/src/wg/cosmo/platform/v1/platform_pb.ts
+++ b/connect/src/wg/cosmo/platform/v1/platform_pb.ts
@@ -2219,6 +2219,11 @@ export class FederatedGraph extends Message<FederatedGraph> {
    */
   contract?: Contract;
 
+  /**
+   * @generated from field: optional string admission_webhook_url = 16;
+   */
+  admissionWebhookUrl?: string;
+
   constructor(data?: PartialMessage<FederatedGraph>) {
     super();
     proto3.util.initPartial(data, this);
@@ -2242,6 +2247,7 @@ export class FederatedGraph extends Message<FederatedGraph> {
     { no: 13, name: "compositionId", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
     { no: 14, name: "supports_federation", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
     { no: 15, name: "contract", kind: "message", T: Contract, opt: true },
+    { no: 16, name: "admission_webhook_url", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): FederatedGraph {

--- a/controlplane/src/core/bufservices/PlatformService.ts
+++ b/controlplane/src/core/bufservices/PlatformService.ts
@@ -7093,6 +7093,7 @@ export default function (opts: RouterOptions): Partial<ServiceImpl<typeof Platfo
             requestSeries: requestSeriesList[g.id] ?? [],
             supportsFederation: g.supportsFederation,
             contract: g.contract,
+            admissionWebhookUrl: g.admissionWebhookURL,
           })),
           response: {
             code: EnumStatusCode.OK,
@@ -7146,6 +7147,7 @@ export default function (opts: RouterOptions): Partial<ServiceImpl<typeof Platfo
             targetId: g.targetId,
             supportsFederation: g.supportsFederation,
             contract: g.contract,
+            admissionWebhookUrl: g.admissionWebhookURL,
           })),
           response: {
             code: EnumStatusCode.OK,
@@ -7336,6 +7338,7 @@ export default function (opts: RouterOptions): Partial<ServiceImpl<typeof Platfo
             readme: federatedGraph.readme,
             supportsFederation: federatedGraph.supportsFederation,
             contract: federatedGraph.contract,
+            admissionWebhookUrl: federatedGraph.admissionWebhookURL,
           },
           subgraphs: list.map((g) => ({
             id: g.id,

--- a/proto/wg/cosmo/platform/v1/platform.proto
+++ b/proto/wg/cosmo/platform/v1/platform.proto
@@ -280,6 +280,7 @@ message FederatedGraph {
   optional string compositionId = 13;
   bool supports_federation = 14;
   optional Contract contract = 15;
+  optional string admission_webhook_url = 16;
 }
 
 message GetFederatedGraphsResponse {

--- a/studio/src/pages/[organizationSlug]/[namespace]/graph/[slug]/index.tsx
+++ b/studio/src/pages/[organizationSlug]/[namespace]/graph/[slug]/index.tsx
@@ -374,20 +374,19 @@ const GraphOverviewPage: NextPageWithLayout = () => {
                   />
                 </div>
               )}
-              <span className="text-muted-foreground">Router Url</span>
-              <CLI className="mt-1 md:w-full" command={routingURL} />
               {admissionWebhookUrl && (
-                <>
-                  <span className="mt-4 text-muted-foreground">
+                <div className="mb-4 w-full">
+                  <span className="text-muted-foreground">
                     Admission Webhook Url
                   </span>
                   <CLI
                     className="mt-1 md:w-full"
                     command={admissionWebhookUrl}
                   />
-                </>
+                </div>
               )}
-
+              <span className="text-muted-foreground">Router Url</span>
+              <CLI className="mt-1 md:w-full" command={routingURL} />
               <RunRouterCommand
                 open={open}
                 setOpen={setOpen}

--- a/studio/src/pages/[organizationSlug]/[namespace]/graph/[slug]/index.tsx
+++ b/studio/src/pages/[organizationSlug]/[namespace]/graph/[slug]/index.tsx
@@ -107,6 +107,7 @@ const GraphOverviewPage: NextPageWithLayout = () => {
     namespace,
     compositionId,
     contract,
+    admissionWebhookUrl,
   } = graphContext.graph;
 
   const validGraph = isComposable && !!lastUpdatedAt;
@@ -375,6 +376,17 @@ const GraphOverviewPage: NextPageWithLayout = () => {
               )}
               <span className="text-muted-foreground">Router Url</span>
               <CLI className="mt-1 md:w-full" command={routingURL} />
+              {admissionWebhookUrl && (
+                <>
+                  <span className="mt-4 text-muted-foreground">
+                    Admission Webhook Url
+                  </span>
+                  <CLI
+                    className="mt-1 md:w-full"
+                    command={admissionWebhookUrl}
+                  />
+                </>
+              )}
 
               <RunRouterCommand
                 open={open}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->

## Motivation and Context

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

The admission webhook URL was not being updated on passing empty string. Also shows it on the frontend

<img width="752" alt="image" src="https://github.com/wundergraph/cosmo/assets/44922285/4ede7fa5-2fcf-4bd1-85d4-4e748b97883b">



## TODO

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [x] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
