### PR TITLE
fix:  make full-demo-up failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ full-demo-down:
 	docker compose -f docker-compose.full.yml --profile default --profile router --profile subgraphs down --remove-orphans -v
 
 dc-federation-demo:
-	docker compose -f docker-compose.full.yml --profile default --profile router --profile subgraphs up --remove-orphans --detach
+	docker compose -f docker-compose.full.yml --profile default --profile router --profile subgraphs  --parallel 3  up --remove-orphans --detach
 
 DC_FLAGS=
 dc-subgraphs-demo:


### PR DESCRIPTION
fix full-demo-up hang or killed while Start the subgraphs and the router

✅ Closes: https://github.com/wundergraph/cosmo/issues/886

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->

## Motivation and Context

when I  run make full-demo-up,  It will hang or be killed  like this
![image](https://github.com/user-attachments/assets/95689ed6-ae8b-47c6-a3de-ac144a04eb86)
 

It is  useless when  I change the Memory and CPU
![image](https://github.com/user-attachments/assets/f0e1c646-775e-420b-8f3e-94a68e30b326)



I think the docker-compose use too much concurrency case any issues.
After I set the param of --parallel 3. It was work well

## TODO

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
