### PR TITLE
fix(websocket): prevent ws headers leaking to the subgraph ws connection (#1149)

### DIFF
--- a/router/core/header_rule_engine.go
+++ b/router/core/header_rule_engine.go
@@ -45,7 +45,7 @@ var (
 		"Accept",
 
 		// Web Socket negotiation headers. We must never propagate the client headers to the upstream.
-		"Sec-WebSocket-Extensions",
+		"Sec-Websocket-Extensions",
 		"Sec-Websocket-Key",
 		"Sec-Websocket-Protocol",
 		"Sec-Websocket-Version",

--- a/router/core/header_rule_engine.go
+++ b/router/core/header_rule_engine.go
@@ -43,6 +43,12 @@ var (
 		"Accept-Encoding",
 		"Accept-Charset",
 		"Accept",
+
+		// Web Socket negotiation headers. We must never propagate the client headers to the upstream.
+		"Sec-WebSocket-Extensions",
+		"Sec-Websocket-Key",
+		"Sec-Websocket-Protocol",
+		"Sec-Websocket-Version",
 	}
 )
 


### PR DESCRIPTION
## Motivation and Context

As seen in https://github.com/wundergraph/cosmo/issues/1149, when forwarding all the headers, the web socket connection doesn't work anymore. The change made with this pull request assures that the headers part of the web socket specification are not forwarded to the subgraph web socket connection.

## Checklist

- [X] I have discussed my proposed changes in an issue and have received approval to proceed.
- [X] I have followed the coding standards of the project.
- [X] Tests or benchmarks have been added or updated.
- [X] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [X] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->