### PR TITLE
fix: optimize max concurrency for medium, high load, don't retry on 2xx status codes

### DIFF
--- a/router/core/router.go
+++ b/router/core/router.go
@@ -777,7 +777,7 @@ func (r *Router) Start(ctx context.Context) error {
 
 	// Start the server with the static config without polling
 	if r.staticRouterConfig != nil {
-		r.logger.Info("Static router config  provided. Polling is disabled. Updating router config is only possible by providing a config.")
+		r.logger.Info("Static router config provided. Polling is disabled. Updating router config is only possible by providing a config.")
 
 		if err := r.newServer(ctx, r.staticRouterConfig); err != nil {
 			return err

--- a/router/internal/retrytransport/retry_transport.go
+++ b/router/internal/retrytransport/retry_transport.go
@@ -59,8 +59,8 @@ func NewRetryHTTPTransport(roundTripper http.RoundTripper, retryOptions RetryOpt
 func (rt *RetryHTTPTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	resp, err := rt.RoundTripper.RoundTrip(req)
-	// Short circuit if the request was successful
-	if err == nil && resp.StatusCode == http.StatusOK {
+	// Short circuit if the request was successful.
+	if err == nil && isResponseOK(resp) {
 		return resp, nil
 	}
 
@@ -92,13 +92,19 @@ func (rt *RetryHTTPTransport) RoundTrip(req *http.Request) (*http.Response, erro
 		resp, err = rt.RoundTripper.RoundTrip(req)
 
 		// Short circuit if the request was successful
-		if err == nil && resp.StatusCode == http.StatusOK {
+		if err == nil && isResponseOK(resp) {
 			return resp, nil
 		}
 
 	}
 
 	return resp, err
+}
+
+func isResponseOK(resp *http.Response) bool {
+	// Ensure we don't wait for no reason when subgraphs don't behave
+	// spec-compliant and returns a different status code than 200.
+	return resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices
 }
 
 func IsRetryableError(err error, resp *http.Response) bool {

--- a/router/internal/retrytransport/retry_transport.go
+++ b/router/internal/retrytransport/retry_transport.go
@@ -104,7 +104,7 @@ func (rt *RetryHTTPTransport) RoundTrip(req *http.Request) (*http.Response, erro
 func isResponseOK(resp *http.Response) bool {
 	// Ensure we don't wait for no reason when subgraphs don't behave
 	// spec-compliant and returns a different status code than 200.
-	return resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices
+	return resp.StatusCode >= 200 && resp.StatusCode < 300
 }
 
 func IsRetryableError(err error, resp *http.Response) bool {

--- a/router/pkg/config/config.go
+++ b/router/pkg/config/config.go
@@ -211,7 +211,7 @@ type EngineExecutionConfiguration struct {
 	EnableSingleFlight                     bool                     `default:"true" envconfig:"ENGINE_ENABLE_SINGLE_FLIGHT" yaml:"enable_single_flight"`
 	EnableRequestTracing                   bool                     `default:"true" envconfig:"ENGINE_ENABLE_REQUEST_TRACING" yaml:"enable_request_tracing"`
 	EnableExecutionPlanCacheResponseHeader bool                     `default:"false" envconfig:"ENGINE_ENABLE_EXECUTION_PLAN_CACHE_RESPONSE_HEADER" yaml:"enable_execution_plan_cache_response_header"`
-	MaxConcurrentResolvers                 int                      `default:"32" envconfig:"ENGINE_MAX_CONCURRENT_RESOLVERS" yaml:"max_concurrent_resolvers,omitempty"`
+	MaxConcurrentResolvers                 int                      `default:"256" envconfig:"ENGINE_MAX_CONCURRENT_RESOLVERS" yaml:"max_concurrent_resolvers,omitempty"`
 	EnableWebSocketEpollKqueue             bool                     `default:"true" envconfig:"ENGINE_ENABLE_WEBSOCKET_EPOLL_KQUEUE" yaml:"enable_websocket_epoll_kqueue"`
 	EpollKqueuePollTimeout                 time.Duration            `default:"1s" envconfig:"ENGINE_EPOLL_KQUEUE_POLL_TIMEOUT" yaml:"epoll_kqueue_poll_timeout,omitempty"`
 	EpollKqueueConnBufferSize              int                      `default:"128" envconfig:"ENGINE_EPOLL_KQUEUE_CONN_BUFFER_SIZE" yaml:"epoll_kqueue_conn_buffer_size,omitempty"`

--- a/router/pkg/config/testdata/config_defaults.json
+++ b/router/pkg/config/testdata/config_defaults.json
@@ -192,7 +192,7 @@
     "EnableSingleFlight": true,
     "EnableRequestTracing": true,
     "EnableExecutionPlanCacheResponseHeader": false,
-    "MaxConcurrentResolvers": 32,
+    "MaxConcurrentResolvers": 256,
     "EnableWebSocketEpollKqueue": true,
     "EpollKqueuePollTimeout": 1000000000,
     "EpollKqueueConnBufferSize": 128,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->

## Motivation and Context

`ENGINE_MAX_CONCURRENT_RESOLVERS` has been chosen too low (32). The latency for medium and high load scenarios is increased a lot because max concurrency is implemented as a semaphore and blocks new requests. This PR increase the limit to `256`.

### Test case

The settings has been validated with the following scenario.

400 VUs (Virtual users) over 30 seconds

- ENGINE_MAX_CONCURRENT_RESOLVERS: 256
- Artificial subgraph latency: 200ms
- Subgraph response size: 200KB

Memory consumption: ~300MB

Additionally, I've found out that we retry subgraph requests when the subgraph returns a different code than 2xx than 200 OK.



<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

## TODO

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
