### PR TITLE
fix: reset queries on organization change

### DIFF
--- a/studio/src/components/app-provider.tsx
+++ b/studio/src/components/app-provider.tsx
@@ -14,6 +14,7 @@ import { useCookieOrganization } from "@/hooks/use-cookie-organization";
 export const UserContext = createContext<User | undefined>(undefined);
 
 const queryClient = new QueryClient();
+const sessionQueryClient = new QueryClient();
 
 const publicPaths = ["/login", "/signup"];
 
@@ -127,7 +128,7 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
         return failureCount < 3;
       },
     },
-    queryClient,
+    sessionQueryClient,
   );
 
   const [user, setUser] = useState<User>();
@@ -204,6 +205,10 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
       }
     }
   }, [router, data, isFetching, error, cookieOrgSlug]);
+
+  useEffect(() => {
+    queryClient.resetQueries();
+  }, [transport]);
 
   if (!transport) {
     return <UserContext.Provider value={user}>{children}</UserContext.Provider>;

--- a/studio/src/components/dashboard/NamespaceSelector.tsx
+++ b/studio/src/components/dashboard/NamespaceSelector.tsx
@@ -30,17 +30,6 @@ export const NamespaceSelector = () => {
   const applyParams = useApplyParams();
 
   useEffect(() => {
-    if (
-      !user ||
-      !user.currentOrganization ||
-      !user.currentOrganization.slug ||
-      !refetch
-    )
-      return;
-    refetch();
-  }, [refetch, user, user?.currentOrganization.slug]);
-
-  useEffect(() => {
     if (!data || data.namespaces.length === 0) return;
 
     if (!data.namespaces.some((ns) => ns.name === namespace)) {

--- a/studio/src/pages/[organizationSlug]/apikeys.tsx
+++ b/studio/src/pages/[organizationSlug]/apikeys.tsx
@@ -777,17 +777,6 @@ const APIKeysPage: NextPageWithLayout = () => {
   const [openApiKeyCreatedDialog, setOpenApiKeyCreatedDialog] = useState(false);
 
   useEffect(() => {
-    if (
-      !user ||
-      !user.currentOrganization ||
-      !user.currentOrganization.slug ||
-      !refetch
-    )
-      return;
-    refetch();
-  }, [refetch, user, user?.currentOrganization.slug]);
-
-  useEffect(() => {
     if (!openApiKeyCreatedDialog) setApiKey(undefined);
   }, [openApiKeyCreatedDialog, setApiKey]);
 

--- a/studio/src/pages/[organizationSlug]/audit-log.tsx
+++ b/studio/src/pages/[organizationSlug]/audit-log.tsx
@@ -10,35 +10,19 @@ import { getDashboardLayout } from "@/components/layout/dashboard-layout";
 import { Button } from "@/components/ui/button";
 import { Loader } from "@/components/ui/loader";
 import { Pagination } from "@/components/ui/pagination";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Toolbar } from "@/components/ui/toolbar";
 import { useFeatureLimit } from "@/hooks/use-feature-limit";
 import { createDateRange } from "@/lib/insights-helpers";
 import { NextPageWithLayout } from "@/lib/page";
-import { ExclamationTriangleIcon } from "@heroicons/react/24/outline";
-import {
-  ChevronLeftIcon,
-  ChevronRightIcon,
-  DoubleArrowLeftIcon,
-  DoubleArrowRightIcon,
-} from "@radix-ui/react-icons";
 import { useQuery } from "@connectrpc/connect-query";
+import { ExclamationTriangleIcon } from "@heroicons/react/24/outline";
 import { EnumStatusCode } from "@wundergraph/cosmo-connect/dist/common/common_pb";
 import { getAuditLogs } from "@wundergraph/cosmo-connect/dist/platform/v1/platform-PlatformService_connectquery";
 import { formatISO } from "date-fns";
 import { useRouter } from "next/router";
-import { useCallback, useEffect } from "react";
-import { useUser } from "@/hooks/use-user";
 
 const AuditLogPage: NextPageWithLayout = () => {
   const router = useRouter();
-  const user = useUser();
   const pageNumber = router.query.page
     ? parseInt(router.query.page as string)
     : 1;
@@ -53,26 +37,12 @@ const AuditLogPage: NextPageWithLayout = () => {
   const startDate = range ? createDateRange(range).start : start;
   const endDate = range ? createDateRange(range).end : end;
 
-  const { data, isLoading, error, refetch } = useQuery(
-    getAuditLogs,
-    {
-      limit: limit > 50 ? 50 : limit,
-      offset: (pageNumber - 1) * limit,
-      startDate: formatISO(startDate),
-      endDate: formatISO(endDate),
-    },
-  );
-
-  useEffect(() => {
-    if (
-      !user ||
-      !user.currentOrganization ||
-      !user.currentOrganization.slug ||
-      !refetch
-    )
-      return;
-    refetch();
-  }, [refetch, user, user?.currentOrganization.slug]);
+  const { data, isLoading, error, refetch } = useQuery(getAuditLogs, {
+    limit: limit > 50 ? 50 : limit,
+    offset: (pageNumber - 1) * limit,
+    startDate: formatISO(startDate),
+    endDate: formatISO(endDate),
+  });
 
   if (isLoading) return <Loader fullscreen />;
 

--- a/studio/src/pages/[organizationSlug]/graphs.tsx
+++ b/studio/src/pages/[organizationSlug]/graphs.tsx
@@ -67,16 +67,6 @@ const GraphsDashboardPage: NextPageWithLayout = () => {
   });
 
   // refetch the query when the organization changes
-  useEffect(() => {
-    if (
-      !user ||
-      !user.currentOrganization ||
-      !user.currentOrganization.slug ||
-      !refetch
-    )
-      return;
-    refetch();
-  }, [refetch, user, user?.currentOrganization.slug]);
 
   if (isLoading) return <Loader fullscreen />;
 

--- a/studio/src/pages/[organizationSlug]/integrations.tsx
+++ b/studio/src/pages/[organizationSlug]/integrations.tsx
@@ -545,17 +545,6 @@ const IntegrationsPage: NextPageWithLayout = () => {
   );
 
   useEffect(() => {
-    if (
-      !user ||
-      !user.currentOrganization ||
-      !user.currentOrganization.slug ||
-      !refetch
-    )
-      return;
-    refetch();
-  }, [refetch, user, user?.currentOrganization.slug]);
-
-  useEffect(() => {
     if (!code) {
       setShouldCreate(false);
       return;

--- a/studio/src/pages/[organizationSlug]/lint-policy.tsx
+++ b/studio/src/pages/[organizationSlug]/lint-policy.tsx
@@ -100,17 +100,6 @@ const LintPolicyPage: NextPageWithLayout = () => {
   const [countByCategory, setCountByCategory] = useState<number[]>();
 
   useEffect(() => {
-    if (
-      !user ||
-      !user.currentOrganization ||
-      !user.currentOrganization.slug ||
-      !refetch
-    )
-      return;
-    refetch();
-  }, [refetch, user, user?.currentOrganization.slug]);
-
-  useEffect(() => {
     if (!data) return;
     setSelectedLintRules(data.configs);
     setLinterEnabled(data.linterEnabled);

--- a/studio/src/pages/[organizationSlug]/members.tsx
+++ b/studio/src/pages/[organizationSlug]/members.tsx
@@ -361,17 +361,6 @@ const PendingInvitations = () => {
 
   const noOfPages = Math.ceil((data?.totalCount ?? 0) / limit);
 
-  useEffect(() => {
-    if (
-      !user ||
-      !user.currentOrganization ||
-      !user.currentOrganization.slug ||
-      !refetch
-    )
-      return;
-    refetch();
-  }, [refetch, user, user?.currentOrganization.slug]);
-
   if (isLoading) return <Loader fullscreen />;
 
   if (error || data?.response?.code !== EnumStatusCode.OK || !user)
@@ -442,17 +431,6 @@ const AcceptedMembers = () => {
   });
 
   const noOfPages = Math.ceil((data?.totalCount ?? 0) / limit);
-
-  useEffect(() => {
-    if (
-      !user ||
-      !user.currentOrganization ||
-      !user.currentOrganization.slug ||
-      !refetch
-    )
-      return;
-    refetch();
-  }, [refetch, user, user?.currentOrganization.slug]);
 
   if (isLoading) return <Loader fullscreen />;
 
@@ -595,17 +573,6 @@ const MembersPage: NextPageWithLayout = () => {
     },
     search: debouncedSearch,
   });
-
-  useEffect(() => {
-    if (
-      !user ||
-      !user.currentOrganization ||
-      !user.currentOrganization.slug ||
-      !refetch
-    )
-      return;
-    refetch();
-  }, [refetch, user, user?.currentOrganization.slug]);
 
   return (
     <div className="flex h-full flex-col gap-y-6">

--- a/studio/src/pages/[organizationSlug]/subgraphs.tsx
+++ b/studio/src/pages/[organizationSlug]/subgraphs.tsx
@@ -34,26 +34,12 @@ const SubgraphsDashboardPage: NextPageWithLayout = () => {
 
   const applyParams = useApplyParams();
 
-  const { data, isLoading, error, refetch } = useQuery(
-    getSubgraphs,
-    {
-      namespace,
-      query,
-      limit,
-      offset,
-    },
-  );
-
-  useEffect(() => {
-    if (
-      !user ||
-      !user.currentOrganization ||
-      !user.currentOrganization.slug ||
-      !refetch
-    )
-      return;
-    refetch();
-  }, [refetch, user, user?.currentOrganization.slug]);
+  const { data, isLoading, error, refetch } = useQuery(getSubgraphs, {
+    namespace,
+    query,
+    limit,
+    offset,
+  });
 
   let content;
 

--- a/studio/src/pages/[organizationSlug]/usages.tsx
+++ b/studio/src/pages/[organizationSlug]/usages.tsx
@@ -90,17 +90,6 @@ const UsagesPage: NextPageWithLayout = () => {
   const requestLimitRaw = useFeatureLimit("requests", 1000);
   const requestLimit = requestLimitRaw === -1 ? -1 : requestLimitRaw * 10 ** 6;
 
-  useEffect(() => {
-    if (
-      !user ||
-      !user.currentOrganization ||
-      !user.currentOrganization.slug ||
-      !refetch
-    )
-      return;
-    refetch();
-  }, [refetch, user, user?.currentOrganization.slug]);
-
   if (isLoading) return <Loader fullscreen />;
 
   if (error || data?.response?.code !== EnumStatusCode.OK)

--- a/studio/src/pages/[organizationSlug]/webhooks.tsx
+++ b/studio/src/pages/[organizationSlug]/webhooks.tsx
@@ -475,17 +475,6 @@ const WebhooksPage: NextPageWithLayout = () => {
     getOrganizationWebhookConfigs,
   );
 
-  useEffect(() => {
-    if (
-      !user ||
-      !user.currentOrganization ||
-      !user.currentOrganization.slug ||
-      !refetch
-    )
-      return;
-    refetch();
-  }, [refetch, user, user?.currentOrganization.slug]);
-
   if (isLoading) return <Loader fullscreen />;
 
   if (error || data?.response?.code !== EnumStatusCode.OK)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->

## Motivation and Context

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

Refresh queries used to occuer even before the transport was set. Now we handle the reset in the app provider

## TODO

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [x] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
