### PR TITLE
Pluginize Persisted Operations

### DIFF
--- a/router-tests/persisted_operations_test.go
+++ b/router-tests/persisted_operations_test.go
@@ -135,7 +135,7 @@ func TestPersistedOperationsCache(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Equal(t, `{"data":{"employees":[{"details":{"pets":null}},{"details":{"pets":null}},{"details":{"pets":[{"name":"Snappy","__typename":"Alligator"}]}},{"details":{"pets":[{"name":"Abby","__typename":"Dog","breed":"GOLDEN_RETRIEVER","class":"MAMMAL","gender":"FEMALE"},{"name":"Survivor","__typename":"Pony"}]}},{"details":{"pets":[{"name":"Blotch","__typename":"Cat","class":"MAMMAL","gender":"FEMALE","type":"STREET"},{"name":"Grayone","__typename":"Cat","class":"MAMMAL","gender":"MALE","type":"STREET"},{"name":"Rusty","__typename":"Cat","class":"MAMMAL","gender":"MALE","type":"STREET"},{"name":"Manya","__typename":"Cat","class":"MAMMAL","gender":"FEMALE","type":"HOME"},{"name":"Peach","__typename":"Cat","class":"MAMMAL","gender":"MALE","type":"STREET"},{"name":"Panda","__typename":"Cat","class":"MAMMAL","gender":"MALE","type":"HOME"},{"name":"Mommy","__typename":"Cat","class":"MAMMAL","gender":"FEMALE","type":"STREET"},{"name":"Terry","__typename":"Cat","class":"MAMMAL","gender":"FEMALE","type":"HOME"},{"name":"Tilda","__typename":"Cat","class":"MAMMAL","gender":"FEMALE","type":"HOME"},{"name":"Vasya","__typename":"Cat","class":"MAMMAL","gender":"MALE","type":"HOME"}]}},{"details":{"pets":null}},{"details":{"pets":null}},{"details":{"pets":[{"name":"Vanson","__typename":"Mouse"}]}},{"details":{"pets":null}},{"details":{"pets":[{"name":"Pepper","__typename":"Cat","class":"MAMMAL","gender":"FEMALE","type":"HOME"}]}}]}}`, res.Body)
-		require.Equal(t, "HIT", res.Response.Header.Get(core.PersistedOperationCacheHeader))
+		require.Equal(t, "MISS", res.Response.Header.Get(core.PersistedOperationCacheHeader))
 		require.Equal(t, "HIT", res.Response.Header.Get(core.ExecutionPlanCacheHeader))
 	}
 
@@ -170,7 +170,7 @@ func TestPersistedOperationsCache(t *testing.T) {
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			sendTwoRequests(t, xEnv)
 			numberOfCDNRequests := retrieveNumberOfCDNRequests(t, xEnv.CDN.URL)
-			require.Equal(t, 2, numberOfCDNRequests)
+			require.Equal(t, 3, numberOfCDNRequests)
 		})
 	})
 }
@@ -198,7 +198,7 @@ func TestPersistedOperationCacheWithVariables(t *testing.T) {
 			Variables:     []byte(`{"withAligators": true,"withCats": true,"skipDogs": false,"skipMouses": true}`),
 		})
 		require.NoError(t, err)
-		require.Equal(t, "HIT", res.Response.Header.Get(core.PersistedOperationCacheHeader))
+		require.Equal(t, "MISS", res.Response.Header.Get(core.PersistedOperationCacheHeader))
 		require.Equal(t, `{"data":{"employees":[{"details":{"pets":null}},{"details":{"pets":null}},{"details":{"pets":[{"name":"Snappy","__typename":"Alligator","class":"REPTILE","dangerous":"yes","gender":"UNKNOWN"}]}},{"details":{"pets":[{"name":"Abby","__typename":"Dog","breed":"GOLDEN_RETRIEVER","class":"MAMMAL","gender":"FEMALE"},{"name":"Survivor","__typename":"Pony"}]}},{"details":{"pets":[{"name":"Blotch","__typename":"Cat","class":"MAMMAL","gender":"FEMALE","type":"STREET"},{"name":"Grayone","__typename":"Cat","class":"MAMMAL","gender":"MALE","type":"STREET"},{"name":"Rusty","__typename":"Cat","class":"MAMMAL","gender":"MALE","type":"STREET"},{"name":"Manya","__typename":"Cat","class":"MAMMAL","gender":"FEMALE","type":"HOME"},{"name":"Peach","__typename":"Cat","class":"MAMMAL","gender":"MALE","type":"STREET"},{"name":"Panda","__typename":"Cat","class":"MAMMAL","gender":"MALE","type":"HOME"},{"name":"Mommy","__typename":"Cat","class":"MAMMAL","gender":"FEMALE","type":"STREET"},{"name":"Terry","__typename":"Cat","class":"MAMMAL","gender":"FEMALE","type":"HOME"},{"name":"Tilda","__typename":"Cat","class":"MAMMAL","gender":"FEMALE","type":"HOME"},{"name":"Vasya","__typename":"Cat","class":"MAMMAL","gender":"MALE","type":"HOME"}]}},{"details":{"pets":null}},{"details":{"pets":null}},{"details":{"pets":[{"name":"Vanson","__typename":"Mouse"}]}},{"details":{"pets":null}},{"details":{"pets":[{"name":"Pepper","__typename":"Cat","class":"MAMMAL","gender":"FEMALE","type":"HOME"}]}}]}}`, res.Body)
 
 		res, err = xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
@@ -218,7 +218,7 @@ func TestPersistedOperationCacheWithVariables(t *testing.T) {
 			Variables:     []byte(`{"withAligators": false,"withCats": true,"skipDogs": false,"skipMouses": true}`),
 		})
 		require.NoError(t, err)
-		require.Equal(t, "HIT", res.Response.Header.Get(core.PersistedOperationCacheHeader))
+		require.Equal(t, "MISS", res.Response.Header.Get(core.PersistedOperationCacheHeader))
 		require.Equal(t, `{"data":{"employees":[{"details":{"pets":null}},{"details":{"pets":null}},{"details":{"pets":[{"name":"Snappy","__typename":"Alligator"}]}},{"details":{"pets":[{"name":"Abby","__typename":"Dog","breed":"GOLDEN_RETRIEVER","class":"MAMMAL","gender":"FEMALE"},{"name":"Survivor","__typename":"Pony"}]}},{"details":{"pets":[{"name":"Blotch","__typename":"Cat","class":"MAMMAL","gender":"FEMALE","type":"STREET"},{"name":"Grayone","__typename":"Cat","class":"MAMMAL","gender":"MALE","type":"STREET"},{"name":"Rusty","__typename":"Cat","class":"MAMMAL","gender":"MALE","type":"STREET"},{"name":"Manya","__typename":"Cat","class":"MAMMAL","gender":"FEMALE","type":"HOME"},{"name":"Peach","__typename":"Cat","class":"MAMMAL","gender":"MALE","type":"STREET"},{"name":"Panda","__typename":"Cat","class":"MAMMAL","gender":"MALE","type":"HOME"},{"name":"Mommy","__typename":"Cat","class":"MAMMAL","gender":"FEMALE","type":"STREET"},{"name":"Terry","__typename":"Cat","class":"MAMMAL","gender":"FEMALE","type":"HOME"},{"name":"Tilda","__typename":"Cat","class":"MAMMAL","gender":"FEMALE","type":"HOME"},{"name":"Vasya","__typename":"Cat","class":"MAMMAL","gender":"MALE","type":"HOME"}]}},{"details":{"pets":null}},{"details":{"pets":null}},{"details":{"pets":[{"name":"Vanson","__typename":"Mouse"}]}},{"details":{"pets":null}},{"details":{"pets":[{"name":"Pepper","__typename":"Cat","class":"MAMMAL","gender":"FEMALE","type":"HOME"}]}}]}}`, res.Body)
 
 		res, err = xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
@@ -238,7 +238,7 @@ func TestPersistedOperationCacheWithVariables(t *testing.T) {
 			Variables:     []byte(`{"id":4,"withAligators": false,"withCats": true,"skipDogs": false,"skipMouses": true}`),
 		})
 		require.NoError(t, err)
-		require.Equal(t, "HIT", res.Response.Header.Get(core.PersistedOperationCacheHeader))
+		require.Equal(t, "MISS", res.Response.Header.Get(core.PersistedOperationCacheHeader))
 		require.Equal(t, `{"data":{"employee":{"details":{"pets":[{"name":"Abby","__typename":"Dog","breed":"GOLDEN_RETRIEVER","class":"MAMMAL","gender":"FEMALE"},{"name":"Survivor","__typename":"Pony"}]}}}}`, res.Body)
 
 		res, err = xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
@@ -248,7 +248,7 @@ func TestPersistedOperationCacheWithVariables(t *testing.T) {
 			Variables:     []byte(`{"id":4,"withCats": true,"skipDogs": false,"skipMouses": true,"withAligators": false}`),
 		})
 		require.NoError(t, err)
-		require.Equal(t, "HIT", res.Response.Header.Get(core.PersistedOperationCacheHeader))
+		require.Equal(t, "MISS", res.Response.Header.Get(core.PersistedOperationCacheHeader))
 		require.Equal(t, `{"data":{"employee":{"details":{"pets":[{"name":"Abby","__typename":"Dog","breed":"GOLDEN_RETRIEVER","class":"MAMMAL","gender":"FEMALE"},{"name":"Survivor","__typename":"Pony"}]}}}}`, res.Body)
 
 		res, err = xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
@@ -268,7 +268,7 @@ func TestPersistedOperationCacheWithVariables(t *testing.T) {
 			Variables:     []byte(`{"withCats": true,"skipDogs": false,"skipMouses": true,"withAligators": false}`),
 		})
 		require.NoError(t, err)
-		require.Equal(t, "HIT", res.Response.Header.Get(core.PersistedOperationCacheHeader))
+		require.Equal(t, "MISS", res.Response.Header.Get(core.PersistedOperationCacheHeader))
 		require.Equal(t, `{"data":{"employee":{"details":{"pets":[{"name":"Abby","__typename":"Dog","breed":"GOLDEN_RETRIEVER","class":"MAMMAL","gender":"FEMALE"},{"name":"Survivor","__typename":"Pony"}]}}}}`, res.Body)
 
 		res, err = xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
@@ -278,7 +278,7 @@ func TestPersistedOperationCacheWithVariables(t *testing.T) {
 			Variables:     []byte(`{"withCats": true,"skipDogs": false,"skipMouses": true,"withAligators": false,"id":3}`),
 		})
 		require.NoError(t, err)
-		require.Equal(t, "HIT", res.Response.Header.Get(core.PersistedOperationCacheHeader))
+		require.Equal(t, "MISS", res.Response.Header.Get(core.PersistedOperationCacheHeader))
 		require.Equal(t, `{"data":{"employee":{"details":{"pets":[{"name":"Snappy","__typename":"Alligator"}]}}}}`, res.Body)
 	})
 }
@@ -305,7 +305,7 @@ func TestPersistedOperationsWithNestedVariablesExtraction(t *testing.T) {
 			Variables:     []byte(`{"arg":"a"}`),
 		})
 		require.NoError(t, err)
-		require.Equal(t, "HIT", res.Response.Header.Get(core.PersistedOperationCacheHeader))
+		require.Equal(t, "MISS", res.Response.Header.Get(core.PersistedOperationCacheHeader))
 		require.Equal(t, `{"data":{"rootFieldWithListOfInputArg":[{"arg":"a"}]}}`, res.Body)
 		res, err = xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
 			OperationName: []byte(`"NormalizationQuery"`),
@@ -314,7 +314,7 @@ func TestPersistedOperationsWithNestedVariablesExtraction(t *testing.T) {
 			Variables:     []byte(`{"arg":"b"}`),
 		})
 		require.NoError(t, err)
-		require.Equal(t, "HIT", res.Response.Header.Get(core.PersistedOperationCacheHeader))
+		require.Equal(t, "MISS", res.Response.Header.Get(core.PersistedOperationCacheHeader))
 		require.Equal(t, `{"data":{"rootFieldWithListOfInputArg":[{"arg":"b"}]}}`, res.Body)
 	})
 }
@@ -339,7 +339,7 @@ func TestPersistedOperationCacheWithVariablesAndDefaultValues(t *testing.T) {
 			Variables:     []byte(`{}`),
 		})
 		require.NoError(t, err)
-		require.Equal(t, "HIT", res.Response.Header.Get(core.PersistedOperationCacheHeader))
+		require.Equal(t, "MISS", res.Response.Header.Get(core.PersistedOperationCacheHeader))
 		require.Equal(t, `{"data":{"employee":{"details":{"forename":"Jens","surname":"Neuse"}}}}`, res.Body)
 		res, err = xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
 			OperationName: []byte(`"MyQuery"`),
@@ -358,7 +358,7 @@ func TestPersistedOperationCacheWithVariablesAndDefaultValues(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Equal(t, `{"data":{"employee":{"details":{"forename":"Jens"}}}}`, res.Body)
-		require.Equal(t, "HIT", res.Response.Header.Get(core.PersistedOperationCacheHeader))
+		require.Equal(t, "MISS", res.Response.Header.Get(core.PersistedOperationCacheHeader))
 		res, err = xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
 			OperationName: []byte(`"MyQuery"`),
 			Extensions:    []byte(`{"persistedQuery": {"version": 1, "sha256Hash": "skipVariableWithDefault"}}`),
@@ -376,7 +376,7 @@ func TestPersistedOperationCacheWithVariablesAndDefaultValues(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Equal(t, `{"data":{"employee":{"details":{"forename":"Jens","surname":"Neuse"}}}}`, res.Body)
-		require.Equal(t, "HIT", res.Response.Header.Get(core.PersistedOperationCacheHeader))
+		require.Equal(t, "MISS", res.Response.Header.Get(core.PersistedOperationCacheHeader))
 	})
 }
 
@@ -401,7 +401,7 @@ func TestPersistedOperationCacheWithVariablesCoercion(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Equal(t, `{"data":{"rootFieldWithListArg":["a"]}}`, res.Body)
-		require.Equal(t, "HIT", res.Response.Header.Get(core.PersistedOperationCacheHeader))
+		require.Equal(t, "MISS", res.Response.Header.Get(core.PersistedOperationCacheHeader))
 		res, err = xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
 			OperationName: []byte(`"MyQuery"`),
 			Extensions:    []byte(`{"persistedQuery": {"version": 1, "sha256Hash": "listArgQuery"}}`),
@@ -410,7 +410,7 @@ func TestPersistedOperationCacheWithVariablesCoercion(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Equal(t, `{"data":{"rootFieldWithListArg":["b"]}}`, res.Body)
-		require.Equal(t, "HIT", res.Response.Header.Get(core.PersistedOperationCacheHeader))
+		require.Equal(t, "MISS", res.Response.Header.Get(core.PersistedOperationCacheHeader))
 
 		res, err = xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
 			OperationName: []byte(`"MyQuery"`),
@@ -429,7 +429,7 @@ func TestPersistedOperationCacheWithVariablesCoercion(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Equal(t, `{"data":{"rootFieldWithListArg":["a"]}}`, res.Body)
-		require.Equal(t, "HIT", res.Response.Header.Get(core.PersistedOperationCacheHeader))
+		require.Equal(t, "MISS", res.Response.Header.Get(core.PersistedOperationCacheHeader))
 		res, err = xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
 			OperationName: []byte(`"MyQuery"`),
 			Extensions:    []byte(`{"persistedQuery": {"version": 1, "sha256Hash": "listArgQueryWithDefault"}}`),
@@ -438,7 +438,7 @@ func TestPersistedOperationCacheWithVariablesCoercion(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Equal(t, `{"data":{"rootFieldWithListArg":["b"]}}`, res.Body)
-		require.Equal(t, "HIT", res.Response.Header.Get(core.PersistedOperationCacheHeader))
+		require.Equal(t, "MISS", res.Response.Header.Get(core.PersistedOperationCacheHeader))
 		res, err = xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
 			OperationName: []byte(`"MyQuery"`),
 			Extensions:    []byte(`{"persistedQuery": {"version": 1, "sha256Hash": "listArgQueryWithDefault"}}`),
@@ -447,7 +447,7 @@ func TestPersistedOperationCacheWithVariablesCoercion(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Equal(t, `{"data":{"rootFieldWithListArg":["c"]}}`, res.Body)
-		require.Equal(t, "HIT", res.Response.Header.Get(core.PersistedOperationCacheHeader))
+		require.Equal(t, "MISS", res.Response.Header.Get(core.PersistedOperationCacheHeader))
 
 		// nested list of enums
 		res, err = xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
@@ -467,7 +467,7 @@ func TestPersistedOperationCacheWithVariablesCoercion(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Equal(t, `{"data":{"rootFieldWithInput":"B"}}`, res.Body)
-		require.Equal(t, "HIT", res.Response.Header.Get(core.PersistedOperationCacheHeader))
+		require.Equal(t, "MISS", res.Response.Header.Get(core.PersistedOperationCacheHeader))
 	})
 }
 

--- a/router-tests/telemetry_test.go
+++ b/router-tests/telemetry_test.go
@@ -711,11 +711,11 @@ func TestTelemetry(t *testing.T) {
 			})
 			require.NoError(t, err)
 			require.Equal(t, `{"data":{"rootFieldWithListArg":["a"]}}`, res.Body)
-			require.Equal(t, "HIT", res.Response.Header.Get(core.PersistedOperationCacheHeader))
+			require.Equal(t, "MISS", res.Response.Header.Get(core.PersistedOperationCacheHeader))
 
 			sn = exporter.GetSpans().Snapshots()
 
-			require.Len(t, sn, 8, "expected 8 spans, got %d", len(sn))
+			require.Len(t, sn, 9, "expected 9 spans, got %d", len(sn))
 			require.NotEqualf(t, "Load Persisted Operation", sn[1].Name(), "excepted no span because it was a cache hit")
 		})
 	})

--- a/router/core/operation_metrics.go
+++ b/router/core/operation_metrics.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/wundergraph/cosmo/router/pkg/otel"
+	"github.com/wundergraph/cosmo/router/pkg/clientinfo"
 
 	"go.uber.org/zap"
 
@@ -75,13 +76,13 @@ func (m *OperationMetrics) AddAttributes(kv ...attribute.KeyValue) {
 
 // AddClientInfo adds the client info to the operation metrics. If OperationMetrics
 // is nil, it's a no-op.
-func (m *OperationMetrics) AddClientInfo(info *ClientInfo) {
+func (m *OperationMetrics) AddClientInfo(info clientinfo.DetailedClientInfo) {
 	if info == nil {
 		return
 	}
 	// Add client info to metrics base fields
-	m.metricBaseFields = append(m.metricBaseFields, otel.WgClientName.String(info.Name))
-	m.metricBaseFields = append(m.metricBaseFields, otel.WgClientVersion.String(info.Version))
+	m.metricBaseFields = append(m.metricBaseFields, otel.WgClientName.String(info.Name()))
+	m.metricBaseFields = append(m.metricBaseFields, otel.WgClientVersion.String(info.Version()))
 }
 
 type OperationMetricsOptions struct {

--- a/router/core/operation_planner.go
+++ b/router/core/operation_planner.go
@@ -13,6 +13,7 @@ import (
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/postprocess"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+	"github.com/wundergraph/cosmo/router/pkg/clientinfo"
 )
 
 type planWithMetaData struct {
@@ -109,7 +110,7 @@ func (p *OperationPlanner) preparePlan(ctx *operationContext) (*planWithMetaData
 
 type PlanOptions struct {
 	Protocol             OperationProtocol
-	ClientInfo           *ClientInfo
+	DetailedClientInfo   clientinfo.DetailedClientInfo
 	TraceOptions         resolve.TraceOptions
 	ExecutionOptions     resolve.ExecutionOptions
 	TrackSchemaUsageInfo bool

--- a/router/core/operation_processor_test.go
+++ b/router/core/operation_processor_test.go
@@ -11,6 +11,19 @@ import (
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan"
 )
 
+type testBuildDetailedClientInfo struct {
+    name string
+    version string
+}
+
+func (d *testBuildDetailedClientInfo) Name() string {
+    return d.name
+}
+
+func (d *testBuildDetailedClientInfo) Version() string {
+    return d.version
+}
+
 func TestOperationProcessorPersistentOperations(t *testing.T) {
 	executor := &Executor{
 		PlanConfig:      plan.Configuration{},
@@ -23,10 +36,10 @@ func TestOperationProcessorPersistentOperations(t *testing.T) {
 		MaxOperationSizeInBytes: 10 << 20,
 		ParseKitPoolSize:        4,
 	})
-	clientInfo := &ClientInfo{
-		Name:    "test",
-		Version: "1.0.0",
-	}
+	detailedClientInfo := &testBuildDetailedClientInfo{
+        name: "test",
+        version: "1.0.0",
+    }
 	testCases := []struct {
 		ExpectedType  string
 		ExpectedError error
@@ -56,7 +69,7 @@ func TestOperationProcessorPersistentOperations(t *testing.T) {
 
 			require.NoError(t, err)
 
-			_, err = kit.FetchPersistedOperation(context.Background(), clientInfo, nil)
+			_, err = kit.FetchPersistedOperation(context.Background(), detailedClientInfo, nil)
 
 			if err != nil {
 				require.EqualError(t, tc.ExpectedError, err.Error())

--- a/router/core/router.go
+++ b/router/core/router.go
@@ -38,6 +38,7 @@ import (
 	"github.com/wundergraph/cosmo/router/pkg/controlplane/selfregister"
 	"github.com/wundergraph/cosmo/router/pkg/cors"
 	"github.com/wundergraph/cosmo/router/pkg/health"
+	"github.com/wundergraph/cosmo/router/pkg/clientinfo"
 	rmetric "github.com/wundergraph/cosmo/router/pkg/metric"
 	"github.com/wundergraph/cosmo/router/pkg/otel/otelconfig"
 	rtrace "github.com/wundergraph/cosmo/router/pkg/trace"
@@ -166,6 +167,7 @@ type (
 		cdnConfig                 config.CDNConfiguration
 		persistedOperationClient  persistedoperation.Client
 		persistedOperationsConfig config.PersistedOperationsConfig
+		detailedClientInfoBuilder        *clientinfo.BuildDetailedClientInfo
 		apolloCompatibilityFlags  config.ApolloCompatibilityFlags
 		storageProviders          config.StorageProviders
 		eventsConfig              config.EventsConfiguration
@@ -1589,6 +1591,18 @@ func WithConfigPollerConfig(cfg *RouterConfigPollerConfig) Option {
 func WithPersistedOperationsConfig(cfg config.PersistedOperationsConfig) Option {
 	return func(r *Router) {
 		r.persistedOperationsConfig = cfg
+	}
+}
+
+func WithPersistedOperationClient(client persistedoperation.Client) Option {
+	return func(r *Router) {
+		r.persistedOperationClient = client
+	}
+}
+
+func WithDetailedClientInfoBuilder(client *clientinfo.BuildDetailedClientInfo) Option {
+	return func(r *Router) {
+		r.detailedClientInfoBuilder = client
 	}
 }
 

--- a/router/internal/persistedoperation/s3/client.go
+++ b/router/internal/persistedoperation/s3/client.go
@@ -14,6 +14,7 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
+	"github.com/wundergraph/cosmo/router/pkg/clientinfo"
 )
 
 type Option func(*Client)
@@ -76,14 +77,14 @@ func NewClient(endpoint string, options *Options) (persistedoperation.Client, er
 	return client, nil
 }
 
-func (c Client) PersistedOperation(ctx context.Context, clientName, sha256Hash string, attributes []attribute.KeyValue) ([]byte, error) {
+func (c Client) PersistedOperation(ctx context.Context, clientInfo clientinfo.DetailedClientInfo, sha256Hash string, attributes []attribute.KeyValue) ([]byte, error) {
 	ctx, span := c.tracer.Start(ctx, "Load Persisted Operation",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(attributes...),
 	)
 	defer span.End()
 
-	content, err := c.persistedOperation(ctx, clientName, sha256Hash, attributes)
+	content, err := c.persistedOperation(ctx, clientInfo, sha256Hash, attributes)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -93,7 +94,7 @@ func (c Client) PersistedOperation(ctx context.Context, clientName, sha256Hash s
 	return content, nil
 }
 
-func (c Client) persistedOperation(ctx context.Context, clientName, sha256Hash string, attributes []attribute.KeyValue) ([]byte, error) {
+func (c Client) persistedOperation(ctx context.Context, clientInfo clientinfo.DetailedClientInfo, sha256Hash string, attributes []attribute.KeyValue) ([]byte, error) {
 	objectPath := fmt.Sprintf("%s/%s.json", c.options.ObjectPathPrefix, sha256Hash)
 	reader, err := c.client.GetObject(ctx, c.options.BucketName, objectPath, minio.GetObjectOptions{})
 	if err != nil {

--- a/router/pkg/clientinfo/clientinfo.go
+++ b/router/pkg/clientinfo/clientinfo.go
@@ -1,0 +1,65 @@
+package clientinfo
+
+import (
+    "net/http"
+	ctrace "github.com/wundergraph/cosmo/router/pkg/trace"
+    "github.com/wundergraph/cosmo/router/pkg/config"
+)
+
+type DetailedClientInfo interface {
+    Name() string
+    Version() string
+}
+
+type Token interface {
+	// WGRequestToken contains the token to authenticate the request from the platform
+	WGRequestToken() string
+}
+
+type defaultBuildDetailedClientInfo struct {
+    name string
+    version string
+    wgRequestToken string
+}
+
+func (d *defaultBuildDetailedClientInfo) Name() string {
+    return d.name
+}
+
+func (d *defaultBuildDetailedClientInfo) Version() string {
+    return d.version
+}
+
+func (d *defaultBuildDetailedClientInfo) WGRequestToken() string {
+    return d.wgRequestToken
+}
+
+func defaultBuildClientInfo(r *http.Request, clientHeader config.ClientHeader) (DetailedClientInfo, error) {
+    clientName := ctrace.GetClientHeader(r.Header, []string{clientHeader.Name, "graphql-client-name", "apollographql-client-name"}, "unknown")
+	clientVersion := ctrace.GetClientHeader(r.Header, []string{clientHeader.Version, "graphql-client-version", "apollographql-client-version"}, "missing")
+    requestToken := r.Header.Get("X-WG-Token")
+
+    return &defaultBuildDetailedClientInfo{
+        name: clientName,
+        version: clientVersion,
+        wgRequestToken: requestToken,
+    }, nil
+}
+
+type BuildDetailedClientInfo func(r *http.Request) (DetailedClientInfo, error)
+
+func NewDetailedClientInfoFromRequest(
+    r *http.Request,
+    clientHeader config.ClientHeader,
+    buildDetailedClientInfo *BuildDetailedClientInfo,
+) (DetailedClientInfo, error) {
+    var detailedClientInfo DetailedClientInfo
+    var err error
+    if buildDetailedClientInfo == nil {
+        detailedClientInfo, err = defaultBuildClientInfo(r, clientHeader)
+    } else {
+        detailedClientInfo, err = (*buildDetailedClientInfo)(r)
+    }
+
+     return detailedClientInfo, err
+}

--- a/router/pkg/config/config.schema.json
+++ b/router/pkg/config/config.schema.json
@@ -1,12 +1,11 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
-  "additionalProperties": false,
+  "additionalProperties": true,
   "properties": {
     "version": {
       "type": "string",
-      "description": "The version of the configuration file. This is used to ensure that the configuration file is compatible.",
-      "enum": ["1"]
+      "description": "The version of the configuration file. This is used to ensure that the configuration file is compatible."
     },
     "instance_id": {
       "type": "string",

--- a/router/pkg/config/config.schema.json
+++ b/router/pkg/config/config.schema.json
@@ -1,11 +1,12 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "version": {
       "type": "string",
-      "description": "The version of the configuration file. This is used to ensure that the configuration file is compatible."
+      "description": "The version of the configuration file. This is used to ensure that the configuration file is compatible.",
+      "enum": ["1"]
     },
     "instance_id": {
       "type": "string",

--- a/router/pkg/persistedoperation/client.go
+++ b/router/pkg/persistedoperation/client.go
@@ -1,0 +1,22 @@
+package persistedoperation
+
+import (
+	"context"
+	"fmt"
+	"github.com/wundergraph/cosmo/router/pkg/clientinfo"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+type PersistentOperationNotFoundError struct {
+	ClientName string
+	Sha256Hash string
+}
+
+func (e *PersistentOperationNotFoundError) Error() string {
+	return fmt.Sprintf("operation %s for client %s not found", e.Sha256Hash, e.ClientName)
+}
+
+type Client interface {
+	PersistedOperation(ctx context.Context, clientInfo clientinfo.DetailedClientInfo, sha256Hash string, attributes []attribute.KeyValue) ([]byte, error)
+	Close()
+}


### PR DESCRIPTION
## Motivation and Context

This pull request is to pluginize Persisted Operations. 
1) Expose Persisted Operations interface in pkg directory, this provides flexibility to implement customized logic for FetchPersistedOperations. 
2) Expose ClientInfo interface to give users flexibility to provide customized information. These information can be used as input parameters for Persisted Operations interface or other packages.
3) Fix the 2nd layer cache issue for Persisted Operations reported here https://github.com/wundergraph/cosmo/issues/1179. All integration tests changes are due to the changes for this logic. 

