### PR TITLE
chore(deps): sync pnpm version into Dockerfiles

### DIFF
--- a/admission-server/Dockerfile
+++ b/admission-server/Dockerfile
@@ -3,7 +3,7 @@ FROM --platform=${BUILDPLATFORM} node:lts AS builder
 WORKDIR /app
 
 # Ensure we have pnpm available to us
-RUN npm install --global pnpm@8
+RUN npm install --global pnpm@9
 
 # Files required by pnpm install.
 COPY .npmrc package.json pnpm-lock.yaml pnpm-workspace.yaml ./

--- a/cdn-server/Dockerfile
+++ b/cdn-server/Dockerfile
@@ -3,7 +3,7 @@ FROM --platform=${BUILDPLATFORM} node:lts AS builder
 WORKDIR /app
 
 # Ensure we have pnpm available to us
-RUN npm install --global pnpm@8
+RUN npm install --global pnpm@9
 
 # Files required by pnpm install.
 COPY .npmrc package.json pnpm-lock.yaml pnpm-workspace.yaml ./

--- a/controlplane/Dockerfile
+++ b/controlplane/Dockerfile
@@ -5,7 +5,7 @@ ARG TARGETARCH
 WORKDIR /app
 
 # Ensure we have pnpm available to us
-RUN npm install --global pnpm@8
+RUN npm install --global pnpm@9
 
 # Files required by pnpm install.
 COPY .npmrc package.json pnpm-lock.yaml pnpm-workspace.yaml ./

--- a/studio/Dockerfile
+++ b/studio/Dockerfile
@@ -3,7 +3,7 @@ FROM --platform=${BUILDPLATFORM} node:lts AS builder
 WORKDIR /app
 
 # Ensure we have pnpm available to us
-RUN npm install --global pnpm@8
+RUN npm install --global pnpm@9
 
 # Files required by pnpm install
 COPY .npmrc package.json pnpm-lock.yaml pnpm-workspace.yaml ./


### PR DESCRIPTION
## Motivation and Context

 => ERROR [cdn builder  7/10] RUN pnpm install --filter=.  0.9s
------                                                          
 > [cdn builder  7/10] RUN pnpm install --filter=./cdn-server/cdn --filter=./cdn-server --frozen-lockfile:                      
0.821  ERR_PNPM_UNSUPPORTED_ENGINE  Unsupported environment (bad pnpm and/or Node.js version)                                   
0.821                                                           
0.821 Your pnpm version is incompatible with "/app".
0.821 
0.821 Expected version: 9
0.821 Got: 8.15.9

4 Dockerfiles have:
RUN npm install --global pnpm@8

Upgrading to:
RUN npm install --global pnpm@9

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).
