### PR TITLE
fix: allow configuration of `AllowWildcard`

### DIFF
--- a/router/cmd/instance.go
+++ b/router/cmd/instance.go
@@ -138,6 +138,7 @@ func NewRouter(params Params, additionalOptions ...core.Option) (*core.Router, e
 			AllowOrigins:     cfg.CORS.AllowOrigins,
 			AllowMethods:     cfg.CORS.AllowMethods,
 			AllowCredentials: cfg.CORS.AllowCredentials,
+			AllowWildcard: 	  cfg.CORS.AllowWildcard,
 			AllowHeaders:     cfg.CORS.AllowHeaders,
 			MaxAge:           cfg.CORS.MaxAge,
 		}),

--- a/router/pkg/config/config.go
+++ b/router/pkg/config/config.go
@@ -114,6 +114,7 @@ type CORS struct {
 	AllowMethods     []string      `yaml:"allow_methods" default:"HEAD,GET,POST" envconfig:"CORS_ALLOW_METHODS"`
 	AllowHeaders     []string      `yaml:"allow_headers" default:"Origin,Content-Length,Content-Type" envconfig:"CORS_ALLOW_HEADERS"`
 	AllowCredentials bool          `yaml:"allow_credentials" default:"true" envconfig:"CORS_ALLOW_CREDENTIALS"`
+	AllowWildcard    bool	       `yaml:"allow_wildcard" default:"true" envconfig:"CORS_ALLOW_WILDCARD"`
 	MaxAge           time.Duration `yaml:"max_age" default:"5m" envconfig:"CORS_MAX_AGE"`
 }
 

--- a/router/pkg/config/config.schema.json
+++ b/router/pkg/config/config.schema.json
@@ -519,6 +519,11 @@
           "default": true,
           "description": "The allowed credentials. The default value is to allow credentials. This allows the browser to send cookies and authentication headers."
         },
+        "allow_wildcard": {
+          "type": "boolean",
+          "default": true,
+          "description": "Allow wildcard origins in the allowed origins list. e.g. http://some-domain/*, https://api.* or http://some.*.subdomain.com."
+        },
         "max_age": {
           "type": "string",
           "duration": {

--- a/router/pkg/config/fixtures/full.yaml
+++ b/router/pkg/config/fixtures/full.yaml
@@ -42,6 +42,7 @@ cors:
     - Content-Length
     - Content-Type
   allow_credentials: true
+  allow_wildcard: true
   max_age: 5m
 
 compliance:

--- a/router/pkg/config/testdata/config_defaults.json
+++ b/router/pkg/config/testdata/config_defaults.json
@@ -57,6 +57,7 @@
       "Content-Type"
     ],
     "AllowCredentials": true,
+    "AllowWildcard": true,
     "MaxAge": 300000000000
   },
   "Cluster": {

--- a/router/pkg/config/testdata/config_full.json
+++ b/router/pkg/config/testdata/config_full.json
@@ -75,6 +75,7 @@
       "Content-Type"
     ],
     "AllowCredentials": true,
+    "AllowWildcard": true,
     "MaxAge": 300000000000
   },
   "Cluster": {


### PR DESCRIPTION
This MR fixes #879

## Motivation and Context

Wildcard added to `cors.allow_origins` won't work without this MR as `AllowWildcard` is always `false`.

Let me know if my PR is missing stuff!