### PR TITLE
feat: add playground and graphl path env variables to aws-router-lambda 

### DIFF
--- a/aws-lambda-router/cmd/main.go
+++ b/aws-lambda-router/cmd/main.go
@@ -29,6 +29,8 @@ var (
 	stage             = os.Getenv("STAGE")
 	graphApiToken     = os.Getenv("GRAPH_API_TOKEN")
 	httpPort          = os.Getenv("HTTP_PORT")
+	playgroundPath    = os.Getenv("PLAYGROUND_PATH")
+	graphqlPath       = os.Getenv("GRAPHQL_PATH")
 )
 
 func main() {
@@ -48,6 +50,8 @@ func main() {
 		internal.WithGraphApiToken(graphApiToken),
 		internal.WithLogger(logger),
 		internal.WithRouterConfigPath(routerConfigPath),
+		internal.WithPlaygroundPath(playgroundPath),
+		internal.WithGraphQLPath(graphqlPath),
 		internal.WithTelemetryServiceName(telemetryServiceName),
 		internal.WithStage(stage),
 		internal.WithTraceSampleRate(defaultSampleRate),

--- a/aws-lambda-router/internal/router.go
+++ b/aws-lambda-router/internal/router.go
@@ -13,6 +13,8 @@ type Option func(*RouterConfig)
 
 type RouterConfig struct {
 	RouterConfigPath     string
+	PlaygroundPath       string
+	GraphqlPath          string
 	TelemetryServiceName string
 	RouterOpts           []core.Option
 	GraphApiToken        string
@@ -49,6 +51,14 @@ func NewRouter(opts ...Option) *core.Router {
 		core.WithStaticRouterConfig(routerConfig),
 		core.WithAwsLambdaRuntime(),
 		core.WithGraphApiToken(rc.GraphApiToken),
+	}
+
+	if rc.PlaygroundPath != "" {
+		routerOpts = append(routerOpts, core.WithPlaygroundPath(rc.PlaygroundPath))
+	}
+
+	if rc.GraphqlPath != "" {
+		routerOpts = append(routerOpts, core.WithGraphQLPath(rc.GraphqlPath))
 	}
 
 	if rc.HttpPort != "" {
@@ -97,6 +107,18 @@ func NewRouter(opts ...Option) *core.Router {
 func WithRouterConfigPath(path string) Option {
 	return func(r *RouterConfig) {
 		r.RouterConfigPath = path
+	}
+}
+
+func WithPlaygroundPath(path string) Option {
+	return func(r *RouterConfig) {
+		r.PlaygroundPath = path
+	}
+}
+
+func WithGraphQLPath(path string) Option {
+	return func(r *RouterConfig) {
+		r.GraphqlPath = path
 	}
 }
 

--- a/aws-lambda-router/template.yaml
+++ b/aws-lambda-router/template.yaml
@@ -47,6 +47,8 @@ Resources:
           GRAPH_API_TOKEN: "" # Add your Graph API token here
           STAGE: "Prod" # Add the stage e.g. "Prod" if you use the Lambda default endpoint
           DEV_MODE: "false" # Set to "true" to enable the dev mode
+          GRAPHQL_PATH: "" # Add your custom graphql path
+          PLAYGROUND_PATH: "" # Add your custom playground path
 
 Outputs:
   Endpoint:


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->

## Motivation and Context

I need this feature to implement my solution with AWS lambda router.

Related with this issue: #871 

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

## TODO

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
