### PR TITLE
fix: display graphql operation and variables after truncation in trace detail view

### DIFF
--- a/studio/src/components/analytics/trace-details.tsx
+++ b/studio/src/components/analytics/trace-details.tsx
@@ -62,10 +62,6 @@ export const TraceDetails = ({ ast }: { ast: GraphQLSchema | null }) => {
       setVariables(formattedVariables);
     };
 
-    if (!data) {
-      return;
-    }
-
     // Find the operation content and variables span
     // In that way, we don't rely on the order of the spans
 

--- a/studio/src/components/analytics/trace-details.tsx
+++ b/studio/src/components/analytics/trace-details.tsx
@@ -73,7 +73,12 @@ export const TraceDetails = ({ ast }: { ast: GraphQLSchema | null }) => {
       set(
           routerSpan.attributes?.operationContent || "",
           routerSpan.attributes?.operationVariables || "",
-      ).catch((e) => console.error("Error formatting", e));
+      ).catch((e) => {
+        console.error("Error formatting. Printing content as it is.", e)
+
+        setContent(routerSpan.attributes?.operationContent || "");
+        setVariables(routerSpan.attributes?.operationVariables || "");
+      });
     }
 
   }, [data]);
@@ -100,7 +105,7 @@ export const TraceDetails = ({ ast }: { ast: GraphQLSchema | null }) => {
       <div className="mb-3 mt-4">
         <div className="mb-1">Operation and Variables</div>
         <div className="text-xs text-muted-foreground">
-          To view the GraphQL variables of the operation, please enable variable
+          Content is truncated to 3KB. To view the GraphQL variables of the operation, please enable variable
           export in the router.{" "}
           <a
             target="_blank"

--- a/studio/src/components/analytics/trace-details.tsx
+++ b/studio/src/components/analytics/trace-details.tsx
@@ -45,6 +45,10 @@ export const TraceDetails = ({ ast }: { ast: GraphQLSchema | null }) => {
   );
 
   useEffect(() => {
+    if (!data) {
+      return;
+    }
+
     const set = async (content: string, variables: string) => {
       const formattedContent = await prettier.format(content, {
         parser: "graphql",
@@ -58,10 +62,6 @@ export const TraceDetails = ({ ast }: { ast: GraphQLSchema | null }) => {
       setVariables(formattedVariables);
     };
 
-    if (!data) {
-      return;
-    }
-
     // Find the operation content and variables span
     // In that way, we don't rely on the order of the spans
 
@@ -69,10 +69,13 @@ export const TraceDetails = ({ ast }: { ast: GraphQLSchema | null }) => {
       (span) => !!span.attributes?.operationContent,
     );
 
-    set(
-      routerSpan?.attributes?.operationContent || "",
-      routerSpan?.attributes?.operationVariables || "",
-    ).catch((e) => console.error("Error formatting", e));
+    if (routerSpan) {
+      set(
+          routerSpan.attributes?.operationContent || "",
+          routerSpan.attributes?.operationVariables || "",
+      ).catch((e) => console.error("Error formatting", e));
+    }
+
   }, [data]);
 
   if (isLoading) {

--- a/studio/src/components/analytics/trace-details.tsx
+++ b/studio/src/components/analytics/trace-details.tsx
@@ -73,9 +73,7 @@ export const TraceDetails = ({ ast }: { ast: GraphQLSchema | null }) => {
       set(
           routerSpan.attributes?.operationContent || "",
           routerSpan.attributes?.operationVariables || "",
-      ).catch((e) => {
-        console.error("Error formatting. Printing content as it is.", e)
-
+      ).catch(() => {
         setContent(routerSpan.attributes?.operationContent || "");
         setVariables(routerSpan.attributes?.operationVariables || "");
       });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->

## Motivation and Context

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

## TODO

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
