### PR TITLE
feat: allow to add custom OTEL attributes

### DIFF
--- a/otelcollector/otel-config.yaml
+++ b/otelcollector/otel-config.yaml
@@ -21,7 +21,8 @@ processors:
         action: insert
   batch:
     send_batch_size: 10000
-    timeout: 5s
+    send_batch_max_size: 20000
+    timeout: 15s
 
 exporters:
   clickhouse:

--- a/router-tests/prometheus_test.go
+++ b/router-tests/prometheus_test.go
@@ -484,7 +484,7 @@ func TestPrometheus(t *testing.T) {
 		})
 	})
 
-	t.Run("Collect and export OTEL metrics in respect to custom attributes", func(t *testing.T) {
+	t.Run("Collect and export OTEL metrics in respect to custom attributes / from header", func(t *testing.T) {
 		t.Parallel()
 
 		exporter := tracetest.NewInMemoryExporter(t)
@@ -503,8 +503,8 @@ func TestPrometheus(t *testing.T) {
 			},
 			OtelAttributes: []config.OtelAttribute{
 				{
-					Key:   "custom",
-					Value: "value",
+					Key:     "custom",
+					Default: "value_different",
 					ValueFrom: &config.OtelAttributeFromValue{
 						RequestHeader: "x-custom-header",
 					},
@@ -512,6 +512,530 @@ func TestPrometheus(t *testing.T) {
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+				Header: map[string][]string{
+					"x-custom-header": {"value"},
+				},
+				Query: `query myQuery { employees { id } }`,
+			})
+			require.JSONEq(t, employeesIDData, res.Body)
+
+			mf, err := promRegistry.Gather()
+			require.NoError(t, err)
+
+			targetInfo := findMetricFamilyByName(mf, "target_info")
+			customResourceLabel := findMetricLabelByName(targetInfo.GetMetric(), "custom_resource")
+
+			require.NotNil(t, customResourceLabel)
+			customResourceLabelValue := "value"
+			require.Equal(t, customResourceLabel.Value, &customResourceLabelValue)
+
+			requestTotal := findMetricFamilyByName(mf, "router_http_requests_total")
+			requestTotalMetrics := requestTotal.GetMetric()
+
+			require.Len(t, requestTotalMetrics, 2)
+			require.Len(t, requestTotalMetrics[0].Label, 13)
+			require.Len(t, requestTotalMetrics[1].Label, 14)
+
+			require.Equal(t, []*io_prometheus_client.LabelPair{
+				{
+					Name:  PointerOf("custom"),
+					Value: PointerOf("value"),
+				},
+				{
+					Name:  PointerOf("http_status_code"),
+					Value: PointerOf("200"),
+				},
+				{
+					Name:  PointerOf("otel_scope_name"),
+					Value: PointerOf("cosmo.router.prometheus"),
+				},
+				{
+					Name:  PointerOf("otel_scope_version"),
+					Value: PointerOf("0.0.1"),
+				},
+				{
+					Name:  PointerOf("wg_client_name"),
+					Value: PointerOf("unknown"),
+				},
+				{
+					Name:  PointerOf("wg_client_version"),
+					Value: PointerOf("missing"),
+				},
+				{
+					Name:  PointerOf("wg_federated_graph_id"),
+					Value: PointerOf("graph"),
+				},
+				{
+					Name:  PointerOf("wg_operation_name"),
+					Value: PointerOf("myQuery"),
+				},
+				{
+					Name:  PointerOf("wg_operation_protocol"),
+					Value: PointerOf("http"),
+				},
+				{
+					Name:  PointerOf("wg_operation_type"),
+					Value: PointerOf("query"),
+				},
+				{
+					Name:  PointerOf("wg_router_cluster_name"),
+					Value: PointerOf(""),
+				},
+				{
+					Name:  PointerOf("wg_router_config_version"),
+					Value: PointerOf(""),
+				},
+				{
+					Name:  PointerOf("wg_router_version"),
+					Value: PointerOf("dev"),
+				},
+			}, requestTotalMetrics[0].Label)
+
+			require.Equal(t, []*io_prometheus_client.LabelPair{
+				{
+					Name:  PointerOf("custom"),
+					Value: PointerOf("value"),
+				},
+				{
+					Name:  PointerOf("otel_scope_name"),
+					Value: PointerOf("cosmo.router.prometheus"),
+				},
+				{
+					Name:  PointerOf("otel_scope_version"),
+					Value: PointerOf("0.0.1"),
+				},
+				{
+					Name:  PointerOf("wg_client_name"),
+					Value: PointerOf("unknown"),
+				},
+				{
+					Name:  PointerOf("wg_client_version"),
+					Value: PointerOf("missing"),
+				},
+				{
+					Name:  PointerOf("wg_federated_graph_id"),
+					Value: PointerOf("graph"),
+				},
+				{
+					Name:  PointerOf("wg_operation_name"),
+					Value: PointerOf("myQuery"),
+				},
+				{
+					Name:  PointerOf("wg_operation_protocol"),
+					Value: PointerOf("http"),
+				},
+				{
+					Name:  PointerOf("wg_operation_type"),
+					Value: PointerOf("query"),
+				},
+				{
+					Name:  PointerOf("wg_router_cluster_name"),
+					Value: PointerOf(""),
+				},
+				{
+					Name:  PointerOf("wg_router_config_version"),
+					Value: PointerOf(""),
+				},
+				{
+					Name:  PointerOf("wg_router_version"),
+					Value: PointerOf("dev"),
+				},
+				{
+					Name:  PointerOf("wg_subgraph_id"),
+					Value: PointerOf("0"),
+				},
+				{
+					Name:  PointerOf("wg_subgraph_name"),
+					Value: PointerOf("employees"),
+				},
+			}, requestTotalMetrics[1].Label)
+
+			requestsInFlight := findMetricFamilyByName(mf, "router_http_requests_in_flight")
+			requestsInFlightMetrics := requestsInFlight.GetMetric()
+
+			require.Len(t, requestsInFlightMetrics, 2)
+			require.Len(t, requestsInFlightMetrics[0].Label, 10)
+			require.Len(t, requestsInFlightMetrics[1].Label, 14)
+
+			require.Equal(t, []*io_prometheus_client.LabelPair{
+				{
+					Name:  PointerOf("custom"),
+					Value: PointerOf("value"),
+				},
+				{
+					Name:  PointerOf("otel_scope_name"),
+					Value: PointerOf("cosmo.router.prometheus"),
+				},
+				{
+					Name:  PointerOf("otel_scope_version"),
+					Value: PointerOf("0.0.1"),
+				},
+				{
+					Name:  PointerOf("wg_client_name"),
+					Value: PointerOf("unknown"),
+				},
+				{
+					Name:  PointerOf("wg_client_version"),
+					Value: PointerOf("missing"),
+				},
+				{
+					Name:  PointerOf("wg_federated_graph_id"),
+					Value: PointerOf("graph"),
+				},
+				{
+					Name:  PointerOf("wg_operation_protocol"),
+					Value: PointerOf("http"),
+				},
+				{
+					Name:  PointerOf("wg_router_cluster_name"),
+					Value: PointerOf(""),
+				},
+				{
+					Name:  PointerOf("wg_router_config_version"),
+					Value: PointerOf(""),
+				},
+				{
+					Name:  PointerOf("wg_router_version"),
+					Value: PointerOf("dev"),
+				},
+			}, requestsInFlightMetrics[0].Label)
+
+			require.Equal(t, []*io_prometheus_client.LabelPair{
+				{
+					Name:  PointerOf("custom"),
+					Value: PointerOf("value"),
+				},
+				{
+					Name:  PointerOf("otel_scope_name"),
+					Value: PointerOf("cosmo.router.prometheus"),
+				},
+				{
+					Name:  PointerOf("otel_scope_version"),
+					Value: PointerOf("0.0.1"),
+				},
+				{
+					Name:  PointerOf("wg_client_name"),
+					Value: PointerOf("unknown"),
+				},
+				{
+					Name:  PointerOf("wg_client_version"),
+					Value: PointerOf("missing"),
+				},
+				{
+					Name:  PointerOf("wg_federated_graph_id"),
+					Value: PointerOf("graph"),
+				},
+				{
+					Name:  PointerOf("wg_operation_name"),
+					Value: PointerOf("myQuery"),
+				},
+				{
+					Name:  PointerOf("wg_operation_protocol"),
+					Value: PointerOf("http"),
+				},
+				{
+					Name:  PointerOf("wg_operation_type"),
+					Value: PointerOf("query"),
+				},
+				{
+					Name:  PointerOf("wg_router_cluster_name"),
+					Value: PointerOf(""),
+				},
+				{
+					Name:  PointerOf("wg_router_config_version"),
+					Value: PointerOf(""),
+				},
+				{
+					Name:  PointerOf("wg_router_version"),
+					Value: PointerOf("dev"),
+				},
+				{
+					Name:  PointerOf("wg_subgraph_id"),
+					Value: PointerOf("0"),
+				},
+				{
+					Name:  PointerOf("wg_subgraph_name"),
+					Value: PointerOf("employees"),
+				},
+			}, requestsInFlightMetrics[1].Label)
+
+			requestDuration := findMetricFamilyByName(mf, "router_http_request_duration_milliseconds")
+			requestDurationMetrics := requestDuration.GetMetric()
+
+			require.Len(t, requestDurationMetrics, 2)
+			require.Len(t, requestDurationMetrics[0].Label, 13)
+			require.Len(t, requestDurationMetrics[1].Label, 14)
+
+			require.Equal(t, []*io_prometheus_client.LabelPair{
+				{
+					Name:  PointerOf("custom"),
+					Value: PointerOf("value"),
+				},
+				{
+					Name:  PointerOf("http_status_code"),
+					Value: PointerOf("200"),
+				},
+				{
+					Name:  PointerOf("otel_scope_name"),
+					Value: PointerOf("cosmo.router.prometheus"),
+				},
+				{
+					Name:  PointerOf("otel_scope_version"),
+					Value: PointerOf("0.0.1"),
+				},
+				{
+					Name:  PointerOf("wg_client_name"),
+					Value: PointerOf("unknown"),
+				},
+				{
+					Name:  PointerOf("wg_client_version"),
+					Value: PointerOf("missing"),
+				},
+				{
+					Name:  PointerOf("wg_federated_graph_id"),
+					Value: PointerOf("graph"),
+				},
+				{
+					Name:  PointerOf("wg_operation_name"),
+					Value: PointerOf("myQuery"),
+				},
+				{
+					Name:  PointerOf("wg_operation_protocol"),
+					Value: PointerOf("http"),
+				},
+				{
+					Name:  PointerOf("wg_operation_type"),
+					Value: PointerOf("query"),
+				},
+				{
+					Name:  PointerOf("wg_router_cluster_name"),
+					Value: PointerOf(""),
+				},
+				{
+					Name:  PointerOf("wg_router_config_version"),
+					Value: PointerOf(""),
+				},
+				{
+					Name:  PointerOf("wg_router_version"),
+					Value: PointerOf("dev"),
+				},
+			}, requestDurationMetrics[0].Label)
+
+			require.Equal(t, []*io_prometheus_client.LabelPair{
+				{
+					Name:  PointerOf("custom"),
+					Value: PointerOf("value"),
+				},
+				{
+					Name:  PointerOf("otel_scope_name"),
+					Value: PointerOf("cosmo.router.prometheus"),
+				},
+				{
+					Name:  PointerOf("otel_scope_version"),
+					Value: PointerOf("0.0.1"),
+				},
+				{
+					Name:  PointerOf("wg_client_name"),
+					Value: PointerOf("unknown"),
+				},
+				{
+					Name:  PointerOf("wg_client_version"),
+					Value: PointerOf("missing"),
+				},
+				{
+					Name:  PointerOf("wg_federated_graph_id"),
+					Value: PointerOf("graph"),
+				},
+				{
+					Name:  PointerOf("wg_operation_name"),
+					Value: PointerOf("myQuery"),
+				},
+				{
+					Name:  PointerOf("wg_operation_protocol"),
+					Value: PointerOf("http"),
+				},
+				{
+					Name:  PointerOf("wg_operation_type"),
+					Value: PointerOf("query"),
+				},
+				{
+					Name:  PointerOf("wg_router_cluster_name"),
+					Value: PointerOf(""),
+				},
+				{
+					Name:  PointerOf("wg_router_config_version"),
+					Value: PointerOf(""),
+				},
+				{
+					Name:  PointerOf("wg_router_version"),
+					Value: PointerOf("dev"),
+				},
+				{
+					Name:  PointerOf("wg_subgraph_id"),
+					Value: PointerOf("0"),
+				},
+				{
+					Name:  PointerOf("wg_subgraph_name"),
+					Value: PointerOf("employees"),
+				},
+			}, requestDurationMetrics[1].Label)
+
+			responseContentLength := findMetricFamilyByName(mf, "router_http_response_content_length_total")
+			responseContentLengthMetrics := responseContentLength.GetMetric()
+
+			require.Len(t, responseContentLengthMetrics, 2)
+			require.Len(t, responseContentLengthMetrics[0].Label, 13)
+			require.Len(t, responseContentLengthMetrics[1].Label, 15)
+
+			require.Equal(t, []*io_prometheus_client.LabelPair{
+				{
+					Name:  PointerOf("custom"),
+					Value: PointerOf("value"),
+				},
+				{
+					Name:  PointerOf("http_status_code"),
+					Value: PointerOf("200"),
+				},
+				{
+					Name:  PointerOf("otel_scope_name"),
+					Value: PointerOf("cosmo.router.prometheus"),
+				},
+				{
+					Name:  PointerOf("otel_scope_version"),
+					Value: PointerOf("0.0.1"),
+				},
+				{
+					Name:  PointerOf("wg_client_name"),
+					Value: PointerOf("unknown"),
+				},
+				{
+					Name:  PointerOf("wg_client_version"),
+					Value: PointerOf("missing"),
+				},
+				{
+					Name:  PointerOf("wg_federated_graph_id"),
+					Value: PointerOf("graph"),
+				},
+				{
+					Name:  PointerOf("wg_operation_name"),
+					Value: PointerOf("myQuery"),
+				},
+				{
+					Name:  PointerOf("wg_operation_protocol"),
+					Value: PointerOf("http"),
+				},
+				{
+					Name:  PointerOf("wg_operation_type"),
+					Value: PointerOf("query"),
+				},
+				{
+					Name:  PointerOf("wg_router_cluster_name"),
+					Value: PointerOf(""),
+				},
+				{
+					Name:  PointerOf("wg_router_config_version"),
+					Value: PointerOf(""),
+				},
+				{
+					Name:  PointerOf("wg_router_version"),
+					Value: PointerOf("dev"),
+				},
+			}, responseContentLengthMetrics[0].Label)
+
+			require.Equal(t, []*io_prometheus_client.LabelPair{
+				{
+					Name:  PointerOf("custom"),
+					Value: PointerOf("value"),
+				},
+				{
+					Name:  PointerOf("http_status_code"),
+					Value: PointerOf("200"),
+				},
+				{
+					Name:  PointerOf("otel_scope_name"),
+					Value: PointerOf("cosmo.router.prometheus"),
+				},
+				{
+					Name:  PointerOf("otel_scope_version"),
+					Value: PointerOf("0.0.1"),
+				},
+				{
+					Name:  PointerOf("wg_client_name"),
+					Value: PointerOf("unknown"),
+				},
+				{
+					Name:  PointerOf("wg_client_version"),
+					Value: PointerOf("missing"),
+				},
+				{
+					Name:  PointerOf("wg_federated_graph_id"),
+					Value: PointerOf("graph"),
+				},
+				{
+					Name:  PointerOf("wg_operation_name"),
+					Value: PointerOf("myQuery"),
+				},
+				{
+					Name:  PointerOf("wg_operation_protocol"),
+					Value: PointerOf("http"),
+				},
+				{
+					Name:  PointerOf("wg_operation_type"),
+					Value: PointerOf("query"),
+				},
+				{
+					Name:  PointerOf("wg_router_cluster_name"),
+					Value: PointerOf(""),
+				},
+				{
+					Name:  PointerOf("wg_router_config_version"),
+					Value: PointerOf(""),
+				},
+				{
+					Name:  PointerOf("wg_router_version"),
+					Value: PointerOf("dev"),
+				},
+				{
+					Name:  PointerOf("wg_subgraph_id"),
+					Value: PointerOf("0"),
+				},
+				{
+					Name:  PointerOf("wg_subgraph_name"),
+					Value: PointerOf("employees"),
+				},
+			}, responseContentLengthMetrics[1].Label)
+
+		})
+	})
+
+	t.Run("Collect and export OTEL metrics in respect to custom attributes / static", func(t *testing.T) {
+		t.Parallel()
+
+		exporter := tracetest.NewInMemoryExporter(t)
+		metricReader := metric.NewManualReader()
+		promRegistry := prometheus.NewRegistry()
+
+		testenv.Run(t, &testenv.Config{
+			TraceExporter:      exporter,
+			MetricReader:       metricReader,
+			PrometheusRegistry: promRegistry,
+			OtelResourceAttributes: []config.OtelResourceAttribute{
+				{
+					Key:   "custom.resource",
+					Value: "value",
+				},
+			},
+			OtelAttributes: []config.OtelAttribute{
+				{
+					Key:     "custom",
+					Default: "value",
+				},
+			},
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+				Header: map[string][]string{
+					"x-custom-header": {"value_different"},
+				},
 				Query: `query myQuery { employees { id } }`,
 			})
 			require.JSONEq(t, employeesIDData, res.Body)

--- a/router-tests/prometheus_test.go
+++ b/router-tests/prometheus_test.go
@@ -5,6 +5,7 @@ import (
 	io_prometheus_client "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/require"
 	"github.com/wundergraph/cosmo/router-tests/testenv"
+	"github.com/wundergraph/cosmo/router/pkg/config"
 	"github.com/wundergraph/cosmo/router/pkg/trace/tracetest"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"net/http"
@@ -36,7 +37,7 @@ func TestPrometheus(t *testing.T) {
 			mf, err := promRegistry.Gather()
 			require.NoError(t, err)
 
-			requestTotal := findMetricByName(mf, "router_http_requests_total")
+			requestTotal := findMetricFamilyByName(mf, "router_http_requests_total")
 			requestTotalMetrics := requestTotal.GetMetric()
 
 			require.Len(t, requestTotalMetrics, 2)
@@ -149,11 +150,11 @@ func TestPrometheus(t *testing.T) {
 				},
 			}, requestTotalMetrics[1].Label)
 
-			requestsInFlight := findMetricByName(mf, "router_http_requests_in_flight")
+			requestsInFlight := findMetricFamilyByName(mf, "router_http_requests_in_flight")
 			requestsInFlightMetrics := requestsInFlight.GetMetric()
 
 			require.Len(t, requestsInFlightMetrics, 2)
-			require.Len(t, requestsInFlightMetrics[0].Label, 6)
+			require.Len(t, requestsInFlightMetrics[0].Label, 9)
 			require.Len(t, requestsInFlightMetrics[1].Label, 13)
 
 			require.Equal(t, []*io_prometheus_client.LabelPair{
@@ -166,8 +167,20 @@ func TestPrometheus(t *testing.T) {
 					Value: PointerOf("0.0.1"),
 				},
 				{
+					Name:  PointerOf("wg_client_name"),
+					Value: PointerOf("unknown"),
+				},
+				{
+					Name:  PointerOf("wg_client_version"),
+					Value: PointerOf("missing"),
+				},
+				{
 					Name:  PointerOf("wg_federated_graph_id"),
 					Value: PointerOf("graph"),
+				},
+				{
+					Name:  PointerOf("wg_operation_protocol"),
+					Value: PointerOf("http"),
 				},
 				{
 					Name:  PointerOf("wg_router_cluster_name"),
@@ -238,7 +251,7 @@ func TestPrometheus(t *testing.T) {
 				},
 			}, requestsInFlightMetrics[1].Label)
 
-			requestDuration := findMetricByName(mf, "router_http_request_duration_milliseconds")
+			requestDuration := findMetricFamilyByName(mf, "router_http_request_duration_milliseconds")
 			requestDurationMetrics := requestDuration.GetMetric()
 
 			require.Len(t, requestDurationMetrics, 2)
@@ -351,7 +364,7 @@ func TestPrometheus(t *testing.T) {
 				},
 			}, requestDurationMetrics[1].Label)
 
-			responseContentLength := findMetricByName(mf, "router_http_response_content_length_total")
+			responseContentLength := findMetricFamilyByName(mf, "router_http_response_content_length_total")
 			responseContentLengthMetrics := responseContentLength.GetMetric()
 
 			require.Len(t, responseContentLengthMetrics, 2)
@@ -471,6 +484,527 @@ func TestPrometheus(t *testing.T) {
 		})
 	})
 
+	t.Run("Collect and export OTEL metrics in respect to custom attributes", func(t *testing.T) {
+		t.Parallel()
+
+		exporter := tracetest.NewInMemoryExporter(t)
+		metricReader := metric.NewManualReader()
+		promRegistry := prometheus.NewRegistry()
+
+		testenv.Run(t, &testenv.Config{
+			TraceExporter:      exporter,
+			MetricReader:       metricReader,
+			PrometheusRegistry: promRegistry,
+			OtelResourceAttributes: []config.OtelResourceAttribute{
+				{
+					Key:   "custom.resource",
+					Value: "value",
+				},
+			},
+			OtelAttributes: []config.OtelAttribute{
+				{
+					Key:   "custom",
+					Value: "value",
+					ValueFrom: &config.OtelAttributeFromValue{
+						RequestHeader: "x-custom-header",
+					},
+				},
+			},
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+				Query: `query myQuery { employees { id } }`,
+			})
+			require.JSONEq(t, employeesIDData, res.Body)
+
+			mf, err := promRegistry.Gather()
+			require.NoError(t, err)
+
+			targetInfo := findMetricFamilyByName(mf, "target_info")
+			customResourceLabel := findMetricLabelByName(targetInfo.GetMetric(), "custom_resource")
+
+			require.NotNil(t, customResourceLabel)
+			customResourceLabelValue := "value"
+			require.Equal(t, customResourceLabel.Value, &customResourceLabelValue)
+
+			requestTotal := findMetricFamilyByName(mf, "router_http_requests_total")
+			requestTotalMetrics := requestTotal.GetMetric()
+
+			require.Len(t, requestTotalMetrics, 2)
+			require.Len(t, requestTotalMetrics[0].Label, 13)
+			require.Len(t, requestTotalMetrics[1].Label, 14)
+
+			require.Equal(t, []*io_prometheus_client.LabelPair{
+				{
+					Name:  PointerOf("custom"),
+					Value: PointerOf("value"),
+				},
+				{
+					Name:  PointerOf("http_status_code"),
+					Value: PointerOf("200"),
+				},
+				{
+					Name:  PointerOf("otel_scope_name"),
+					Value: PointerOf("cosmo.router.prometheus"),
+				},
+				{
+					Name:  PointerOf("otel_scope_version"),
+					Value: PointerOf("0.0.1"),
+				},
+				{
+					Name:  PointerOf("wg_client_name"),
+					Value: PointerOf("unknown"),
+				},
+				{
+					Name:  PointerOf("wg_client_version"),
+					Value: PointerOf("missing"),
+				},
+				{
+					Name:  PointerOf("wg_federated_graph_id"),
+					Value: PointerOf("graph"),
+				},
+				{
+					Name:  PointerOf("wg_operation_name"),
+					Value: PointerOf("myQuery"),
+				},
+				{
+					Name:  PointerOf("wg_operation_protocol"),
+					Value: PointerOf("http"),
+				},
+				{
+					Name:  PointerOf("wg_operation_type"),
+					Value: PointerOf("query"),
+				},
+				{
+					Name:  PointerOf("wg_router_cluster_name"),
+					Value: PointerOf(""),
+				},
+				{
+					Name:  PointerOf("wg_router_config_version"),
+					Value: PointerOf(""),
+				},
+				{
+					Name:  PointerOf("wg_router_version"),
+					Value: PointerOf("dev"),
+				},
+			}, requestTotalMetrics[0].Label)
+
+			require.Equal(t, []*io_prometheus_client.LabelPair{
+				{
+					Name:  PointerOf("custom"),
+					Value: PointerOf("value"),
+				},
+				{
+					Name:  PointerOf("otel_scope_name"),
+					Value: PointerOf("cosmo.router.prometheus"),
+				},
+				{
+					Name:  PointerOf("otel_scope_version"),
+					Value: PointerOf("0.0.1"),
+				},
+				{
+					Name:  PointerOf("wg_client_name"),
+					Value: PointerOf("unknown"),
+				},
+				{
+					Name:  PointerOf("wg_client_version"),
+					Value: PointerOf("missing"),
+				},
+				{
+					Name:  PointerOf("wg_federated_graph_id"),
+					Value: PointerOf("graph"),
+				},
+				{
+					Name:  PointerOf("wg_operation_name"),
+					Value: PointerOf("myQuery"),
+				},
+				{
+					Name:  PointerOf("wg_operation_protocol"),
+					Value: PointerOf("http"),
+				},
+				{
+					Name:  PointerOf("wg_operation_type"),
+					Value: PointerOf("query"),
+				},
+				{
+					Name:  PointerOf("wg_router_cluster_name"),
+					Value: PointerOf(""),
+				},
+				{
+					Name:  PointerOf("wg_router_config_version"),
+					Value: PointerOf(""),
+				},
+				{
+					Name:  PointerOf("wg_router_version"),
+					Value: PointerOf("dev"),
+				},
+				{
+					Name:  PointerOf("wg_subgraph_id"),
+					Value: PointerOf("0"),
+				},
+				{
+					Name:  PointerOf("wg_subgraph_name"),
+					Value: PointerOf("employees"),
+				},
+			}, requestTotalMetrics[1].Label)
+
+			requestsInFlight := findMetricFamilyByName(mf, "router_http_requests_in_flight")
+			requestsInFlightMetrics := requestsInFlight.GetMetric()
+
+			require.Len(t, requestsInFlightMetrics, 2)
+			require.Len(t, requestsInFlightMetrics[0].Label, 10)
+			require.Len(t, requestsInFlightMetrics[1].Label, 14)
+
+			require.Equal(t, []*io_prometheus_client.LabelPair{
+				{
+					Name:  PointerOf("custom"),
+					Value: PointerOf("value"),
+				},
+				{
+					Name:  PointerOf("otel_scope_name"),
+					Value: PointerOf("cosmo.router.prometheus"),
+				},
+				{
+					Name:  PointerOf("otel_scope_version"),
+					Value: PointerOf("0.0.1"),
+				},
+				{
+					Name:  PointerOf("wg_client_name"),
+					Value: PointerOf("unknown"),
+				},
+				{
+					Name:  PointerOf("wg_client_version"),
+					Value: PointerOf("missing"),
+				},
+				{
+					Name:  PointerOf("wg_federated_graph_id"),
+					Value: PointerOf("graph"),
+				},
+				{
+					Name:  PointerOf("wg_operation_protocol"),
+					Value: PointerOf("http"),
+				},
+				{
+					Name:  PointerOf("wg_router_cluster_name"),
+					Value: PointerOf(""),
+				},
+				{
+					Name:  PointerOf("wg_router_config_version"),
+					Value: PointerOf(""),
+				},
+				{
+					Name:  PointerOf("wg_router_version"),
+					Value: PointerOf("dev"),
+				},
+			}, requestsInFlightMetrics[0].Label)
+
+			require.Equal(t, []*io_prometheus_client.LabelPair{
+				{
+					Name:  PointerOf("custom"),
+					Value: PointerOf("value"),
+				},
+				{
+					Name:  PointerOf("otel_scope_name"),
+					Value: PointerOf("cosmo.router.prometheus"),
+				},
+				{
+					Name:  PointerOf("otel_scope_version"),
+					Value: PointerOf("0.0.1"),
+				},
+				{
+					Name:  PointerOf("wg_client_name"),
+					Value: PointerOf("unknown"),
+				},
+				{
+					Name:  PointerOf("wg_client_version"),
+					Value: PointerOf("missing"),
+				},
+				{
+					Name:  PointerOf("wg_federated_graph_id"),
+					Value: PointerOf("graph"),
+				},
+				{
+					Name:  PointerOf("wg_operation_name"),
+					Value: PointerOf("myQuery"),
+				},
+				{
+					Name:  PointerOf("wg_operation_protocol"),
+					Value: PointerOf("http"),
+				},
+				{
+					Name:  PointerOf("wg_operation_type"),
+					Value: PointerOf("query"),
+				},
+				{
+					Name:  PointerOf("wg_router_cluster_name"),
+					Value: PointerOf(""),
+				},
+				{
+					Name:  PointerOf("wg_router_config_version"),
+					Value: PointerOf(""),
+				},
+				{
+					Name:  PointerOf("wg_router_version"),
+					Value: PointerOf("dev"),
+				},
+				{
+					Name:  PointerOf("wg_subgraph_id"),
+					Value: PointerOf("0"),
+				},
+				{
+					Name:  PointerOf("wg_subgraph_name"),
+					Value: PointerOf("employees"),
+				},
+			}, requestsInFlightMetrics[1].Label)
+
+			requestDuration := findMetricFamilyByName(mf, "router_http_request_duration_milliseconds")
+			requestDurationMetrics := requestDuration.GetMetric()
+
+			require.Len(t, requestDurationMetrics, 2)
+			require.Len(t, requestDurationMetrics[0].Label, 13)
+			require.Len(t, requestDurationMetrics[1].Label, 14)
+
+			require.Equal(t, []*io_prometheus_client.LabelPair{
+				{
+					Name:  PointerOf("custom"),
+					Value: PointerOf("value"),
+				},
+				{
+					Name:  PointerOf("http_status_code"),
+					Value: PointerOf("200"),
+				},
+				{
+					Name:  PointerOf("otel_scope_name"),
+					Value: PointerOf("cosmo.router.prometheus"),
+				},
+				{
+					Name:  PointerOf("otel_scope_version"),
+					Value: PointerOf("0.0.1"),
+				},
+				{
+					Name:  PointerOf("wg_client_name"),
+					Value: PointerOf("unknown"),
+				},
+				{
+					Name:  PointerOf("wg_client_version"),
+					Value: PointerOf("missing"),
+				},
+				{
+					Name:  PointerOf("wg_federated_graph_id"),
+					Value: PointerOf("graph"),
+				},
+				{
+					Name:  PointerOf("wg_operation_name"),
+					Value: PointerOf("myQuery"),
+				},
+				{
+					Name:  PointerOf("wg_operation_protocol"),
+					Value: PointerOf("http"),
+				},
+				{
+					Name:  PointerOf("wg_operation_type"),
+					Value: PointerOf("query"),
+				},
+				{
+					Name:  PointerOf("wg_router_cluster_name"),
+					Value: PointerOf(""),
+				},
+				{
+					Name:  PointerOf("wg_router_config_version"),
+					Value: PointerOf(""),
+				},
+				{
+					Name:  PointerOf("wg_router_version"),
+					Value: PointerOf("dev"),
+				},
+			}, requestDurationMetrics[0].Label)
+
+			require.Equal(t, []*io_prometheus_client.LabelPair{
+				{
+					Name:  PointerOf("custom"),
+					Value: PointerOf("value"),
+				},
+				{
+					Name:  PointerOf("otel_scope_name"),
+					Value: PointerOf("cosmo.router.prometheus"),
+				},
+				{
+					Name:  PointerOf("otel_scope_version"),
+					Value: PointerOf("0.0.1"),
+				},
+				{
+					Name:  PointerOf("wg_client_name"),
+					Value: PointerOf("unknown"),
+				},
+				{
+					Name:  PointerOf("wg_client_version"),
+					Value: PointerOf("missing"),
+				},
+				{
+					Name:  PointerOf("wg_federated_graph_id"),
+					Value: PointerOf("graph"),
+				},
+				{
+					Name:  PointerOf("wg_operation_name"),
+					Value: PointerOf("myQuery"),
+				},
+				{
+					Name:  PointerOf("wg_operation_protocol"),
+					Value: PointerOf("http"),
+				},
+				{
+					Name:  PointerOf("wg_operation_type"),
+					Value: PointerOf("query"),
+				},
+				{
+					Name:  PointerOf("wg_router_cluster_name"),
+					Value: PointerOf(""),
+				},
+				{
+					Name:  PointerOf("wg_router_config_version"),
+					Value: PointerOf(""),
+				},
+				{
+					Name:  PointerOf("wg_router_version"),
+					Value: PointerOf("dev"),
+				},
+				{
+					Name:  PointerOf("wg_subgraph_id"),
+					Value: PointerOf("0"),
+				},
+				{
+					Name:  PointerOf("wg_subgraph_name"),
+					Value: PointerOf("employees"),
+				},
+			}, requestDurationMetrics[1].Label)
+
+			responseContentLength := findMetricFamilyByName(mf, "router_http_response_content_length_total")
+			responseContentLengthMetrics := responseContentLength.GetMetric()
+
+			require.Len(t, responseContentLengthMetrics, 2)
+			require.Len(t, responseContentLengthMetrics[0].Label, 13)
+			require.Len(t, responseContentLengthMetrics[1].Label, 15)
+
+			require.Equal(t, []*io_prometheus_client.LabelPair{
+				{
+					Name:  PointerOf("custom"),
+					Value: PointerOf("value"),
+				},
+				{
+					Name:  PointerOf("http_status_code"),
+					Value: PointerOf("200"),
+				},
+				{
+					Name:  PointerOf("otel_scope_name"),
+					Value: PointerOf("cosmo.router.prometheus"),
+				},
+				{
+					Name:  PointerOf("otel_scope_version"),
+					Value: PointerOf("0.0.1"),
+				},
+				{
+					Name:  PointerOf("wg_client_name"),
+					Value: PointerOf("unknown"),
+				},
+				{
+					Name:  PointerOf("wg_client_version"),
+					Value: PointerOf("missing"),
+				},
+				{
+					Name:  PointerOf("wg_federated_graph_id"),
+					Value: PointerOf("graph"),
+				},
+				{
+					Name:  PointerOf("wg_operation_name"),
+					Value: PointerOf("myQuery"),
+				},
+				{
+					Name:  PointerOf("wg_operation_protocol"),
+					Value: PointerOf("http"),
+				},
+				{
+					Name:  PointerOf("wg_operation_type"),
+					Value: PointerOf("query"),
+				},
+				{
+					Name:  PointerOf("wg_router_cluster_name"),
+					Value: PointerOf(""),
+				},
+				{
+					Name:  PointerOf("wg_router_config_version"),
+					Value: PointerOf(""),
+				},
+				{
+					Name:  PointerOf("wg_router_version"),
+					Value: PointerOf("dev"),
+				},
+			}, responseContentLengthMetrics[0].Label)
+
+			require.Equal(t, []*io_prometheus_client.LabelPair{
+				{
+					Name:  PointerOf("custom"),
+					Value: PointerOf("value"),
+				},
+				{
+					Name:  PointerOf("http_status_code"),
+					Value: PointerOf("200"),
+				},
+				{
+					Name:  PointerOf("otel_scope_name"),
+					Value: PointerOf("cosmo.router.prometheus"),
+				},
+				{
+					Name:  PointerOf("otel_scope_version"),
+					Value: PointerOf("0.0.1"),
+				},
+				{
+					Name:  PointerOf("wg_client_name"),
+					Value: PointerOf("unknown"),
+				},
+				{
+					Name:  PointerOf("wg_client_version"),
+					Value: PointerOf("missing"),
+				},
+				{
+					Name:  PointerOf("wg_federated_graph_id"),
+					Value: PointerOf("graph"),
+				},
+				{
+					Name:  PointerOf("wg_operation_name"),
+					Value: PointerOf("myQuery"),
+				},
+				{
+					Name:  PointerOf("wg_operation_protocol"),
+					Value: PointerOf("http"),
+				},
+				{
+					Name:  PointerOf("wg_operation_type"),
+					Value: PointerOf("query"),
+				},
+				{
+					Name:  PointerOf("wg_router_cluster_name"),
+					Value: PointerOf(""),
+				},
+				{
+					Name:  PointerOf("wg_router_config_version"),
+					Value: PointerOf(""),
+				},
+				{
+					Name:  PointerOf("wg_router_version"),
+					Value: PointerOf("dev"),
+				},
+				{
+					Name:  PointerOf("wg_subgraph_id"),
+					Value: PointerOf("0"),
+				},
+				{
+					Name:  PointerOf("wg_subgraph_name"),
+					Value: PointerOf("employees"),
+				},
+			}, responseContentLengthMetrics[1].Label)
+
+		})
+	})
+
 	t.Run("Subgraph errors are tracked through request error metric", func(t *testing.T) {
 		exporter := tracetest.NewInMemoryExporter(t)
 		metricReader := metric.NewManualReader()
@@ -500,7 +1034,7 @@ func TestPrometheus(t *testing.T) {
 			mf, err := promRegistry.Gather()
 			require.NoError(t, err)
 
-			responseContentLength := findMetricByName(mf, "router_http_requests_error_total")
+			responseContentLength := findMetricFamilyByName(mf, "router_http_requests_error_total")
 			responseContentLengthMetrics := responseContentLength.GetMetric()
 
 			require.Len(t, responseContentLengthMetrics, 3)
@@ -647,10 +1181,21 @@ func TestPrometheus(t *testing.T) {
 	})
 }
 
-func findMetricByName(mf []*io_prometheus_client.MetricFamily, name string) *io_prometheus_client.MetricFamily {
+func findMetricFamilyByName(mf []*io_prometheus_client.MetricFamily, name string) *io_prometheus_client.MetricFamily {
 	for _, m := range mf {
 		if m.GetName() == name {
 			return m
+		}
+	}
+	return nil
+}
+
+func findMetricLabelByName(mf []*io_prometheus_client.Metric, name string) *io_prometheus_client.LabelPair {
+	for _, m := range mf {
+		for _, l := range m.GetLabel() {
+			if l.GetName() == name {
+				return l
+			}
 		}
 	}
 	return nil

--- a/router-tests/telemetry_test.go
+++ b/router-tests/telemetry_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/stretchr/testify/require"
 	"github.com/wundergraph/cosmo/router-tests/testenv"
+	"github.com/wundergraph/cosmo/router/pkg/config"
 	"github.com/wundergraph/cosmo/router/pkg/otel"
 	"github.com/wundergraph/cosmo/router/pkg/trace/tracetest"
 	"go.opentelemetry.io/otel/attribute"
@@ -13,7 +14,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
 	"go.opentelemetry.io/otel/trace"
 	"net/http"
 	"testing"
@@ -47,41 +48,260 @@ func TestTelemetry(t *testing.T) {
 			 */
 
 			// Pre-Handler Operation steps
+
 			require.Equal(t, "Operation - Parse", sn[0].Name())
 			require.Equal(t, trace.SpanKindInternal, sn[0].SpanKind())
 			require.Equal(t, sdktrace.Status{Code: codes.Unset}, sn[0].Status())
+
+			// Span Resource attributes
+
+			rs := attribute.NewSet(sn[0].Resource().Attributes()...)
+
+			require.True(t, rs.HasValue("host.name"))
+			require.True(t, rs.HasValue("os.type"))
+			require.True(t, rs.HasValue("process.pid"))
+
+			require.NotEmpty(t, sn[0].Resource().Attributes(), attribute.String("telemetry.sdk.version", "1.24.0"))
+			require.Contains(t, sn[0].Resource().Attributes(), attribute.String("service.instance.id", "test-instance"))
+			require.Contains(t, sn[0].Resource().Attributes(), attribute.String("telemetry.sdk.name", "opentelemetry"))
+			require.Contains(t, sn[0].Resource().Attributes(), attribute.String("telemetry.sdk.language", "go"))
+			require.Contains(t, sn[0].Resource().Attributes(), attribute.String("service.version", "dev"))
+			require.Contains(t, sn[0].Resource().Attributes(), attribute.String("service.name", "cosmo-router"))
+
+			// Span attributes
+
+			require.Len(t, sn[0].Attributes(), 3)
+			require.Contains(t, sn[0].Attributes(), otel.WgClientName.String("unknown"))
+			require.Contains(t, sn[0].Attributes(), otel.WgClientVersion.String("missing"))
+			require.Contains(t, sn[0].Attributes(), otel.WgOperationProtocol.String("http"))
 
 			require.Equal(t, "Operation - Normalize", sn[1].Name())
 			require.Equal(t, trace.SpanKindInternal, sn[1].SpanKind())
 			require.Equal(t, sdktrace.Status{Code: codes.Unset}, sn[1].Status())
 
+			// Span Resource attributes
+
+			rs = attribute.NewSet(sn[1].Resource().Attributes()...)
+
+			require.True(t, rs.HasValue("host.name"))
+			require.True(t, rs.HasValue("os.type"))
+			require.True(t, rs.HasValue("process.pid"))
+
+			require.NotEmpty(t, sn[1].Resource().Attributes(), attribute.String("telemetry.sdk.version", "1.24.0"))
+			require.Contains(t, sn[1].Resource().Attributes(), attribute.String("service.instance.id", "test-instance"))
+			require.Contains(t, sn[1].Resource().Attributes(), attribute.String("telemetry.sdk.name", "opentelemetry"))
+			require.Contains(t, sn[1].Resource().Attributes(), attribute.String("telemetry.sdk.language", "go"))
+			require.Contains(t, sn[1].Resource().Attributes(), attribute.String("service.version", "dev"))
+			require.Contains(t, sn[1].Resource().Attributes(), attribute.String("service.name", "cosmo-router"))
+
+			// Span attributes
+
+			require.Len(t, sn[1].Attributes(), 2)
+			require.Contains(t, sn[1].Attributes(), otel.WgOperationName.String(""))
+			require.Contains(t, sn[1].Attributes(), otel.WgOperationType.String("query"))
+
 			require.Equal(t, "Operation - Validate", sn[2].Name())
 			require.Equal(t, trace.SpanKindInternal, sn[2].SpanKind())
 			require.Equal(t, sdktrace.Status{Code: codes.Unset}, sn[2].Status())
 
+			// Span Resource attributes
+
+			rs = attribute.NewSet(sn[2].Resource().Attributes()...)
+
+			require.True(t, rs.HasValue("host.name"))
+			require.True(t, rs.HasValue("os.type"))
+			require.True(t, rs.HasValue("process.pid"))
+
+			require.NotEmpty(t, sn[2].Resource().Attributes(), attribute.String("telemetry.sdk.version", "1.24.0"))
+			require.Contains(t, sn[2].Resource().Attributes(), attribute.String("service.instance.id", "test-instance"))
+			require.Contains(t, sn[2].Resource().Attributes(), attribute.String("telemetry.sdk.name", "opentelemetry"))
+			require.Contains(t, sn[2].Resource().Attributes(), attribute.String("telemetry.sdk.language", "go"))
+			require.Contains(t, sn[2].Resource().Attributes(), attribute.String("service.version", "dev"))
+			require.Contains(t, sn[2].Resource().Attributes(), attribute.String("service.name", "cosmo-router"))
+
+			// Span attributes
+
+			require.Len(t, sn[2].Attributes(), 0)
+
 			require.Equal(t, "Operation - Plan", sn[3].Name())
 			require.Equal(t, trace.SpanKindInternal, sn[3].SpanKind())
 			require.Equal(t, sdktrace.Status{Code: codes.Unset}, sn[3].Status())
+
+			// Span Resource attributes
+
+			rs = attribute.NewSet(sn[3].Resource().Attributes()...)
+
+			require.True(t, rs.HasValue("host.name"))
+			require.True(t, rs.HasValue("os.type"))
+			require.True(t, rs.HasValue("process.pid"))
+
+			require.NotEmpty(t, sn[3].Resource().Attributes(), attribute.String("telemetry.sdk.version", "1.24.0"))
+			require.Contains(t, sn[3].Resource().Attributes(), attribute.String("service.instance.id", "test-instance"))
+			require.Contains(t, sn[3].Resource().Attributes(), attribute.String("telemetry.sdk.name", "opentelemetry"))
+			require.Contains(t, sn[3].Resource().Attributes(), attribute.String("telemetry.sdk.language", "go"))
+			require.Contains(t, sn[3].Resource().Attributes(), attribute.String("service.version", "dev"))
+			require.Contains(t, sn[3].Resource().Attributes(), attribute.String("service.name", "cosmo-router"))
+
+			// Span attributes
+
+			require.Len(t, sn[3].Attributes(), 2)
+			require.Contains(t, sn[3].Attributes(), otel.WgEngineRequestTracingEnabled.Bool(false))
+			require.Contains(t, sn[3].Attributes(), otel.WgEnginePlanCacheHit.Bool(false))
 
 			// Engine Transport
 			require.Equal(t, "query unnamed", sn[4].Name())
 			require.Equal(t, trace.SpanKindClient, sn[4].SpanKind())
 			require.Equal(t, sdktrace.Status{Code: codes.Unset}, sn[4].Status())
 
+			// Span Resource attributes
+
+			rs = attribute.NewSet(sn[4].Resource().Attributes()...)
+
+			require.True(t, rs.HasValue("host.name"))
+			require.True(t, rs.HasValue("os.type"))
+			require.True(t, rs.HasValue("process.pid"))
+
+			require.NotEmpty(t, sn[4].Resource().Attributes(), attribute.String("telemetry.sdk.version", "1.24.0"))
+			require.Contains(t, sn[4].Resource().Attributes(), attribute.String("service.instance.id", "test-instance"))
+			require.Contains(t, sn[4].Resource().Attributes(), attribute.String("telemetry.sdk.name", "opentelemetry"))
+			require.Contains(t, sn[4].Resource().Attributes(), attribute.String("telemetry.sdk.language", "go"))
+			require.Contains(t, sn[4].Resource().Attributes(), attribute.String("service.version", "dev"))
+			require.Contains(t, sn[4].Resource().Attributes(), attribute.String("service.name", "cosmo-router"))
+
+			// Span attributes
+
+			sa := attribute.NewSet(sn[4].Attributes()...)
+
+			require.Len(t, sn[4].Attributes(), 17)
+			require.True(t, sa.HasValue(semconv.HTTPURLKey))
+			require.True(t, sa.HasValue(semconv.NetPeerPortKey))
+
+			require.Contains(t, sn[4].Attributes(), otel.WgComponentName.String("engine-transport"))
+			require.Contains(t, sn[4].Attributes(), semconv.HTTPMethod("POST"))
+			require.Contains(t, sn[4].Attributes(), semconv.HTTPFlavorKey.String("1.1"))
+			require.Contains(t, sn[4].Attributes(), semconv.NetPeerName("127.0.0.1"))
+			require.Contains(t, sn[4].Attributes(), semconv.HTTPRequestContentLength(28))
+			require.Contains(t, sn[4].Attributes(), otel.WgClientName.String("unknown"))
+			require.Contains(t, sn[4].Attributes(), otel.WgClientVersion.String("missing"))
+			require.Contains(t, sn[4].Attributes(), otel.WgOperationName.String(""))
+			require.Contains(t, sn[4].Attributes(), otel.WgOperationType.String("query"))
+			require.Contains(t, sn[4].Attributes(), otel.WgOperationProtocol.String("http"))
+			require.Contains(t, sn[4].Attributes(), otel.WgOperationHash.String("14226210703439426856"))
+			require.Contains(t, sn[4].Attributes(), otel.WgSubgraphID.String("0"))
+			require.Contains(t, sn[4].Attributes(), otel.WgSubgraphName.String("employees"))
+			require.Contains(t, sn[4].Attributes(), semconv.HTTPStatusCode(200))
+			require.Contains(t, sn[4].Attributes(), semconv.HTTPResponseContentLength(117))
+
 			// Engine Loader Hooks
 			require.Equal(t, "Engine - Fetch", sn[5].Name())
 			require.Equal(t, trace.SpanKindInternal, sn[5].SpanKind())
 			require.Equal(t, sdktrace.Status{Code: codes.Unset}, sn[5].Status())
+
+			// Span Resource attributes
+
+			rs = attribute.NewSet(sn[5].Resource().Attributes()...)
+
+			require.True(t, rs.HasValue("host.name"))
+			require.True(t, rs.HasValue("os.type"))
+			require.True(t, rs.HasValue("process.pid"))
+
+			require.NotEmpty(t, sn[5].Resource().Attributes(), attribute.String("telemetry.sdk.version", "1.24.0"))
+			require.Contains(t, sn[5].Resource().Attributes(), attribute.String("service.instance.id", "test-instance"))
+			require.Contains(t, sn[5].Resource().Attributes(), attribute.String("telemetry.sdk.name", "opentelemetry"))
+			require.Contains(t, sn[5].Resource().Attributes(), attribute.String("telemetry.sdk.language", "go"))
+			require.Contains(t, sn[5].Resource().Attributes(), attribute.String("service.version", "dev"))
+			require.Contains(t, sn[5].Resource().Attributes(), attribute.String("service.name", "cosmo-router"))
+
+			// Span attributes
+
+			require.Len(t, sn[5].Attributes(), 10)
+
+			require.Contains(t, sn[5].Attributes(), otel.WgSubgraphID.String("0"))
+			require.Contains(t, sn[5].Attributes(), otel.WgSubgraphName.String("employees"))
+			require.Contains(t, sn[5].Attributes(), semconv.HTTPStatusCode(200))
+			require.Contains(t, sn[5].Attributes(), otel.WgComponentName.String("engine-loader"))
+			require.Contains(t, sn[5].Attributes(), otel.WgClientName.String("unknown"))
+			require.Contains(t, sn[5].Attributes(), otel.WgClientVersion.String("missing"))
+			require.Contains(t, sn[5].Attributes(), otel.WgOperationName.String(""))
+			require.Contains(t, sn[5].Attributes(), otel.WgOperationType.String("query"))
+			require.Contains(t, sn[5].Attributes(), otel.WgOperationProtocol.String("http"))
+			require.Contains(t, sn[5].Attributes(), otel.WgOperationHash.String("14226210703439426856"))
 
 			// GraphQL handler
 			require.Equal(t, "Operation - Execute", sn[6].Name())
 			require.Equal(t, trace.SpanKindInternal, sn[6].SpanKind())
 			require.Equal(t, sdktrace.Status{Code: codes.Unset}, sn[6].Status())
 
+			// Span Resource attributes
+
+			rs = attribute.NewSet(sn[6].Resource().Attributes()...)
+
+			require.True(t, rs.HasValue("host.name"))
+			require.True(t, rs.HasValue("os.type"))
+			require.True(t, rs.HasValue("process.pid"))
+
+			require.NotEmpty(t, sn[6].Resource().Attributes(), attribute.String("telemetry.sdk.version", "1.24.0"))
+			require.Contains(t, sn[6].Resource().Attributes(), attribute.String("service.instance.id", "test-instance"))
+			require.Contains(t, sn[6].Resource().Attributes(), attribute.String("telemetry.sdk.name", "opentelemetry"))
+			require.Contains(t, sn[6].Resource().Attributes(), attribute.String("telemetry.sdk.language", "go"))
+			require.Contains(t, sn[6].Resource().Attributes(), attribute.String("service.version", "dev"))
+			require.Contains(t, sn[6].Resource().Attributes(), attribute.String("service.name", "cosmo-router"))
+
+			// Span attributes
+
+			require.Len(t, sn[6].Attributes(), 0)
+
 			// Root Server middleware
 			require.Equal(t, "query unnamed", sn[7].Name())
 			require.Equal(t, trace.SpanKindServer, sn[7].SpanKind())
 			require.Equal(t, sdktrace.Status{Code: codes.Unset}, sn[7].Status())
+
+			// Span Resource attributes
+
+			rs = attribute.NewSet(sn[7].Resource().Attributes()...)
+
+			require.True(t, rs.HasValue("host.name"))
+			require.True(t, rs.HasValue("os.type"))
+			require.True(t, rs.HasValue("process.pid"))
+
+			require.NotEmpty(t, sn[7].Resource().Attributes(), attribute.String("telemetry.sdk.version", "1.24.0"))
+			require.Contains(t, sn[7].Resource().Attributes(), attribute.String("service.instance.id", "test-instance"))
+			require.Contains(t, sn[7].Resource().Attributes(), attribute.String("telemetry.sdk.name", "opentelemetry"))
+			require.Contains(t, sn[7].Resource().Attributes(), attribute.String("telemetry.sdk.language", "go"))
+			require.Contains(t, sn[7].Resource().Attributes(), attribute.String("service.version", "dev"))
+			require.Contains(t, sn[7].Resource().Attributes(), attribute.String("service.name", "cosmo-router"))
+
+			sa = attribute.NewSet(sn[7].Attributes()...)
+
+			require.Len(t, sn[7].Attributes(), 26)
+			require.True(t, sa.HasValue(semconv.NetHostPortKey))
+			require.True(t, sa.HasValue(semconv.NetSockPeerAddrKey))
+			require.True(t, sa.HasValue(semconv.NetSockPeerPortKey))
+			require.True(t, sa.HasValue(otel.WgRouterConfigVersion))
+			require.True(t, sa.HasValue(otel.WgFederatedGraphID))
+			require.True(t, sa.HasValue("http.user_agent"))
+			require.True(t, sa.HasValue("http.host"))
+			require.True(t, sa.HasValue("http.read_bytes"))
+			require.True(t, sa.HasValue("http.wrote_bytes"))
+
+			require.Contains(t, sn[7].Attributes(), semconv.HTTPMethod("POST"))
+			require.Contains(t, sn[7].Attributes(), semconv.HTTPScheme("http"))
+			require.Contains(t, sn[7].Attributes(), semconv.HTTPFlavorKey.String("1.1"))
+			require.Contains(t, sn[7].Attributes(), semconv.NetHostName("localhost"))
+			require.Contains(t, sn[7].Attributes(), otel.WgRouterVersion.String("dev"))
+			require.Contains(t, sn[7].Attributes(), otel.WgRouterClusterName.String(""))
+			require.Contains(t, sn[7].Attributes(), otel.WgComponentName.String("router-server"))
+			require.Contains(t, sn[7].Attributes(), otel.WgRouterRootSpan.Bool(true))
+			require.Contains(t, sn[7].Attributes(), semconv.HTTPTarget("/graphql"))
+			require.Contains(t, sn[7].Attributes(), otel.WgClientName.String("unknown"))
+			require.Contains(t, sn[7].Attributes(), otel.WgClientVersion.String("missing"))
+			require.Contains(t, sn[7].Attributes(), otel.WgOperationProtocol.String("http"))
+			require.Contains(t, sn[7].Attributes(), otel.WgOperationName.String(""))
+			require.Contains(t, sn[7].Attributes(), otel.WgOperationType.String("query"))
+			require.Contains(t, sn[7].Attributes(), otel.WgOperationContent.String("{employees {id}}"))
+			require.Contains(t, sn[7].Attributes(), otel.WgFederatedGraphID.String("graph"))
+			require.Contains(t, sn[7].Attributes(), otel.WgOperationHash.String("14226210703439426856"))
+			require.Contains(t, sn[7].Attributes(), semconv.HTTPStatusCode(200))
 
 			/**
 			* Metrics
@@ -279,7 +499,10 @@ func TestTelemetry(t *testing.T) {
 					DataPoints: []metricdata.DataPoint[int64]{
 						{
 							Attributes: attribute.NewSet(
+								otel.WgClientName.String("unknown"),
+								otel.WgClientVersion.String("missing"),
 								otel.WgFederatedGraphID.String("graph"),
+								otel.WgOperationProtocol.String("http"),
 								otel.WgRouterClusterName.String(""),
 								otel.WgRouterConfigVersion.String(""),
 								otel.WgRouterVersion.String("dev"),
@@ -321,6 +544,391 @@ func TestTelemetry(t *testing.T) {
 					requestInFlightMetric,
 				},
 			}
+
+			rs = attribute.NewSet(rm.Resource.Attributes()...)
+
+			require.True(t, rs.HasValue("host.name"))
+			require.True(t, rs.HasValue("os.type"))
+			require.True(t, rs.HasValue("process.pid"))
+
+			require.NotEmpty(t, rm.Resource.Attributes(), attribute.String("telemetry.sdk.version", "1.24.0"))
+			require.Contains(t, rm.Resource.Attributes(), attribute.String("service.instance.id", "test-instance"))
+			require.Contains(t, rm.Resource.Attributes(), attribute.String("telemetry.sdk.name", "opentelemetry"))
+			require.Contains(t, rm.Resource.Attributes(), attribute.String("telemetry.sdk.language", "go"))
+			require.Contains(t, rm.Resource.Attributes(), attribute.String("service.version", "dev"))
+			require.Contains(t, rm.Resource.Attributes(), attribute.String("service.name", "cosmo-router"))
+
+			require.Equal(t, 1, len(rm.ScopeMetrics), "expected 1 ScopeMetrics, got %d", len(rm.ScopeMetrics))
+			require.Equal(t, 5, len(rm.ScopeMetrics[0].Metrics), "expected 5 Metrics, got %d", len(rm.ScopeMetrics[0].Metrics))
+
+			metricdatatest.AssertEqual(t, want, rm.ScopeMetrics[0], metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue())
+
+			metricdatatest.AssertEqual(t, httpRequestsMetric, rm.ScopeMetrics[0].Metrics[0], metricdatatest.IgnoreTimestamp())
+			metricdatatest.AssertEqual(t, requestContentLengthMetric, rm.ScopeMetrics[0].Metrics[2], metricdatatest.IgnoreTimestamp())
+			metricdatatest.AssertEqual(t, responseContentLengthMetric, rm.ScopeMetrics[0].Metrics[3], metricdatatest.IgnoreTimestamp())
+			metricdatatest.AssertEqual(t, requestInFlightMetric, rm.ScopeMetrics[0].Metrics[4], metricdatatest.IgnoreTimestamp())
+
+		})
+	})
+
+	t.Run("Custom span and resource attributes are attached to all metrics and spans", func(t *testing.T) {
+		t.Parallel()
+
+		metricReader := metric.NewManualReader()
+		exporter := tracetest.NewInMemoryExporter(t)
+
+		testenv.Run(t, &testenv.Config{
+			TraceExporter: exporter,
+			MetricReader:  metricReader,
+			OtelResourceAttributes: []config.OtelResourceAttribute{
+				{
+					Key:   "custom.resource",
+					Value: "value",
+				},
+			},
+			OtelAttributes: []config.OtelAttribute{
+				{
+					Key:   "custom",
+					Value: "value",
+					ValueFrom: &config.OtelAttributeFromValue{
+						RequestHeader: "x-custom-header",
+					},
+				},
+			},
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+				Header: map[string][]string{
+					"x-custom-header": {"value"},
+				},
+				Query: `query { employees { id } }`,
+			})
+			require.JSONEq(t, employeesIDData, res.Body)
+
+			sn := exporter.GetSpans().Snapshots()
+			require.Len(t, sn, 8, "expected 8 spans, got %d", len(sn))
+
+			/**
+			* Spans
+			 */
+
+			// Pre-Handler Operation steps
+			require.Equal(t, "Operation - Parse", sn[0].Name())
+			require.Equal(t, trace.SpanKindInternal, sn[0].SpanKind())
+			require.Equal(t, sdktrace.Status{Code: codes.Unset}, sn[0].Status())
+			require.Contains(t, sn[0].Attributes(), attribute.String("custom", "value"))
+			require.Contains(t, sn[0].Resource().Attributes(), attribute.String("custom.resource", "value"))
+
+			require.Equal(t, "Operation - Normalize", sn[1].Name())
+			require.Equal(t, trace.SpanKindInternal, sn[1].SpanKind())
+			require.Equal(t, sdktrace.Status{Code: codes.Unset}, sn[1].Status())
+			require.Contains(t, sn[1].Attributes(), attribute.String("custom", "value"))
+			require.Contains(t, sn[1].Resource().Attributes(), attribute.String("custom.resource", "value"))
+
+			require.Equal(t, "Operation - Validate", sn[2].Name())
+			require.Equal(t, trace.SpanKindInternal, sn[2].SpanKind())
+			require.Equal(t, sdktrace.Status{Code: codes.Unset}, sn[2].Status())
+			require.Contains(t, sn[2].Attributes(), attribute.String("custom", "value"))
+			require.Contains(t, sn[2].Resource().Attributes(), attribute.String("custom.resource", "value"))
+
+			require.Equal(t, "Operation - Plan", sn[3].Name())
+			require.Equal(t, trace.SpanKindInternal, sn[3].SpanKind())
+			require.Equal(t, sdktrace.Status{Code: codes.Unset}, sn[3].Status())
+			require.Contains(t, sn[3].Attributes(), attribute.String("custom", "value"))
+			require.Contains(t, sn[3].Resource().Attributes(), attribute.String("custom.resource", "value"))
+
+			// Engine Transport
+			require.Equal(t, "query unnamed", sn[4].Name())
+			require.Equal(t, trace.SpanKindClient, sn[4].SpanKind())
+			require.Equal(t, sdktrace.Status{Code: codes.Unset}, sn[4].Status())
+			require.Contains(t, sn[4].Attributes(), attribute.String("custom", "value"))
+			require.Contains(t, sn[4].Resource().Attributes(), attribute.String("custom.resource", "value"))
+
+			// Engine Loader Hooks
+			require.Equal(t, "Engine - Fetch", sn[5].Name())
+			require.Equal(t, trace.SpanKindInternal, sn[5].SpanKind())
+			require.Equal(t, sdktrace.Status{Code: codes.Unset}, sn[5].Status())
+			require.Contains(t, sn[5].Attributes(), attribute.String("custom", "value"))
+			require.Contains(t, sn[5].Resource().Attributes(), attribute.String("custom.resource", "value"))
+
+			// GraphQL handler
+			require.Equal(t, "Operation - Execute", sn[6].Name())
+			require.Equal(t, trace.SpanKindInternal, sn[6].SpanKind())
+			require.Equal(t, sdktrace.Status{Code: codes.Unset}, sn[6].Status())
+			require.Contains(t, sn[6].Attributes(), attribute.String("custom", "value"))
+			require.Contains(t, sn[6].Resource().Attributes(), attribute.String("custom.resource", "value"))
+
+			// Root Server middleware
+			require.Equal(t, "query unnamed", sn[7].Name())
+			require.Equal(t, trace.SpanKindServer, sn[7].SpanKind())
+			require.Equal(t, sdktrace.Status{Code: codes.Unset}, sn[7].Status())
+			require.Contains(t, sn[7].Attributes(), attribute.String("custom", "value"))
+			require.Contains(t, sn[7].Resource().Attributes(), attribute.String("custom.resource", "value"))
+
+			/**
+			* Metrics
+			 */
+			rm := metricdata.ResourceMetrics{}
+			err := metricReader.Collect(context.Background(), &rm)
+			require.NoError(t, err)
+
+			httpRequestsMetric := metricdata.Metrics{
+				Name:        "router.http.requests",
+				Description: "Total number of requests",
+				Unit:        "",
+				Data: metricdata.Sum[int64]{
+					Temporality: metricdata.CumulativeTemporality,
+					IsMonotonic: true,
+					DataPoints: []metricdata.DataPoint[int64]{
+						{
+							Attributes: attribute.NewSet(
+								attribute.String("custom", "value"),
+								otel.WgClientName.String("unknown"),
+								otel.WgClientVersion.String("missing"),
+								otel.WgFederatedGraphID.String("graph"),
+								otel.WgOperationHash.String("14226210703439426856"),
+								otel.WgOperationName.String(""),
+								otel.WgOperationProtocol.String("http"),
+								otel.WgOperationType.String("query"),
+								otel.WgRouterClusterName.String(""),
+								otel.WgRouterConfigVersion.String(""),
+								otel.WgRouterVersion.String("dev"),
+								otel.WgSubgraphID.String("0"),
+								otel.WgSubgraphName.String("employees"),
+							),
+							Value: 1,
+						},
+						{
+							Attributes: attribute.NewSet(
+								attribute.String("custom", "value"),
+								semconv.HTTPStatusCode(200),
+								otel.WgClientName.String("unknown"),
+								otel.WgClientVersion.String("missing"),
+								otel.WgFederatedGraphID.String("graph"),
+								otel.WgOperationHash.String("14226210703439426856"),
+								otel.WgOperationName.String(""),
+								otel.WgOperationProtocol.String("http"),
+								otel.WgOperationType.String("query"),
+								otel.WgRouterClusterName.String(""),
+								otel.WgRouterConfigVersion.String(""),
+								otel.WgRouterVersion.String("dev"),
+							),
+							Value: 1,
+						},
+					},
+				},
+			}
+
+			requestDurationMetric := metricdata.Metrics{
+				Name:        "router.http.request.duration_milliseconds",
+				Description: "Server latency in milliseconds",
+				Unit:        "ms",
+				Data: metricdata.Histogram[float64]{
+					Temporality: metricdata.CumulativeTemporality,
+					DataPoints: []metricdata.HistogramDataPoint[float64]{
+						{
+							Attributes: attribute.NewSet(
+								attribute.String("custom", "value"),
+								otel.WgClientName.String("unknown"),
+								otel.WgClientVersion.String("missing"),
+								otel.WgFederatedGraphID.String("graph"),
+								otel.WgOperationHash.String("14226210703439426856"),
+								otel.WgOperationName.String(""),
+								otel.WgOperationProtocol.String("http"),
+								otel.WgOperationType.String("query"),
+								otel.WgRouterClusterName.String(""),
+								otel.WgRouterConfigVersion.String(""),
+								otel.WgRouterVersion.String("dev"),
+								otel.WgSubgraphID.String("0"),
+								otel.WgSubgraphName.String("employees"),
+							),
+							Sum: 0,
+						},
+						{
+							Attributes: attribute.NewSet(
+								attribute.String("custom", "value"),
+								semconv.HTTPStatusCode(200),
+								otel.WgClientName.String("unknown"),
+								otel.WgClientVersion.String("missing"),
+								otel.WgFederatedGraphID.String("graph"),
+								otel.WgOperationHash.String("14226210703439426856"),
+								otel.WgOperationName.String(""),
+								otel.WgOperationProtocol.String("http"),
+								otel.WgOperationType.String("query"),
+								otel.WgRouterClusterName.String(""),
+								otel.WgRouterConfigVersion.String(""),
+								otel.WgRouterVersion.String("dev"),
+							),
+							Sum: 0,
+						},
+					},
+				},
+			}
+
+			requestContentLengthMetric := metricdata.Metrics{
+				Name:        "router.http.request.content_length",
+				Description: "Total number of request bytes",
+				Unit:        "bytes",
+				Data: metricdata.Sum[int64]{
+					Temporality: metricdata.CumulativeTemporality,
+					IsMonotonic: true,
+					DataPoints: []metricdata.DataPoint[int64]{
+						{
+							Attributes: attribute.NewSet(
+								attribute.String("custom", "value"),
+								otel.WgClientName.String("unknown"),
+								otel.WgClientVersion.String("missing"),
+								otel.WgFederatedGraphID.String("graph"),
+								otel.WgOperationHash.String("14226210703439426856"),
+								otel.WgOperationName.String(""),
+								otel.WgOperationProtocol.String("http"),
+								otel.WgOperationType.String("query"),
+								otel.WgRouterClusterName.String(""),
+								otel.WgRouterConfigVersion.String(""),
+								otel.WgRouterVersion.String("dev"),
+								otel.WgSubgraphID.String("0"),
+								otel.WgSubgraphName.String("employees"),
+							),
+							Value: 28,
+						},
+						{
+							Attributes: attribute.NewSet(
+								attribute.String("custom", "value"),
+								semconv.HTTPStatusCode(200),
+								otel.WgClientName.String("unknown"),
+								otel.WgClientVersion.String("missing"),
+								otel.WgFederatedGraphID.String("graph"),
+								otel.WgOperationHash.String("14226210703439426856"),
+								otel.WgOperationName.String(""),
+								otel.WgOperationProtocol.String("http"),
+								otel.WgOperationType.String("query"),
+								otel.WgRouterClusterName.String(""),
+								otel.WgRouterConfigVersion.String(""),
+								otel.WgRouterVersion.String("dev"),
+							),
+							Value: 38,
+						},
+					},
+				},
+			}
+
+			responseContentLengthMetric := metricdata.Metrics{
+				Name:        "router.http.response.content_length",
+				Description: "Total number of response bytes",
+				Unit:        "bytes",
+				Data: metricdata.Sum[int64]{
+					Temporality: metricdata.CumulativeTemporality,
+					IsMonotonic: true,
+					DataPoints: []metricdata.DataPoint[int64]{
+						{
+							Attributes: attribute.NewSet(
+								attribute.String("custom", "value"),
+								semconv.HTTPStatusCode(200),
+								otel.WgClientName.String("unknown"),
+								otel.WgClientVersion.String("missing"),
+								otel.WgFederatedGraphID.String("graph"),
+								otel.WgOperationHash.String("14226210703439426856"),
+								otel.WgOperationName.String(""),
+								otel.WgOperationProtocol.String("http"),
+								otel.WgOperationType.String("query"),
+								otel.WgRouterClusterName.String(""),
+								otel.WgRouterConfigVersion.String(""),
+								otel.WgRouterVersion.String("dev"),
+								otel.WgSubgraphID.String("0"),
+								otel.WgSubgraphName.String("employees"),
+							),
+							Value: 117,
+						},
+						{
+							Attributes: attribute.NewSet(
+								attribute.String("custom", "value"),
+								semconv.HTTPStatusCode(200),
+								otel.WgClientName.String("unknown"),
+								otel.WgClientVersion.String("missing"),
+								otel.WgFederatedGraphID.String("graph"),
+								otel.WgOperationHash.String("14226210703439426856"),
+								otel.WgOperationName.String(""),
+								otel.WgOperationProtocol.String("http"),
+								otel.WgOperationType.String("query"),
+								otel.WgRouterClusterName.String(""),
+								otel.WgRouterConfigVersion.String(""),
+								otel.WgRouterVersion.String("dev"),
+							),
+							Value: 117,
+						},
+					},
+				},
+			}
+
+			requestInFlightMetric := metricdata.Metrics{
+				Name:        "router.http.requests.in_flight",
+				Description: "Number of requests in flight",
+				Unit:        "",
+				Data: metricdata.Sum[int64]{
+					Temporality: metricdata.CumulativeTemporality,
+					DataPoints: []metricdata.DataPoint[int64]{
+						{
+							Attributes: attribute.NewSet(
+								attribute.String("custom", "value"),
+								otel.WgClientName.String("unknown"),
+								otel.WgClientVersion.String("missing"),
+								otel.WgFederatedGraphID.String("graph"),
+								otel.WgOperationProtocol.String("http"),
+								otel.WgRouterClusterName.String(""),
+								otel.WgRouterConfigVersion.String(""),
+								otel.WgRouterVersion.String("dev"),
+							),
+							Value: 0,
+						},
+						{
+							Attributes: attribute.NewSet(
+								attribute.String("custom", "value"),
+								otel.WgClientName.String("unknown"),
+								otel.WgClientVersion.String("missing"),
+								otel.WgFederatedGraphID.String("graph"),
+								otel.WgOperationHash.String("14226210703439426856"),
+								otel.WgOperationName.String(""),
+								otel.WgOperationProtocol.String("http"),
+								otel.WgOperationType.String("query"),
+								otel.WgRouterClusterName.String(""),
+								otel.WgRouterConfigVersion.String(""),
+								otel.WgRouterVersion.String("dev"),
+								otel.WgSubgraphID.String("0"),
+								otel.WgSubgraphName.String("employees"),
+							),
+							Value: 0,
+						},
+					},
+				},
+			}
+
+			want := metricdata.ScopeMetrics{
+				Scope: instrumentation.Scope{
+					Name:      "cosmo.router",
+					SchemaURL: "",
+					Version:   "0.0.1",
+				},
+				Metrics: []metricdata.Metrics{
+					httpRequestsMetric,
+					requestDurationMetric,
+					requestContentLengthMetric,
+					responseContentLengthMetric,
+					requestInFlightMetric,
+				},
+			}
+
+			rs := attribute.NewSet(rm.Resource.Attributes()...)
+
+			require.True(t, rs.HasValue("host.name"))
+			require.True(t, rs.HasValue("os.type"))
+			require.True(t, rs.HasValue("process.pid"))
+
+			require.Contains(t, rm.Resource.Attributes(), attribute.String("custom.resource", "value"))
+			require.NotEmpty(t, rm.Resource.Attributes(), attribute.String("telemetry.sdk.version", "1.24.0"))
+			require.Contains(t, rm.Resource.Attributes(), attribute.String("service.instance.id", "test-instance"))
+			require.Contains(t, rm.Resource.Attributes(), attribute.String("telemetry.sdk.name", "opentelemetry"))
+			require.Contains(t, rm.Resource.Attributes(), attribute.String("telemetry.sdk.language", "go"))
+			require.Contains(t, rm.Resource.Attributes(), attribute.String("service.version", "dev"))
+			require.Contains(t, rm.Resource.Attributes(), attribute.String("service.name", "cosmo-router"))
 
 			require.Equal(t, 1, len(rm.ScopeMetrics), "expected 1 ScopeMetrics, got %d", len(rm.ScopeMetrics))
 			require.Equal(t, 5, len(rm.ScopeMetrics[0].Metrics), "expected 5 Metrics, got %d", len(rm.ScopeMetrics[0].Metrics))

--- a/router/core/router.go
+++ b/router/core/router.go
@@ -2002,12 +2002,14 @@ func buildAttributesMapper(attributes []config.OtelAttribute) func(req *http.Req
 					hv := req.Header.Get(attr.ValueFrom.RequestHeader)
 					if hv != "" {
 						result = append(result, attribute.String(attr.Key, hv))
-					} else if attr.Value != "" {
-						result = append(result, attribute.String(attr.Key, attr.Value))
+					} else if attr.Default != "" {
+						result = append(result, attribute.String(attr.Key, attr.Default))
 					}
-				} else if attr.Value != "" {
-					result = append(result, attribute.String(attr.Key, attr.Value))
+				} else if attr.Default != "" {
+					result = append(result, attribute.String(attr.Key, attr.Default))
 				}
+			} else if attr.Default != "" {
+				result = append(result, attribute.String(attr.Key, attr.Default))
 			}
 		}
 

--- a/router/core/router.go
+++ b/router/core/router.go
@@ -419,7 +419,7 @@ func NewRouter(opts ...Option) (*Router, error) {
 	}
 
 	// Add default tracing exporter if needed
-	if r.traceConfig.Enabled && len(r.traceConfig.Exporters) == 0 {
+	if r.traceConfig.Enabled && len(r.traceConfig.Exporters) == 0 && r.traceConfig.TestMemoryExporter == nil {
 		if endpoint := otelconfig.DefaultEndpoint(); endpoint != "" {
 			r.logger.Debug("Using default trace exporter", zap.String("endpoint", endpoint))
 			r.traceConfig.Exporters = append(r.traceConfig.Exporters, &rtrace.ExporterConfig{
@@ -432,7 +432,7 @@ func NewRouter(opts ...Option) (*Router, error) {
 	}
 
 	// Add default metric exporter if none are configured
-	if r.metricConfig.OpenTelemetry.Enabled && len(r.metricConfig.OpenTelemetry.Exporters) == 0 {
+	if r.metricConfig.OpenTelemetry.Enabled && len(r.metricConfig.OpenTelemetry.Exporters) == 0 && r.metricConfig.OpenTelemetry.TestReader == nil {
 		if endpoint := otelconfig.DefaultEndpoint(); endpoint != "" {
 			r.logger.Debug("Using default metrics exporter", zap.String("endpoint", endpoint))
 			r.metricConfig.OpenTelemetry.Exporters = append(r.metricConfig.OpenTelemetry.Exporters, &rmetric.OpenTelemetryExporter{
@@ -1057,9 +1057,7 @@ func (r *Router) newServer(ctx context.Context, routerConfig *nodev1.RouterConfi
 	var traceHandler *rtrace.Middleware
 	if r.traceConfig.Enabled {
 		spanStartOptions := []oteltrace.SpanStartOption{
-			oteltrace.WithAttributes(
-				baseAttributes...,
-			),
+			oteltrace.WithAttributes(baseAttributes...),
 			oteltrace.WithAttributes(
 				otel.RouterServerAttribute,
 				otel.WgRouterRootSpan.Bool(true),
@@ -1071,6 +1069,7 @@ func (r *Router) newServer(ctx context.Context, routerConfig *nodev1.RouterConfi
 		}
 
 		traceHandler = rtrace.NewMiddleware(
+			r.traceConfig.SpanAttributesMapper,
 			otelhttp.WithSpanOptions(spanStartOptions...),
 			otelhttp.WithFilter(rtrace.CommonRequestFilter),
 			otelhttp.WithFilter(rtrace.PrefixRequestFilter(
@@ -1183,9 +1182,7 @@ func (r *Router) newServer(ctx context.Context, routerConfig *nodev1.RouterConfi
 			rmetric.WithLogger(r.logger),
 			rmetric.WithProcessStartTime(r.processStartTime),
 			rmetric.WithRouterRuntimeMetrics(r.metricConfig.OpenTelemetry.RouterRuntime),
-			rmetric.WithAttributes(
-				baseAttributes...,
-			),
+			rmetric.WithAttributes(baseAttributes...),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create metric handler: %w", err)
@@ -1225,6 +1222,7 @@ func (r *Router) newServer(ctx context.Context, routerConfig *nodev1.RouterConfi
 				},
 			},
 			TracerProvider:                r.tracerProvider,
+			AttributesMapper:              r.traceConfig.SpanAttributesMapper,
 			LocalhostFallbackInsideDocker: r.localhostFallbackInsideDocker,
 			Logger:                        r.logger,
 		},
@@ -1291,7 +1289,8 @@ func (r *Router) newServer(ctx context.Context, routerConfig *nodev1.RouterConfi
 		TracerProvider:                         r.tracerProvider,
 		Authorizer:                             NewCosmoAuthorizer(authorizerOptions),
 		SubgraphErrorPropagation:               r.subgraphErrorPropagation,
-		EngineLoaderHooks:                      NewEngineRequestHooks(ro.metricStore),
+		EngineLoaderHooks:                      NewEngineRequestHooks(ro.metricStore, r.traceConfig.SpanAttributesMapper),
+		SpanAttributesMapper:                   r.traceConfig.SpanAttributesMapper,
 	}
 
 	if r.Config.redisClient != nil {
@@ -1342,6 +1341,7 @@ func (r *Router) newServer(ctx context.Context, routerConfig *nodev1.RouterConfi
 		TracerProvider:              r.tracerProvider,
 		FlushTelemetryAfterResponse: r.awsLambda,
 		TraceExportVariables:        r.traceConfig.ExportGraphQLVariables.Enabled,
+		SpanAttributesMapper:        r.traceConfig.SpanAttributesMapper,
 	})
 
 	graphqlChiRouter := chi.NewRouter()
@@ -1985,9 +1985,43 @@ func TraceConfigFromTelemetry(cfg *config.Telemetry) *rtrace.Config {
 		ExportGraphQLVariables: rtrace.ExportGraphQLVariables{
 			Enabled: cfg.Tracing.ExportGraphQLVariables,
 		},
-		Exporters:   exporters,
-		Propagators: propagators,
+		SpanAttributesMapper: buildAttributesMapper(cfg.Attributes),
+		ResourceAttributes:   buildResourceAttributes(cfg.ResourceAttributes),
+		Exporters:            exporters,
+		Propagators:          propagators,
 	}
+}
+
+func buildAttributesMapper(attributes []config.OtelAttribute) func(req *http.Request) []attribute.KeyValue {
+	return func(req *http.Request) []attribute.KeyValue {
+		var result []attribute.KeyValue
+
+		for _, attr := range attributes {
+			if attr.ValueFrom != nil {
+				if req != nil && attr.ValueFrom.RequestHeader != "" {
+					hv := req.Header.Get(attr.ValueFrom.RequestHeader)
+					if hv != "" {
+						result = append(result, attribute.String(attr.Key, hv))
+					} else if attr.Value != "" {
+						result = append(result, attribute.String(attr.Key, attr.Value))
+					}
+				} else if attr.Value != "" {
+					result = append(result, attribute.String(attr.Key, attr.Value))
+				}
+			}
+		}
+
+		return result
+	}
+}
+
+func buildResourceAttributes(attributes []config.OtelResourceAttribute) []attribute.KeyValue {
+	var result []attribute.KeyValue
+	for _, attr := range attributes {
+		result = append(result, attribute.String(attr.Key, attr.Value))
+	}
+	r := attribute.NewSet(result...)
+	return r.ToSlice()
 }
 
 func MetricConfigFromTelemetry(cfg *config.Telemetry) *rmetric.Config {
@@ -2003,8 +2037,10 @@ func MetricConfigFromTelemetry(cfg *config.Telemetry) *rmetric.Config {
 	}
 
 	return &rmetric.Config{
-		Name:    cfg.ServiceName,
-		Version: Version,
+		Name:               cfg.ServiceName,
+		Version:            Version,
+		AttributesMapper:   buildAttributesMapper(cfg.Attributes),
+		ResourceAttributes: buildResourceAttributes(cfg.ResourceAttributes),
 		OpenTelemetry: rmetric.OpenTelemetry{
 			Enabled:       cfg.Metrics.OTLP.Enabled,
 			RouterRuntime: cfg.Metrics.OTLP.RouterRuntime,

--- a/router/pkg/config/config.go
+++ b/router/pkg/config/config.go
@@ -97,7 +97,7 @@ type OtelAttributeFromValue struct {
 
 type OtelAttribute struct {
 	Key       string                  `yaml:"key"`
-	Value     string                  `yaml:"value"`
+	Default   string                  `yaml:"default"`
 	ValueFrom *OtelAttributeFromValue `yaml:"value_from,omitempty"`
 }
 

--- a/router/pkg/config/config.go
+++ b/router/pkg/config/config.go
@@ -43,11 +43,12 @@ type TracingExporter struct {
 }
 
 type Tracing struct {
-	Enabled               bool              `yaml:"enabled" default:"true" envconfig:"TRACING_ENABLED"`
-	SamplingRate          float64           `yaml:"sampling_rate" default:"1" envconfig:"TRACING_SAMPLING_RATE"`
-	ParentBasedSampler    bool              `yaml:"parent_based_sampler" default:"true" envconfig:"TRACING_PARENT_BASED_SAMPLER"`
-	Exporters             []TracingExporter `yaml:"exporters"`
-	Propagation           PropagationConfig `yaml:"propagation"`
+	Enabled            bool              `yaml:"enabled" default:"true" envconfig:"TRACING_ENABLED"`
+	SamplingRate       float64           `yaml:"sampling_rate" default:"1" envconfig:"TRACING_SAMPLING_RATE"`
+	ParentBasedSampler bool              `yaml:"parent_based_sampler" default:"true" envconfig:"TRACING_PARENT_BASED_SAMPLER"`
+	Exporters          []TracingExporter `yaml:"exporters"`
+	Propagation        PropagationConfig `yaml:"propagation"`
+
 	TracingGlobalFeatures `yaml:",inline"`
 }
 
@@ -85,10 +86,27 @@ type MetricsOTLP struct {
 	Exporters     []MetricsOTLPExporter `yaml:"exporters"`
 }
 
+type OtelResourceAttribute struct {
+	Key   string `yaml:"key"`
+	Value string `yaml:"value"`
+}
+
+type OtelAttributeFromValue struct {
+	RequestHeader string `yaml:"request_header"`
+}
+
+type OtelAttribute struct {
+	Key       string                  `yaml:"key"`
+	Value     string                  `yaml:"value"`
+	ValueFrom *OtelAttributeFromValue `yaml:"value_from,omitempty"`
+}
+
 type Telemetry struct {
-	ServiceName string  `yaml:"service_name" default:"cosmo-router" envconfig:"TELEMETRY_SERVICE_NAME"`
-	Tracing     Tracing `yaml:"tracing"`
-	Metrics     Metrics `yaml:"metrics"`
+	ServiceName        string                  `yaml:"service_name" default:"cosmo-router" envconfig:"TELEMETRY_SERVICE_NAME"`
+	Attributes         []OtelAttribute         `yaml:"attributes" envconfig:"TELEMETRY_ATTRIBUTES"`
+	ResourceAttributes []OtelResourceAttribute `yaml:"resource_attributes" envconfig:"TELEMETRY_RESOURCE_ATTRIBUTES"`
+	Tracing            Tracing                 `yaml:"tracing"`
+	Metrics            Metrics                 `yaml:"metrics"`
 }
 
 type CORS struct {

--- a/router/pkg/config/config.schema.json
+++ b/router/pkg/config/config.schema.json
@@ -215,10 +215,11 @@
         },
         "resource_attributes": {
           "type": "array",
-          "description": "The resource attributes to add to OTEL metrics and traces. The resource attributes identify the entity producing the traces and metrics. Because Prometheus metrics rely on the OpenTelemetry metrics, the resource attributes are also added to the Prometheus metrics.",
+          "description": "The resource attributes to add to OTEL metrics and traces. The resource attributes identify the entity producing the traces and metrics. Because Prometheus metrics rely on the OpenTelemetry metrics, the resource attributes are also added to the Prometheus target_info metric.",
           "items": {
             "type": "object",
             "additionalProperties": false,
+            "required": ["key", "value"],
             "properties": {
               "key": {
                 "type": "string",
@@ -226,7 +227,7 @@
               },
               "value": {
                 "type": "string",
-                "description": "The static value of the attribute."
+                "description": "The value of the attribute."
               }
             }
           }
@@ -237,6 +238,7 @@
           "items": {
             "type": "object",
             "additionalProperties": false,
+            "required": ["key"],
             "properties": {
               "key": {
                 "type": "string",
@@ -244,7 +246,7 @@
               },
               "default": {
                 "type": "string",
-                "description": "The static value of the attribute. If the value is not set, the value_from is used. If both value and value_from are set, value_from has precedence. You can use default to fallback when value_from could not be resolved."
+                "description": "The default value of the attribute. If the value is not set, value_from is used. If both value and value_from are set, value_from has precedence and in case of a missing value_from, the default value is used."
               },
               "value_from": {
                 "type": "object",

--- a/router/pkg/config/config.schema.json
+++ b/router/pkg/config/config.schema.json
@@ -242,18 +242,18 @@
                 "type": "string",
                 "description": "The key of the attribute."
               },
-              "value": {
+              "default": {
                 "type": "string",
-                "description": "The static value of the attribute."
+                "description": "The static value of the attribute. If the value is not set, the value_from is used. If both value and value_from are set, value_from has precedence. You can use default to fallback when value_from could not be resolved."
               },
               "value_from": {
                 "type": "object",
-                "description": "Defines a source for the attribute value e.g. from a request header. If both value and value_from are set, value_from will be used when no value could be extracted.",
+                "description": "Defines a source for the attribute value e.g. from a request header. If both default and value_from are set, value_from has precedence.",
                 "additionalProperties": false,
                 "properties": {
                   "request_header": {
                     "type": "string",
-                    "description": "The name of the request header from which to extract the value. The value is only extracted when a request context is available."
+                    "description": "The name of the request header from which to extract the value. The value is only extracted when a request context is available otherwise the default value is used."
                   }
                 }
               }

--- a/router/pkg/config/config.schema.json
+++ b/router/pkg/config/config.schema.json
@@ -213,6 +213,53 @@
           "description": "The name of the service. The name is used to identify the service in the traces and metrics. The default value is 'cosmo-router'.",
           "default": "cosmo-router"
         },
+        "resource_attributes": {
+          "type": "array",
+          "description": "The resource attributes to add to OTEL metrics and traces. The resource attributes identify the entity producing the traces and metrics. Because Prometheus metrics rely on the OpenTelemetry metrics, the resource attributes are also added to the Prometheus metrics.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "key": {
+                "type": "string",
+                "description": "The key of the attribute."
+              },
+              "value": {
+                "type": "string",
+                "description": "The static value of the attribute."
+              }
+            }
+          }
+        },
+        "attributes": {
+          "type": "array",
+          "description": "The attributes to add to OTEL metrics and traces. Because Prometheus metrics rely on the OpenTelemetry metrics, the attributes are also added to the Prometheus metrics.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "key": {
+                "type": "string",
+                "description": "The key of the attribute."
+              },
+              "value": {
+                "type": "string",
+                "description": "The static value of the attribute."
+              },
+              "value_from": {
+                "type": "object",
+                "description": "Defines a source for the attribute value e.g. from a request header. If both value and value_from are set, value_from will be used when no value could be extracted.",
+                "additionalProperties": false,
+                "properties": {
+                  "request_header": {
+                    "type": "string",
+                    "description": "The name of the request header from which to extract the value. The value is only extracted when a request context is available."
+                  }
+                }
+              }
+            }
+          }
+        },
         "tracing": {
           "type": "object",
           "additionalProperties": false,

--- a/router/pkg/config/testdata/config_defaults.json
+++ b/router/pkg/config/testdata/config_defaults.json
@@ -7,6 +7,8 @@
   },
   "Telemetry": {
     "ServiceName": "cosmo-router",
+    "Attributes": [],
+    "ResourceAttributes": [],
     "Tracing": {
       "Enabled": true,
       "SamplingRate": 1,

--- a/router/pkg/config/testdata/config_full.json
+++ b/router/pkg/config/testdata/config_full.json
@@ -7,6 +7,8 @@
   },
   "Telemetry": {
     "ServiceName": "cosmo-router",
+    "Attributes": [],
+    "ResourceAttributes": [],
     "Tracing": {
       "Enabled": true,
       "SamplingRate": 1,

--- a/router/pkg/metric/config.go
+++ b/router/pkg/metric/config.go
@@ -3,7 +3,9 @@ package metric
 import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/wundergraph/cosmo/router/pkg/otel/otelconfig"
+	"go.opentelemetry.io/otel/attribute"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"net/http"
 	"net/url"
 	"regexp"
 )
@@ -78,6 +80,12 @@ type Config struct {
 
 	// Prometheus includes the Prometheus configuration
 	Prometheus PrometheusConfig
+
+	// AttributesMapper added to the global attributes for all metrics.
+	AttributesMapper func(req *http.Request) []attribute.KeyValue
+
+	// ResourceAttributes added to the global resource attributes for all metrics.
+	ResourceAttributes []attribute.KeyValue
 }
 
 func (c *Config) IsEnabled() bool {
@@ -88,8 +96,10 @@ func (c *Config) IsEnabled() bool {
 func DefaultConfig(serviceVersion string) *Config {
 
 	return &Config{
-		Name:    DefaultServerName,
-		Version: serviceVersion,
+		Name:               DefaultServerName,
+		Version:            serviceVersion,
+		AttributesMapper:   nil,
+		ResourceAttributes: make([]attribute.KeyValue, 0),
 		OpenTelemetry: OpenTelemetry{
 			Enabled:       false,
 			RouterRuntime: true,

--- a/router/pkg/trace/config.go
+++ b/router/pkg/trace/config.go
@@ -2,7 +2,9 @@ package trace
 
 import (
 	"github.com/wundergraph/cosmo/router/pkg/otel/otelconfig"
+	"go.opentelemetry.io/otel/attribute"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"net/http"
 	"net/url"
 	"time"
 )
@@ -60,6 +62,8 @@ type Config struct {
 	ExportGraphQLVariables ExportGraphQLVariables
 	Exporters              []*ExporterConfig
 	Propagators            []Propagator
+	SpanAttributesMapper   func(req *http.Request) []attribute.KeyValue
+	ResourceAttributes     []attribute.KeyValue
 	// TestMemoryExporter is used for testing purposes. If set, the exporter will be used instead of the configured exporters.
 	TestMemoryExporter sdktrace.SpanExporter
 }
@@ -96,6 +100,8 @@ func DefaultConfig(serviceVersion string) *Config {
 		ExportGraphQLVariables: ExportGraphQLVariables{
 			Enabled: true,
 		},
+		SpanAttributesMapper: nil,
+		ResourceAttributes:   make([]attribute.KeyValue, 0),
 		Exporters: []*ExporterConfig{
 			{
 				Disabled:      false,

--- a/router/pkg/trace/meter.go
+++ b/router/pkg/trace/meter.go
@@ -114,6 +114,7 @@ func NewTracerProvider(ctx context.Context, config *ProviderConfig) (*sdktrace.T
 		resource.WithAttributes(semconv.ServiceNameKey.String(config.Config.Name)),
 		resource.WithAttributes(semconv.ServiceVersionKey.String(config.Config.Version)),
 		resource.WithAttributes(semconv.ServiceInstanceID(config.ServiceInstanceID)),
+		resource.WithAttributes(config.Config.ResourceAttributes...),
 		resource.WithProcessPID(),
 		resource.WithOSType(),
 		resource.WithTelemetrySDK(),

--- a/router/pkg/trace/middleware.go
+++ b/router/pkg/trace/middleware.go
@@ -10,7 +10,8 @@ import (
 )
 
 type Middleware struct {
-	otelOpts []otelhttp.Option
+	otelOpts             []otelhttp.Option
+	spanAttributesMapper func(r *http.Request) []attribute.KeyValue
 }
 
 // SensitiveAttributes that should be redacted by the OTEL http instrumentation package.
@@ -21,9 +22,10 @@ var SensitiveAttributes = []attribute.Key{
 	semconv17.NetSockPeerAddrKey,
 }
 
-func NewMiddleware(opts ...otelhttp.Option) *Middleware {
+func NewMiddleware(SpanAttributesMapper func(r *http.Request) []attribute.KeyValue, opts ...otelhttp.Option) *Middleware {
 	h := &Middleware{
-		otelOpts: opts,
+		spanAttributesMapper: SpanAttributesMapper,
+		otelOpts:             opts,
 	}
 
 	return h
@@ -34,6 +36,11 @@ func (h *Middleware) Handler(next http.Handler) http.Handler {
 	fn := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
 		span := trace.SpanFromContext(r.Context())
+
+		// Add custom attributes to the span
+		if h.spanAttributesMapper != nil {
+			span.SetAttributes(h.spanAttributesMapper(r)...)
+		}
 
 		// Add request target as attribute, so we can filter by path and query
 		span.SetAttributes(semconv17.HTTPTarget(r.RequestURI))

--- a/router/pkg/trace/middleware_test.go
+++ b/router/pkg/trace/middleware_test.go
@@ -19,7 +19,7 @@ func TestWrapHttpHandler(t *testing.T) {
 
 	t.Run("create a span for every request", func(t *testing.T) {
 		exporter := tracetest.NewInMemoryExporter(t)
-		h := NewMiddleware()
+		h := NewMiddleware(nil)
 
 		router := chi.NewRouter()
 
@@ -67,7 +67,7 @@ func TestWrapHttpHandler(t *testing.T) {
 
 		for _, test := range statusCodeTests {
 			router := chi.NewRouter()
-			h := NewMiddleware()
+			h := NewMiddleware(nil)
 
 			statusCode := test.statusCode
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->

## Motivation and Context

Config

```yaml
cors:
  allow_headers:
    - "x-service"
telemetry:
  resource_attributes:
    - key: env
      value: "prod"
  attributes:
    - key: service
      default: "static"
      value_from:
        request_header: "x-service"
```

A resource attribute `env=prod` is added. Additionally, we add the attribute `service=static` to all metrics and spans unless the client has sent us a request header `x-service` with a set value.

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

## TODO

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
