### PR TITLE
fix: dont scope schema usage to single schema version

### DIFF
--- a/controlplane/src/core/bufservices/PlatformService.ts
+++ b/controlplane/src/core/bufservices/PlatformService.ts
@@ -9777,7 +9777,6 @@ export default function (opts: RouterOptions): Partial<ServiceImpl<typeof Platfo
         logger = enrichLogger(ctx, logger, authContext);
 
         const federatedGraphRepo = new FederatedGraphRepository(logger, opts.db, authContext.organizationId);
-        const featureFlagRepo = new FeatureFlagRepository(logger, opts.db, authContext.organizationId);
         const namespaceRepo = new NamespaceRepository(opts.db, authContext.organizationId);
 
         if (!opts.chClient) {

--- a/controlplane/src/core/bufservices/PlatformService.ts
+++ b/controlplane/src/core/bufservices/PlatformService.ts
@@ -9825,51 +9825,11 @@ export default function (opts: RouterOptions): Partial<ServiceImpl<typeof Platfo
           };
         }
 
-        let routerConfigVersion = graph.composedSchemaVersionId;
-        if (req.featureFlagName) {
-          const featureFlag = await featureFlagRepo.getFeatureFlagByName({
-            featureFlagName: req.featureFlagName,
-            namespaceId: namespace.id,
-          });
-
-          if (!featureFlag) {
-            return {
-              response: {
-                code: EnumStatusCode.ERR_NOT_FOUND,
-                details: `Feature flag '${req.featureFlagName}' not found`,
-              },
-              clients: [],
-              requestSeries: [],
-            };
-          }
-
-          if (routerConfigVersion) {
-            const ffSchemaVersion = await featureFlagRepo.getFeatureFlagSchemaVersionByBaseSchemaVersion({
-              baseSchemaVersionId: routerConfigVersion,
-              featureFlagId: featureFlag.id,
-            });
-
-            if (!ffSchemaVersion) {
-              return {
-                response: {
-                  code: EnumStatusCode.ERR_NOT_FOUND,
-                  details: `Feature flag '${req.featureFlagName}' isnt part of the latest composition.`,
-                },
-                clients: [],
-                requestSeries: [],
-              };
-            }
-            routerConfigVersion = ffSchemaVersion.schemaVersionId;
-          }
-        }
-
         const { clients, requestSeries, meta } = await usageRepo.getFieldUsage({
           federatedGraphId: graph.id,
           organizationId: authContext.organizationId,
           typename: req.typename,
           field: req.field,
-          // In the schema UI we only show the latest valid version which represents the composed schema
-          routerConfigVersion,
           namedType: req.namedType,
           range: req.range,
           dateRange: dr,

--- a/controlplane/src/core/repositories/analytics/UsageRepository.ts
+++ b/controlplane/src/core/repositories/analytics/UsageRepository.ts
@@ -145,9 +145,6 @@ export class UsageRepository {
     if (input.namedType) {
       whereSql += ` AND NamedType = '${input.namedType}'`;
     }
-    if (input.routerConfigVersion) {
-      whereSql += ` AND RouterConfigVersion = '${input.routerConfigVersion}'`;
-    }
 
     const [requestSeries, clients, meta] = await Promise.all([
       this.getUsageRequestSeries(whereSql, timeFilters),

--- a/controlplane/src/core/repositories/analytics/UsageRepository.ts
+++ b/controlplane/src/core/repositories/analytics/UsageRepository.ts
@@ -129,7 +129,6 @@ export class UsageRepository {
     namedType?: string;
     range?: number;
     dateRange?: DateRange;
-    routerConfigVersion?: string;
     organizationId: string;
     federatedGraphId: string;
   }) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->

## Motivation and Context

We have scoped schema usage always to a specific schema version. This resulted in the condition that after a schema change the usage has been reset. Types and fields can vary over versions but if we find usage it is valid across them.

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

## TODO

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
