### PR TITLE
fix: unmarshal YAML once before validation

### DIFF
--- a/router/pkg/config/config.go
+++ b/router/pkg/config/config.go
@@ -625,6 +625,10 @@ type Config struct {
 	PersistedOperationsConfig PersistedOperationsConfig `yaml:"persisted_operations"`
 }
 
+func (c *Config) Validate() error {
+	return validateConfig(c, JSONSchema)
+}
+
 type LoadResult struct {
 	Config        Config
 	DefaultLoaded bool
@@ -685,15 +689,13 @@ func LoadConfig(configFilePath string, envOverride string) (*LoadResult, error) 
 
 		configFileBytes = []byte(configYamlData)
 
-		err = ValidateConfig(configFileBytes, JSONSchema)
-		if err != nil {
-			return nil, fmt.Errorf("router config validation error: %w", err)
-		}
-
-		// Unmarshal the final config
-
 		if err := yaml.Unmarshal(configFileBytes, &cfg.Config); err != nil {
 			return nil, err
+		}
+
+		err = cfg.Config.Validate()
+		if err != nil {
+			return nil, fmt.Errorf("router config validation error: %w", err)
 		}
 	}
 

--- a/router/pkg/config/json_schema.go
+++ b/router/pkg/config/json_schema.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"github.com/dustin/go-humanize"
 	"github.com/goccy/go-json"
-	"github.com/goccy/go-yaml"
 	"github.com/santhosh-tekuri/jsonschema/v6"
 	"golang.org/x/text/message"
 	"io/fs"
@@ -82,7 +81,7 @@ func goDurationVocab() *jsonschema.Vocabulary {
 			"properties": {
 				"minimum": {
 					"type": "string"
-				},	
+				},
 				"maximum": {
 					"type": "string"
 				}
@@ -217,7 +216,7 @@ func humanBytesVocab() *jsonschema.Vocabulary {
 			"properties": {
 				"minimum": {
 					"type": "string"
-				},	
+				},
 				"minimum": {
 					"type": "string"
 				}
@@ -286,16 +285,11 @@ var (
 	hostnameRegexRFC1123 = regexp.MustCompile(hostnameRegexStringRFC1123)
 )
 
-func ValidateConfig(yamlData []byte, schema []byte) error {
+func validateConfig(v *Config, schema []byte) error {
 	var s any
 	err := json.Unmarshal(schema, &s)
 	if err != nil {
 		return err
-	}
-
-	var v any
-	if err := yaml.Unmarshal(yamlData, &v); err != nil {
-		log.Fatal(err)
 	}
 
 	c := jsonschema.NewCompiler()


### PR DESCRIPTION
This way consumers can use the validation function without needing to use Cosmo to directly read the file.

## Motivation and Context

Before config validation was somewhat hidden inside of Cosmo. Now config can be loaded from disk and validated outside of the Cosmo library since the config struct contains its own validation logic.

- [x] Tests or benchmark included (existing tests cover behavior)
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [x] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
