### PR TITLE
fix: get discussions only when targetId exists

### DIFF
--- a/studio/src/components/schema/sdl-viewer.tsx
+++ b/studio/src/components/schema/sdl-viewer.tsx
@@ -233,10 +233,14 @@ const Block = ({
 
   const [newDiscussionLine, setNewDiscussionLine] = useState(-1);
 
-  const { data, refetch } = useQuery(getAllDiscussions, {
-    schemaVersionId: versionId,
-    targetId,
-  });
+  const { data, refetch } = useQuery(
+    getAllDiscussions,
+    {
+      schemaVersionId: versionId,
+      targetId: targetId,
+    },
+    { enabled: !!targetId },
+  );
 
   const { data: membersData } = useQuery(getOrganizationMembers);
 

--- a/studio/src/pages/[organizationSlug]/[namespace]/graph/[slug]/schema/index.tsx
+++ b/studio/src/pages/[organizationSlug]/[namespace]/graph/[slug]/schema/index.tsx
@@ -522,10 +522,14 @@ const TypeDiscussions = ({
 
   const applyParams = useApplyParams();
 
-  const { data, isLoading, error, refetch } = useQuery(getAllDiscussions, {
-    targetId: graphData?.graph?.targetId,
-    schemaVersionId,
-  });
+  const { data, isLoading, error, refetch } = useQuery(
+    getAllDiscussions,
+    {
+      targetId: graphData?.graph?.targetId,
+      schemaVersionId,
+    },
+    { enabled: !!graphData?.graph?.targetId },
+  );
 
   const { data: membersData } = useQuery(getOrganizationMembers);
 


### PR DESCRIPTION
## TODO

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [x] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
