### PR TITLE
fix: dont initialize persisted operation client when disabled

### DIFF
--- a/router/core/router.go
+++ b/router/core/router.go
@@ -857,22 +857,24 @@ func (r *Router) buildClients() error {
 		)
 	}
 
-	// For backwards compatibility with cdn config field
-	cacheSize := r.persistedOperationsConfig.Cache.Size.Uint64()
-	if cacheSize <= 0 {
-		cacheSize = r.cdnConfig.CacheSize.Uint64()
-	}
+	if pClient != nil {
+		// For backwards compatibility with cdn config field
+		cacheSize := r.persistedOperationsConfig.Cache.Size.Uint64()
+		if cacheSize <= 0 {
+			cacheSize = r.cdnConfig.CacheSize.Uint64()
+		}
 
-	c, err := persistedoperation.NewClient(&persistedoperation.Options{
-		CacheSize:      cacheSize,
-		Logger:         r.logger,
-		ProviderClient: pClient,
-	})
-	if err != nil {
-		return err
-	}
+		c, err := persistedoperation.NewClient(&persistedoperation.Options{
+			CacheSize:      cacheSize,
+			Logger:         r.logger,
+			ProviderClient: pClient,
+		})
+		if err != nil {
+			return err
+		}
 
-	r.persistedOperationClient = c
+		r.persistedOperationClient = c
+	}
 
 	var rClient routerconfig.Client
 


### PR DESCRIPTION
## Motivation and Context

In the new version of the router, panic happens in the `persistedoperation` package when a SIGINT signal is received.
