### PR TITLE
fix: empty admission webhook secret

### DIFF
--- a/controlplane/src/core/repositories/FederatedGraphRepository.ts
+++ b/controlplane/src/core/repositories/FederatedGraphRepository.ts
@@ -526,6 +526,7 @@ export class FederatedGraphRepository {
       namespace: resp[0].namespaceName,
       namespaceId: resp[0].namespaceId,
       admissionWebhookURL: resp[0].admissionWebhookURL ?? '',
+      admissionWebhookSecret: resp[0].admissionWebhookSecret ?? undefined,
       supportsFederation: resp[0].supportsFederation,
       contract,
     };
@@ -1454,6 +1455,8 @@ export class FederatedGraphRepository {
             message: e.message,
           })),
         );
+
+        console.log(federatedGraph.admissionWebhookSecret);
 
         const deployment = await composer.deployComposition({
           composedGraph: mapResultToComposedGraph(federatedGraph, subgraphs, errors, result),


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->

## Motivation and Context

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

The repository was not returning the secret to be passed to the controller.

## TODO

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [x] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
