### PR TITLE
chore(router): use automic's CAS to allow to shutdown the router concurrently

### DIFF
--- a/router/core/router.go
+++ b/router/core/router.go
@@ -1094,14 +1094,12 @@ func (r *Router) Start(ctx context.Context) error {
 }
 
 // Shutdown gracefully shuts down the router. It blocks until the server is shutdown.
-// If the router is already shutdown, the method returns immediately without error. Not safe for concurrent use.
+// If the router is already shutdown, the method returns immediately without error.
 func (r *Router) Shutdown(ctx context.Context) (err error) {
 
-	if r.shutdown.Load() {
+	if !r.shutdown.CompareAndSwap(false, true) {
 		return nil
 	}
-
-	r.shutdown.Store(true)
 
 	// Respect grace period
 	if r.routerGracePeriod > 0 {


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

## Motivation and Context

It now uses load and store when checking if the server is shutdown, so it might introduce data race if calls the shutdown function at the same time. We can work around this by using CAS operation in atomic.

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please describe in detail the impact of this change. Attach screenshots if applicable.
-->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->