### PR TITLE
chore(migration): data migration to maintain table name traces_mv

### DIFF
--- a/data_migrations/controlplane/1726744316_add_span_id_to_trace/files/migrate.go
+++ b/data_migrations/controlplane/1726744316_add_span_id_to_trace/files/migrate.go
@@ -86,7 +86,7 @@ ORDER BY (
 TTL toDateTime(Timestamp) + toIntervalDay(30)
 SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
 
-CREATE MATERIALIZED VIEW IF NOT EXISTS cosmo.temp_traces_mv TO cosmo.traces AS
+CREATE MATERIALIZED VIEW IF NOT EXISTS cosmo.traces_mv TO cosmo.traces AS
 SELECT TraceId,
     SpanId,
     toDateTime(Timestamp, 'UTC') as Timestamp,


### PR DESCRIPTION
The migration is not consistent with the overview in the readme “ We need to drop both the traces_mv materialized view and traces table, recreate and repopulate them. We do the repopulation in hourly batches.” as traces_mv is renamed to temp_traces_mv. This PR tweaks the code to make it consistent with the readme.