### PR TITLE
feat: use Helm tpl function on .Values.commonConfiguration

### DIFF
--- a/helm/cosmo/charts/router/Chart.yaml
+++ b/helm/cosmo/charts/router/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.4
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/cosmo/charts/router/README.md
+++ b/helm/cosmo/charts/router/README.md
@@ -1,6 +1,6 @@
 # router
 
-![Version: 0.2.4](https://img.shields.io/badge/Version-0.2.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 This is the official Helm Chart for the WunderGraph Cosmo Router.
 
@@ -13,11 +13,11 @@ This is the official Helm Chart for the WunderGraph Cosmo Router.
 | autoscaling.maxReplicas | int | `100` |  |
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
-| commonConfiguration | string | `"version: \"1\"\nlog_level: \"info\""` | For a full list of available configuration options, see https://cosmo-docs.wundergraph.com/router/configuration |
+| commonConfiguration | string | `"version: \"1\"\nlog_level: \"info\""` | You can use this to provide the router configuration via yaml. Values here have precedence over the configurations section. For a full list of available configuration options, see https://cosmo-docs.wundergraph.com/router/configuration This value is processed with the helm `tpl` function allowing referencing of variables and inclusion of templates |
 | configuration.cdnUrl | string | `""` |  |
 | configuration.controlplaneUrl | string | `""` | The URL of the Cosmo Controlplane. Should be internal to the cluster. Default to cloud if not set. |
 | configuration.devMode | bool | `false` | Set to true to enable the development mode. This allows for Advanced Request Tracing (ART) in the GraphQL Playground |
-| configuration.executionConfig | string | `""` | If your config exceeds 1MB (Kubernetes limit), you have to mount it as a file and set the path in routerConfigPath instead |
+| configuration.executionConfig | string | `""` | The execution config file to statically configure the router. If set, polling of the config is disabled. If your config exceeds 1MB (Kubernetes limit), you have to mount it as a file and set the path in routerConfigPath instead |
 | configuration.graphApiToken | string | `"replace-me"` | The router token is used to authenticate the router against the controlplane (required) |
 | configuration.graphqlMetricsCollectorUrl | string | `""` | The URL of the Cosmo GraphQL Metrics Collector. Should be internal to the cluster. Default to cloud if not set. |
 | configuration.logLevel | string | `"info"` | The log level of the router. Default to info if not set. |
@@ -25,9 +25,9 @@ This is the official Helm Chart for the WunderGraph Cosmo Router.
 | configuration.prometheus.enabled | bool | `true` | Enables prometheus metrics support. Default is true. |
 | configuration.prometheus.path | string | `"/metrics"` | The HTTP path where metrics are exposed. Default is "/metrics". |
 | configuration.prometheus.port | int | `8088` | The port where metrics are exposed. Default is port 8088. |
-| configuration.routerConfigPath | string | `""` | A possible to solution could be to use an init container to download the file from a CDN. If set, polling of the config is disabled. |
+| configuration.routerConfigPath | string | `""` | The path to the router execution config file. Before, you have to mount the file as a volume and set the path here. A possible to solution could be to use an init container to download the file from a CDN. If set, polling of the config is disabled. |
 | deploymentStrategy | object | `{}` |  |
-| existingConfigmap | string | `""` | If this is set, the commonConfiguration section is ignored. |
+| existingConfigmap | string | `""` | The name of the configmap to use for the router configuration. The key "config.yaml" is required in the configmap. If this is set, the commonConfiguration section is ignored. |
 | existingSecret | string | `""` | Existing secret in the same namespace containing the graphApiToken. The secret key has to match with current secret. |
 | extraEnvVars | list | `[]` | Allows to set additional environment / runtime variables on the container. Useful for global application non-specific settings. |
 | extraEnvVarsCM | string | `""` | Name of existing ConfigMap containing extra env vars |

--- a/helm/cosmo/charts/router/templates/config-map.yaml
+++ b/helm/cosmo/charts/router/templates/config-map.yaml
@@ -12,7 +12,7 @@ data:
   config.yaml: |-
     # User-supplied common configuration:
     {{- if .Values.commonConfiguration }}
-    {{- .Values.commonConfiguration | nindent 4 }}
+    {{- tpl .Values.commonConfiguration . | nindent 4 }}
     {{- end }}
   logLevel: "{{ .Values.configuration.logLevel }}"
   devMode: "{{ .Values.configuration.devMode }}"

--- a/helm/cosmo/charts/router/values.yaml
+++ b/helm/cosmo/charts/router/values.yaml
@@ -176,7 +176,7 @@ global:
 # Only in that way, we guarantee that sensitive information are stored as secrets in the cluster.
 
 # -- The name of the configmap to use for the router configuration. The key "config.yaml" is required in the configmap.
-# -- If this is set, the commonConfiguration section is ignored.
+# If this is set, the commonConfiguration section is ignored.
 existingConfigmap: ""
 
 # -- Existing secret in the same namespace containing the graphApiToken. The secret key has to match with current secret.
@@ -184,7 +184,8 @@ existingSecret: ""
 
 # Use this section to pass the graphApiToken or to configure simple settings.
 # -- You can use this to provide the router configuration via yaml. Values here have precedence over the configurations section.
-# -- For a full list of available configuration options, see https://cosmo-docs.wundergraph.com/router/configuration
+# For a full list of available configuration options, see https://cosmo-docs.wundergraph.com/router/configuration
+# This value is processed with the helm `tpl` function allowing referencing of variables and inclusion of templates
 commonConfiguration: |-
   version: "1"
   log_level: "info"
@@ -194,7 +195,7 @@ configuration:
   # -- The router token is used to authenticate the router against the controlplane (required)
   graphApiToken: "replace-me"
   # -- The execution config file to statically configure the router. If set, polling of the config is disabled.
-  # -- If your config exceeds 1MB (Kubernetes limit), you have to mount it as a file and set the path in routerConfigPath instead
+  # If your config exceeds 1MB (Kubernetes limit), you have to mount it as a file and set the path in routerConfigPath instead
   executionConfig: ""
   # -- The log level of the router. Default to info if not set.
   logLevel: "info"
@@ -209,7 +210,7 @@ configuration:
   #-- The URL of the Cosmo CDN. Should be internal to the cluster. Default to cloud if not set.
   cdnUrl: ""
   # -- The path to the router execution config file. Before, you have to mount the file as a volume and set the path here.
-  # -- A possible to solution could be to use an init container to download the file from a CDN. If set, polling of the config is disabled.
+  # A possible to solution could be to use an init container to download the file from a CDN. If set, polling of the config is disabled.
   routerConfigPath: ""
 
   # Use this section to disable/enable and configure prometheus metrics.


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->

## Motivation and Context

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

Allows users of the Helm chart to use dynamic content for `.Values.commonConfiguration` string -- used in the Config Map.

```
commonConfiguration: |-
  headers:
    subgraphs:
      someSubgraph:
        {{- include "subgraph.headers" . | nindent 6 }}
```

Without this change, `.Values.commonConfiguration` is just a string, and the dynamic part does not get expanded.        

## TODO

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [x] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
