### PR TITLE
fix: update text snippet in messages_en.properties

### DIFF
--- a/keycloak/theme/src/main/resources/theme/cosmo/login/messages/messages_en.properties
+++ b/keycloak/theme/src/main/resources/theme/cosmo/login/messages/messages_en.properties
@@ -1,5 +1,5 @@
 doRegister=Sign Up
-termsText=<p>Thank you for your interest in WunderGraph Cosmo! We're happy you're here.<br/><br/>In order to sign up for Cosmo, please read and accept the <a href="https://wundergraph.com/cosmo-managed-service-terms" target="_blank">Cosmo Terms of Use.</a></p>
+termsText=<p>Thank you for your interest in WunderGraph Cosmo! We're happy you're here.<br/><br/>In order to sign up for Cosmo, please read and accept the <a href="https://wundergraph.com/cosmo-managed-service-terms" target="_blank">Cosmo Managed Service Terms of Use.</a></p>
 loginAccountTitle= Sign in
 emailInstruction=Enter your email address and we will send you instructions on how to create a new password.
 oauthGrantRequest=Do you want to grant access to cosmo-cli?

--- a/keycloak/theme/src/main/resources/theme/cosmo/login/resources/scss/login.scss
+++ b/keycloak/theme/src/main/resources/theme/cosmo/login/resources/scss/login.scss
@@ -201,7 +201,7 @@ div.kc-logo-text span {
 }
 
 #kc-terms-text {
-  margin-bottom: 20px;
+  margin-bottom: 24px;
   text-align: justify;
   a {
     @apply text-pink-600 hover:text-pink-700 no-underline;

--- a/keycloak/theme/src/main/resources/theme/cosmo/login/terms.ftl
+++ b/keycloak/theme/src/main/resources/theme/cosmo/login/terms.ftl
@@ -5,7 +5,7 @@
     <#elseif section = "form">
         <div id="kc-terms-text">
             <p>
-                Thank you for your interest in WunderGraph Cosmo! We're happy you're here.<br/><br/>In order to sign up for Cosmo, please read and accept the <a href="https://wundergraph.com/cosmo-managed-service-terms" target="_blank">Cosmo Terms of Use.</a>
+                Thank you for your interest in WunderGraph Cosmo! We're happy you're here.<br/><br/>In order to sign up for Cosmo, please read and accept the <a href="https://wundergraph.com/cosmo-managed-service-terms" target="_blank">Cosmo Managed Service Terms of Use.</a>
             </p>
         </div>
         <form class="form-actions" action="${url.loginAction}" method="POST">


### PR DESCRIPTION
Added "managed service" to match the exact legal name of the terms document in the consent modal.