### PR TITLE
fix: log commit check failure as warning instead of error

### DIFF
--- a/controlplane/src/core/bufservices/PlatformService.ts
+++ b/controlplane/src/core/bufservices/PlatformService.ts
@@ -2271,7 +2271,7 @@ export default function (opts: RouterOptions): Partial<ServiceImpl<typeof Platfo
               composedGraphs: result.compositions.map((c) => c.name),
             });
           } catch (e) {
-            logger.error(e, 'Error creating commit check');
+            logger.warn(e, 'Error creating commit check');
           }
         }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->

## Motivation and Context

This does not fail the check process anyways. It reduces alerting in case the organization does not give permission to the GitHub app

## TODO

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [x] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
