### PR TITLE
feat: implement set header

### DIFF
--- a/router-tests/header_propagation_test.go
+++ b/router-tests/header_propagation_test.go
@@ -1,18 +1,17 @@
 package integration
 
 import (
-	"net/http"
-	"strings"
-	"testing"
-	"time"
-
 	"github.com/stretchr/testify/require"
 	"github.com/wundergraph/cosmo/router-tests/testenv"
 	"github.com/wundergraph/cosmo/router/core"
 	"github.com/wundergraph/cosmo/router/pkg/config"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
 )
 
-func TestHeaderPropagation(t *testing.T) {
+func TestHeaderRules(t *testing.T) {
 	t.Parallel()
 
 	const (
@@ -38,71 +37,93 @@ func TestHeaderPropagation(t *testing.T) {
 	  }
 	}`
 
-	getRule := func(alg config.ResponseHeaderRuleAlgorithm, named, defaultVal string) *config.ResponseHeaderRule {
-		rule := &config.ResponseHeaderRule{
-			Operation: config.HeaderRuleOperationPropagate,
-			Algorithm: alg,
+	t.Run("Operation: Propagation", func(t *testing.T) {
+		getRule := func(alg config.ResponseHeaderRuleAlgorithm, named, defaultVal string) *config.ResponseHeaderRule {
+			rule := &config.ResponseHeaderRule{
+				Operation: config.HeaderRuleOperationPropagate,
+				Algorithm: alg,
+			}
+			if named != "" {
+				rule.Named = named
+			}
+			if defaultVal != "" {
+				rule.Default = defaultVal
+			}
+			return rule
 		}
-		if named != "" {
-			rule.Named = named
-		}
-		if defaultVal != "" {
-			rule.Default = defaultVal
-		}
-		return rule
-	}
 
-	global := func(alg config.ResponseHeaderRuleAlgorithm, named, defaultVal string) []core.Option {
-		return []core.Option{
-			core.WithHeaderRules(config.HeaderRules{
-				All: &config.GlobalHeaderRule{
-					Response: []*config.ResponseHeaderRule{
-						getRule(alg, named, defaultVal),
-					},
-				},
-			}),
-		}
-	}
-
-	partial := func(alg config.ResponseHeaderRuleAlgorithm, named, defaultVal string) []core.Option {
-		return []core.Option{
-			core.WithHeaderRules(config.HeaderRules{
-				Subgraphs: map[string]*config.GlobalHeaderRule{
-					"employees": {
+		global := func(alg config.ResponseHeaderRuleAlgorithm, named, defaultVal string) []core.Option {
+			return []core.Option{
+				core.WithHeaderRules(config.HeaderRules{
+					All: &config.GlobalHeaderRule{
 						Response: []*config.ResponseHeaderRule{
 							getRule(alg, named, defaultVal),
 						},
 					},
-				},
-			}),
+				}),
+			}
 		}
-	}
 
-	local := func(alg config.ResponseHeaderRuleAlgorithm, named, defaultValA, defaultValB string) []core.Option {
-		return []core.Option{
-			core.WithHeaderRules(config.HeaderRules{
-				Subgraphs: map[string]*config.GlobalHeaderRule{
-					"employees": {
-						Response: []*config.ResponseHeaderRule{
-							getRule(alg, named, defaultValA),
+		partial := func(alg config.ResponseHeaderRuleAlgorithm, named, defaultVal string) []core.Option {
+			return []core.Option{
+				core.WithHeaderRules(config.HeaderRules{
+					Subgraphs: map[string]*config.GlobalHeaderRule{
+						"employees": {
+							Response: []*config.ResponseHeaderRule{
+								getRule(alg, named, defaultVal),
+							},
 						},
 					},
-					"hobbies": {
-						Response: []*config.ResponseHeaderRule{
-							getRule(alg, named, defaultValB),
+				}),
+			}
+		}
+
+		local := func(alg config.ResponseHeaderRuleAlgorithm, named, defaultValA, defaultValB string) []core.Option {
+			return []core.Option{
+				core.WithHeaderRules(config.HeaderRules{
+					Subgraphs: map[string]*config.GlobalHeaderRule{
+						"employees": {
+							Response: []*config.ResponseHeaderRule{
+								getRule(alg, named, defaultValA),
+							},
+						},
+						"hobbies": {
+							Response: []*config.ResponseHeaderRule{
+								getRule(alg, named, defaultValB),
+							},
 						},
 					},
-				},
-			}),
+				}),
+			}
 		}
-	}
 
-	setSubgraphPropagateHeader := func(header, valA, valB string) testenv.SubgraphsConfig {
-		return testenv.SubgraphsConfig{
+		setSubgraphPropagateHeader := func(header, valA, valB string) testenv.SubgraphsConfig {
+			return testenv.SubgraphsConfig{
+				Employees: testenv.SubgraphConfig{
+					Middleware: func(handler http.Handler) http.Handler {
+						return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+							w.Header().Set(header, valA)
+							handler.ServeHTTP(w, r)
+						})
+					},
+				},
+				Hobbies: testenv.SubgraphConfig{
+					Middleware: func(handler http.Handler) http.Handler {
+						return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+							w.Header().Set(header, valB)
+							handler.ServeHTTP(w, r)
+						})
+					},
+				},
+			}
+		}
+
+		subgraphsWithExpiresHeader := testenv.SubgraphsConfig{
 			Employees: testenv.SubgraphConfig{
 				Middleware: func(handler http.Handler) http.Handler {
 					return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-						w.Header().Set(header, valA)
+						expiresTime := time.Now().UTC().Add(10 * time.Minute).Format(http.TimeFormat)
+						w.Header().Set("Expires", expiresTime)
 						handler.ServeHTTP(w, r)
 					})
 				},
@@ -110,343 +131,281 @@ func TestHeaderPropagation(t *testing.T) {
 			Hobbies: testenv.SubgraphConfig{
 				Middleware: func(handler http.Handler) http.Handler {
 					return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-						w.Header().Set(header, valB)
+						expiresTime := time.Now().UTC().Add(5 * time.Minute).Format(http.TimeFormat)
+						w.Header().Set("Expires", expiresTime) // Earlier, more restrictive
 						handler.ServeHTTP(w, r)
 					})
 				},
 			},
 		}
-	}
 
-	subgraphsWithExpiresHeader := testenv.SubgraphsConfig{
-		Employees: testenv.SubgraphConfig{
-			Middleware: func(handler http.Handler) http.Handler {
-				return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					expiresTime := time.Now().UTC().Add(10 * time.Minute).Format(http.TimeFormat)
-					w.Header().Set("Expires", expiresTime)
-					handler.ServeHTTP(w, r)
-				})
-			},
-		},
-		Hobbies: testenv.SubgraphConfig{
-			Middleware: func(handler http.Handler) http.Handler {
-				return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					expiresTime := time.Now().UTC().Add(5 * time.Minute).Format(http.TimeFormat)
-					w.Header().Set("Expires", expiresTime) // Earlier, more restrictive
-					handler.ServeHTTP(w, r)
-				})
-			},
-		},
-	}
+		cacheOptions := func(cacheControlEmployees, cacheControlHobbies string) testenv.SubgraphsConfig {
+			return setSubgraphPropagateHeader("Cache-Control", cacheControlEmployees, cacheControlHobbies)
+		}
 
-	cacheOptions := func(cacheControlEmployees, cacheControlHobbies string) testenv.SubgraphsConfig {
-		return setSubgraphPropagateHeader("Cache-Control", cacheControlEmployees, cacheControlHobbies)
-	}
+		var (
+			subgraphsPropagateCustomHeader = setSubgraphPropagateHeader(customHeader, employeeVal, hobbyVal)
+		)
 
-	var (
-		subgraphsPropagateCustomHeader = setSubgraphPropagateHeader(customHeader, employeeVal, hobbyVal)
-	)
-
-	t.Run(" no propagate", func(t *testing.T) {
-		t.Parallel()
-		testenv.Run(t, &testenv.Config{
-			Subgraphs: subgraphsPropagateCustomHeader,
-		}, func(t *testing.T, xEnv *testenv.Environment) {
-			res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
-				Query: queryEmployeeWithHobby,
-			})
-			ch := strings.Join(res.Response.Header.Values(customHeader), ",")
-			require.Equal(t, "", ch)
-			require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
-		})
-	})
-
-	t.Run("LastWriteWins", func(t *testing.T) {
-		t.Run("global last write wins", func(t *testing.T) {
+		t.Run(" no propagate", func(t *testing.T) {
 			t.Parallel()
 			testenv.Run(t, &testenv.Config{
-				RouterOptions: global(config.ResponseHeaderRuleAlgorithmLastWrite, customHeader, ""),
-				Subgraphs:     subgraphsPropagateCustomHeader,
+				Subgraphs: subgraphsPropagateCustomHeader,
 			}, func(t *testing.T, xEnv *testenv.Environment) {
 				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
 					Query: queryEmployeeWithHobby,
 				})
 				ch := strings.Join(res.Response.Header.Values(customHeader), ",")
-				require.Equal(t, hobbyVal, ch)
+				require.Equal(t, "", ch)
 				require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
 			})
 		})
 
-		t.Run("local last write wins", func(t *testing.T) {
-			t.Parallel()
-			testenv.Run(t, &testenv.Config{
-				RouterOptions: local(config.ResponseHeaderRuleAlgorithmLastWrite, customHeader, "", ""),
-				Subgraphs:     subgraphsPropagateCustomHeader,
-			}, func(t *testing.T, xEnv *testenv.Environment) {
-				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
-					Query: queryEmployeeWithHobby,
-				})
-				ch := strings.Join(res.Response.Header.Values(customHeader), ",")
-				require.Equal(t, hobbyVal, ch)
-				require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
-			})
-		})
-
-		t.Run("partial last write wins", func(t *testing.T) {
-			t.Parallel()
-			testenv.Run(t, &testenv.Config{
-				RouterOptions: partial(config.ResponseHeaderRuleAlgorithmLastWrite, customHeader, ""),
-				Subgraphs:     subgraphsPropagateCustomHeader,
-			}, func(t *testing.T, xEnv *testenv.Environment) {
-				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
-					Query: queryEmployeeWithHobby,
-				})
-				ch := strings.Join(res.Response.Header.Values(customHeader), ",")
-				require.Equal(t, employeeVal, ch)
-				require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
-			})
-		})
-	})
-
-	// Test for the First Write Wins Algorithm
-	t.Run("FirstWriteWins", func(t *testing.T) {
-		t.Run("global first write wins", func(t *testing.T) {
-			t.Parallel()
-			testenv.Run(t, &testenv.Config{
-				RouterOptions: global(config.ResponseHeaderRuleAlgorithmFirstWrite, customHeader, ""),
-				Subgraphs:     subgraphsPropagateCustomHeader,
-			}, func(t *testing.T, xEnv *testenv.Environment) {
-				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
-					Query: queryEmployeeWithHobby,
-				})
-				ch := strings.Join(res.Response.Header.Values(customHeader), ",")
-				require.Equal(t, employeeVal, ch) // First write is "employee-value"
-				require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
-			})
-		})
-
-		t.Run("local first write wins", func(t *testing.T) {
-			t.Parallel()
-			testenv.Run(t, &testenv.Config{
-				RouterOptions: local(config.ResponseHeaderRuleAlgorithmFirstWrite, customHeader, "", ""),
-				Subgraphs:     subgraphsPropagateCustomHeader,
-			}, func(t *testing.T, xEnv *testenv.Environment) {
-				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
-					Query: queryEmployeeWithHobby,
-				})
-				ch := strings.Join(res.Response.Header.Values(customHeader), ",")
-				require.Equal(t, employeeVal, ch) // First write is "employee-value"
-				require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
-			})
-		})
-
-		t.Run("partial first write wins", func(t *testing.T) {
-			t.Parallel()
-			testenv.Run(t, &testenv.Config{
-				RouterOptions: partial(config.ResponseHeaderRuleAlgorithmFirstWrite, customHeader, ""),
-				Subgraphs:     subgraphsPropagateCustomHeader,
-			}, func(t *testing.T, xEnv *testenv.Environment) {
-				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
-					Query: queryEmployeeWithHobby,
-				})
-				ch := strings.Join(res.Response.Header.Values(customHeader), ",")
-				require.Equal(t, employeeVal, ch) // First write is "employee-value"
-				require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
-			})
-		})
-	})
-
-	// Test for the Append Algorithm
-	t.Run("AppendHeaders", func(t *testing.T) {
-		t.Run("global append headers", func(t *testing.T) {
-			t.Parallel()
-			testenv.Run(t, &testenv.Config{
-				RouterOptions: global(config.ResponseHeaderRuleAlgorithmAppend, customHeader, ""),
-				Subgraphs:     subgraphsPropagateCustomHeader,
-			}, func(t *testing.T, xEnv *testenv.Environment) {
-				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
-					Query: queryEmployeeWithHobby,
-				})
-				ch := strings.Join(res.Response.Header.Values(customHeader), ",")
-				require.Equal(t, "employee-value,hobby-value", ch) // Headers are appended
-				require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
-			})
-		})
-
-		t.Run("local append headers", func(t *testing.T) {
-			t.Parallel()
-			testenv.Run(t, &testenv.Config{
-				RouterOptions: local(config.ResponseHeaderRuleAlgorithmAppend, customHeader, "", ""),
-				Subgraphs:     subgraphsPropagateCustomHeader,
-			}, func(t *testing.T, xEnv *testenv.Environment) {
-				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
-					Query: queryEmployeeWithHobby,
-				})
-				ch := strings.Join(res.Response.Header.Values(customHeader), ",")
-				require.Equal(t, "employee-value,hobby-value", ch) // Headers are appended
-				require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
-			})
-		})
-
-		t.Run("partial append headers", func(t *testing.T) {
-			t.Parallel()
-			testenv.Run(t, &testenv.Config{
-				RouterOptions: partial(config.ResponseHeaderRuleAlgorithmAppend, customHeader, ""),
-				Subgraphs:     subgraphsPropagateCustomHeader,
-			}, func(t *testing.T, xEnv *testenv.Environment) {
-				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
-					Query: queryEmployeeWithHobby,
-				})
-				ch := strings.Join(res.Response.Header.Values(customHeader), ",")
-				require.Equal(t, employeeVal, ch) // Only employee's header is appended
-				require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
-			})
-		})
-	})
-
-	t.Run("MostRestrictiveCacheControl", func(t *testing.T) {
-		// Global test: All subgraphs' responses are considered and most restrictive cache directive wins
-		t.Run("global most restrictive cache control", func(t *testing.T) {
-			t.Parallel()
-			testenv.Run(t, &testenv.Config{
-				RouterOptions: global(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", ""),
-				Subgraphs:     cacheOptions("max-age=120", "max-age=60"),
-			}, func(t *testing.T, xEnv *testenv.Environment) {
-				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
-					Query: queryEmployeeWithHobby,
-				})
-				cc := res.Response.Header.Get("Cache-Control")
-				require.Equal(t, "max-age=60", cc) // Most restrictive wins
-				require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
-			})
-		})
-
-		// Local test: Cache control rules are applied per subgraph (employees and hobbies)
-		t.Run("local most restrictive cache control", func(t *testing.T) {
-			t.Parallel()
-			testenv.Run(t, &testenv.Config{
-				RouterOptions: local(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", "", ""),
-				Subgraphs:     cacheOptions("max-age=120", "max-age=60"),
-			}, func(t *testing.T, xEnv *testenv.Environment) {
-				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
-					Query: queryEmployeeWithHobby,
-				})
-				cc := res.Response.Header.Get("Cache-Control")
-				require.Equal(t, "max-age=60", cc) // Most restrictive wins
-				require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
-			})
-		})
-
-		// Partial test: Only one subgraph's response is considered (e.g., employees)
-		t.Run("partial most restrictive cache control", func(t *testing.T) {
-			t.Parallel()
-			testenv.Run(t, &testenv.Config{
-				RouterOptions: partial(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", ""),
-				Subgraphs:     cacheOptions("max-age=120", "max-age=60"),
-			}, func(t *testing.T, xEnv *testenv.Environment) {
-				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
-					Query: queryEmployeeWithHobby,
-				})
-				cc := res.Response.Header.Get("Cache-Control")
-				require.Equal(t, "max-age=120", cc) // Only employee subgraph is considered
-				require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
-			})
-		})
-
-		// Test case for no-store being the most restrictive
-		t.Run("global no-store wins", func(t *testing.T) {
-			t.Parallel()
-			testenv.Run(t, &testenv.Config{
-				RouterOptions: global(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", ""),
-				Subgraphs:     cacheOptions("no-store", "max-age=300"),
-			}, func(t *testing.T, xEnv *testenv.Environment) {
-				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
-					Query: queryEmployeeWithHobby,
-				})
-				cc := res.Response.Header.Get("Cache-Control")
-				require.Equal(t, "no-store", cc) // no-store wins
-				require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
-			})
-		})
-
-		// Test case for no-cache being more restrictive than max-age
-		t.Run("global no-cache wins", func(t *testing.T) {
-			t.Parallel()
-			testenv.Run(t, &testenv.Config{
-				RouterOptions: global(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", ""),
-				Subgraphs:     cacheOptions("no-cache", "max-age=300"),
-			}, func(t *testing.T, xEnv *testenv.Environment) {
-				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
-					Query: queryEmployeeWithHobby,
-				})
-				cc := res.Response.Header.Get("Cache-Control")
-				require.Equal(t, "no-cache", cc) // no-cache wins over max-age
-				require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
-			})
-		})
-
-		t.Run("global no-cache wins against no value", func(t *testing.T) {
-			t.Parallel()
-			testenv.Run(t, &testenv.Config{
-				RouterOptions: global(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", ""),
-				Subgraphs:     cacheOptions("no-cache", ""),
-			}, func(t *testing.T, xEnv *testenv.Environment) {
-				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
-					Query: queryEmployeeWithHobby,
-				})
-				cc := res.Response.Header.Get("Cache-Control")
-				require.Equal(t, "no-cache", cc) // no-cache wins over max-age
-				require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
-			})
-		})
-
-		// Test case for max-age: shortest max-age wins
-		t.Run("global shortest max-age wins", func(t *testing.T) {
-			t.Parallel()
-			testenv.Run(t, &testenv.Config{
-				RouterOptions: global(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", ""),
-				Subgraphs:     cacheOptions("max-age=600", "max-age=300"),
-			}, func(t *testing.T, xEnv *testenv.Environment) {
-				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
-					Query: queryEmployeeWithHobby,
-				})
-				cc := res.Response.Header.Get("Cache-Control")
-				require.Equal(t, "max-age=300", cc) // Shorter max-age wins
-				require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
-			})
-		})
-
-		// Test case for Expires header: earliest expiration wins
-		t.Run("global earliest Expires wins", func(t *testing.T) {
-			t.Parallel()
-			testenv.Run(t, &testenv.Config{
-				RouterOptions: global(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", ""),
-				Subgraphs:     subgraphsWithExpiresHeader,
-			}, func(t *testing.T, xEnv *testenv.Environment) {
-				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
-					Query: queryEmployeeWithHobby,
-				})
-				expires := res.Response.Header.Get("Expires")
-				require.NotEmpty(t, expires)
-
-				// Parse the Expires header and convert both times to UTC for comparison
-				parsedExpires, err := http.ParseTime(expires)
-				require.NoError(t, err)
-
-				now := time.Now().Add(5 * time.Minute)                        // Example expiration
-				require.WithinDuration(t, now, parsedExpires, 20*time.Second) // Ensure expiration is within expected range
-				require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
-			})
-		})
-
-		t.Run("default value adds max age", func(t *testing.T) {
-			t.Parallel()
-
-			t.Run("global default age sets for all requests", func(t *testing.T) {
+		t.Run("LastWriteWins", func(t *testing.T) {
+			t.Run("global last write wins", func(t *testing.T) {
 				t.Parallel()
 				testenv.Run(t, &testenv.Config{
-					RouterOptions: global(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", "max-age=300"),
-					Subgraphs:     cacheOptions("", "max-age=600"),
+					RouterOptions: global(config.ResponseHeaderRuleAlgorithmLastWrite, customHeader, ""),
+					Subgraphs:     subgraphsPropagateCustomHeader,
+				}, func(t *testing.T, xEnv *testenv.Environment) {
+					res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+						Query: queryEmployeeWithHobby,
+					})
+					ch := strings.Join(res.Response.Header.Values(customHeader), ",")
+					require.Equal(t, hobbyVal, ch)
+					require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
+				})
+			})
+
+			t.Run("local last write wins", func(t *testing.T) {
+				t.Parallel()
+				testenv.Run(t, &testenv.Config{
+					RouterOptions: local(config.ResponseHeaderRuleAlgorithmLastWrite, customHeader, "", ""),
+					Subgraphs:     subgraphsPropagateCustomHeader,
+				}, func(t *testing.T, xEnv *testenv.Environment) {
+					res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+						Query: queryEmployeeWithHobby,
+					})
+					ch := strings.Join(res.Response.Header.Values(customHeader), ",")
+					require.Equal(t, hobbyVal, ch)
+					require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
+				})
+			})
+
+			t.Run("partial last write wins", func(t *testing.T) {
+				t.Parallel()
+				testenv.Run(t, &testenv.Config{
+					RouterOptions: partial(config.ResponseHeaderRuleAlgorithmLastWrite, customHeader, ""),
+					Subgraphs:     subgraphsPropagateCustomHeader,
+				}, func(t *testing.T, xEnv *testenv.Environment) {
+					res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+						Query: queryEmployeeWithHobby,
+					})
+					ch := strings.Join(res.Response.Header.Values(customHeader), ",")
+					require.Equal(t, employeeVal, ch)
+					require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
+				})
+			})
+		})
+
+		// Test for the First Write Wins Algorithm
+		t.Run("FirstWriteWins", func(t *testing.T) {
+			t.Run("global first write wins", func(t *testing.T) {
+				t.Parallel()
+				testenv.Run(t, &testenv.Config{
+					RouterOptions: global(config.ResponseHeaderRuleAlgorithmFirstWrite, customHeader, ""),
+					Subgraphs:     subgraphsPropagateCustomHeader,
+				}, func(t *testing.T, xEnv *testenv.Environment) {
+					res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+						Query: queryEmployeeWithHobby,
+					})
+					ch := strings.Join(res.Response.Header.Values(customHeader), ",")
+					require.Equal(t, employeeVal, ch) // First write is "employee-value"
+					require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
+				})
+			})
+
+			t.Run("local first write wins", func(t *testing.T) {
+				t.Parallel()
+				testenv.Run(t, &testenv.Config{
+					RouterOptions: local(config.ResponseHeaderRuleAlgorithmFirstWrite, customHeader, "", ""),
+					Subgraphs:     subgraphsPropagateCustomHeader,
+				}, func(t *testing.T, xEnv *testenv.Environment) {
+					res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+						Query: queryEmployeeWithHobby,
+					})
+					ch := strings.Join(res.Response.Header.Values(customHeader), ",")
+					require.Equal(t, employeeVal, ch) // First write is "employee-value"
+					require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
+				})
+			})
+
+			t.Run("partial first write wins", func(t *testing.T) {
+				t.Parallel()
+				testenv.Run(t, &testenv.Config{
+					RouterOptions: partial(config.ResponseHeaderRuleAlgorithmFirstWrite, customHeader, ""),
+					Subgraphs:     subgraphsPropagateCustomHeader,
+				}, func(t *testing.T, xEnv *testenv.Environment) {
+					res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+						Query: queryEmployeeWithHobby,
+					})
+					ch := strings.Join(res.Response.Header.Values(customHeader), ",")
+					require.Equal(t, employeeVal, ch) // First write is "employee-value"
+					require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
+				})
+			})
+		})
+
+		// Test for the Append Algorithm
+		t.Run("AppendHeaders", func(t *testing.T) {
+			t.Run("global append headers", func(t *testing.T) {
+				t.Parallel()
+				testenv.Run(t, &testenv.Config{
+					RouterOptions: global(config.ResponseHeaderRuleAlgorithmAppend, customHeader, ""),
+					Subgraphs:     subgraphsPropagateCustomHeader,
+				}, func(t *testing.T, xEnv *testenv.Environment) {
+					res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+						Query: queryEmployeeWithHobby,
+					})
+					ch := strings.Join(res.Response.Header.Values(customHeader), ",")
+					require.Equal(t, "employee-value,hobby-value", ch) // Headers are appended
+					require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
+				})
+			})
+
+			t.Run("local append headers", func(t *testing.T) {
+				t.Parallel()
+				testenv.Run(t, &testenv.Config{
+					RouterOptions: local(config.ResponseHeaderRuleAlgorithmAppend, customHeader, "", ""),
+					Subgraphs:     subgraphsPropagateCustomHeader,
+				}, func(t *testing.T, xEnv *testenv.Environment) {
+					res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+						Query: queryEmployeeWithHobby,
+					})
+					ch := strings.Join(res.Response.Header.Values(customHeader), ",")
+					require.Equal(t, "employee-value,hobby-value", ch) // Headers are appended
+					require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
+				})
+			})
+
+			t.Run("partial append headers", func(t *testing.T) {
+				t.Parallel()
+				testenv.Run(t, &testenv.Config{
+					RouterOptions: partial(config.ResponseHeaderRuleAlgorithmAppend, customHeader, ""),
+					Subgraphs:     subgraphsPropagateCustomHeader,
+				}, func(t *testing.T, xEnv *testenv.Environment) {
+					res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+						Query: queryEmployeeWithHobby,
+					})
+					ch := strings.Join(res.Response.Header.Values(customHeader), ",")
+					require.Equal(t, employeeVal, ch) // Only employee's header is appended
+					require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
+				})
+			})
+		})
+
+		t.Run("MostRestrictiveCacheControl", func(t *testing.T) {
+			// Global test: All subgraphs' responses are considered and most restrictive cache directive wins
+			t.Run("global most restrictive cache control", func(t *testing.T) {
+				t.Parallel()
+				testenv.Run(t, &testenv.Config{
+					RouterOptions: global(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", ""),
+					Subgraphs:     cacheOptions("max-age=120", "max-age=60"),
+				}, func(t *testing.T, xEnv *testenv.Environment) {
+					res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+						Query: queryEmployeeWithHobby,
+					})
+					cc := res.Response.Header.Get("Cache-Control")
+					require.Equal(t, "max-age=60", cc) // Most restrictive wins
+					require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
+				})
+			})
+
+			// Local test: Cache control rules are applied per subgraph (employees and hobbies)
+			t.Run("local most restrictive cache control", func(t *testing.T) {
+				t.Parallel()
+				testenv.Run(t, &testenv.Config{
+					RouterOptions: local(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", "", ""),
+					Subgraphs:     cacheOptions("max-age=120", "max-age=60"),
+				}, func(t *testing.T, xEnv *testenv.Environment) {
+					res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+						Query: queryEmployeeWithHobby,
+					})
+					cc := res.Response.Header.Get("Cache-Control")
+					require.Equal(t, "max-age=60", cc) // Most restrictive wins
+					require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
+				})
+			})
+
+			// Partial test: Only one subgraph's response is considered (e.g., employees)
+			t.Run("partial most restrictive cache control", func(t *testing.T) {
+				t.Parallel()
+				testenv.Run(t, &testenv.Config{
+					RouterOptions: partial(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", ""),
+					Subgraphs:     cacheOptions("max-age=120", "max-age=60"),
+				}, func(t *testing.T, xEnv *testenv.Environment) {
+					res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+						Query: queryEmployeeWithHobby,
+					})
+					cc := res.Response.Header.Get("Cache-Control")
+					require.Equal(t, "max-age=120", cc) // Only employee subgraph is considered
+					require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
+				})
+			})
+
+			// Test case for no-store being the most restrictive
+			t.Run("global no-store wins", func(t *testing.T) {
+				t.Parallel()
+				testenv.Run(t, &testenv.Config{
+					RouterOptions: global(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", ""),
+					Subgraphs:     cacheOptions("no-store", "max-age=300"),
+				}, func(t *testing.T, xEnv *testenv.Environment) {
+					res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+						Query: queryEmployeeWithHobby,
+					})
+					cc := res.Response.Header.Get("Cache-Control")
+					require.Equal(t, "no-store", cc) // no-store wins
+					require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
+				})
+			})
+
+			// Test case for no-cache being more restrictive than max-age
+			t.Run("global no-cache wins", func(t *testing.T) {
+				t.Parallel()
+				testenv.Run(t, &testenv.Config{
+					RouterOptions: global(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", ""),
+					Subgraphs:     cacheOptions("no-cache", "max-age=300"),
+				}, func(t *testing.T, xEnv *testenv.Environment) {
+					res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+						Query: queryEmployeeWithHobby,
+					})
+					cc := res.Response.Header.Get("Cache-Control")
+					require.Equal(t, "no-cache", cc) // no-cache wins over max-age
+					require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
+				})
+			})
+
+			t.Run("global no-cache wins against no value", func(t *testing.T) {
+				t.Parallel()
+				testenv.Run(t, &testenv.Config{
+					RouterOptions: global(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", ""),
+					Subgraphs:     cacheOptions("no-cache", ""),
+				}, func(t *testing.T, xEnv *testenv.Environment) {
+					res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+						Query: queryEmployeeWithHobby,
+					})
+					cc := res.Response.Header.Get("Cache-Control")
+					require.Equal(t, "no-cache", cc) // no-cache wins over max-age
+					require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
+				})
+			})
+
+			// Test case for max-age: shortest max-age wins
+			t.Run("global shortest max-age wins", func(t *testing.T) {
+				t.Parallel()
+				testenv.Run(t, &testenv.Config{
+					RouterOptions: global(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", ""),
+					Subgraphs:     cacheOptions("max-age=600", "max-age=300"),
 				}, func(t *testing.T, xEnv *testenv.Environment) {
 					res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
 						Query: queryEmployeeWithHobby,
@@ -457,94 +416,136 @@ func TestHeaderPropagation(t *testing.T) {
 				})
 			})
 
-			t.Run("global no-cache sets for all requests", func(t *testing.T) {
+			// Test case for Expires header: earliest expiration wins
+			t.Run("global earliest Expires wins", func(t *testing.T) {
 				t.Parallel()
 				testenv.Run(t, &testenv.Config{
-					RouterOptions: global(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", "no-cache"),
-					Subgraphs:     cacheOptions("", "max-age=600"),
+					RouterOptions: global(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", ""),
+					Subgraphs:     subgraphsWithExpiresHeader,
 				}, func(t *testing.T, xEnv *testenv.Environment) {
 					res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
 						Query: queryEmployeeWithHobby,
 					})
-					cc := res.Response.Header.Get("Cache-Control")
-					require.Equal(t, "no-cache", cc) // Shorter max-age wins
+					expires := res.Response.Header.Get("Expires")
+					require.NotEmpty(t, expires)
+
+					// Parse the Expires header and convert both times to UTC for comparison
+					parsedExpires, err := http.ParseTime(expires)
+					require.NoError(t, err)
+
+					now := time.Now().Add(5 * time.Minute)                        // Example expiration
+					require.WithinDuration(t, now, parsedExpires, 20*time.Second) // Ensure expiration is within expected range
 					require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
 				})
 			})
 
-			t.Run("global default age sets for all requests", func(t *testing.T) {
+			t.Run("default value adds max age", func(t *testing.T) {
 				t.Parallel()
-				testenv.Run(t, &testenv.Config{
-					RouterOptions: global(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", "no-cache"),
-					Subgraphs:     cacheOptions("max-age=60", "max-age=300"),
-				}, func(t *testing.T, xEnv *testenv.Environment) {
-					res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
-						Query: queryEmployeeWithHobby,
-					})
-					cc := res.Response.Header.Get("Cache-Control")
-					require.Equal(t, "no-cache", cc) // Shorter max-age wins
-					require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
-				})
-			})
 
-			t.Run("allows subgraph to override default", func(t *testing.T) {
-				t.Parallel()
-				testenv.Run(t, &testenv.Config{
-					RouterOptions: global(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", "max-age=300"),
-					Subgraphs:     cacheOptions("max-age=60", "max-age=180"),
-				}, func(t *testing.T, xEnv *testenv.Environment) {
-					res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
-						Query: queryEmployeeWithHobby,
+				t.Run("global default age sets for all requests", func(t *testing.T) {
+					t.Parallel()
+					testenv.Run(t, &testenv.Config{
+						RouterOptions: global(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", "max-age=300"),
+						Subgraphs:     cacheOptions("", "max-age=600"),
+					}, func(t *testing.T, xEnv *testenv.Environment) {
+						res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+							Query: queryEmployeeWithHobby,
+						})
+						cc := res.Response.Header.Get("Cache-Control")
+						require.Equal(t, "max-age=300", cc) // Shorter max-age wins
+						require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
 					})
-					cc := res.Response.Header.Get("Cache-Control")
-					require.Equal(t, "max-age=60", cc) // Shorter max-age wins
-					require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
 				})
-			})
 
-			t.Run("partial default age sets for requests with information", func(t *testing.T) {
-				t.Parallel()
-				testenv.Run(t, &testenv.Config{
-					RouterOptions: local(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", "", "max-age=300"),
-					Subgraphs:     cacheOptions("", ""),
-				}, func(t *testing.T, xEnv *testenv.Environment) {
-					res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
-						Query: queryEmployeeWithHobby,
+				t.Run("global no-cache sets for all requests", func(t *testing.T) {
+					t.Parallel()
+					testenv.Run(t, &testenv.Config{
+						RouterOptions: global(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", "no-cache"),
+						Subgraphs:     cacheOptions("", "max-age=600"),
+					}, func(t *testing.T, xEnv *testenv.Environment) {
+						res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+							Query: queryEmployeeWithHobby,
+						})
+						cc := res.Response.Header.Get("Cache-Control")
+						require.Equal(t, "no-cache", cc) // Shorter max-age wins
+						require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
 					})
-					cc := res.Response.Header.Get("Cache-Control")
-					require.Equal(t, "max-age=300", cc) // Shorter max-age wins
-					require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
 				})
-			})
 
-			t.Run("partial default age doesn't set for unassociated requests", func(t *testing.T) {
-				t.Parallel()
-				testenv.Run(t, &testenv.Config{
-					RouterOptions: local(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", "", "max-age=300"),
-					Subgraphs:     cacheOptions("", ""),
-				}, func(t *testing.T, xEnv *testenv.Environment) {
-					res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
-						Query: queryEmployeeWithNoHobby,
+				t.Run("global default age sets for all requests", func(t *testing.T) {
+					t.Parallel()
+					testenv.Run(t, &testenv.Config{
+						RouterOptions: global(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", "no-cache"),
+						Subgraphs:     cacheOptions("max-age=60", "max-age=300"),
+					}, func(t *testing.T, xEnv *testenv.Environment) {
+						res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+							Query: queryEmployeeWithHobby,
+						})
+						cc := res.Response.Header.Get("Cache-Control")
+						require.Equal(t, "no-cache", cc) // Shorter max-age wins
+						require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
 					})
-					cc := res.Response.Header.Get("Cache-Control")
-					require.Equal(t, "", cc)
-					require.Equal(t, `{"data":{"employee":{"id":1}}}`, res.Body)
 				})
-			})
 
-			t.Run("no-cache is set for all mutations", func(t *testing.T) {
-				t.Parallel()
-				testenv.Run(t, &testenv.Config{
-					RouterOptions: global(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", "max-age=300"),
-					Subgraphs:     cacheOptions("", ""),
-				}, func(t *testing.T, xEnv *testenv.Environment) {
-					res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
-						Query: `mutation { updateEmployeeTag(id: 1, tag: "test") { id tag } }`,
+				t.Run("allows subgraph to override default", func(t *testing.T) {
+					t.Parallel()
+					testenv.Run(t, &testenv.Config{
+						RouterOptions: global(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", "max-age=300"),
+						Subgraphs:     cacheOptions("max-age=60", "max-age=180"),
+					}, func(t *testing.T, xEnv *testenv.Environment) {
+						res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+							Query: queryEmployeeWithHobby,
+						})
+						cc := res.Response.Header.Get("Cache-Control")
+						require.Equal(t, "max-age=60", cc) // Shorter max-age wins
+						require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
 					})
-					cc := res.Response.Header.Get("Cache-Control")
-					require.Equal(t, "no-cache", cc)
-					require.Equal(t, http.StatusOK, res.Response.StatusCode)
-					require.Equal(t, `{"data":{"updateEmployeeTag":{"id":1,"tag":"test"}}}`, res.Body)
+				})
+
+				t.Run("partial default age sets for requests with information", func(t *testing.T) {
+					t.Parallel()
+					testenv.Run(t, &testenv.Config{
+						RouterOptions: local(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", "", "max-age=300"),
+						Subgraphs:     cacheOptions("", ""),
+					}, func(t *testing.T, xEnv *testenv.Environment) {
+						res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+							Query: queryEmployeeWithHobby,
+						})
+						cc := res.Response.Header.Get("Cache-Control")
+						require.Equal(t, "max-age=300", cc) // Shorter max-age wins
+						require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
+					})
+				})
+
+				t.Run("partial default age doesn't set for unassociated requests", func(t *testing.T) {
+					t.Parallel()
+					testenv.Run(t, &testenv.Config{
+						RouterOptions: local(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", "", "max-age=300"),
+						Subgraphs:     cacheOptions("", ""),
+					}, func(t *testing.T, xEnv *testenv.Environment) {
+						res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+							Query: queryEmployeeWithNoHobby,
+						})
+						cc := res.Response.Header.Get("Cache-Control")
+						require.Equal(t, "", cc)
+						require.Equal(t, `{"data":{"employee":{"id":1}}}`, res.Body)
+					})
+				})
+
+				t.Run("no-cache is set for all mutations", func(t *testing.T) {
+					t.Parallel()
+					testenv.Run(t, &testenv.Config{
+						RouterOptions: global(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", "max-age=300"),
+						Subgraphs:     cacheOptions("", ""),
+					}, func(t *testing.T, xEnv *testenv.Environment) {
+						res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+							Query: `mutation { updateEmployeeTag(id: 1, tag: "test") { id tag } }`,
+						})
+						cc := res.Response.Header.Get("Cache-Control")
+						require.Equal(t, "no-cache", cc)
+						require.Equal(t, http.StatusOK, res.Response.StatusCode)
+						require.Equal(t, `{"data":{"updateEmployeeTag":{"id":1,"tag":"test"}}}`, res.Body)
+					})
 				})
 			})
 		})

--- a/router-tests/header_propagation_test.go
+++ b/router-tests/header_propagation_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 )
 
-func TestHeaderRules(t *testing.T) {
+func TestHeaderPropagation(t *testing.T) {
 	t.Parallel()
 
 	const (
@@ -37,93 +37,71 @@ func TestHeaderRules(t *testing.T) {
 	  }
 	}`
 
-	t.Run("Operation: Propagation", func(t *testing.T) {
-		getRule := func(alg config.ResponseHeaderRuleAlgorithm, named, defaultVal string) *config.ResponseHeaderRule {
-			rule := &config.ResponseHeaderRule{
-				Operation: config.HeaderRuleOperationPropagate,
-				Algorithm: alg,
-			}
-			if named != "" {
-				rule.Named = named
-			}
-			if defaultVal != "" {
-				rule.Default = defaultVal
-			}
-			return rule
+	getRule := func(alg config.ResponseHeaderRuleAlgorithm, named, defaultVal string) *config.ResponseHeaderRule {
+		rule := &config.ResponseHeaderRule{
+			Operation: config.HeaderRuleOperationPropagate,
+			Algorithm: alg,
 		}
+		if named != "" {
+			rule.Named = named
+		}
+		if defaultVal != "" {
+			rule.Default = defaultVal
+		}
+		return rule
+	}
 
-		global := func(alg config.ResponseHeaderRuleAlgorithm, named, defaultVal string) []core.Option {
-			return []core.Option{
-				core.WithHeaderRules(config.HeaderRules{
-					All: &config.GlobalHeaderRule{
+	global := func(alg config.ResponseHeaderRuleAlgorithm, named, defaultVal string) []core.Option {
+		return []core.Option{
+			core.WithHeaderRules(config.HeaderRules{
+				All: &config.GlobalHeaderRule{
+					Response: []*config.ResponseHeaderRule{
+						getRule(alg, named, defaultVal),
+					},
+				},
+			}),
+		}
+	}
+
+	partial := func(alg config.ResponseHeaderRuleAlgorithm, named, defaultVal string) []core.Option {
+		return []core.Option{
+			core.WithHeaderRules(config.HeaderRules{
+				Subgraphs: map[string]*config.GlobalHeaderRule{
+					"employees": {
 						Response: []*config.ResponseHeaderRule{
 							getRule(alg, named, defaultVal),
 						},
 					},
-				}),
-			}
+				},
+			}),
 		}
+	}
 
-		partial := func(alg config.ResponseHeaderRuleAlgorithm, named, defaultVal string) []core.Option {
-			return []core.Option{
-				core.WithHeaderRules(config.HeaderRules{
-					Subgraphs: map[string]*config.GlobalHeaderRule{
-						"employees": {
-							Response: []*config.ResponseHeaderRule{
-								getRule(alg, named, defaultVal),
-							},
+	local := func(alg config.ResponseHeaderRuleAlgorithm, named, defaultValA, defaultValB string) []core.Option {
+		return []core.Option{
+			core.WithHeaderRules(config.HeaderRules{
+				Subgraphs: map[string]*config.GlobalHeaderRule{
+					"employees": {
+						Response: []*config.ResponseHeaderRule{
+							getRule(alg, named, defaultValA),
 						},
 					},
-				}),
-			}
-		}
-
-		local := func(alg config.ResponseHeaderRuleAlgorithm, named, defaultValA, defaultValB string) []core.Option {
-			return []core.Option{
-				core.WithHeaderRules(config.HeaderRules{
-					Subgraphs: map[string]*config.GlobalHeaderRule{
-						"employees": {
-							Response: []*config.ResponseHeaderRule{
-								getRule(alg, named, defaultValA),
-							},
+					"hobbies": {
+						Response: []*config.ResponseHeaderRule{
+							getRule(alg, named, defaultValB),
 						},
-						"hobbies": {
-							Response: []*config.ResponseHeaderRule{
-								getRule(alg, named, defaultValB),
-							},
-						},
-					},
-				}),
-			}
-		}
-
-		setSubgraphPropagateHeader := func(header, valA, valB string) testenv.SubgraphsConfig {
-			return testenv.SubgraphsConfig{
-				Employees: testenv.SubgraphConfig{
-					Middleware: func(handler http.Handler) http.Handler {
-						return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-							w.Header().Set(header, valA)
-							handler.ServeHTTP(w, r)
-						})
 					},
 				},
-				Hobbies: testenv.SubgraphConfig{
-					Middleware: func(handler http.Handler) http.Handler {
-						return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-							w.Header().Set(header, valB)
-							handler.ServeHTTP(w, r)
-						})
-					},
-				},
-			}
+			}),
 		}
+	}
 
-		subgraphsWithExpiresHeader := testenv.SubgraphsConfig{
+	setSubgraphPropagateHeader := func(header, valA, valB string) testenv.SubgraphsConfig {
+		return testenv.SubgraphsConfig{
 			Employees: testenv.SubgraphConfig{
 				Middleware: func(handler http.Handler) http.Handler {
 					return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-						expiresTime := time.Now().UTC().Add(10 * time.Minute).Format(http.TimeFormat)
-						w.Header().Set("Expires", expiresTime)
+						w.Header().Set(header, valA)
 						handler.ServeHTTP(w, r)
 					})
 				},
@@ -131,281 +109,343 @@ func TestHeaderRules(t *testing.T) {
 			Hobbies: testenv.SubgraphConfig{
 				Middleware: func(handler http.Handler) http.Handler {
 					return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-						expiresTime := time.Now().UTC().Add(5 * time.Minute).Format(http.TimeFormat)
-						w.Header().Set("Expires", expiresTime) // Earlier, more restrictive
+						w.Header().Set(header, valB)
 						handler.ServeHTTP(w, r)
 					})
 				},
 			},
 		}
+	}
 
-		cacheOptions := func(cacheControlEmployees, cacheControlHobbies string) testenv.SubgraphsConfig {
-			return setSubgraphPropagateHeader("Cache-Control", cacheControlEmployees, cacheControlHobbies)
-		}
+	subgraphsWithExpiresHeader := testenv.SubgraphsConfig{
+		Employees: testenv.SubgraphConfig{
+			Middleware: func(handler http.Handler) http.Handler {
+				return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					expiresTime := time.Now().UTC().Add(10 * time.Minute).Format(http.TimeFormat)
+					w.Header().Set("Expires", expiresTime)
+					handler.ServeHTTP(w, r)
+				})
+			},
+		},
+		Hobbies: testenv.SubgraphConfig{
+			Middleware: func(handler http.Handler) http.Handler {
+				return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					expiresTime := time.Now().UTC().Add(5 * time.Minute).Format(http.TimeFormat)
+					w.Header().Set("Expires", expiresTime) // Earlier, more restrictive
+					handler.ServeHTTP(w, r)
+				})
+			},
+		},
+	}
 
-		var (
-			subgraphsPropagateCustomHeader = setSubgraphPropagateHeader(customHeader, employeeVal, hobbyVal)
-		)
+	cacheOptions := func(cacheControlEmployees, cacheControlHobbies string) testenv.SubgraphsConfig {
+		return setSubgraphPropagateHeader("Cache-Control", cacheControlEmployees, cacheControlHobbies)
+	}
 
-		t.Run(" no propagate", func(t *testing.T) {
+	var (
+		subgraphsPropagateCustomHeader = setSubgraphPropagateHeader(customHeader, employeeVal, hobbyVal)
+	)
+
+	t.Run(" no propagate", func(t *testing.T) {
+		t.Parallel()
+		testenv.Run(t, &testenv.Config{
+			Subgraphs: subgraphsPropagateCustomHeader,
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+				Query: queryEmployeeWithHobby,
+			})
+			ch := strings.Join(res.Response.Header.Values(customHeader), ",")
+			require.Equal(t, "", ch)
+			require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
+		})
+	})
+
+	t.Run("LastWriteWins", func(t *testing.T) {
+		t.Run("global last write wins", func(t *testing.T) {
 			t.Parallel()
 			testenv.Run(t, &testenv.Config{
-				Subgraphs: subgraphsPropagateCustomHeader,
+				RouterOptions: global(config.ResponseHeaderRuleAlgorithmLastWrite, customHeader, ""),
+				Subgraphs:     subgraphsPropagateCustomHeader,
 			}, func(t *testing.T, xEnv *testenv.Environment) {
 				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
 					Query: queryEmployeeWithHobby,
 				})
 				ch := strings.Join(res.Response.Header.Values(customHeader), ",")
-				require.Equal(t, "", ch)
+				require.Equal(t, hobbyVal, ch)
 				require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
 			})
 		})
 
-		t.Run("LastWriteWins", func(t *testing.T) {
-			t.Run("global last write wins", func(t *testing.T) {
-				t.Parallel()
-				testenv.Run(t, &testenv.Config{
-					RouterOptions: global(config.ResponseHeaderRuleAlgorithmLastWrite, customHeader, ""),
-					Subgraphs:     subgraphsPropagateCustomHeader,
-				}, func(t *testing.T, xEnv *testenv.Environment) {
-					res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
-						Query: queryEmployeeWithHobby,
-					})
-					ch := strings.Join(res.Response.Header.Values(customHeader), ",")
-					require.Equal(t, hobbyVal, ch)
-					require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
+		t.Run("local last write wins", func(t *testing.T) {
+			t.Parallel()
+			testenv.Run(t, &testenv.Config{
+				RouterOptions: local(config.ResponseHeaderRuleAlgorithmLastWrite, customHeader, "", ""),
+				Subgraphs:     subgraphsPropagateCustomHeader,
+			}, func(t *testing.T, xEnv *testenv.Environment) {
+				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+					Query: queryEmployeeWithHobby,
 				})
-			})
-
-			t.Run("local last write wins", func(t *testing.T) {
-				t.Parallel()
-				testenv.Run(t, &testenv.Config{
-					RouterOptions: local(config.ResponseHeaderRuleAlgorithmLastWrite, customHeader, "", ""),
-					Subgraphs:     subgraphsPropagateCustomHeader,
-				}, func(t *testing.T, xEnv *testenv.Environment) {
-					res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
-						Query: queryEmployeeWithHobby,
-					})
-					ch := strings.Join(res.Response.Header.Values(customHeader), ",")
-					require.Equal(t, hobbyVal, ch)
-					require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
-				})
-			})
-
-			t.Run("partial last write wins", func(t *testing.T) {
-				t.Parallel()
-				testenv.Run(t, &testenv.Config{
-					RouterOptions: partial(config.ResponseHeaderRuleAlgorithmLastWrite, customHeader, ""),
-					Subgraphs:     subgraphsPropagateCustomHeader,
-				}, func(t *testing.T, xEnv *testenv.Environment) {
-					res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
-						Query: queryEmployeeWithHobby,
-					})
-					ch := strings.Join(res.Response.Header.Values(customHeader), ",")
-					require.Equal(t, employeeVal, ch)
-					require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
-				})
+				ch := strings.Join(res.Response.Header.Values(customHeader), ",")
+				require.Equal(t, hobbyVal, ch)
+				require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
 			})
 		})
 
-		// Test for the First Write Wins Algorithm
-		t.Run("FirstWriteWins", func(t *testing.T) {
-			t.Run("global first write wins", func(t *testing.T) {
-				t.Parallel()
-				testenv.Run(t, &testenv.Config{
-					RouterOptions: global(config.ResponseHeaderRuleAlgorithmFirstWrite, customHeader, ""),
-					Subgraphs:     subgraphsPropagateCustomHeader,
-				}, func(t *testing.T, xEnv *testenv.Environment) {
-					res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
-						Query: queryEmployeeWithHobby,
-					})
-					ch := strings.Join(res.Response.Header.Values(customHeader), ",")
-					require.Equal(t, employeeVal, ch) // First write is "employee-value"
-					require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
+		t.Run("partial last write wins", func(t *testing.T) {
+			t.Parallel()
+			testenv.Run(t, &testenv.Config{
+				RouterOptions: partial(config.ResponseHeaderRuleAlgorithmLastWrite, customHeader, ""),
+				Subgraphs:     subgraphsPropagateCustomHeader,
+			}, func(t *testing.T, xEnv *testenv.Environment) {
+				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+					Query: queryEmployeeWithHobby,
 				})
+				ch := strings.Join(res.Response.Header.Values(customHeader), ",")
+				require.Equal(t, employeeVal, ch)
+				require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
 			})
+		})
+	})
 
-			t.Run("local first write wins", func(t *testing.T) {
-				t.Parallel()
-				testenv.Run(t, &testenv.Config{
-					RouterOptions: local(config.ResponseHeaderRuleAlgorithmFirstWrite, customHeader, "", ""),
-					Subgraphs:     subgraphsPropagateCustomHeader,
-				}, func(t *testing.T, xEnv *testenv.Environment) {
-					res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
-						Query: queryEmployeeWithHobby,
-					})
-					ch := strings.Join(res.Response.Header.Values(customHeader), ",")
-					require.Equal(t, employeeVal, ch) // First write is "employee-value"
-					require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
+	// Test for the First Write Wins Algorithm
+	t.Run("FirstWriteWins", func(t *testing.T) {
+		t.Run("global first write wins", func(t *testing.T) {
+			t.Parallel()
+			testenv.Run(t, &testenv.Config{
+				RouterOptions: global(config.ResponseHeaderRuleAlgorithmFirstWrite, customHeader, ""),
+				Subgraphs:     subgraphsPropagateCustomHeader,
+			}, func(t *testing.T, xEnv *testenv.Environment) {
+				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+					Query: queryEmployeeWithHobby,
 				})
-			})
-
-			t.Run("partial first write wins", func(t *testing.T) {
-				t.Parallel()
-				testenv.Run(t, &testenv.Config{
-					RouterOptions: partial(config.ResponseHeaderRuleAlgorithmFirstWrite, customHeader, ""),
-					Subgraphs:     subgraphsPropagateCustomHeader,
-				}, func(t *testing.T, xEnv *testenv.Environment) {
-					res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
-						Query: queryEmployeeWithHobby,
-					})
-					ch := strings.Join(res.Response.Header.Values(customHeader), ",")
-					require.Equal(t, employeeVal, ch) // First write is "employee-value"
-					require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
-				})
+				ch := strings.Join(res.Response.Header.Values(customHeader), ",")
+				require.Equal(t, employeeVal, ch) // First write is "employee-value"
+				require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
 			})
 		})
 
-		// Test for the Append Algorithm
-		t.Run("AppendHeaders", func(t *testing.T) {
-			t.Run("global append headers", func(t *testing.T) {
-				t.Parallel()
-				testenv.Run(t, &testenv.Config{
-					RouterOptions: global(config.ResponseHeaderRuleAlgorithmAppend, customHeader, ""),
-					Subgraphs:     subgraphsPropagateCustomHeader,
-				}, func(t *testing.T, xEnv *testenv.Environment) {
-					res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
-						Query: queryEmployeeWithHobby,
-					})
-					ch := strings.Join(res.Response.Header.Values(customHeader), ",")
-					require.Equal(t, "employee-value,hobby-value", ch) // Headers are appended
-					require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
+		t.Run("local first write wins", func(t *testing.T) {
+			t.Parallel()
+			testenv.Run(t, &testenv.Config{
+				RouterOptions: local(config.ResponseHeaderRuleAlgorithmFirstWrite, customHeader, "", ""),
+				Subgraphs:     subgraphsPropagateCustomHeader,
+			}, func(t *testing.T, xEnv *testenv.Environment) {
+				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+					Query: queryEmployeeWithHobby,
 				})
-			})
-
-			t.Run("local append headers", func(t *testing.T) {
-				t.Parallel()
-				testenv.Run(t, &testenv.Config{
-					RouterOptions: local(config.ResponseHeaderRuleAlgorithmAppend, customHeader, "", ""),
-					Subgraphs:     subgraphsPropagateCustomHeader,
-				}, func(t *testing.T, xEnv *testenv.Environment) {
-					res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
-						Query: queryEmployeeWithHobby,
-					})
-					ch := strings.Join(res.Response.Header.Values(customHeader), ",")
-					require.Equal(t, "employee-value,hobby-value", ch) // Headers are appended
-					require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
-				})
-			})
-
-			t.Run("partial append headers", func(t *testing.T) {
-				t.Parallel()
-				testenv.Run(t, &testenv.Config{
-					RouterOptions: partial(config.ResponseHeaderRuleAlgorithmAppend, customHeader, ""),
-					Subgraphs:     subgraphsPropagateCustomHeader,
-				}, func(t *testing.T, xEnv *testenv.Environment) {
-					res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
-						Query: queryEmployeeWithHobby,
-					})
-					ch := strings.Join(res.Response.Header.Values(customHeader), ",")
-					require.Equal(t, employeeVal, ch) // Only employee's header is appended
-					require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
-				})
+				ch := strings.Join(res.Response.Header.Values(customHeader), ",")
+				require.Equal(t, employeeVal, ch) // First write is "employee-value"
+				require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
 			})
 		})
 
-		t.Run("MostRestrictiveCacheControl", func(t *testing.T) {
-			// Global test: All subgraphs' responses are considered and most restrictive cache directive wins
-			t.Run("global most restrictive cache control", func(t *testing.T) {
-				t.Parallel()
-				testenv.Run(t, &testenv.Config{
-					RouterOptions: global(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", ""),
-					Subgraphs:     cacheOptions("max-age=120", "max-age=60"),
-				}, func(t *testing.T, xEnv *testenv.Environment) {
-					res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
-						Query: queryEmployeeWithHobby,
-					})
-					cc := res.Response.Header.Get("Cache-Control")
-					require.Equal(t, "max-age=60", cc) // Most restrictive wins
-					require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
+		t.Run("partial first write wins", func(t *testing.T) {
+			t.Parallel()
+			testenv.Run(t, &testenv.Config{
+				RouterOptions: partial(config.ResponseHeaderRuleAlgorithmFirstWrite, customHeader, ""),
+				Subgraphs:     subgraphsPropagateCustomHeader,
+			}, func(t *testing.T, xEnv *testenv.Environment) {
+				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+					Query: queryEmployeeWithHobby,
 				})
+				ch := strings.Join(res.Response.Header.Values(customHeader), ",")
+				require.Equal(t, employeeVal, ch) // First write is "employee-value"
+				require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
 			})
+		})
+	})
 
-			// Local test: Cache control rules are applied per subgraph (employees and hobbies)
-			t.Run("local most restrictive cache control", func(t *testing.T) {
-				t.Parallel()
-				testenv.Run(t, &testenv.Config{
-					RouterOptions: local(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", "", ""),
-					Subgraphs:     cacheOptions("max-age=120", "max-age=60"),
-				}, func(t *testing.T, xEnv *testenv.Environment) {
-					res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
-						Query: queryEmployeeWithHobby,
-					})
-					cc := res.Response.Header.Get("Cache-Control")
-					require.Equal(t, "max-age=60", cc) // Most restrictive wins
-					require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
+	// Test for the Append Algorithm
+	t.Run("AppendHeaders", func(t *testing.T) {
+		t.Run("global append headers", func(t *testing.T) {
+			t.Parallel()
+			testenv.Run(t, &testenv.Config{
+				RouterOptions: global(config.ResponseHeaderRuleAlgorithmAppend, customHeader, ""),
+				Subgraphs:     subgraphsPropagateCustomHeader,
+			}, func(t *testing.T, xEnv *testenv.Environment) {
+				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+					Query: queryEmployeeWithHobby,
 				})
+				ch := strings.Join(res.Response.Header.Values(customHeader), ",")
+				require.Equal(t, "employee-value,hobby-value", ch) // Headers are appended
+				require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
 			})
+		})
 
-			// Partial test: Only one subgraph's response is considered (e.g., employees)
-			t.Run("partial most restrictive cache control", func(t *testing.T) {
-				t.Parallel()
-				testenv.Run(t, &testenv.Config{
-					RouterOptions: partial(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", ""),
-					Subgraphs:     cacheOptions("max-age=120", "max-age=60"),
-				}, func(t *testing.T, xEnv *testenv.Environment) {
-					res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
-						Query: queryEmployeeWithHobby,
-					})
-					cc := res.Response.Header.Get("Cache-Control")
-					require.Equal(t, "max-age=120", cc) // Only employee subgraph is considered
-					require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
+		t.Run("local append headers", func(t *testing.T) {
+			t.Parallel()
+			testenv.Run(t, &testenv.Config{
+				RouterOptions: local(config.ResponseHeaderRuleAlgorithmAppend, customHeader, "", ""),
+				Subgraphs:     subgraphsPropagateCustomHeader,
+			}, func(t *testing.T, xEnv *testenv.Environment) {
+				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+					Query: queryEmployeeWithHobby,
 				})
+				ch := strings.Join(res.Response.Header.Values(customHeader), ",")
+				require.Equal(t, "employee-value,hobby-value", ch) // Headers are appended
+				require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
 			})
+		})
 
-			// Test case for no-store being the most restrictive
-			t.Run("global no-store wins", func(t *testing.T) {
-				t.Parallel()
-				testenv.Run(t, &testenv.Config{
-					RouterOptions: global(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", ""),
-					Subgraphs:     cacheOptions("no-store", "max-age=300"),
-				}, func(t *testing.T, xEnv *testenv.Environment) {
-					res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
-						Query: queryEmployeeWithHobby,
-					})
-					cc := res.Response.Header.Get("Cache-Control")
-					require.Equal(t, "no-store", cc) // no-store wins
-					require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
+		t.Run("partial append headers", func(t *testing.T) {
+			t.Parallel()
+			testenv.Run(t, &testenv.Config{
+				RouterOptions: partial(config.ResponseHeaderRuleAlgorithmAppend, customHeader, ""),
+				Subgraphs:     subgraphsPropagateCustomHeader,
+			}, func(t *testing.T, xEnv *testenv.Environment) {
+				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+					Query: queryEmployeeWithHobby,
 				})
+				ch := strings.Join(res.Response.Header.Values(customHeader), ",")
+				require.Equal(t, employeeVal, ch) // Only employee's header is appended
+				require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
 			})
+		})
+	})
 
-			// Test case for no-cache being more restrictive than max-age
-			t.Run("global no-cache wins", func(t *testing.T) {
-				t.Parallel()
-				testenv.Run(t, &testenv.Config{
-					RouterOptions: global(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", ""),
-					Subgraphs:     cacheOptions("no-cache", "max-age=300"),
-				}, func(t *testing.T, xEnv *testenv.Environment) {
-					res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
-						Query: queryEmployeeWithHobby,
-					})
-					cc := res.Response.Header.Get("Cache-Control")
-					require.Equal(t, "no-cache", cc) // no-cache wins over max-age
-					require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
+	t.Run("MostRestrictiveCacheControl", func(t *testing.T) {
+		// Global test: All subgraphs' responses are considered and most restrictive cache directive wins
+		t.Run("global most restrictive cache control", func(t *testing.T) {
+			t.Parallel()
+			testenv.Run(t, &testenv.Config{
+				RouterOptions: global(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", ""),
+				Subgraphs:     cacheOptions("max-age=120", "max-age=60"),
+			}, func(t *testing.T, xEnv *testenv.Environment) {
+				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+					Query: queryEmployeeWithHobby,
 				})
+				cc := res.Response.Header.Get("Cache-Control")
+				require.Equal(t, "max-age=60", cc) // Most restrictive wins
+				require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
 			})
+		})
 
-			t.Run("global no-cache wins against no value", func(t *testing.T) {
-				t.Parallel()
-				testenv.Run(t, &testenv.Config{
-					RouterOptions: global(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", ""),
-					Subgraphs:     cacheOptions("no-cache", ""),
-				}, func(t *testing.T, xEnv *testenv.Environment) {
-					res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
-						Query: queryEmployeeWithHobby,
-					})
-					cc := res.Response.Header.Get("Cache-Control")
-					require.Equal(t, "no-cache", cc) // no-cache wins over max-age
-					require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
+		// Local test: Cache control rules are applied per subgraph (employees and hobbies)
+		t.Run("local most restrictive cache control", func(t *testing.T) {
+			t.Parallel()
+			testenv.Run(t, &testenv.Config{
+				RouterOptions: local(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", "", ""),
+				Subgraphs:     cacheOptions("max-age=120", "max-age=60"),
+			}, func(t *testing.T, xEnv *testenv.Environment) {
+				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+					Query: queryEmployeeWithHobby,
 				})
+				cc := res.Response.Header.Get("Cache-Control")
+				require.Equal(t, "max-age=60", cc) // Most restrictive wins
+				require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
 			})
+		})
 
-			// Test case for max-age: shortest max-age wins
-			t.Run("global shortest max-age wins", func(t *testing.T) {
+		// Partial test: Only one subgraph's response is considered (e.g., employees)
+		t.Run("partial most restrictive cache control", func(t *testing.T) {
+			t.Parallel()
+			testenv.Run(t, &testenv.Config{
+				RouterOptions: partial(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", ""),
+				Subgraphs:     cacheOptions("max-age=120", "max-age=60"),
+			}, func(t *testing.T, xEnv *testenv.Environment) {
+				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+					Query: queryEmployeeWithHobby,
+				})
+				cc := res.Response.Header.Get("Cache-Control")
+				require.Equal(t, "max-age=120", cc) // Only employee subgraph is considered
+				require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
+			})
+		})
+
+		// Test case for no-store being the most restrictive
+		t.Run("global no-store wins", func(t *testing.T) {
+			t.Parallel()
+			testenv.Run(t, &testenv.Config{
+				RouterOptions: global(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", ""),
+				Subgraphs:     cacheOptions("no-store", "max-age=300"),
+			}, func(t *testing.T, xEnv *testenv.Environment) {
+				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+					Query: queryEmployeeWithHobby,
+				})
+				cc := res.Response.Header.Get("Cache-Control")
+				require.Equal(t, "no-store", cc) // no-store wins
+				require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
+			})
+		})
+
+		// Test case for no-cache being more restrictive than max-age
+		t.Run("global no-cache wins", func(t *testing.T) {
+			t.Parallel()
+			testenv.Run(t, &testenv.Config{
+				RouterOptions: global(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", ""),
+				Subgraphs:     cacheOptions("no-cache", "max-age=300"),
+			}, func(t *testing.T, xEnv *testenv.Environment) {
+				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+					Query: queryEmployeeWithHobby,
+				})
+				cc := res.Response.Header.Get("Cache-Control")
+				require.Equal(t, "no-cache", cc) // no-cache wins over max-age
+				require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
+			})
+		})
+
+		t.Run("global no-cache wins against no value", func(t *testing.T) {
+			t.Parallel()
+			testenv.Run(t, &testenv.Config{
+				RouterOptions: global(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", ""),
+				Subgraphs:     cacheOptions("no-cache", ""),
+			}, func(t *testing.T, xEnv *testenv.Environment) {
+				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+					Query: queryEmployeeWithHobby,
+				})
+				cc := res.Response.Header.Get("Cache-Control")
+				require.Equal(t, "no-cache", cc) // no-cache wins over max-age
+				require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
+			})
+		})
+
+		// Test case for max-age: shortest max-age wins
+		t.Run("global shortest max-age wins", func(t *testing.T) {
+			t.Parallel()
+			testenv.Run(t, &testenv.Config{
+				RouterOptions: global(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", ""),
+				Subgraphs:     cacheOptions("max-age=600", "max-age=300"),
+			}, func(t *testing.T, xEnv *testenv.Environment) {
+				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+					Query: queryEmployeeWithHobby,
+				})
+				cc := res.Response.Header.Get("Cache-Control")
+				require.Equal(t, "max-age=300", cc) // Shorter max-age wins
+				require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
+			})
+		})
+
+		// Test case for Expires header: earliest expiration wins
+		t.Run("global earliest Expires wins", func(t *testing.T) {
+			t.Parallel()
+			testenv.Run(t, &testenv.Config{
+				RouterOptions: global(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", ""),
+				Subgraphs:     subgraphsWithExpiresHeader,
+			}, func(t *testing.T, xEnv *testenv.Environment) {
+				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+					Query: queryEmployeeWithHobby,
+				})
+				expires := res.Response.Header.Get("Expires")
+				require.NotEmpty(t, expires)
+
+				// Parse the Expires header and convert both times to UTC for comparison
+				parsedExpires, err := http.ParseTime(expires)
+				require.NoError(t, err)
+
+				now := time.Now().Add(5 * time.Minute)                        // Example expiration
+				require.WithinDuration(t, now, parsedExpires, 20*time.Second) // Ensure expiration is within expected range
+				require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
+			})
+		})
+
+		t.Run("default value adds max age", func(t *testing.T) {
+			t.Parallel()
+
+			t.Run("global default age sets for all requests", func(t *testing.T) {
 				t.Parallel()
 				testenv.Run(t, &testenv.Config{
-					RouterOptions: global(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", ""),
-					Subgraphs:     cacheOptions("max-age=600", "max-age=300"),
+					RouterOptions: global(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", "max-age=300"),
+					Subgraphs:     cacheOptions("", "max-age=600"),
 				}, func(t *testing.T, xEnv *testenv.Environment) {
 					res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
 						Query: queryEmployeeWithHobby,
@@ -416,136 +456,94 @@ func TestHeaderRules(t *testing.T) {
 				})
 			})
 
-			// Test case for Expires header: earliest expiration wins
-			t.Run("global earliest Expires wins", func(t *testing.T) {
+			t.Run("global no-cache sets for all requests", func(t *testing.T) {
 				t.Parallel()
 				testenv.Run(t, &testenv.Config{
-					RouterOptions: global(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", ""),
-					Subgraphs:     subgraphsWithExpiresHeader,
+					RouterOptions: global(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", "no-cache"),
+					Subgraphs:     cacheOptions("", "max-age=600"),
 				}, func(t *testing.T, xEnv *testenv.Environment) {
 					res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
 						Query: queryEmployeeWithHobby,
 					})
-					expires := res.Response.Header.Get("Expires")
-					require.NotEmpty(t, expires)
-
-					// Parse the Expires header and convert both times to UTC for comparison
-					parsedExpires, err := http.ParseTime(expires)
-					require.NoError(t, err)
-
-					now := time.Now().Add(5 * time.Minute)                        // Example expiration
-					require.WithinDuration(t, now, parsedExpires, 20*time.Second) // Ensure expiration is within expected range
+					cc := res.Response.Header.Get("Cache-Control")
+					require.Equal(t, "no-cache", cc) // Shorter max-age wins
 					require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
 				})
 			})
 
-			t.Run("default value adds max age", func(t *testing.T) {
+			t.Run("global default age sets for all requests", func(t *testing.T) {
 				t.Parallel()
-
-				t.Run("global default age sets for all requests", func(t *testing.T) {
-					t.Parallel()
-					testenv.Run(t, &testenv.Config{
-						RouterOptions: global(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", "max-age=300"),
-						Subgraphs:     cacheOptions("", "max-age=600"),
-					}, func(t *testing.T, xEnv *testenv.Environment) {
-						res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
-							Query: queryEmployeeWithHobby,
-						})
-						cc := res.Response.Header.Get("Cache-Control")
-						require.Equal(t, "max-age=300", cc) // Shorter max-age wins
-						require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
+				testenv.Run(t, &testenv.Config{
+					RouterOptions: global(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", "no-cache"),
+					Subgraphs:     cacheOptions("max-age=60", "max-age=300"),
+				}, func(t *testing.T, xEnv *testenv.Environment) {
+					res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+						Query: queryEmployeeWithHobby,
 					})
+					cc := res.Response.Header.Get("Cache-Control")
+					require.Equal(t, "no-cache", cc) // Shorter max-age wins
+					require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
 				})
+			})
 
-				t.Run("global no-cache sets for all requests", func(t *testing.T) {
-					t.Parallel()
-					testenv.Run(t, &testenv.Config{
-						RouterOptions: global(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", "no-cache"),
-						Subgraphs:     cacheOptions("", "max-age=600"),
-					}, func(t *testing.T, xEnv *testenv.Environment) {
-						res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
-							Query: queryEmployeeWithHobby,
-						})
-						cc := res.Response.Header.Get("Cache-Control")
-						require.Equal(t, "no-cache", cc) // Shorter max-age wins
-						require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
+			t.Run("allows subgraph to override default", func(t *testing.T) {
+				t.Parallel()
+				testenv.Run(t, &testenv.Config{
+					RouterOptions: global(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", "max-age=300"),
+					Subgraphs:     cacheOptions("max-age=60", "max-age=180"),
+				}, func(t *testing.T, xEnv *testenv.Environment) {
+					res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+						Query: queryEmployeeWithHobby,
 					})
+					cc := res.Response.Header.Get("Cache-Control")
+					require.Equal(t, "max-age=60", cc) // Shorter max-age wins
+					require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
 				})
+			})
 
-				t.Run("global default age sets for all requests", func(t *testing.T) {
-					t.Parallel()
-					testenv.Run(t, &testenv.Config{
-						RouterOptions: global(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", "no-cache"),
-						Subgraphs:     cacheOptions("max-age=60", "max-age=300"),
-					}, func(t *testing.T, xEnv *testenv.Environment) {
-						res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
-							Query: queryEmployeeWithHobby,
-						})
-						cc := res.Response.Header.Get("Cache-Control")
-						require.Equal(t, "no-cache", cc) // Shorter max-age wins
-						require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
+			t.Run("partial default age sets for requests with information", func(t *testing.T) {
+				t.Parallel()
+				testenv.Run(t, &testenv.Config{
+					RouterOptions: local(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", "", "max-age=300"),
+					Subgraphs:     cacheOptions("", ""),
+				}, func(t *testing.T, xEnv *testenv.Environment) {
+					res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+						Query: queryEmployeeWithHobby,
 					})
+					cc := res.Response.Header.Get("Cache-Control")
+					require.Equal(t, "max-age=300", cc) // Shorter max-age wins
+					require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
 				})
+			})
 
-				t.Run("allows subgraph to override default", func(t *testing.T) {
-					t.Parallel()
-					testenv.Run(t, &testenv.Config{
-						RouterOptions: global(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", "max-age=300"),
-						Subgraphs:     cacheOptions("max-age=60", "max-age=180"),
-					}, func(t *testing.T, xEnv *testenv.Environment) {
-						res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
-							Query: queryEmployeeWithHobby,
-						})
-						cc := res.Response.Header.Get("Cache-Control")
-						require.Equal(t, "max-age=60", cc) // Shorter max-age wins
-						require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
+			t.Run("partial default age doesn't set for unassociated requests", func(t *testing.T) {
+				t.Parallel()
+				testenv.Run(t, &testenv.Config{
+					RouterOptions: local(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", "", "max-age=300"),
+					Subgraphs:     cacheOptions("", ""),
+				}, func(t *testing.T, xEnv *testenv.Environment) {
+					res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+						Query: queryEmployeeWithNoHobby,
 					})
+					cc := res.Response.Header.Get("Cache-Control")
+					require.Equal(t, "", cc)
+					require.Equal(t, `{"data":{"employee":{"id":1}}}`, res.Body)
 				})
+			})
 
-				t.Run("partial default age sets for requests with information", func(t *testing.T) {
-					t.Parallel()
-					testenv.Run(t, &testenv.Config{
-						RouterOptions: local(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", "", "max-age=300"),
-						Subgraphs:     cacheOptions("", ""),
-					}, func(t *testing.T, xEnv *testenv.Environment) {
-						res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
-							Query: queryEmployeeWithHobby,
-						})
-						cc := res.Response.Header.Get("Cache-Control")
-						require.Equal(t, "max-age=300", cc) // Shorter max-age wins
-						require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
+			t.Run("no-cache is set for all mutations", func(t *testing.T) {
+				t.Parallel()
+				testenv.Run(t, &testenv.Config{
+					RouterOptions: global(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", "max-age=300"),
+					Subgraphs:     cacheOptions("", ""),
+				}, func(t *testing.T, xEnv *testenv.Environment) {
+					res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+						Query: `mutation { updateEmployeeTag(id: 1, tag: "test") { id tag } }`,
 					})
-				})
-
-				t.Run("partial default age doesn't set for unassociated requests", func(t *testing.T) {
-					t.Parallel()
-					testenv.Run(t, &testenv.Config{
-						RouterOptions: local(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", "", "max-age=300"),
-						Subgraphs:     cacheOptions("", ""),
-					}, func(t *testing.T, xEnv *testenv.Environment) {
-						res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
-							Query: queryEmployeeWithNoHobby,
-						})
-						cc := res.Response.Header.Get("Cache-Control")
-						require.Equal(t, "", cc)
-						require.Equal(t, `{"data":{"employee":{"id":1}}}`, res.Body)
-					})
-				})
-
-				t.Run("no-cache is set for all mutations", func(t *testing.T) {
-					t.Parallel()
-					testenv.Run(t, &testenv.Config{
-						RouterOptions: global(config.ResponseHeaderRuleAlgorithmMostRestrictiveCacheControl, "", "max-age=300"),
-						Subgraphs:     cacheOptions("", ""),
-					}, func(t *testing.T, xEnv *testenv.Environment) {
-						res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
-							Query: `mutation { updateEmployeeTag(id: 1, tag: "test") { id tag } }`,
-						})
-						cc := res.Response.Header.Get("Cache-Control")
-						require.Equal(t, "no-cache", cc)
-						require.Equal(t, http.StatusOK, res.Response.StatusCode)
-						require.Equal(t, `{"data":{"updateEmployeeTag":{"id":1,"tag":"test"}}}`, res.Body)
-					})
+					cc := res.Response.Header.Get("Cache-Control")
+					require.Equal(t, "no-cache", cc)
+					require.Equal(t, http.StatusOK, res.Response.StatusCode)
+					require.Equal(t, `{"data":{"updateEmployeeTag":{"id":1,"tag":"test"}}}`, res.Body)
 				})
 			})
 		})

--- a/router-tests/header_set_test.go
+++ b/router-tests/header_set_test.go
@@ -29,12 +29,6 @@ func TestHeaderSet(t *testing.T) {
 	  }
 	}`
 
-	const queryEmployeeWithNoHobby = `{
-	  employee(id: 1) {
-		id
-	  }
-	}`
-
 	t.Run("RequestSet", func(t *testing.T) {
 		getRule := func(name, val string) *config.RequestHeaderRule {
 			rule := &config.RequestHeaderRule{

--- a/router-tests/header_set_test.go
+++ b/router-tests/header_set_test.go
@@ -1,0 +1,150 @@
+package integration
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/require"
+	"github.com/wundergraph/cosmo/router-tests/testenv"
+	"github.com/wundergraph/cosmo/router/core"
+	"github.com/wundergraph/cosmo/router/pkg/config"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestHeaderSet(t *testing.T) {
+	const (
+		customHeader = "X-Custom-Header"
+		employeeVal  = "employee-value"
+		hobbyVal     = "hobby-value"
+	)
+
+	const queryEmployeeWithHobby = `{
+	  employee(id: 1) {
+		id
+		hobbies {
+		  ... on Gaming {
+			name
+		  }
+		}
+	  }
+	}`
+
+	const queryEmployeeWithNoHobby = `{
+	  employee(id: 1) {
+		id
+	  }
+	}`
+
+	t.Run("RequestSet", func(t *testing.T) {
+		getRule := func(name, val string) *config.RequestHeaderRule {
+			rule := &config.RequestHeaderRule{
+				Operation: config.HeaderRuleOperationSet,
+				Name:      name,
+				Value:     val,
+			}
+			return rule
+		}
+
+		global := func(name, defaultVal string) []core.Option {
+			return []core.Option{
+				core.WithHeaderRules(config.HeaderRules{
+					All: &config.GlobalHeaderRule{
+						Request: []*config.RequestHeaderRule{
+							getRule(name, defaultVal),
+						},
+					},
+				}),
+			}
+		}
+
+		t.Run("global request rule sets header", func(t *testing.T) {
+			t.Parallel()
+			testenv.Run(t, &testenv.Config{
+				RouterOptions: global(customHeader, employeeVal),
+			}, func(t *testing.T, xEnv *testenv.Environment) {
+				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+					Header: http.Header{},
+					Query:  fmt.Sprintf(`query { headerValue(name:"%s") }`, customHeader),
+				})
+				require.Equal(t, fmt.Sprintf(`{"data":{"headerValue":"%s"}}`, employeeVal), res.Body)
+			})
+		})
+	})
+
+	t.Run("ResponseSet", func(t *testing.T) {
+		getRule := func(name, val string) *config.ResponseHeaderRule {
+			rule := &config.ResponseHeaderRule{
+				Operation: config.HeaderRuleOperationSet,
+				Name:      name,
+				Value:     val,
+			}
+			return rule
+		}
+
+		global := func(name, defaultVal string) []core.Option {
+			return []core.Option{
+				core.WithHeaderRules(config.HeaderRules{
+					All: &config.GlobalHeaderRule{
+						Response: []*config.ResponseHeaderRule{
+							getRule(name, defaultVal),
+						},
+					},
+				}),
+			}
+		}
+
+		partial := func(name, defaultVal string) []core.Option {
+			return []core.Option{
+				core.WithHeaderRules(config.HeaderRules{
+					Subgraphs: map[string]*config.GlobalHeaderRule{
+						"employees": {
+							Response: []*config.ResponseHeaderRule{
+								getRule(name, defaultVal),
+							},
+						},
+					},
+				}),
+			}
+		}
+
+		t.Run("no set", func(t *testing.T) {
+			t.Parallel()
+			testenv.Run(t, &testenv.Config{}, func(t *testing.T, xEnv *testenv.Environment) {
+				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+					Query: queryEmployeeWithHobby,
+				})
+				ch := strings.Join(res.Response.Header.Values(customHeader), ",")
+				require.Equal(t, "", ch)
+				require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
+			})
+		})
+
+		t.Run("global set works", func(t *testing.T) {
+			t.Parallel()
+			testenv.Run(t, &testenv.Config{
+				RouterOptions: global(customHeader, hobbyVal),
+			}, func(t *testing.T, xEnv *testenv.Environment) {
+				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+					Query: queryEmployeeWithHobby,
+				})
+				ch := strings.Join(res.Response.Header.Values(customHeader), ",")
+				require.Equal(t, hobbyVal, ch)
+				require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
+			})
+		})
+
+		t.Run("subgraph set works", func(t *testing.T) {
+			t.Parallel()
+			testenv.Run(t, &testenv.Config{
+				RouterOptions: partial(customHeader, employeeVal),
+			}, func(t *testing.T, xEnv *testenv.Environment) {
+				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+					Query: queryEmployeeWithHobby,
+				})
+				ch := strings.Join(res.Response.Header.Values(customHeader), ",")
+				require.Equal(t, employeeVal, ch)
+				require.Equal(t, `{"data":{"employee":{"id":1,"hobbies":[{},{"name":"Counter Strike"},{},{},{}]}}}`, res.Body)
+			})
+		})
+	})
+}

--- a/router/pkg/config/config.go
+++ b/router/pkg/config/config.go
@@ -178,6 +178,7 @@ type HeaderRuleOperation string
 
 const (
 	HeaderRuleOperationPropagate HeaderRuleOperation = "propagate"
+	HeaderRuleOperationSet       HeaderRuleOperation = "set"
 )
 
 type HeaderRule interface {
@@ -188,6 +189,7 @@ type HeaderRule interface {
 type RequestHeaderRule struct {
 	// Operation describes the header operation to perform e.g. "propagate"
 	Operation HeaderRuleOperation `yaml:"op"`
+	// Propagate options
 	// Matching is the regex to match the header name against
 	Matching string `yaml:"matching"`
 	// Named is the exact header name to match
@@ -196,6 +198,12 @@ type RequestHeaderRule struct {
 	Rename string `yaml:"rename,omitempty"`
 	// Default is the default value to set if the header is not present
 	Default string `yaml:"default"`
+
+	// Set header options
+	// Name is the name of the header to set
+	Name string `yaml:"name"`
+	// Value is the value of the header to set
+	Value string `yaml:"value"`
 }
 
 func (r *RequestHeaderRule) GetOperation() HeaderRuleOperation {
@@ -232,6 +240,12 @@ type ResponseHeaderRule struct {
 	Default string `yaml:"default"`
 	// Algorithm is the algorithm to use when multiple headers are present
 	Algorithm ResponseHeaderRuleAlgorithm `yaml:"algorithm,omitempty"`
+
+	// Set header options
+	// Name is the name of the header to set
+	Name string `yaml:"name"`
+	// Value is the value of the header to set
+	Value string `yaml:"value"`
 }
 
 func (r *ResponseHeaderRule) GetOperation() HeaderRuleOperation {

--- a/router/pkg/config/config.schema.json
+++ b/router/pkg/config/config.schema.json
@@ -1757,7 +1757,7 @@
         },
         "value": {
           "type": "string",
-          "examples": ["${env.SECRET_FOR_SUBGRAPH}"],
+          "examples": ["My-Secret-Value"],
           "description": "The value to set for the header. This can include environment variables."
         }
       },

--- a/router/pkg/config/config.schema.json
+++ b/router/pkg/config/config.schema.json
@@ -959,13 +959,19 @@
             "request": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/traffic_shaping_header_rule"
+                "oneOf": [
+                  { "$ref": "#/definitions/traffic_shaping_header_rule" },
+                  { "$ref": "#/definitions/set_header_rule" }
+                ]
               }
             },
             "response": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/traffic_shaping_header_response_rule"
+                "oneOf": [
+                  { "$ref": "#/definitions/traffic_shaping_header_response_rule" },
+                  { "$ref": "#/definitions/set_header_rule" }
+                ]
               }
             }
           }
@@ -979,13 +985,19 @@
               "request": {
                 "type": "array",
                 "items": {
-                  "$ref": "#/definitions/traffic_shaping_header_rule"
+                  "oneOf": [
+                    { "$ref": "#/definitions/traffic_shaping_header_rule" },
+                    { "$ref": "#/definitions/set_header_rule" }
+                  ]
                 }
               },
               "response": {
                 "type": "array",
                 "items": {
-                  "$ref": "#/definitions/traffic_shaping_header_response_rule"
+                  "oneOf": [
+                    { "$ref": "#/definitions/traffic_shaping_header_response_rule" },
+                    { "$ref": "#/definitions/set_header_rule" }
+                  ]
                 }
               }
             }
@@ -1727,6 +1739,29 @@
           "rename": {}
         }
       }
+    },
+    "set_header_rule": {
+      "type": "object",
+      "description": "The configuration for setting headers. This is used to set specific headers in requests or responses.",
+      "additionalProperties": false,
+      "properties": {
+        "op": {
+          "type": "string",
+          "const": "set",
+          "description": "The 'set' operation is used to set a specific header value."
+        },
+        "name": {
+          "type": "string",
+          "examples": ["X-API-Key"],
+          "description": "The name of the header to set."
+        },
+        "value": {
+          "type": "string",
+          "examples": ["${env.SECRET_FOR_SUBGRAPH}"],
+          "description": "The value to set for the header. This can include environment variables."
+        }
+      },
+      "required": ["op", "name", "value"]
     }
   }
 }

--- a/router/pkg/config/fixtures/full.yaml
+++ b/router/pkg/config/fixtures/full.yaml
@@ -151,6 +151,9 @@ headers:
       - op: "propagate"
         named: "X-User-Id"
         default: "123"             # Set the value when the header was not set
+      - op: "set"
+        name: "X-API-Key"
+        value: "some-secret"
     response:
       - op: "propagate"
         algorithm: "append"
@@ -164,6 +167,9 @@ headers:
       response:
         - op: "propagate"
           algorithm: "most_restrictive_cache_control"
+        - op: "set"
+          name: "X-Subgraph-Key"
+          value: "some-subgraph-secret"
 
 # Authentication and Authorization
 # See https://cosmo-docs.wundergraph.com/router/authentication-and-authorization for more information

--- a/router/pkg/config/testdata/config_full.json
+++ b/router/pkg/config/testdata/config_full.json
@@ -111,21 +111,36 @@
           "Matching": "",
           "Named": "X-Test-Header",
           "Rename": "",
-          "Default": ""
+          "Default": "",
+          "Name": "",
+          "Value": ""
         },
         {
           "Operation": "propagate",
           "Matching": "(?i)^X-Custom-.*",
           "Named": "",
           "Rename": "",
-          "Default": ""
+          "Default": "",
+          "Name": "",
+          "Value": ""
         },
         {
           "Operation": "propagate",
           "Matching": "",
           "Named": "X-User-Id",
           "Rename": "",
-          "Default": "123"
+          "Default": "123",
+          "Name": "",
+          "Value": ""
+        },
+        {
+          "Operation": "set",
+          "Matching": "",
+          "Named": "",
+          "Rename": "",
+          "Default": "",
+          "Name": "X-API-Key",
+          "Value": "some-secret"
         }
       ],
       "Response": [
@@ -135,7 +150,9 @@
           "Named": "X-Custom-Header",
           "Rename": "",
           "Default": "",
-          "Algorithm": "append"
+          "Algorithm": "append",
+          "Name": "",
+          "Value": ""
         }
       ]
     },
@@ -147,7 +164,9 @@
             "Matching": "",
             "Named": "Subgraph-Secret",
             "Rename": "",
-            "Default": "some-secret"
+            "Default": "some-secret",
+            "Name": "",
+            "Value": ""
           }
         ],
         "Response": [
@@ -157,7 +176,19 @@
             "Named": "",
             "Rename": "",
             "Default": "",
-            "Algorithm": "most_restrictive_cache_control"
+            "Algorithm": "most_restrictive_cache_control",
+            "Name": "",
+            "Value": ""
+          },
+          {
+            "Operation": "set",
+            "Matching": "",
+            "Named": "",
+            "Rename": "",
+            "Default": "",
+            "Algorithm": "",
+            "Name": "X-Subgraph-Key",
+            "Value": "some-subgraph-secret"
           }
         ]
       }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->

## Motivation and Context

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

This PR expands our header propagation abilities, by allowing users to define a value to set on all request/response headers in the format: 

```
headers:
  all: # Header rules for all subgraphs
    request:
      - op: "set"
        name: "X-API-Key"
        value: ${SECRET_FOR_SUBGRAPH}
```

The `set` operation works both for requests and responses, and it can be applied globally (to all requests on the router), or only on a specific subgraph. 

## TODO

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
