### PR TITLE
feat: enable datadog trace propagation

### DIFF
--- a/router-tests/telemetry_test.go
+++ b/router-tests/telemetry_test.go
@@ -2271,6 +2271,10 @@ Downstream errors:
 	t.Run("Datadog Propagation", func(t *testing.T) {
 		var (
 			datadogTraceId = "9532127138774266268"
+			testPropConfig = config.PropagationConfig{
+				TraceContext: true,
+				Datadog:      true,
+			}
 		)
 
 		t.Run("Datadog headers are propagated if enabled", func(t *testing.T) {
@@ -2279,8 +2283,8 @@ Downstream errors:
 			exporter := tracetest.NewInMemoryExporter(t)
 
 			testenv.Run(t, &testenv.Config{
-				TraceExporter:    exporter,
-				DatadogTelemetry: true,
+				TraceExporter:     exporter,
+				PropagationConfig: testPropConfig,
 				Subgraphs: testenv.SubgraphsConfig{
 					Employees: testenv.SubgraphConfig{
 						Middleware: func(handler http.Handler) http.Handler {
@@ -2310,8 +2314,8 @@ Downstream errors:
 			exporter := tracetest.NewInMemoryExporter(t)
 
 			testenv.Run(t, &testenv.Config{
-				TraceExporter:    exporter,
-				DatadogTelemetry: true,
+				TraceExporter:     exporter,
+				PropagationConfig: testPropConfig,
 				Subgraphs: testenv.SubgraphsConfig{
 					Employees: testenv.SubgraphConfig{
 						Middleware: func(handler http.Handler) http.Handler {
@@ -2341,8 +2345,8 @@ Downstream errors:
 			exporter := tracetest.NewInMemoryExporter(t)
 
 			testenv.Run(t, &testenv.Config{
-				TraceExporter:    exporter,
-				DatadogTelemetry: true,
+				TraceExporter:     exporter,
+				PropagationConfig: testPropConfig,
 				Subgraphs: testenv.SubgraphsConfig{
 					Employees: testenv.SubgraphConfig{
 						Middleware: func(handler http.Handler) http.Handler {
@@ -2369,7 +2373,6 @@ Downstream errors:
 				sn := exporter.GetSpans().Snapshots()
 				require.GreaterOrEqual(t, len(sn), 1)
 				require.Equal(t, "00000000000000008448eb211c80319c", sn[0].SpanContext().TraceID().String())
-				//require.Equal(t, "6179b4f63c68cdfd", sn[0].SpanContext().SpanID().String())
 			})
 		})
 
@@ -2379,8 +2382,8 @@ Downstream errors:
 			exporter := tracetest.NewInMemoryExporter(t)
 
 			testenv.Run(t, &testenv.Config{
-				TraceExporter:    exporter,
-				DatadogTelemetry: false,
+				TraceExporter:     exporter,
+				PropagationConfig: config.PropagationConfig{Datadog: false},
 				Subgraphs: testenv.SubgraphsConfig{
 					Employees: testenv.SubgraphConfig{
 						Middleware: func(handler http.Handler) http.Handler {

--- a/router-tests/telemetry_test.go
+++ b/router-tests/telemetry_test.go
@@ -2267,4 +2267,103 @@ Downstream errors:
 			require.Equal(t, "exception", events[0].Name)
 		})
 	})
+
+	t.Run("Datadog Propagation", func(t *testing.T) {
+		var (
+			datadogTraceId = "9532127138774266268"
+		)
+
+		t.Run("Datadog headers are propagated if enabled", func(t *testing.T) {
+			t.Parallel()
+
+			exporter := tracetest.NewInMemoryExporter(t)
+
+			testenv.Run(t, &testenv.Config{
+				TraceExporter:    exporter,
+				DatadogTelemetry: true,
+				Subgraphs: testenv.SubgraphsConfig{
+					Employees: testenv.SubgraphConfig{
+						Middleware: func(handler http.Handler) http.Handler {
+							return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+								require.Equal(t, datadogTraceId, r.Header.Get("x-datadog-trace-id"))
+								require.NotEqual(t, "", r.Header.Get("x-datadog-parent-id"))
+								require.Equal(t, "1", r.Header.Get("x-datadog-sampling-priority"))
+								handler.ServeHTTP(w, r)
+							})
+						},
+					},
+				},
+			}, func(t *testing.T, xEnv *testenv.Environment) {
+				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+					Query: `query myQuery { employees { id } }`,
+					Header: map[string][]string{
+						"traceparent": {"00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203332-01"}, // 01 = sampled
+					},
+				})
+				require.JSONEq(t, employeesIDData, res.Body)
+			})
+		})
+
+		t.Run("Datadog headers correctly recognize sampling bit", func(t *testing.T) {
+			t.Parallel()
+
+			exporter := tracetest.NewInMemoryExporter(t)
+
+			testenv.Run(t, &testenv.Config{
+				TraceExporter:    exporter,
+				DatadogTelemetry: true,
+				Subgraphs: testenv.SubgraphsConfig{
+					Employees: testenv.SubgraphConfig{
+						Middleware: func(handler http.Handler) http.Handler {
+							return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+								require.Equal(t, datadogTraceId, r.Header.Get("x-datadog-trace-id"))
+								require.NotEqual(t, "", r.Header.Get("x-datadog-parent-id"))
+								require.Equal(t, "0", r.Header.Get("x-datadog-sampling-priority"))
+								handler.ServeHTTP(w, r)
+							})
+						},
+					},
+				},
+			}, func(t *testing.T, xEnv *testenv.Environment) {
+				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+					Query: `query myQuery { employees { id } }`,
+					Header: map[string][]string{
+						"traceparent": {"00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203332-00"}, // 01 = sampled
+					},
+				})
+				require.JSONEq(t, employeesIDData, res.Body)
+			})
+		})
+
+		t.Run("Doesn't propagate headers in datadog format if datadog config is not set", func(t *testing.T) {
+			t.Parallel()
+
+			exporter := tracetest.NewInMemoryExporter(t)
+
+			testenv.Run(t, &testenv.Config{
+				TraceExporter:    exporter,
+				DatadogTelemetry: false,
+				Subgraphs: testenv.SubgraphsConfig{
+					Employees: testenv.SubgraphConfig{
+						Middleware: func(handler http.Handler) http.Handler {
+							return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+								require.Equal(t, "", r.Header.Get("x-datadog-trace-id"))
+								require.Equal(t, "", r.Header.Get("x-datadog-parent-id"))
+								require.Equal(t, "", r.Header.Get("x-datadog-sampling-priority"))
+								handler.ServeHTTP(w, r)
+							})
+						},
+					},
+				},
+			}, func(t *testing.T, xEnv *testenv.Environment) {
+				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+					Query: `query myQuery { employees { id } }`,
+					Header: map[string][]string{
+						"traceparent": {"00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203332-00"}, // 01 = sampled
+					},
+				})
+				require.JSONEq(t, employeesIDData, res.Body)
+			})
+		})
+	})
 }

--- a/router-tests/telemetry_test.go
+++ b/router-tests/telemetry_test.go
@@ -2348,7 +2348,7 @@ Downstream errors:
 						Middleware: func(handler http.Handler) http.Handler {
 							return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 								require.Equal(t, datadogTraceId, r.Header.Get("x-datadog-trace-id"))
-								require.NotEqual(t, "12345", r.Header.Get("x-datadog-parent-id"))
+								require.NotEqual(t, "6023947403358210776", r.Header.Get("x-datadog-parent-id"))
 								require.Equal(t, "1", r.Header.Get("x-datadog-sampling-priority"))
 								handler.ServeHTTP(w, r)
 							})
@@ -2360,11 +2360,16 @@ Downstream errors:
 					Query: `query myQuery { employees { id } }`,
 					Header: map[string][]string{
 						"x-datadog-trace-id":          {datadogTraceId},
-						"x-datadog-parent-id":         {"12345"},
+						"x-datadog-parent-id":         {"6023947403358210776"},
 						"x-datadog-sampling-priority": {"1"},
 					},
 				})
 				require.JSONEq(t, employeesIDData, res.Body)
+
+				sn := exporter.GetSpans().Snapshots()
+				require.GreaterOrEqual(t, len(sn), 1)
+				require.Equal(t, "00000000000000008448eb211c80319c", sn[0].SpanContext().TraceID().String())
+				//require.Equal(t, "6179b4f63c68cdfd", sn[0].SpanContext().SpanID().String())
 			})
 		})
 

--- a/router-tests/testenv/testenv.go
+++ b/router-tests/testenv/testenv.go
@@ -126,7 +126,7 @@ type Config struct {
 	PrometheusRegistry                 *prometheus.Registry
 	ShutdownDelay                      time.Duration
 	NoRetryClient                      bool
-	DatadogTelemetry                   bool
+	PropagationConfig                  config.PropagationConfig
 	LogObservation                     LogObservationConfig
 }
 
@@ -680,19 +680,18 @@ func configureRouter(listenerAddr string, testConfig *Config, routerConfig *node
 	}
 
 	if testConfig.TraceExporter != nil {
+		testConfig.PropagationConfig.TraceContext = true
+
 		c := core.TraceConfigFromTelemetry(&config.Telemetry{
 			ServiceName:        "cosmo-router",
 			Attributes:         testConfig.OtelAttributes,
 			ResourceAttributes: testConfig.OtelResourceAttributes,
 			Tracing: config.Tracing{
-				Enabled:            true,
-				SamplingRate:       1,
-				ParentBasedSampler: !testConfig.DisableParentBasedSampler,
-				Exporters:          []config.TracingExporter{},
-				Propagation: config.PropagationConfig{
-					TraceContext: true,
-					Datadog:      testConfig.DatadogTelemetry,
-				},
+				Enabled:               true,
+				SamplingRate:          1,
+				ParentBasedSampler:    !testConfig.DisableParentBasedSampler,
+				Exporters:             []config.TracingExporter{},
+				Propagation:           testConfig.PropagationConfig,
 				TracingGlobalFeatures: config.TracingGlobalFeatures{},
 			},
 		})

--- a/router-tests/testenv/testenv.go
+++ b/router-tests/testenv/testenv.go
@@ -126,6 +126,7 @@ type Config struct {
 	PrometheusRegistry                 *prometheus.Registry
 	ShutdownDelay                      time.Duration
 	NoRetryClient                      bool
+	DatadogTelemetry                   bool
 	LogObservation                     LogObservationConfig
 }
 
@@ -690,6 +691,7 @@ func configureRouter(listenerAddr string, testConfig *Config, routerConfig *node
 				Exporters:          []config.TracingExporter{},
 				Propagation: config.PropagationConfig{
 					TraceContext: true,
+					Datadog:      testConfig.DatadogTelemetry,
 				},
 				TracingGlobalFeatures: config.TracingGlobalFeatures{},
 			},

--- a/router/core/router.go
+++ b/router/core/router.go
@@ -1714,6 +1714,9 @@ func TraceConfigFromTelemetry(cfg *config.Telemetry) *rtrace.Config {
 	if cfg.Tracing.Propagation.Jaeger {
 		propagators = append(propagators, rtrace.PropagatorJaeger)
 	}
+	if cfg.Tracing.Propagation.Datadog {
+		propagators = append(propagators, rtrace.PropagatorDatadog)
+	}
 	if cfg.Tracing.Propagation.Baggage {
 		propagators = append(propagators, rtrace.PropagatorBaggage)
 	}

--- a/router/go.mod
+++ b/router/go.mod
@@ -73,6 +73,7 @@ require (
 	github.com/minio/minio-go/v7 v7.0.74
 	github.com/pquerna/cachecontrol v0.2.0
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.1
+	github.com/tonglil/opentelemetry-go-datadog-propagator v0.1.3
 	github.com/wundergraph/astjson v0.0.0-20240910140849-bb15f94bd362
 	golang.org/x/exp v0.0.0-20240613232115-7f521ea00fb8
 	golang.org/x/text v0.16.0
@@ -130,7 +131,6 @@ require (
 	github.com/tidwall/pretty v1.2.1 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
-	github.com/tonglil/opentelemetry-go-datadog-propagator v0.1.3 // indirect
 	github.com/twmb/franz-go/pkg/kmsg v1.7.0 // indirect
 	github.com/vektah/gqlparser/v2 v2.5.16 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect

--- a/router/go.mod
+++ b/router/go.mod
@@ -130,6 +130,7 @@ require (
 	github.com/tidwall/pretty v1.2.1 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
+	github.com/tonglil/opentelemetry-go-datadog-propagator v0.1.3 // indirect
 	github.com/twmb/franz-go/pkg/kmsg v1.7.0 // indirect
 	github.com/vektah/gqlparser/v2 v2.5.16 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect

--- a/router/go.sum
+++ b/router/go.sum
@@ -258,6 +258,8 @@ github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFA
 github.com/tklauser/go-sysconf v0.3.12/go.mod h1:Ho14jnntGE1fpdOqQEEaiKRpvIavV0hSfmBq8nJbHYI=
 github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk=
 github.com/tklauser/numcpus v0.6.1/go.mod h1:1XfjsgE2zo8GVw7POkMbHENHzVg3GzmoZ9fESEdAacY=
+github.com/tonglil/opentelemetry-go-datadog-propagator v0.1.3 h1:Ozy1UnlID19jL6+vixEcA1t4NMf8hp01uDAY1nwGl8U=
+github.com/tonglil/opentelemetry-go-datadog-propagator v0.1.3/go.mod h1:Ijp5eaviP2mk8CJM+0EDYFKNULr+kicPSB9FOvxOhW0=
 github.com/twmb/franz-go v1.16.1 h1:rpWc7fB9jd7TgmCyfxzenBI+QbgS8ZfJOUQE+tzPtbE=
 github.com/twmb/franz-go v1.16.1/go.mod h1:/pER254UPPGp/4WfGqRi+SIRGE50RSQzVubQp6+N4FA=
 github.com/twmb/franz-go/pkg/kmsg v1.7.0 h1:a457IbvezYfA5UkiBvyV3zj0Is3y1i8EJgqjJYoij2E=

--- a/router/pkg/config/config.go
+++ b/router/pkg/config/config.go
@@ -59,6 +59,7 @@ type PropagationConfig struct {
 	Jaeger       bool `yaml:"jaeger"`
 	B3           bool `yaml:"b3"`
 	Baggage      bool `yaml:"baggage"`
+	Datadog      bool `yaml:"datadog"`
 }
 
 type Prometheus struct {

--- a/router/pkg/config/config.schema.json
+++ b/router/pkg/config/config.schema.json
@@ -551,7 +551,7 @@
                 },
                 "datadog": {
                   "type": "boolean",
-                  "description": "Enable the Datadog propagation, using https://github.com/tonglil/opentelemetry-go-datadog-propagator."
+                  "description": "Enable the Datadog propagation."
                 },
                 "baggage": {
                   "type": "boolean",

--- a/router/pkg/config/config.schema.json
+++ b/router/pkg/config/config.schema.json
@@ -549,6 +549,10 @@
                   "type": "boolean",
                   "description": "Enable the B3 propagation. See https://github.com/openzipkin/b3-propagation (zipkin) for more information."
                 },
+                "datadog": {
+                  "type": "boolean",
+                  "description": "Enable the Datadog propagation, using https://github.com/tonglil/opentelemetry-go-datadog-propagator."
+                },
                 "baggage": {
                   "type": "boolean",
                   "description": "Enable the baggage propagation. See https://www.w3.org/TR/baggage/ for more information."

--- a/router/pkg/config/fixtures/full.yaml
+++ b/router/pkg/config/fixtures/full.yaml
@@ -70,6 +70,7 @@ telemetry:
       jaeger: false
       # https://github.com/openzipkin/b3-propagation (zipkin)
       b3: false
+      datadog: true
     exporters:
       # If no exporters are defined, the default one is used
       - exporter: http # or grpc

--- a/router/pkg/config/testdata/config_defaults.json
+++ b/router/pkg/config/testdata/config_defaults.json
@@ -18,7 +18,8 @@
         "TraceContext": true,
         "Jaeger": false,
         "B3": false,
-        "Baggage": false
+        "Baggage": false,
+        "Datadog": false
       },
       "ExportGraphQLVariables": false,
       "WithNewRoot": false

--- a/router/pkg/config/testdata/config_full.json
+++ b/router/pkg/config/testdata/config_full.json
@@ -28,7 +28,8 @@
         "TraceContext": true,
         "Jaeger": false,
         "B3": false,
-        "Baggage": false
+        "Baggage": false,
+        "Datadog": true
       },
       "ExportGraphQLVariables": true,
       "WithNewRoot": false

--- a/router/pkg/trace/config.go
+++ b/router/pkg/trace/config.go
@@ -19,6 +19,7 @@ const (
 	PropagatorB3           Propagator = "b3"
 	PropagatorJaeger       Propagator = "jaeger"
 	PropagatorBaggage      Propagator = "baggage"
+	PropagatorDatadog      Propagator = "datadog"
 
 	DefaultBatchTimeout  = 10 * time.Second
 	DefaultExportTimeout = 30 * time.Second

--- a/router/pkg/trace/propagation.go
+++ b/router/pkg/trace/propagation.go
@@ -2,6 +2,7 @@ package trace
 
 import (
 	"fmt"
+	datadog "github.com/tonglil/opentelemetry-go-datadog-propagator"
 	"go.opentelemetry.io/contrib/propagators/b3"
 	"go.opentelemetry.io/contrib/propagators/jaeger"
 	"go.opentelemetry.io/otel/propagation"
@@ -17,6 +18,8 @@ func NewCompositePropagator(propagators ...Propagator) (propagation.TextMapPropa
 			allPropagators = append(allPropagators, b3.New(b3.WithInjectEncoding(b3.B3MultipleHeader|b3.B3SingleHeader)))
 		case PropagatorJaeger:
 			allPropagators = append(allPropagators, jaeger.Jaeger{})
+		case PropagatorDatadog:
+			allPropagators = append(allPropagators, datadog.Propagator{})
 		case PropagatorBaggage:
 			allPropagators = append(allPropagators, propagation.Baggage{})
 		default:


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->

## Motivation and Context

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

This PR adds datadog trace propagation for users, which will set subgraph datadog headers (`x-datadog-trace-id`, `x-datadog-parent-id` and `x-datadog-sampling-priority`) based on the trace id/span id. 

In order to enable it, users can add 
```
telemetry: 
  tracing: 
    propagation:
      datadog: true
```

to their configuration
## TODO

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
