### PR TITLE
fix: remove extra assertion

### DIFF
--- a/router/pkg/config/config_test.go
+++ b/router/pkg/config/config_test.go
@@ -458,7 +458,6 @@ execution_config:
 	_, err := LoadConfig(f, "")
 	var js *jsonschema.ValidationError
 	require.ErrorAs(t, err, &js)
-	require.Equal(t, js.Causes[0].Error(), "at '/execution_config': oneOf failed, none matched\n- at '/execution_config': additional properties 'storage' not allowed\n- at '/execution_config': additional properties 'file' not allowed\n- at '/execution_config': additional properties 'file', 'storage' not allowed")
 	require.True(t,
 		js.Causes[0].Error() == "at '/execution_config': oneOf failed, none matched\n- at '/execution_config': additional properties 'storage' not allowed\n- at '/execution_config': additional properties 'file' not allowed\n- at '/execution_config': additional properties 'file', 'storage' not allowed" || js.Causes[0].Error() == "at '/execution_config': oneOf failed, none matched\n- at '/execution_config': additional properties 'storage' not allowed\n- at '/execution_config': additional properties 'file' not allowed\n- at '/execution_config': additional properties 'storage', 'file' not allowed",
 	)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md
Squashed commit must follow https://www.conventionalcommits.org/en/v1.0.0/ so we can generate the changelog.
-->

## Motivation and Context

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please try to describe in detail the impact of this change. Add screenshots if it helps.
-->

Pipelines occasionally flake because of a failure in the assertion, because configuration order isn't guaranteed. We already had a fix in the file (requiring that it one of those two statements be correct), so I'm removing the old assertion to hopefully make the pipelines more reliable

```
--- FAIL: TestInvalidFileExecutionConfig (0.07s)
#15 136.1     config_test.go:461: 
#15 136.1         	Error Trace:	/app/pkg/config/config_test.go:461
#15 136.1         	Error:      	Not equal: 
#15 136.1         	            	expected: "at '/execution_config': oneOf failed, none matched\n- at '/execution_config': additional properties 'storage' not allowed\n- at '/execution_config': additional properties 'file' not allowed\n- at '/execution_config': additional properties 'storage', 'file' not allowed"
#15 136.1         	            	actual  : "at '/execution_config': oneOf failed, none matched\n- at '/execution_config': additional properties 'storage' not allowed\n- at '/execution_config': additional properties 'file' not allowed\n- at '/execution_config': additional properties 'file', 'storage' not allowed"
#15 136.1         	            	
#15 136.1         	            	Diff:
#15 136.1         	            	--- Expected
#15 136.1         	            	+++ Actual
#15 136.1         	            	@@ -3,2 +3,2 @@
#15 136.1         	            	 - at '/execution_config': additional properties 'file' not allowed
#15 136.1         	            	-- at '/execution_config': additional properties 'storage', 'file' not allowed
#15 136.1         	            	+- at '/execution_config': additional properties 'file', 'storage' not allowed
#15 136.1         	Test:       	TestInvalidFileExecutionConfig
```

The test already presents one of these options immediately before it


## TODO

- [ ] Tests or benchmark included
- [ ] Documentation is changed or added on [https://app.gitbook.com/](https://app.gitbook.com/)
- [ ] PR title must follow [conventional-commit-standard](https://github.com/wundergraph/wundergraph/blob/main/CONTRIBUTING.md#conventional-commit-standard)
