### PR TITLE
Pluginzie Persisted Operations with provided client info

### DIFF
--- a/router/core/operation_planner.go
+++ b/router/core/operation_planner.go
@@ -13,6 +13,7 @@ import (
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/postprocess"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+	"github.com/wundergraph/cosmo/router/pkg/client"
 )
 
 type planWithMetaData struct {
@@ -109,7 +110,7 @@ func (p *OperationPlanner) preparePlan(ctx *operationContext) (*planWithMetaData
 
 type PlanOptions struct {
 	Protocol             OperationProtocol
-	ClientInfo           *ClientInfo
+	ClientInfo           client.Info
 	TraceOptions         resolve.TraceOptions
 	ExecutionOptions     resolve.ExecutionOptions
 	TrackSchemaUsageInfo bool

--- a/router/core/operation_processor_test.go
+++ b/router/core/operation_processor_test.go
@@ -11,6 +11,19 @@ import (
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan"
 )
 
+type testBuildClientInfo struct {
+    name string
+    version string
+}
+
+func (d *testBuildClientInfo) Name() string {
+    return d.name
+}
+
+func (d *testBuildClientInfo) Version() string {
+    return d.version
+}
+
 func TestOperationProcessorPersistentOperations(t *testing.T) {
 	executor := &Executor{
 		PlanConfig:      plan.Configuration{},
@@ -23,9 +36,9 @@ func TestOperationProcessorPersistentOperations(t *testing.T) {
 		MaxOperationSizeInBytes: 10 << 20,
 		ParseKitPoolSize:        4,
 	})
-	clientInfo := &ClientInfo{
-		Name:    "test",
-		Version: "1.0.0",
+	clientInfo := &testBuildClientInfo{
+		name:    "test",
+		version: "1.0.0",
 	}
 	testCases := []struct {
 		ExpectedType  string

--- a/router/core/router.go
+++ b/router/core/router.go
@@ -34,6 +34,7 @@ import (
 	"github.com/wundergraph/cosmo/router/internal/retrytransport"
 	"github.com/wundergraph/cosmo/router/internal/stringsx"
 	"github.com/wundergraph/cosmo/router/pkg/config"
+	"github.com/wundergraph/cosmo/router/pkg/client"
 	"github.com/wundergraph/cosmo/router/pkg/controlplane/configpoller"
 	"github.com/wundergraph/cosmo/router/pkg/controlplane/selfregister"
 	"github.com/wundergraph/cosmo/router/pkg/cors"
@@ -166,6 +167,7 @@ type (
 		cdnConfig                 config.CDNConfiguration
 		persistedOperationClient  persistedoperation.Client
 		persistedOperationsConfig config.PersistedOperationsConfig
+		clientInfoBuilder        *client.BuildClientInfo
 		apolloCompatibilityFlags  config.ApolloCompatibilityFlags
 		storageProviders          config.StorageProviders
 		eventsConfig              config.EventsConfiguration
@@ -1584,6 +1586,18 @@ func WithConfigPollerConfig(cfg *RouterConfigPollerConfig) Option {
 func WithPersistedOperationsConfig(cfg config.PersistedOperationsConfig) Option {
 	return func(r *Router) {
 		r.persistedOperationsConfig = cfg
+	}
+}
+
+func WithPersistedOperationClient(client persistedoperation.Client) Option {
+	return func(r *Router) {
+		r.persistedOperationClient = client
+	}
+}
+
+func WithDetailedClientInfoBuilder(client *client.BuildClientInfo) Option {
+	return func(r *Router) {
+		r.clientInfoBuilder = client
 	}
 }
 

--- a/router/core/router_metrics.go
+++ b/router/core/router_metrics.go
@@ -109,8 +109,8 @@ func (m *routerMetrics) ExportSchemaUsageInfo(operationContext *operationContext
 			Version: m.routerConfigVersion,
 		},
 		ClientInfo: &graphqlmetricsv1.ClientInfo{
-			Name:    operationContext.clientInfo.Name,
-			Version: operationContext.clientInfo.Version,
+			Name:    operationContext.clientInfo.Name(),
+			Version: operationContext.clientInfo.Version(),
 		},
 		RequestInfo: &graphqlmetricsv1.RequestInfo{
 			Error:      hasError,

--- a/router/internal/persistedoperation/cdn/client.go
+++ b/router/internal/persistedoperation/cdn/client.go
@@ -9,6 +9,7 @@ import (
 	"github.com/wundergraph/cosmo/router/internal/httpclient"
 	"github.com/wundergraph/cosmo/router/internal/jwt"
 	"github.com/wundergraph/cosmo/router/internal/persistedoperation"
+	cclient "github.com/wundergraph/cosmo/router/pkg/client"
 	"go.opentelemetry.io/otel/codes"
 	semconv12 "go.opentelemetry.io/otel/semconv/v1.12.0"
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
@@ -36,8 +37,8 @@ type client struct {
 	logger         *zap.Logger
 }
 
-func (cdn *client) PersistedOperation(ctx context.Context, clientName string, sha256Hash string) ([]byte, error) {
-	content, err := cdn.persistedOperation(ctx, clientName, sha256Hash)
+func (cdn *client) PersistedOperation(ctx context.Context, clientInfo cclient.Info, sha256Hash string) ([]byte, error) {
+	content, err := cdn.persistedOperation(ctx, clientInfo, sha256Hash)
 	if err != nil {
 		return nil, err
 	}
@@ -45,14 +46,14 @@ func (cdn *client) PersistedOperation(ctx context.Context, clientName string, sh
 	return content, nil
 }
 
-func (cdn *client) persistedOperation(ctx context.Context, clientName string, sha256Hash string) ([]byte, error) {
+func (cdn *client) persistedOperation(ctx context.Context, clientInfo cclient.Info, sha256Hash string) ([]byte, error) {
 
 	span := trace.SpanFromContext(ctx)
 
 	operationPath := fmt.Sprintf("/%s/%s/operations/%s/%s.json",
 		cdn.organizationID,
 		cdn.federatedGraphID,
-		url.PathEscape(clientName),
+		url.PathEscape(clientInfo.Name()),
 		url.PathEscape(sha256Hash))
 	operationURL := cdn.cdnURL.ResolveReference(&url.URL{Path: operationPath})
 
@@ -84,7 +85,7 @@ func (cdn *client) persistedOperation(ctx context.Context, clientName string, sh
 
 		if resp.StatusCode == http.StatusNotFound {
 			return nil, &persistedoperation.PersistentOperationNotFoundError{
-				ClientName: clientName,
+				ClientName: clientInfo.Name(),
 				Sha256Hash: sha256Hash,
 			}
 		}

--- a/router/internal/persistedoperation/s3/client.go
+++ b/router/internal/persistedoperation/s3/client.go
@@ -10,6 +10,7 @@ import (
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
 	"github.com/wundergraph/cosmo/router/internal/persistedoperation"
+	cclient "github.com/wundergraph/cosmo/router/pkg/client"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -74,8 +75,8 @@ func NewClient(endpoint string, options *Options) (persistedoperation.Client, er
 	return client, nil
 }
 
-func (c Client) PersistedOperation(ctx context.Context, clientName, sha256Hash string) ([]byte, error) {
-	content, err := c.persistedOperation(ctx, clientName, sha256Hash)
+func (c Client) PersistedOperation(ctx context.Context, clientInfo cclient.Info, sha256Hash string) ([]byte, error) {
+	content, err := c.persistedOperation(ctx, clientInfo, sha256Hash)
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +84,7 @@ func (c Client) PersistedOperation(ctx context.Context, clientName, sha256Hash s
 	return content, nil
 }
 
-func (c Client) persistedOperation(ctx context.Context, clientName, sha256Hash string) ([]byte, error) {
+func (c Client) persistedOperation(ctx context.Context, cclientInfo cclient.Info, sha256Hash string) ([]byte, error) {
 	objectPath := fmt.Sprintf("%s/%s.json", c.options.ObjectPathPrefix, sha256Hash)
 	reader, err := c.client.GetObject(ctx, c.options.BucketName, objectPath, minio.GetObjectOptions{})
 	if err != nil {

--- a/router/pkg/client/client.go
+++ b/router/pkg/client/client.go
@@ -1,0 +1,65 @@
+package client
+
+import (
+    "net/http"
+	ctrace "github.com/wundergraph/cosmo/router/pkg/trace"
+    "github.com/wundergraph/cosmo/router/pkg/config"
+)
+
+type Info interface {
+    Name() string
+    Version() string
+}
+
+type Token interface {
+	// WGRequestToken contains the token to authenticate the request from the platform
+	WGRequestToken() string
+}
+
+type defaultBuildInfo struct {
+    name string
+    version string
+    wgRequestToken string
+}
+
+func (d *defaultBuildInfo) Name() string {
+    return d.name
+}
+
+func (d *defaultBuildInfo) Version() string {
+    return d.version
+}
+
+func (d *defaultBuildInfo) WGRequestToken() string {
+    return d.wgRequestToken
+}
+
+func defaultBuildClientInfo(r *http.Request, clientHeader config.ClientHeader) (Info, error) {
+	clientName := ctrace.GetClientHeader(r.Header, []string{clientHeader.Name, "graphql-client-name", "apollographql-client-name"}, "unknown")
+	clientVersion := ctrace.GetClientHeader(r.Header, []string{clientHeader.Version, "graphql-client-version", "apollographql-client-version"}, "missing")
+    requestToken := r.Header.Get("X-WG-Token")
+
+    return &defaultBuildInfo{
+        name: clientName,
+        version: clientVersion,
+        wgRequestToken: requestToken,
+    }, nil
+}
+
+type BuildClientInfo func(r *http.Request) (Info, error)
+
+func NewClientInfoFromRequest(
+    r *http.Request,
+    clientHeader config.ClientHeader,
+    buildClientInfo *BuildClientInfo,
+) (Info, error) {
+    var info Info
+    var err error
+    if buildClientInfo == nil {
+        info, err = defaultBuildClientInfo(r, clientHeader)
+    } else {
+        info, err = (*buildClientInfo)(r)
+    }
+
+     return info, err
+}

--- a/router/pkg/persistedoperation/client.go
+++ b/router/pkg/persistedoperation/client.go
@@ -1,0 +1,21 @@
+package persistedoperation
+
+import (
+	"context"
+	"fmt"
+	"github.com/wundergraph/cosmo/router/pkg/client"
+)
+
+type PersistentOperationNotFoundError struct {
+	ClientName string
+	Sha256Hash string
+}
+
+func (e *PersistentOperationNotFoundError) Error() string {
+	return fmt.Sprintf("operation %s for client %s not found", e.Sha256Hash, e.ClientName)
+}
+
+type Client interface {
+	PersistedOperation(ctx context.Context, clientInfo client.Info, sha256Hash string) ([]byte, error)
+	Close()
+}


### PR DESCRIPTION
## Motivation and Context

This change is to implement the feature requested in https://github.com/wundergraph/cosmo/issues/1278 by:
1) Expose Persisted Operations Client interface in pkg directory 
2) Refactor ClientInfo struct into pkg/client interface and allow providing customized client info which can be used as inputs for FetchPersistedOperations
