### PR TITLE
style: add 'flags' alias to 'feature-flags' cli command

### DIFF
--- a/cli/src/commands/feature-flag/index.ts
+++ b/cli/src/commands/feature-flag/index.ts
@@ -7,7 +7,7 @@ import DisableFeatureFlagCommand from './commands/disable.js';
 import UpdateFeatureFlagCommand from './commands/update.js';
 
 export default (opts: BaseCommandOptions) => {
-  const command = new Command('feature-flag');
+  const command = new Command('feature-flag').alias('flags');
   command.description('Provides commands for creating and managing a feature flags.');
 
   command.addCommand(CreateFeatureFlagCommand(opts));


### PR DESCRIPTION
Allows for truncated syntax for executing `wgc` feature-flag related subcommands by adding `flags` alias. 

Before: 

```bash
wgc feature-flag create ... 
```

After: 

```bash
wgc flags create ...
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->

## Motivation and Context

Less typing = better DX. 

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

## TODO

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
