### PR TITLE
fix: delete federated graph audit in deleteNamespace

### DIFF
--- a/controlplane/src/core/bufservices/PlatformService.ts
+++ b/controlplane/src/core/bufservices/PlatformService.ts
@@ -386,7 +386,7 @@ export default function (opts: RouterOptions): Partial<ServiceImpl<typeof Platfo
 
             await auditLogRepo.addAuditLog({
               organizationId: authContext.organizationId,
-              auditAction: 'federated_graph.created',
+              auditAction: 'federated_graph.deleted',
               action: 'deleted',
               actorId: authContext.userId,
               auditableType: 'federated_graph',


### PR DESCRIPTION
## TODO

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [x] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
