### PR TITLE
fix: broken pagination on page size change and subgraphs table with many items

### DIFF
--- a/studio/src/components/dashboard/NamespaceSelector.tsx
+++ b/studio/src/components/dashboard/NamespaceSelector.tsx
@@ -47,18 +47,22 @@ export const NamespaceSelector = ({
     setNamespaces(data.namespaces.map((ns) => ns.name));
   }, [applyParams, data, namespace, setNamespaces]);
 
-  if (!namespaceParam && !!namespace) {
-    applyParams({
-      namespace,
-    });
-  }
+  useEffect(() => {
+    if (!namespaceParam && !!namespace) {
+      applyParams({
+        namespace,
+      });
+    }
+  }, [namespace, namespaceParam, applyParams]);
 
   return (
     <Select
       value={namespace}
       onValueChange={(namespace) => {
         if (shouldRedirect) {
-          router.push(`/${organizationSlug}/feature-flags?namespace=${namespace}`)
+          router.push(
+            `/${organizationSlug}/feature-flags?namespace=${namespace}`,
+          );
         } else {
           applyParams({ namespace });
         }

--- a/studio/src/components/ui/pagination.tsx
+++ b/studio/src/components/ui/pagination.tsx
@@ -44,7 +44,8 @@ export const Pagination = ({
         <Select
           value={`${limit}`}
           onValueChange={(value) => {
-            applyNewParams({ pageSize: value });
+            // Reset page when size changes because the number of pages may not be the same
+            applyNewParams({ pageSize: value, page: "1" });
           }}
         >
           <SelectTrigger className="h-8 w-[70px]">

--- a/studio/src/pages/[organizationSlug]/subgraphs.tsx
+++ b/studio/src/pages/[organizationSlug]/subgraphs.tsx
@@ -120,35 +120,33 @@ const SubgraphsDashboardPage: NextPageWithLayout = () => {
   }
 
   return (
-    <div className="flex h-full flex-col gap-y-4">
+    <div className="flex h-full flex-col">
       <SubgraphPageTabs />
-      <div>
-        <div className="relative mb-4">
-          <MagnifyingGlassIcon className="absolute bottom-0 left-3 top-0 my-auto" />
-          <Input
-            placeholder="Search by name"
-            className="pl-8 pr-10"
-            value={search}
-            onChange={(e) => {
-              setSearch(e.target.value);
-              applyParams({ search: e.target.value });
+      <div className="relative mb-4 mt-8">
+        <MagnifyingGlassIcon className="absolute bottom-0 left-3 top-0 my-auto" />
+        <Input
+          placeholder="Search by name"
+          className="pl-8 pr-10"
+          value={search}
+          onChange={(e) => {
+            setSearch(e.target.value);
+            applyParams({ search: e.target.value });
+          }}
+        />
+        {search && (
+          <Button
+            variant="ghost"
+            className="absolute bottom-0 right-0 top-0 my-auto rounded-l-none"
+            onClick={() => {
+              setSearch("");
+              applyParams({ search: null });
             }}
-          />
-          {search && (
-            <Button
-              variant="ghost"
-              className="absolute bottom-0 right-0 top-0 my-auto rounded-l-none"
-              onClick={() => {
-                setSearch("");
-                applyParams({ search: null });
-              }}
-            >
-              <Cross1Icon />
-            </Button>
-          )}
-        </div>
-        {content}
+          >
+            <Cross1Icon />
+          </Button>
+        )}
       </div>
+      {content}
     </div>
   );
 };


### PR DESCRIPTION
Changing page size when page number is greater than expected leads to empty results. Reset page number on page size change