### PR TITLE
feat: Add metric for active subscriptions

### DIFF
--- a/go.work
+++ b/go.work
@@ -11,4 +11,4 @@ use (
 	./router-tests
 )
 
-//replace github.com/wundergraph/graphql-go-tools/v2 => ../graphql-go-tools/v2
+replace github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.51 => github.com/dfreilich/graphql-go-tools/v2 v2.0.0-rc51df

--- a/go.work.sum
+++ b/go.work.sum
@@ -88,6 +88,8 @@ github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSV
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.0-20210816181553-5444fa50b93d h1:1iy2qD6JEhHKKhUOA9IWs7mjco7lnw2qx8FsRI2wirE=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.0-20210816181553-5444fa50b93d/go.mod h1:tmAIfUFEirG/Y8jhZ9M+h36obRZAk/1fcSpXwAVlfqE=
+github.com/dfreilich/graphql-go-tools/v2 v2.0.0-rc51df h1:Dhr4CfuFZJq15ySV6mjPXwRtgUtsqCo+NmDAALnOFD8=
+github.com/dfreilich/graphql-go-tools/v2 v2.0.0-rc51df/go.mod h1:YCJyt5TSr4luj4YWFGk93ayC/0KwHVEJmhgcNhcfLBc=
 github.com/dmarkham/enumer v1.5.9 h1:NM/1ma/AUNieHZg74w67GkHFBNB15muOt3sj486QVZk=
 github.com/dmarkham/enumer v1.5.9/go.mod h1:e4VILe2b1nYK3JKJpRmNdl5xbDQvELc6tQ8b+GsGk6E=
 github.com/docker/cli v23.0.3+incompatible h1:Zcse1DuDqBdgI7OQDV8Go7b83xLgfhW1eza4HfEdxpY=

--- a/router-tests/testutils/metrics.go
+++ b/router-tests/testutils/metrics.go
@@ -1,0 +1,58 @@
+package testutils
+
+import (
+	"context"
+	"github.com/stretchr/testify/require"
+	"github.com/wundergraph/cosmo/router/pkg/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
+	"testing"
+)
+
+func RequireMetricsToContain(t *testing.T, metricReader metric.Reader, expectedMetric metricdata.Metrics) {
+	var rm metricdata.ResourceMetrics
+	err := metricReader.Collect(context.Background(), &rm)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(rm.ScopeMetrics), "expected ScopeMetrics to exist")
+	require.GreaterOrEqualf(t, len(rm.ScopeMetrics[0].Metrics), 1, "expected at least 1 metric, got %d", len(rm.ScopeMetrics[0].Metrics))
+	receivedMetric := FindScopeMetricByName(rm, expectedMetric.Name)
+	require.NotNil(t, receivedMetric, "%s metric wasn't found", expectedMetric.Name)
+	metricdatatest.AssertEqual(t, expectedMetric, *receivedMetric, metricdatatest.IgnoreTimestamp())
+
+}
+
+func GetSubscriptionCountMetric(val int64) metricdata.Metrics {
+	return metricdata.Metrics{
+		Name:        "router.graph.active_subscriptions",
+		Description: "Number of active subscriptions",
+		Unit:        "",
+		Data: metricdata.Sum[int64]{
+			Temporality: metricdata.CumulativeTemporality,
+			DataPoints: []metricdata.DataPoint[int64]{
+				{
+					Attributes: attribute.NewSet(
+						otel.WgFederatedGraphID.String("graph"),
+						otel.WgRouterClusterName.String(""),
+						otel.WgRouterConfigVersion.String(""),
+						otel.WgRouterVersion.String("dev"),
+					),
+					Value: val,
+				},
+			},
+		},
+	}
+}
+
+func FindScopeMetricByName(rm metricdata.ResourceMetrics, name string) *metricdata.Metrics {
+	var metric *metricdata.Metrics
+	for _, m := range rm.ScopeMetrics[0].Metrics {
+		if m.Name == name {
+			metric = &m
+			break
+		}
+	}
+
+	return metric
+}

--- a/router/core/executor.go
+++ b/router/core/executor.go
@@ -46,7 +46,7 @@ type Executor struct {
 	RenameTypeNames []resolve.RenameTypeName
 }
 
-func (b *ExecutorConfigurationBuilder) Build(ctx context.Context, routerConfig *nodev1.RouterConfig, routerEngineConfig *RouterEngineConfiguration, pubSubProviders *EnginePubSubProviders, reporter resolve.Reporter) (*Executor, error) {
+func (b *ExecutorConfigurationBuilder) Build(ctx context.Context, routerConfig *nodev1.RouterConfig, routerEngineConfig *RouterEngineConfiguration, pubSubProviders *EnginePubSubProviders, reporter resolve.Reporter, metrics resolve.Metrics) (*Executor, error) {
 	planConfig, err := b.buildPlannerConfiguration(ctx, routerConfig, routerEngineConfig, pubSubProviders)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build planner configuration: %w", err)
@@ -56,6 +56,7 @@ func (b *ExecutorConfigurationBuilder) Build(ctx context.Context, routerConfig *
 		MaxConcurrency:               routerEngineConfig.Execution.MaxConcurrentResolvers,
 		Debug:                        routerEngineConfig.Execution.Debug.EnableResolverDebugging,
 		Reporter:                     reporter,
+		Metrics:                      metrics,
 		PropagateSubgraphErrors:      routerEngineConfig.SubgraphErrorPropagation.Enabled,
 		PropagateSubgraphStatusCodes: routerEngineConfig.SubgraphErrorPropagation.PropagateStatusCodes,
 		RewriteSubgraphErrorPaths:    routerEngineConfig.SubgraphErrorPropagation.RewritePaths,

--- a/router/core/router.go
+++ b/router/core/router.go
@@ -1245,7 +1245,7 @@ func (r *Router) newServer(ctx context.Context, routerConfig *nodev1.RouterConfi
 	}
 	ro.pubSubProviders = pubSubProviders
 
-	executor, err := ecb.Build(ctx, routerConfig, routerEngineConfig, pubSubProviders, r.WebsocketStats)
+	executor, err := ecb.Build(ctx, routerConfig, routerEngineConfig, pubSubProviders, r.WebsocketStats, ro.metricStore)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build plan configuration: %w", err)
 	}

--- a/router/pkg/metric/measurements.go
+++ b/router/pkg/metric/measurements.go
@@ -81,5 +81,15 @@ func createMeasures(meter otelmetric.Meter) (*Measurements, error) {
 
 	h.upDownCounters[InFlightRequestsUpDownCounter] = inFlightRequestsGauge
 
+	activeSubscriptionsGauge, err := meter.Int64UpDownCounter(
+		ActiveSubscriptionsCounter,
+		ActiveSubscriptionsUpDownCounterOptions...,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create active subscriptions gauge: %w", err)
+	}
+
+	h.upDownCounters[ActiveSubscriptionsCounter] = activeSubscriptionsGauge
+
 	return h, nil
 }

--- a/router/pkg/metric/metric_store.go
+++ b/router/pkg/metric/metric_store.go
@@ -20,6 +20,7 @@ const (
 	ResponseContentLengthCounter  = "router.http.response.content_length"       // Outgoing response bytes total
 	InFlightRequestsUpDownCounter = "router.http.requests.in_flight"            // Number of requests in flight
 	RequestError                  = "router.http.requests.error"                // Total request error count
+	ActiveSubscriptionsCounter    = "router.graph.active_subscriptions"         // Number of active subscriptions
 
 	unitBytes        = "bytes"
 	unitMilliseconds = "ms"
@@ -55,6 +56,11 @@ var (
 	InFlightRequestsUpDownCounterOptions     = []otelmetric.Int64UpDownCounterOption{
 		otelmetric.WithDescription(InFlightRequestsUpDownCounterDescription),
 	}
+
+	ActiveSubscriptionsUpDownCounterDescription = "Number of active subscriptions"
+	ActiveSubscriptionsUpDownCounterOptions     = []otelmetric.Int64UpDownCounterOption{
+		otelmetric.WithDescription(ActiveSubscriptionsUpDownCounterDescription),
+	}
 )
 
 type (
@@ -82,6 +88,7 @@ type (
 		MeasureResponseSize(ctx context.Context, size int64, attr ...attribute.KeyValue)
 		MeasureLatency(ctx context.Context, requestStartTime time.Time, attr ...attribute.KeyValue)
 		MeasureRequestError(ctx context.Context, attr ...attribute.KeyValue)
+		MeasureActiveSubscriptions(ctx context.Context, count int, attr ...attribute.KeyValue)
 		Flush(ctx context.Context) error
 	}
 )
@@ -157,6 +164,11 @@ func (h *Metrics) MeasureLatency(ctx context.Context, requestStartTime time.Time
 func (h *Metrics) MeasureRequestError(ctx context.Context, attr ...attribute.KeyValue) {
 	h.otlpRequestMetrics.MeasureRequestError(ctx, attr...)
 	h.promRequestMetrics.MeasureRequestError(ctx, attr...)
+}
+
+func (h *Metrics) MeasureActiveSubscriptions(ctx context.Context, count int, attr ...attribute.KeyValue) {
+	h.otlpRequestMetrics.MeasureActiveSubscriptions(ctx, count, attr...)
+	h.promRequestMetrics.MeasureActiveSubscriptions(ctx, count, attr...)
 }
 
 // Flush flushes the metrics to the backend synchronously.

--- a/router/pkg/metric/noop_metrics.go
+++ b/router/pkg/metric/noop_metrics.go
@@ -32,6 +32,9 @@ func (n NoopMetrics) MeasureResponseSize(ctx context.Context, size int64, attr .
 func (n NoopMetrics) MeasureLatency(ctx context.Context, requestStartTime time.Time, attr ...attribute.KeyValue) {
 }
 
+func (n NoopMetrics) MeasureActiveSubscriptions(ctx context.Context, count int, attr ...attribute.KeyValue) {
+}
+
 func (n NoopMetrics) Flush(ctx context.Context) error {
 	return nil
 }

--- a/router/pkg/metric/otlp_metric_store.go
+++ b/router/pkg/metric/otlp_metric_store.go
@@ -133,6 +133,19 @@ func (h *OtlpMetricStore) MeasureRequestError(ctx context.Context, attr ...attri
 	}
 }
 
+func (h *OtlpMetricStore) MeasureActiveSubscriptions(ctx context.Context, count int, attr ...attribute.KeyValue) {
+	var baseKeys []attribute.KeyValue
+
+	baseKeys = append(baseKeys, h.baseAttributes...)
+	baseKeys = append(baseKeys, attr...)
+
+	baseAttributes := otelmetric.WithAttributes(baseKeys...)
+
+	if c, ok := h.measurements.upDownCounters[ActiveSubscriptionsCounter]; ok {
+		c.Add(ctx, int64(count), baseAttributes)
+	}
+}
+
 func (h *OtlpMetricStore) Flush(ctx context.Context) error {
 	return h.meterProvider.ForceFlush(ctx)
 }

--- a/router/pkg/metric/prom_metric_store.go
+++ b/router/pkg/metric/prom_metric_store.go
@@ -133,6 +133,19 @@ func (h *PromMetricStore) MeasureRequestError(ctx context.Context, attr ...attri
 	}
 }
 
+func (h *PromMetricStore) MeasureActiveSubscriptions(ctx context.Context, count int, attr ...attribute.KeyValue) {
+	var baseKeys []attribute.KeyValue
+
+	baseKeys = append(baseKeys, h.baseAttributes...)
+	baseKeys = append(baseKeys, attr...)
+
+	baseAttributes := otelmetric.WithAttributes(baseKeys...)
+
+	if c, ok := h.measurements.upDownCounters[ActiveSubscriptionsCounter]; ok {
+		c.Add(ctx, int64(count), baseAttributes)
+	}
+}
+
 func (h *PromMetricStore) Flush(ctx context.Context) error {
 	return h.meterProvider.ForceFlush(ctx)
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->

## Motivation and Context

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->
This PR adds an active subscription metric. It is dependent on https://github.com/wundergraph/graphql-go-tools/pull/832, and utilizes an extension of the engine to enable collecting up-to-date metrics on the active subscriber count. 

## TODO
* Discuss in terms of architecture whether the current mechanism (extending the engine by injecting metrics collection) is preferable to just doing it as part of the websocket statistics collections
* Discuss the pros/cons of adding more tests
- [x] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [x] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
