### PR TITLE
fix: cannot make composition with multiple interfaces for interfaceObject 

### DIFF
--- a/composition/tests/resolvability.test.ts
+++ b/composition/tests/resolvability.test.ts
@@ -1202,6 +1202,16 @@ describe('Field resolvability tests', () => {
   });
 });
 
+test('that not fails implementing multiple interfaces for interfaceObject', () => {
+  const { errors, federationResult } = federateSubgraphs([subgraphBM, subgraphBO]);
+  expect(errors).toBeUndefined();
+});
+
+test('that fails implementing multiple interfaces for interfaceObject', () => {
+  const { errors, federationResult } = federateSubgraphs([subgraphBN, subgraphBO]);
+  expect(errors).toBeUndefined();
+});
+
 const subgraphA: Subgraph = {
   name: 'subgraph-a',
   url: '',
@@ -2367,6 +2377,69 @@ const subgraphBL: Subgraph = {
       idTwo: ID!
       age: Int!
       entityTwo: EntityTwo! @shareable
+    }
+  `),
+};
+
+const subgraphBM: Subgraph = {
+  name: 'subgraph-bm',
+  url: '',
+  definitions: parse(`
+    interface Updatable @key(fields: "id") {
+      id: ID!
+    }
+    interface Deletable @key(fields: "id") {
+      id: ID!
+    }
+    interface Sharable @key(fields: "id") {
+      id: ID!
+    }
+    type Entity implements Updatable @key(fields: "id") {
+      id: ID!
+    }
+    type Query {
+      entity: Entity!
+    }
+  `),
+};
+
+const subgraphBN: Subgraph = {
+  name: 'subgraph-bn',
+  url: '',
+  definitions: parse(`
+    interface Updatable @key(fields: "id") {
+      id: ID!
+    }
+    interface Deletable @key(fields: "id") {
+      id: ID!
+    }
+    interface Sharable @key(fields: "id") {
+      id: ID!
+    }
+    type Entity implements Updatable & Deletable & Sharable @key(fields: "id") {
+      id: ID!
+    }
+    type Query {
+      entity: Entity!
+    }
+  `),
+};
+
+const subgraphBO: Subgraph = {
+  name: 'subgraph-bo',
+  url: '',
+  definitions: parse(`
+    type Updatable @key(fields: "id") @interfaceObject {
+      id: ID!
+      viewerCanUpdate: Boolean!
+    }
+    type Deletable @key(fields: "id") @interfaceObject {
+      id: ID!
+      viewerCanDelete: Boolean!
+    }
+    type Sharable @key(fields: "id") @interfaceObject {
+      id: ID!
+      viewerCanShare: Boolean!
     }
   `),
 };


### PR DESCRIPTION
I created two tests to indicate the use case I tried to do. I wanted to implement Updatable, Deletable, Shareable interfaces and make its implementation via interfaceObject. Cosmo works fine if Entity implements only 1 of these 3 interfaces... but fails when we do more than 1.

## Motivation and Context

Provided two tests that should help identifying the issue.

## TODO

- [x] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [x] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
