### PR TITLE
fix: don't propagate client content negotiation headers with wildcard

### DIFF
--- a/router/core/header_rule_engine.go
+++ b/router/core/header_rule_engine.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"slices"
 
 	"github.com/wundergraph/cosmo/router/pkg/config"
 
@@ -94,7 +95,7 @@ func (h HeaderRuleEngine) OnOriginRequest(request *http.Request, ctx RequestCont
 
 			if rule.Rename != "" && rule.Named != "" {
 				// Ignore the rule when the target header is in the ignored list
-				if contains(ignoredHeaders, rule.Rename) {
+				if slices.Contains(ignoredHeaders, rule.Rename) {
 					continue
 				}
 
@@ -117,7 +118,7 @@ func (h HeaderRuleEngine) OnOriginRequest(request *http.Request, ctx RequestCont
 			 */
 
 			if rule.Named != "" {
-				if contains(ignoredHeaders, rule.Named) {
+				if slices.Contains(ignoredHeaders, rule.Named) {
 					continue
 				}
 
@@ -146,7 +147,7 @@ func (h HeaderRuleEngine) OnOriginRequest(request *http.Request, ctx RequestCont
 						 */
 						if rule.Rename != "" && rule.Named == "" {
 
-							if contains(ignoredHeaders, rule.Rename) {
+							if slices.Contains(ignoredHeaders, rule.Rename) {
 								continue
 							}
 
@@ -165,7 +166,7 @@ func (h HeaderRuleEngine) OnOriginRequest(request *http.Request, ctx RequestCont
 						/**
 						 *	Propagate the header as is
 						 */
-						if contains(ignoredHeaders, name) {
+						if slices.Contains(ignoredHeaders, name) {
 							continue
 						}
 						request.Header.Set(name, ctx.Request().Header.Get(name))
@@ -176,15 +177,6 @@ func (h HeaderRuleEngine) OnOriginRequest(request *http.Request, ctx RequestCont
 	}
 
 	return request, nil
-}
-
-func contains(list []string, item string) bool {
-	for _, l := range list {
-		if l == item {
-			return true
-		}
-	}
-	return false
 }
 
 // SubgraphRules returns the list of header rules for the subgraph with the given name

--- a/router/core/header_rule_engine_test.go
+++ b/router/core/header_rule_engine_test.go
@@ -14,198 +14,307 @@ import (
 	"go.uber.org/zap"
 )
 
-func TestNamedPropagateHeaderRule(t *testing.T) {
+func TestPropagateHeaderRule(t *testing.T) {
 
-	ht, err := NewHeaderTransformer(config.HeaderRules{
-		All: config.GlobalHeaderRule{
-			Request: []config.RequestHeaderRule{
-				{
-					Operation: "propagate",
-					Named:     "X-Test-1",
+	t.Run("Should propagate with named header name / named", func(t *testing.T) {
+
+		ht, err := NewHeaderTransformer(config.HeaderRules{
+			All: config.GlobalHeaderRule{
+				Request: []config.RequestHeaderRule{
+					{
+						Operation: "propagate",
+						Named:     "X-Test-1",
+					},
 				},
 			},
-		},
+		})
+		assert.Nil(t, err)
+
+		rr := httptest.NewRecorder()
+
+		clientReq, err := http.NewRequest("POST", "http://localhost", nil)
+		require.NoError(t, err)
+		clientReq.Header.Set("X-Test-1", "test1")
+		clientReq.Header.Set("X-Test-2", "test2")
+
+		originReq, err := http.NewRequest("POST", "http://localhost", nil)
+		assert.Nil(t, err)
+
+		updatedClientReq, _ := ht.OnOriginRequest(originReq, &requestContext{
+			logger:           zap.NewNop(),
+			responseWriter:   rr,
+			request:          clientReq,
+			operation:        &operationContext{},
+			subgraphResolver: NewSubgraphResolver(nil),
+		})
+
+		assert.Len(t, updatedClientReq.Header, 1)
+		assert.Equal(t, "test1", updatedClientReq.Header.Get("X-Test-1"))
+		assert.Empty(t, updatedClientReq.Header.Get("X-Test-2"))
+
 	})
-	assert.Nil(t, err)
 
-	rr := httptest.NewRecorder()
-
-	clientReq, err := http.NewRequest("POST", "http://localhost", nil)
-	require.NoError(t, err)
-	clientReq.Header.Set("X-Test-1", "test1")
-	clientReq.Header.Set("X-Test-2", "test2")
-
-	originReq, err := http.NewRequest("POST", "http://localhost", nil)
-	assert.Nil(t, err)
-
-	updatedClientReq, _ := ht.OnOriginRequest(originReq, &requestContext{
-		logger:           zap.NewNop(),
-		responseWriter:   rr,
-		request:          clientReq,
-		operation:        &operationContext{},
-		subgraphResolver: NewSubgraphResolver(nil),
-	})
-
-	assert.Equal(t, "test1", updatedClientReq.Header.Get("X-Test-1"))
-	assert.Empty(t, updatedClientReq.Header.Get("X-Test-2"))
-}
-
-func TestReNamedPropagateHeaderRule(t *testing.T) {
-
-	ht, err := NewHeaderTransformer(config.HeaderRules{
-		All: config.GlobalHeaderRule{
-			Request: []config.RequestHeaderRule{
-				{
-					Operation: "propagate",
-					Named:     "X-Test-1",
-					Rename:    "X-Test-Renamed",
+	t.Run("Should propagate based on matching regex / matching", func(t *testing.T) {
+		ht, err := NewHeaderTransformer(config.HeaderRules{
+			All: config.GlobalHeaderRule{
+				Request: []config.RequestHeaderRule{
+					{
+						Operation: "propagate",
+						Matching:  "(?i)X-Test-.*",
+					},
 				},
 			},
-		},
+		})
+		assert.Nil(t, err)
+
+		rr := httptest.NewRecorder()
+
+		clientReq, err := http.NewRequest("POST", "http://localhost", nil)
+		require.NoError(t, err)
+		clientReq.Header.Set("X-Test-1", "test1")
+		clientReq.Header.Set("X-Test-2", "test2")
+		clientReq.Header.Set("Y-Test", "test3")
+
+		originReq, err := http.NewRequest("POST", "http://localhost", nil)
+		assert.Nil(t, err)
+
+		updatedClientReq, _ := ht.OnOriginRequest(originReq, &requestContext{
+			logger:           zap.NewNop(),
+			responseWriter:   rr,
+			request:          clientReq,
+			operation:        &operationContext{},
+			subgraphResolver: NewSubgraphResolver(nil),
+		})
+
+		assert.Len(t, updatedClientReq.Header, 2)
+		assert.Equal(t, "test1", updatedClientReq.Header.Get("X-Test-1"))
+		assert.Equal(t, "test2", updatedClientReq.Header.Get("X-Test-2"))
+		assert.Empty(t, updatedClientReq.Header.Get("Y-Test"))
 	})
-	assert.Nil(t, err)
 
-	rr := httptest.NewRecorder()
-
-	clientReq, err := http.NewRequest("POST", "http://localhost", nil)
-	require.NoError(t, err)
-	clientReq.Header.Set("X-Test-1", "test1")
-	clientReq.Header.Set("X-Test-2", "test2")
-
-	originReq, err := http.NewRequest("POST", "http://localhost", nil)
-	assert.Nil(t, err)
-
-	updatedClientReq, _ := ht.OnOriginRequest(originReq, &requestContext{
-		logger:           zap.NewNop(),
-		responseWriter:   rr,
-		request:          clientReq,
-		operation:        &operationContext{},
-		subgraphResolver: NewSubgraphResolver(nil),
-	})
-
-	assert.Equal(t, "test1", updatedClientReq.Header.Get("X-Test-Renamed"))
-	assert.Empty(t, updatedClientReq.Header.Get("X-Test-1"))
-	assert.Empty(t, updatedClientReq.Header.Get("X-Test-2"))
-}
-
-func TestReNamedMatchingPropagateHeaderRule(t *testing.T) {
-
-	ht, err := NewHeaderTransformer(config.HeaderRules{
-		All: config.GlobalHeaderRule{
-			Request: []config.RequestHeaderRule{
-				{
-					Operation: "propagate",
-					Matching:  "(?i)X-Test-.*",
-					Rename:    "X-Test-Renamed-1",
-				},
-				{
-					Operation: "propagate",
-					Matching:  "(?i)X-Test-Default-.*",
-					Rename:    "X-Test-Renamed-Default-2",
-					Default:   "default",
+	t.Run("Should propagate with default value / named + default", func(t *testing.T) {
+		ht, err := NewHeaderTransformer(config.HeaderRules{
+			All: config.GlobalHeaderRule{
+				Request: []config.RequestHeaderRule{
+					{
+						Operation: "propagate",
+						Named:     "X-Test-1",
+						Default:   "default",
+					},
 				},
 			},
-		},
+		})
+		assert.Nil(t, err)
+
+		rr := httptest.NewRecorder()
+
+		clientReq, err := http.NewRequest("POST", "http://localhost", nil)
+		require.NoError(t, err)
+
+		originReq, err := http.NewRequest("POST", "http://localhost", nil)
+		assert.Nil(t, err)
+
+		updatedClientReq, _ := ht.OnOriginRequest(originReq, &requestContext{
+			logger:           zap.NewNop(),
+			responseWriter:   rr,
+			request:          clientReq,
+			operation:        &operationContext{},
+			subgraphResolver: NewSubgraphResolver(nil),
+		})
+
+		assert.Len(t, updatedClientReq.Header, 1)
+		assert.Equal(t, "default", updatedClientReq.Header.Get("X-Test-1"))
 	})
-	assert.Nil(t, err)
 
-	rr := httptest.NewRecorder()
+	t.Run("Should not propagate as disallowed headers / named", func(t *testing.T) {
 
-	clientReq, err := http.NewRequest("POST", "http://localhost", nil)
-	require.NoError(t, err)
-	clientReq.Header.Set("X-Test-1", "test1")
-	clientReq.Header.Set("X-Test-Default-2", "")
+		rules := []config.RequestHeaderRule{
+			{
+				Operation: "propagate",
+				Named:     "X-Test-1",
+			},
+		}
 
-	originReq, err := http.NewRequest("POST", "http://localhost", nil)
-	assert.Nil(t, err)
+		for _, name := range ignoredHeaders {
+			rules = append(rules, config.RequestHeaderRule{
+				Operation: "propagate",
+				Named:     name,
+			})
+		}
 
-	updatedClientReq, _ := ht.OnOriginRequest(originReq, &requestContext{
-		logger:           zap.NewNop(),
-		responseWriter:   rr,
-		request:          clientReq,
-		operation:        &operationContext{},
-		subgraphResolver: NewSubgraphResolver(nil),
+		ht, err := NewHeaderTransformer(config.HeaderRules{
+			All: config.GlobalHeaderRule{
+				Request: rules,
+			},
+		})
+		assert.Nil(t, err)
+
+		rr := httptest.NewRecorder()
+
+		clientReq, err := http.NewRequest("POST", "http://localhost", nil)
+		require.NoError(t, err)
+		clientReq.Header.Set("X-Test-1", "test1")
+
+		for i, name := range ignoredHeaders {
+			clientReq.Header.Set(name, fmt.Sprintf("test-%d", i))
+		}
+
+		originReq, err := http.NewRequest("POST", "http://localhost", nil)
+		assert.Nil(t, err)
+
+		updatedClientReq, _ := ht.OnOriginRequest(originReq, &requestContext{
+			logger:           zap.NewNop(),
+			responseWriter:   rr,
+			request:          clientReq,
+			operation:        &operationContext{},
+			subgraphResolver: NewSubgraphResolver(nil),
+		})
+
+		assert.Len(t, updatedClientReq.Header, 1)
+		assert.Equal(t, "test1", updatedClientReq.Header.Get("X-Test-1"))
+
 	})
-
-	assert.Equal(t, "test1", updatedClientReq.Header.Get("X-Test-Renamed-1"))
-	assert.Equal(t, "default", updatedClientReq.Header.Get("X-Test-Renamed-Default-2"))
-	assert.Empty(t, updatedClientReq.Header.Get("X-Test-1"))
-	assert.Empty(t, updatedClientReq.Header.Get("X-Test-2"))
 }
 
-func TestRegexPropagateHeaderRule(t *testing.T) {
+func TestRenamePropagateHeaderRule(t *testing.T) {
 
-	ht, err := NewHeaderTransformer(config.HeaderRules{
-		All: config.GlobalHeaderRule{
-			Request: []config.RequestHeaderRule{
-				{
-					Operation: "propagate",
-					Matching:  "(?i)X-Test-.*",
+	t.Run("Rename header / named", func(t *testing.T) {
+
+		ht, err := NewHeaderTransformer(config.HeaderRules{
+			All: config.GlobalHeaderRule{
+				Request: []config.RequestHeaderRule{
+					{
+						Operation: "propagate",
+						Named:     "X-Test-1",
+						Rename:    "X-Test-Renamed",
+					},
 				},
 			},
-		},
+		})
+		assert.Nil(t, err)
+
+		rr := httptest.NewRecorder()
+
+		clientReq, err := http.NewRequest("POST", "http://localhost", nil)
+		require.NoError(t, err)
+		clientReq.Header.Set("X-Test-1", "test1")
+		clientReq.Header.Set("X-Test-2", "test2")
+
+		originReq, err := http.NewRequest("POST", "http://localhost", nil)
+		assert.Nil(t, err)
+
+		updatedClientReq, _ := ht.OnOriginRequest(originReq, &requestContext{
+			logger:           zap.NewNop(),
+			responseWriter:   rr,
+			request:          clientReq,
+			operation:        &operationContext{},
+			subgraphResolver: NewSubgraphResolver(nil),
+		})
+
+		assert.Len(t, updatedClientReq.Header, 1)
+		assert.Equal(t, "test1", updatedClientReq.Header.Get("X-Test-Renamed"))
+		assert.Empty(t, updatedClientReq.Header.Get("X-Test-1"))
+		assert.Empty(t, updatedClientReq.Header.Get("X-Test-2"))
 	})
-	assert.Nil(t, err)
 
-	rr := httptest.NewRecorder()
+	t.Run("Rename based on matching regex pattern / matching", func(t *testing.T) {
 
-	clientReq, err := http.NewRequest("POST", "http://localhost", nil)
-	require.NoError(t, err)
-	clientReq.Header.Set("X-Test-1", "test1")
-	clientReq.Header.Set("X-Test-2", "test2")
-	clientReq.Header.Set("Y-Test", "test3")
-
-	originReq, err := http.NewRequest("POST", "http://localhost", nil)
-	assert.Nil(t, err)
-
-	updatedClientReq, _ := ht.OnOriginRequest(originReq, &requestContext{
-		logger:           zap.NewNop(),
-		responseWriter:   rr,
-		request:          clientReq,
-		operation:        &operationContext{},
-		subgraphResolver: NewSubgraphResolver(nil),
-	})
-
-	assert.Equal(t, "test1", updatedClientReq.Header.Get("X-Test-1"))
-	assert.Equal(t, "test2", updatedClientReq.Header.Get("X-Test-2"))
-	assert.Empty(t, updatedClientReq.Header.Get("Y-Test"))
-}
-
-func TestNamedPropagateDefaultValue(t *testing.T) {
-
-	ht, err := NewHeaderTransformer(config.HeaderRules{
-		All: config.GlobalHeaderRule{
-			Request: []config.RequestHeaderRule{
-				{
-					Operation: "propagate",
-					Named:     "X-Test-1",
-					Default:   "default",
+		ht, err := NewHeaderTransformer(config.HeaderRules{
+			All: config.GlobalHeaderRule{
+				Request: []config.RequestHeaderRule{
+					{
+						Operation: "propagate",
+						Matching:  "(?i)X-Test-.*",
+						Rename:    "X-Test-Renamed-1",
+					},
+					{
+						Operation: "propagate",
+						Matching:  "(?i)X-Test-Default-.*",
+						Rename:    "X-Test-Renamed-Default-2",
+						Default:   "default",
+					},
 				},
 			},
-		},
+		})
+		assert.Nil(t, err)
+
+		rr := httptest.NewRecorder()
+
+		clientReq, err := http.NewRequest("POST", "http://localhost", nil)
+		require.NoError(t, err)
+		clientReq.Header.Set("X-Test-1", "test1")
+		clientReq.Header.Set("X-Test-Default-2", "")
+
+		originReq, err := http.NewRequest("POST", "http://localhost", nil)
+		assert.Nil(t, err)
+
+		updatedClientReq, _ := ht.OnOriginRequest(originReq, &requestContext{
+			logger:           zap.NewNop(),
+			responseWriter:   rr,
+			request:          clientReq,
+			operation:        &operationContext{},
+			subgraphResolver: NewSubgraphResolver(nil),
+		})
+
+		assert.Len(t, updatedClientReq.Header, 2)
+		assert.Equal(t, "test1", updatedClientReq.Header.Get("X-Test-Renamed-1"))
+		assert.Equal(t, "default", updatedClientReq.Header.Get("X-Test-Renamed-Default-2"))
+		assert.Empty(t, updatedClientReq.Header.Get("X-Test-1"))
+		assert.Empty(t, updatedClientReq.Header.Get("X-Test-2"))
 	})
-	assert.Nil(t, err)
 
-	rr := httptest.NewRecorder()
+	t.Run("Should not rename to disallowed headers / named", func(t *testing.T) {
 
-	clientReq, err := http.NewRequest("POST", "http://localhost", nil)
-	require.NoError(t, err)
+		rules := []config.RequestHeaderRule{
+			{
+				Operation: "propagate",
+				Named:     "X-Test-Old",
+				Rename:    "X-Test-Renamed",
+			},
+		}
 
-	originReq, err := http.NewRequest("POST", "http://localhost", nil)
-	assert.Nil(t, err)
+		for _, name := range ignoredHeaders {
+			rules = append(rules, config.RequestHeaderRule{
+				Operation: "propagate",
+				Named:     fmt.Sprintf("X-Test-%s", name),
+				Rename:    name,
+			})
+		}
 
-	updatedClientReq, _ := ht.OnOriginRequest(originReq, &requestContext{
-		logger:           zap.NewNop(),
-		responseWriter:   rr,
-		request:          clientReq,
-		operation:        &operationContext{},
-		subgraphResolver: NewSubgraphResolver(nil),
+		ht, err := NewHeaderTransformer(config.HeaderRules{
+			All: config.GlobalHeaderRule{
+				Request: rules,
+			},
+		})
+		assert.Nil(t, err)
+
+		rr := httptest.NewRecorder()
+
+		clientReq, err := http.NewRequest("POST", "http://localhost", nil)
+		require.NoError(t, err)
+		clientReq.Header.Set("X-Test-Old", "test1")
+
+		for i, name := range ignoredHeaders {
+			clientReq.Header.Set(fmt.Sprintf("X-Test-%s", name), fmt.Sprintf("X-Test-%d", i))
+		}
+
+		originReq, err := http.NewRequest("POST", "http://localhost", nil)
+		assert.Nil(t, err)
+
+		updatedClientReq, _ := ht.OnOriginRequest(originReq, &requestContext{
+			logger:           zap.NewNop(),
+			responseWriter:   rr,
+			request:          clientReq,
+			operation:        &operationContext{},
+			subgraphResolver: NewSubgraphResolver(nil),
+		})
+
+		assert.Len(t, updatedClientReq.Header, 1)
+		assert.Equal(t, "test1", updatedClientReq.Header.Get("X-Test-Renamed"))
 	})
-
-	assert.Equal(t, "default", updatedClientReq.Header.Get("X-Test-1"))
 }
 
-func TestSkipHopHeadersRegex(t *testing.T) {
+func TestSkipAllIgnoredHeaders(t *testing.T) {
 
 	ht, err := NewHeaderTransformer(config.HeaderRules{
 		All: config.GlobalHeaderRule{
@@ -225,7 +334,7 @@ func TestSkipHopHeadersRegex(t *testing.T) {
 	require.NoError(t, err)
 	clientReq.Header.Set("X-Test-1", "test1")
 
-	for i, header := range hopHeaders {
+	for i, header := range ignoredHeaders {
 		clientReq.Header.Set(header, fmt.Sprintf("test-%d", i))
 	}
 
@@ -240,12 +349,491 @@ func TestSkipHopHeadersRegex(t *testing.T) {
 		subgraphResolver: NewSubgraphResolver(nil),
 	})
 
-	for _, header := range hopHeaders {
+	for _, header := range ignoredHeaders {
 		assert.Empty(t, updatedClientReq.Header.Get(header), fmt.Sprintf("header %s should be empty", header))
 	}
 
 	assert.Equal(t, "test1", updatedClientReq.Header.Get("X-Test-1"))
 
+}
+
+func TestSubgraphPropagateHeaderRule(t *testing.T) {
+
+	t.Run("Should propagate set header / named", func(t *testing.T) {
+
+		ht, err := NewHeaderTransformer(config.HeaderRules{
+			Subgraphs: map[string]config.GlobalHeaderRule{
+				"subgraph-1": {
+					Request: []config.RequestHeaderRule{
+						{
+							Operation: "propagate",
+							Named:     "X-Test-Subgraph",
+						},
+					},
+				},
+			},
+		})
+		assert.Nil(t, err)
+
+		rr := httptest.NewRecorder()
+
+		clientReq, err := http.NewRequest("POST", "http://localhost", nil)
+		require.NoError(t, err)
+		clientReq.Header.Set("X-Test-Subgraph", "Test-Value")
+
+		sg1Url, _ := url.Parse("http://subgraph-1.local")
+
+		subgraphResolver := NewSubgraphResolver([]Subgraph{
+			{
+				Name:      "subgraph-1",
+				Id:        "subgraph-1",
+				Url:       sg1Url,
+				UrlString: sg1Url.String(),
+			},
+		})
+
+		ctx := &requestContext{
+			logger:           zap.NewNop(),
+			responseWriter:   rr,
+			request:          clientReq,
+			operation:        &operationContext{},
+			subgraphResolver: subgraphResolver,
+		}
+
+		originReq1, err := http.NewRequest("POST", "http://subgraph-1.local", nil)
+		assert.Nil(t, err)
+		updatedClientReq1, _ := ht.OnOriginRequest(originReq1, ctx)
+
+		assert.Len(t, updatedClientReq1.Header, 1)
+		assert.Equal(t, "Test-Value", updatedClientReq1.Header.Get("X-Test-Subgraph"))
+		assert.Empty(t, updatedClientReq1.Header.Get("Test-Value"))
+	})
+
+	t.Run("Should propagate set header / matching", func(t *testing.T) {
+		ht, err := NewHeaderTransformer(config.HeaderRules{
+			Subgraphs: map[string]config.GlobalHeaderRule{
+				"subgraph-1": {
+					Request: []config.RequestHeaderRule{
+						{
+							Operation: "propagate",
+							Matching:  "(?i)X-Test-.*",
+						},
+					},
+				},
+			},
+		})
+		assert.Nil(t, err)
+
+		rr := httptest.NewRecorder()
+
+		clientReq, err := http.NewRequest("POST", "http://localhost", nil)
+		require.NoError(t, err)
+		clientReq.Header.Set("X-Test-Subgraph", "Test-Value")
+
+		sg1Url, _ := url.Parse("http://subgraph-1.local")
+
+		subgraphResolver := NewSubgraphResolver([]Subgraph{
+			{
+				Name:      "subgraph-1",
+				Id:        "subgraph-1",
+				Url:       sg1Url,
+				UrlString: sg1Url.String(),
+			},
+		})
+
+		ctx := &requestContext{
+			logger:           zap.NewNop(),
+			responseWriter:   rr,
+			request:          clientReq,
+			operation:        &operationContext{},
+			subgraphResolver: subgraphResolver,
+		}
+
+		originReq1, err := http.NewRequest("POST", "http://subgraph-1.local", nil)
+		assert.Nil(t, err)
+		updatedClientReq1, _ := ht.OnOriginRequest(originReq1, ctx)
+
+		assert.Equal(t, "Test-Value", updatedClientReq1.Header.Get("X-Test-Subgraph"))
+		assert.Empty(t, updatedClientReq1.Header.Get("Test-Value"))
+	})
+
+	t.Run("Should not propagate disallowed header / named", func(t *testing.T) {
+		rules := []config.RequestHeaderRule{
+			{
+				Operation: "propagate",
+				Named:     "X-Test-Subgraph",
+			},
+		}
+
+		for _, name := range ignoredHeaders {
+			rules = append(rules, config.RequestHeaderRule{
+				Operation: "propagate",
+				Named:     name,
+			})
+		}
+
+		ht, err := NewHeaderTransformer(config.HeaderRules{
+			Subgraphs: map[string]config.GlobalHeaderRule{
+				"subgraph-1": {
+					Request: rules,
+				},
+			},
+		})
+		assert.Nil(t, err)
+
+		rr := httptest.NewRecorder()
+
+		clientReq, err := http.NewRequest("POST", "http://localhost", nil)
+		require.NoError(t, err)
+		clientReq.Header.Set("X-Test-Subgraph", "Test-Value")
+
+		for i, name := range ignoredHeaders {
+			clientReq.Header.Set(name, fmt.Sprintf("X-Test-%d", i))
+		}
+
+		sg1Url, _ := url.Parse("http://subgraph-1.local")
+
+		subgraphResolver := NewSubgraphResolver([]Subgraph{
+			{
+				Name:      "subgraph-1",
+				Id:        "subgraph-1",
+				Url:       sg1Url,
+				UrlString: sg1Url.String(),
+			},
+		})
+
+		ctx := &requestContext{
+			logger:           zap.NewNop(),
+			responseWriter:   rr,
+			request:          clientReq,
+			operation:        &operationContext{},
+			subgraphResolver: subgraphResolver,
+		}
+
+		originReq1, err := http.NewRequest("POST", "http://subgraph-1.local", nil)
+		assert.Nil(t, err)
+		updatedClientReq1, _ := ht.OnOriginRequest(originReq1, ctx)
+
+		assert.Len(t, updatedClientReq1.Header, 1)
+		assert.Equal(t, "Test-Value", updatedClientReq1.Header.Get("X-Test-Subgraph"))
+		assert.Empty(t, updatedClientReq1.Header.Get("Test-Value"))
+	})
+
+	t.Run("Should not propagate disallowed headers / matching", func(t *testing.T) {
+
+		rules := []config.RequestHeaderRule{
+			{
+				Operation: "propagate",
+				Matching:  ".*",
+			},
+		}
+
+		for _, name := range ignoredHeaders {
+			rules = append(rules, config.RequestHeaderRule{
+				Operation: "propagate",
+				Named:     fmt.Sprintf("X-Test-%s", name),
+				Rename:    name,
+			})
+		}
+
+		ht, err := NewHeaderTransformer(config.HeaderRules{
+			Subgraphs: map[string]config.GlobalHeaderRule{
+				"subgraph-1": {
+					Request: rules,
+				},
+			},
+		})
+		assert.Nil(t, err)
+
+		rr := httptest.NewRecorder()
+
+		clientReq, err := http.NewRequest("POST", "http://localhost", nil)
+		require.NoError(t, err)
+		clientReq.Header.Set("X-Test-Subgraph", "Test-Value")
+
+		for i, name := range ignoredHeaders {
+			clientReq.Header.Set(name, fmt.Sprintf("X-Test-%d", i))
+		}
+
+		sg1Url, _ := url.Parse("http://subgraph-1.local")
+
+		subgraphResolver := NewSubgraphResolver([]Subgraph{
+			{
+				Name:      "subgraph-1",
+				Id:        "subgraph-1",
+				Url:       sg1Url,
+				UrlString: sg1Url.String(),
+			},
+		})
+
+		ctx := &requestContext{
+			logger:           zap.NewNop(),
+			responseWriter:   rr,
+			request:          clientReq,
+			operation:        &operationContext{},
+			subgraphResolver: subgraphResolver,
+		}
+
+		originReq1, err := http.NewRequest("POST", "http://subgraph-1.local", nil)
+		assert.Nil(t, err)
+		updatedClientReq1, _ := ht.OnOriginRequest(originReq1, ctx)
+
+		assert.Len(t, updatedClientReq1.Header, 1)
+		assert.Equal(t, "Test-Value", updatedClientReq1.Header.Get("X-Test-Subgraph"))
+		assert.Empty(t, updatedClientReq1.Header.Get("Test-Value"))
+	})
+
+}
+
+func TestSubgraphRenamePropagateHeaderRule(t *testing.T) {
+
+	t.Run("Should rename header / named", func(t *testing.T) {
+		ht, err := NewHeaderTransformer(config.HeaderRules{
+			Subgraphs: map[string]config.GlobalHeaderRule{
+				"subgraph-1": {
+					Request: []config.RequestHeaderRule{
+						{
+							Operation: "propagate",
+							Named:     "X-Test-Subgraph",
+							Rename:    "X-Test-Subgraph-Renamed",
+						},
+					},
+				},
+			},
+		})
+		assert.Nil(t, err)
+
+		rr := httptest.NewRecorder()
+
+		clientReq, err := http.NewRequest("POST", "http://localhost", nil)
+		require.NoError(t, err)
+		clientReq.Header.Set("X-Test-Subgraph", "Test-Value")
+
+		sg1Url, _ := url.Parse("http://subgraph-1.local")
+
+		subgraphResolver := NewSubgraphResolver([]Subgraph{
+			{
+				Name:      "subgraph-1",
+				Id:        "subgraph-1",
+				Url:       sg1Url,
+				UrlString: sg1Url.String(),
+			},
+		})
+
+		ctx := &requestContext{
+			logger:           zap.NewNop(),
+			responseWriter:   rr,
+			request:          clientReq,
+			operation:        &operationContext{},
+			subgraphResolver: subgraphResolver,
+		}
+
+		originReq1, err := http.NewRequest("POST", "http://subgraph-1.local", nil)
+		assert.Nil(t, err)
+		updatedClientReq1, _ := ht.OnOriginRequest(originReq1, ctx)
+
+		assert.Equal(t, "Test-Value", updatedClientReq1.Header.Get("X-Test-Subgraph-Renamed"))
+		assert.Empty(t, updatedClientReq1.Header.Get("X-Test-Subgraph"))
+	})
+
+	t.Run("Should fallback to default value when header value is not set / named", func(t *testing.T) {
+		ht, err := NewHeaderTransformer(config.HeaderRules{
+			Subgraphs: map[string]config.GlobalHeaderRule{
+				"subgraph-1": {
+					Request: []config.RequestHeaderRule{
+						{
+							Operation: "propagate",
+							Rename:    "X-Test-Subgraph-Renamed-2",
+							Named:     "X-Test-Subgraph-2",
+							Default:   "Test-Value-Default-2",
+						},
+					},
+				},
+			},
+		})
+		assert.Nil(t, err)
+
+		rr := httptest.NewRecorder()
+
+		clientReq, err := http.NewRequest("POST", "http://localhost", nil)
+		require.NoError(t, err)
+		clientReq.Header.Set("X-Test-Subgraph-2", "")
+
+		sg1Url, _ := url.Parse("http://subgraph-1.local")
+
+		subgraphResolver := NewSubgraphResolver([]Subgraph{
+			{
+				Name:      "subgraph-1",
+				Id:        "subgraph-1",
+				Url:       sg1Url,
+				UrlString: sg1Url.String(),
+			},
+		})
+
+		ctx := &requestContext{
+			logger:           zap.NewNop(),
+			responseWriter:   rr,
+			request:          clientReq,
+			operation:        &operationContext{},
+			subgraphResolver: subgraphResolver,
+		}
+
+		originReq1, err := http.NewRequest("POST", "http://subgraph-1.local", nil)
+		assert.Nil(t, err)
+		updatedClientReq1, _ := ht.OnOriginRequest(originReq1, ctx)
+
+		assert.Equal(t, "Test-Value-Default-2", updatedClientReq1.Header.Get("X-Test-Subgraph-Renamed-2"))
+		assert.Empty(t, updatedClientReq1.Header.Get("X-Test-Subgraph"))
+	})
+
+	t.Run("Should rename header and don't fallback to default value when header is set / named", func(t *testing.T) {
+		ht, err := NewHeaderTransformer(config.HeaderRules{
+			Subgraphs: map[string]config.GlobalHeaderRule{
+				"subgraph-1": {
+					Request: []config.RequestHeaderRule{
+						{
+							Operation: "propagate",
+							Rename:    "X-Test-Subgraph-Renamed",
+							Named:     "X-Test-Subgraph",
+							Default:   "Test-Value-Default",
+						},
+					},
+				},
+			},
+		})
+		assert.Nil(t, err)
+
+		rr := httptest.NewRecorder()
+
+		clientReq, err := http.NewRequest("POST", "http://localhost", nil)
+		require.NoError(t, err)
+		clientReq.Header.Set("X-Test-Subgraph", "Test-Value")
+
+		sg1Url, _ := url.Parse("http://subgraph-1.local")
+
+		subgraphResolver := NewSubgraphResolver([]Subgraph{
+			{
+				Name:      "subgraph-1",
+				Id:        "subgraph-1",
+				Url:       sg1Url,
+				UrlString: sg1Url.String(),
+			},
+		})
+
+		ctx := &requestContext{
+			logger:           zap.NewNop(),
+			responseWriter:   rr,
+			request:          clientReq,
+			operation:        &operationContext{},
+			subgraphResolver: subgraphResolver,
+		}
+
+		originReq1, err := http.NewRequest("POST", "http://subgraph-1.local", nil)
+		assert.Nil(t, err)
+		updatedClientReq1, _ := ht.OnOriginRequest(originReq1, ctx)
+
+		assert.Equal(t, "Test-Value", updatedClientReq1.Header.Get("X-Test-Subgraph-Renamed"))
+		assert.Empty(t, updatedClientReq1.Header.Get("X-Test-Subgraph"))
+	})
+
+	t.Run("Should rename headers based / matching rule", func(t *testing.T) {
+		ht, err := NewHeaderTransformer(config.HeaderRules{
+			Subgraphs: map[string]config.GlobalHeaderRule{
+				"subgraph-1": {
+					Request: []config.RequestHeaderRule{
+						{
+							Operation: "propagate",
+							Rename:    "X-Test-Subgraph-Renamed",
+							Matching:  "(?i)X-Test-.*",
+						},
+					},
+				},
+			},
+		})
+		assert.Nil(t, err)
+
+		rr := httptest.NewRecorder()
+
+		clientReq, err := http.NewRequest("POST", "http://localhost", nil)
+		require.NoError(t, err)
+		clientReq.Header.Set("X-Test-Subgraph", "Test-Value")
+
+		sg1Url, _ := url.Parse("http://subgraph-1.local")
+
+		subgraphResolver := NewSubgraphResolver([]Subgraph{
+			{
+				Name:      "subgraph-1",
+				Id:        "subgraph-1",
+				Url:       sg1Url,
+				UrlString: sg1Url.String(),
+			},
+		})
+
+		ctx := &requestContext{
+			logger:           zap.NewNop(),
+			responseWriter:   rr,
+			request:          clientReq,
+			operation:        &operationContext{},
+			subgraphResolver: subgraphResolver,
+		}
+
+		originReq1, err := http.NewRequest("POST", "http://subgraph-1.local", nil)
+		assert.Nil(t, err)
+		updatedClientReq1, _ := ht.OnOriginRequest(originReq1, ctx)
+
+		assert.Equal(t, "Test-Value", updatedClientReq1.Header.Get("X-Test-Subgraph-Renamed"))
+		assert.Empty(t, updatedClientReq1.Header.Get("X-Test-Subgraph"))
+	})
+
+	t.Run("Should rename headers and fallback to default value when header value is not set / matching rule", func(t *testing.T) {
+		ht, err := NewHeaderTransformer(config.HeaderRules{
+			Subgraphs: map[string]config.GlobalHeaderRule{
+				"subgraph-1": {
+					Request: []config.RequestHeaderRule{
+						{
+							Operation: "propagate",
+							Rename:    "X-Test-Subgraph-Default-Renamed",
+							Matching:  "(?i)X-Test-Default.*",
+							Default:   "Default",
+						},
+					},
+				},
+			},
+		})
+		assert.Nil(t, err)
+
+		rr := httptest.NewRecorder()
+
+		clientReq, err := http.NewRequest("POST", "http://localhost", nil)
+		require.NoError(t, err)
+		clientReq.Header.Set("X-Test-Default-Subgraph", "")
+
+		sg1Url, _ := url.Parse("http://subgraph-1.local")
+
+		subgraphResolver := NewSubgraphResolver([]Subgraph{
+			{
+				Name:      "subgraph-1",
+				Id:        "subgraph-1",
+				Url:       sg1Url,
+				UrlString: sg1Url.String(),
+			},
+		})
+
+		ctx := &requestContext{
+			logger:           zap.NewNop(),
+			responseWriter:   rr,
+			request:          clientReq,
+			operation:        &operationContext{},
+			subgraphResolver: subgraphResolver,
+		}
+
+		originReq1, err := http.NewRequest("POST", "http://subgraph-1.local", nil)
+		assert.Nil(t, err)
+		updatedClientReq1, _ := ht.OnOriginRequest(originReq1, ctx)
+
+		assert.Equal(t, "Default", updatedClientReq1.Header.Get("X-Test-Subgraph-Default-Renamed"))
+		assert.Empty(t, updatedClientReq1.Header.Get("X-Test-Default-Subgraph"))
+	})
 }
 
 func TestInvalidRegex(t *testing.T) {
@@ -261,243 +849,4 @@ func TestInvalidRegex(t *testing.T) {
 		},
 	})
 	assert.Error(t, err)
-}
-
-func TestSubgraphNamedHeaderRule(t *testing.T) {
-	ht, err := NewHeaderTransformer(config.HeaderRules{
-		Subgraphs: map[string]config.GlobalHeaderRule{
-			"subgraph-1": {
-				Request: []config.RequestHeaderRule{
-					{
-						Operation: "propagate",
-						Named:     "X-Test-Subgraph-1",
-						Default:   "Test-Value-1",
-					},
-				},
-			},
-			"subgraph-2": {
-				Request: []config.RequestHeaderRule{
-					{
-						Operation: "propagate",
-						Named:     "X-Test-Subgraph-2",
-					},
-				},
-			},
-		},
-	})
-	assert.Nil(t, err)
-
-	rr := httptest.NewRecorder()
-
-	clientReq, err := http.NewRequest("POST", "http://localhost", nil)
-	require.NoError(t, err)
-	clientReq.Header.Set("X-Test-Subgraph-2", "Test-Value-2")
-
-	sg1Url, _ := url.Parse("http://subgraph-1.local")
-	sg2Url, _ := url.Parse("http://subgraph-2.local")
-
-	subgraphResolver := NewSubgraphResolver([]Subgraph{
-		{
-			Name:      "subgraph-1",
-			Id:        "subgraph-1",
-			Url:       sg1Url,
-			UrlString: sg1Url.String(),
-		},
-		{
-			Name:      "subgraph-2",
-			Id:        "subgraph-2",
-			Url:       sg2Url,
-			UrlString: sg2Url.String(),
-		},
-	})
-
-	ctx := &requestContext{
-		logger:           zap.NewNop(),
-		responseWriter:   rr,
-		request:          clientReq,
-		operation:        &operationContext{},
-		subgraphResolver: subgraphResolver,
-	}
-
-	originReq1, err := http.NewRequest("POST", "http://subgraph-1.local", nil)
-	assert.Nil(t, err)
-	updatedClientReq1, _ := ht.OnOriginRequest(originReq1, ctx)
-
-	assert.Equal(t, "Test-Value-1", updatedClientReq1.Header.Get("X-Test-Subgraph-1"))
-	assert.Empty(t, updatedClientReq1.Header.Get("X-Test-Subgraph-2"))
-
-	originReq2, err := http.NewRequest("POST", "http://subgraph-2.local", nil)
-	assert.Nil(t, err)
-	updatedClientReq2, _ := ht.OnOriginRequest(originReq2, ctx)
-
-	assert.Empty(t, updatedClientReq2.Header.Get("X-Test-Subgraph-1"))
-	assert.Equal(t, "Test-Value-2", updatedClientReq2.Header.Get("X-Test-Subgraph-2"))
-}
-
-func TestSubgraphRenameNamedHeaderRule(t *testing.T) {
-	ht, err := NewHeaderTransformer(config.HeaderRules{
-		Subgraphs: map[string]config.GlobalHeaderRule{
-			"subgraph-1": {
-				Request: []config.RequestHeaderRule{
-					{
-						Operation: "propagate",
-						Named:     "X-Test-Subgraph",
-						Rename:    "X-Test-Subgraph-Renamed",
-					},
-				},
-			},
-		},
-	})
-	assert.Nil(t, err)
-
-	rr := httptest.NewRecorder()
-
-	clientReq, err := http.NewRequest("POST", "http://localhost", nil)
-	require.NoError(t, err)
-	clientReq.Header.Set("X-Test-Subgraph", "Test-Value")
-
-	sg1Url, _ := url.Parse("http://subgraph-1.local")
-
-	subgraphResolver := NewSubgraphResolver([]Subgraph{
-		{
-			Name:      "subgraph-1",
-			Id:        "subgraph-1",
-			Url:       sg1Url,
-			UrlString: sg1Url.String(),
-		},
-	})
-
-	ctx := &requestContext{
-		logger:           zap.NewNop(),
-		responseWriter:   rr,
-		request:          clientReq,
-		operation:        &operationContext{},
-		subgraphResolver: subgraphResolver,
-	}
-
-	originReq1, err := http.NewRequest("POST", "http://subgraph-1.local", nil)
-	assert.Nil(t, err)
-	updatedClientReq1, _ := ht.OnOriginRequest(originReq1, ctx)
-
-	assert.Equal(t, "Test-Value", updatedClientReq1.Header.Get("X-Test-Subgraph-Renamed"))
-	assert.Empty(t, updatedClientReq1.Header.Get("X-Test-Subgraph"))
-
-}
-
-func TestSubgraphRenameWithDefaultHeaderRule(t *testing.T) {
-	ht, err := NewHeaderTransformer(config.HeaderRules{
-		Subgraphs: map[string]config.GlobalHeaderRule{
-			"subgraph-1": {
-				Request: []config.RequestHeaderRule{
-					{
-						Operation: "propagate",
-						Rename:    "X-Test-Subgraph-Renamed",
-						Named:     "X-Test-Subgraph",
-						Default:   "Test-Value-Default",
-					},
-					{
-						Operation: "propagate",
-						Rename:    "X-Test-Subgraph-Renamed-2",
-						Named:     "X-Test-Subgraph-2",
-						Default:   "Test-Value-Default-2",
-					},
-				},
-			},
-		},
-	})
-	assert.Nil(t, err)
-
-	rr := httptest.NewRecorder()
-
-	clientReq, err := http.NewRequest("POST", "http://localhost", nil)
-	require.NoError(t, err)
-	clientReq.Header.Set("X-Test-Subgraph", "Test-Value")
-	clientReq.Header.Set("X-Test-Subgraph-2", "")
-
-	sg1Url, _ := url.Parse("http://subgraph-1.local")
-
-	subgraphResolver := NewSubgraphResolver([]Subgraph{
-		{
-			Name:      "subgraph-1",
-			Id:        "subgraph-1",
-			Url:       sg1Url,
-			UrlString: sg1Url.String(),
-		},
-	})
-
-	ctx := &requestContext{
-		logger:           zap.NewNop(),
-		responseWriter:   rr,
-		request:          clientReq,
-		operation:        &operationContext{},
-		subgraphResolver: subgraphResolver,
-	}
-
-	originReq1, err := http.NewRequest("POST", "http://subgraph-1.local", nil)
-	assert.Nil(t, err)
-	updatedClientReq1, _ := ht.OnOriginRequest(originReq1, ctx)
-
-	assert.Equal(t, "Test-Value", updatedClientReq1.Header.Get("X-Test-Subgraph-Renamed"))
-	assert.Equal(t, "Test-Value-Default-2", updatedClientReq1.Header.Get("X-Test-Subgraph-Renamed-2"))
-	assert.Empty(t, updatedClientReq1.Header.Get("X-Test-Subgraph"))
-
-}
-
-func TestSubgraphRenameMatchedHeaderRule(t *testing.T) {
-	ht, err := NewHeaderTransformer(config.HeaderRules{
-		Subgraphs: map[string]config.GlobalHeaderRule{
-			"subgraph-1": {
-				Request: []config.RequestHeaderRule{
-					{
-						Operation: "propagate",
-						Rename:    "X-Test-Subgraph-Renamed",
-						Matching:  "(?i)X-Test-.*",
-					},
-					{
-						Operation: "propagate",
-						Rename:    "X-Test-Subgraph-Default-Renamed",
-						Matching:  "(?i)X-Test-Default.*",
-						Default:   "Default",
-					},
-				},
-			},
-		},
-	})
-	assert.Nil(t, err)
-
-	rr := httptest.NewRecorder()
-
-	clientReq, err := http.NewRequest("POST", "http://localhost", nil)
-	require.NoError(t, err)
-	clientReq.Header.Set("X-Test-Subgraph", "Test-Value")
-	clientReq.Header.Set("X-Test-Default-Subgraph", "")
-
-	sg1Url, _ := url.Parse("http://subgraph-1.local")
-
-	subgraphResolver := NewSubgraphResolver([]Subgraph{
-		{
-			Name:      "subgraph-1",
-			Id:        "subgraph-1",
-			Url:       sg1Url,
-			UrlString: sg1Url.String(),
-		},
-	})
-
-	ctx := &requestContext{
-		logger:           zap.NewNop(),
-		responseWriter:   rr,
-		request:          clientReq,
-		operation:        &operationContext{},
-		subgraphResolver: subgraphResolver,
-	}
-
-	originReq1, err := http.NewRequest("POST", "http://subgraph-1.local", nil)
-	assert.Nil(t, err)
-	updatedClientReq1, _ := ht.OnOriginRequest(originReq1, ctx)
-
-	assert.Equal(t, "Test-Value", updatedClientReq1.Header.Get("X-Test-Subgraph-Renamed"))
-	assert.Equal(t, "Default", updatedClientReq1.Header.Get("X-Test-Subgraph-Default-Renamed"))
-	assert.Empty(t, updatedClientReq1.Header.Get("X-Test-Subgraph"))
-	assert.Empty(t, updatedClientReq1.Header.Get("X-Test-Default-Subgraph"))
-
 }


### PR DESCRIPTION


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->

## Motivation and Context

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

## TODO

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
