### PR TITLE
fix: disabled state of feature flag overview page

### DIFF
--- a/studio/src/components/feature-flag-details.tsx
+++ b/studio/src/components/feature-flag-details.tsx
@@ -25,9 +25,11 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 const FeatureFlagOverview = ({
   federatedGraphs,
   featureSubgraphs,
+  isEnabled,
 }: {
   federatedGraphs: { federatedGraph: FederatedGraph; isConnected: boolean }[];
   featureSubgraphs: Subgraph[];
+  isEnabled: boolean;
 }) => {
   const router = useRouter();
   const slug = router.query.slug as string;
@@ -60,6 +62,24 @@ const FeatureFlagOverview = ({
                 command: `npx wgc feature-flag update <feature-flag-name> --namespace ${router.query.namespace} --feature-subgraphs <featureSubgraphs...>`,
               },
             ]}
+          />
+        }
+      />
+    );
+  } else if (!isEnabled) {
+    content = (
+      <EmptyState
+        icon={<ExclamationTriangleIcon className="text-red-500" />}
+        title="Feature flag is not used for composition."
+        description={
+          <>
+            Feature flag is disabled. To enable the feature flag, use the below
+            command.
+          </>
+        }
+        actions={
+          <CLI
+            command={`npx wgc feature-flag enable <feature-flag-name> --namespace <namespace>`}
           />
         }
       />
@@ -188,7 +208,9 @@ export const FeatureFlagDetails = ({
           </div>
           <div className="flex-start flex max-w-[250px] flex-1 flex-col gap-2 ">
             <dt className="text-sm text-muted-foreground">Created By</dt>
-            <dd className="whitespace-nowrap text-sm">{createdBy || "unknown user"}</dd>
+            <dd className="whitespace-nowrap text-sm">
+              {createdBy || "unknown user"}
+            </dd>
           </div>
           <div className="flex-start flex max-w-[250px] flex-1 flex-col gap-2 ">
             <dt className="text-sm text-muted-foreground">Created At</dt>
@@ -289,6 +311,7 @@ export const FeatureFlagDetails = ({
                   <FeatureFlagOverview
                     featureSubgraphs={featureSubgraphs}
                     federatedGraphs={federatedGraphs}
+                    isEnabled={isEnabled}
                   />
                 </TabsContent>
               )}


### PR DESCRIPTION
## TODO

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [x] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)

<img width="1722" alt="image" src="https://github.com/user-attachments/assets/2b880b25-ee49-40f1-9753-08687a49be56">
