### PR TITLE
fix: use volume name instead of config map name

### DIFF
--- a/helm/cosmo/charts/otelcollector/templates/deployment.yaml
+++ b/helm/cosmo/charts/otelcollector/templates/deployment.yaml
@@ -86,7 +86,7 @@ spec:
           {{- if .Values.existingConfigmap }}
           volumeMounts:
             - mountPath: /etc/otel-config.yaml
-              name: {{ .Values.existingConfigmap }}
+              name: otelcollector-config-volume
               subPath: otel-config.yaml
               readOnly: true
           {{ end }}


### PR DESCRIPTION
## Motivation and Context

Fixes the usage of the cm name as the volume name.  

## TODO

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [x] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
