### PR TITLE
fix(router): l2 cache uses client name in key, persisted operation not found returns 200

### DIFF
--- a/router-tests/automatic_persisted_queries_test.go
+++ b/router-tests/automatic_persisted_queries_test.go
@@ -27,11 +27,9 @@ func TestAutomaticPersistedQueries(t *testing.T) {
 					Enabled: true,
 				},
 			}, func(t *testing.T, xEnv *testenv.Environment) {
-				res, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
+				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
 					Extensions: []byte(`{"persistedQuery": {"version": 1, "sha256Hash": "does-not-exist"}}`),
 				})
-				require.NoError(t, err)
-				require.Equal(t, http.StatusBadRequest, res.Response.StatusCode)
 				require.Equal(t, `{"errors":[{"message":"persisted query not found","extensions":{"code":"PERSISTED_QUERY_NOT_FOUND"}}]}`, res.Body)
 			})
 		})
@@ -47,12 +45,10 @@ func TestAutomaticPersistedQueries(t *testing.T) {
 			}, func(t *testing.T, xEnv *testenv.Environment) {
 				header := make(http.Header)
 				header.Add("graphql-client-name", "my-client")
-				res0, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
+				res0 := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
 					Extensions: []byte(`{"persistedQuery": {"version": 1, "sha256Hash": "ecf4edb46db40b5132295c0291d62fb65d6759a9eedfa4d5d612dd5ec54a6b38"}}`),
 					Header:     header,
 				})
-				require.NoError(t, err)
-				require.Equal(t, http.StatusBadRequest, res0.Response.StatusCode)
 				require.Equal(t, `{"errors":[{"message":"persisted query not found","extensions":{"code":"PERSISTED_QUERY_NOT_FOUND"}}]}`, res0.Body)
 
 				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
@@ -92,12 +88,10 @@ func TestAutomaticPersistedQueries(t *testing.T) {
 
 				time.Sleep(3 * time.Second)
 
-				res0, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
+				res0 := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
 					Extensions: []byte(`{"persistedQuery": {"version": 1, "sha256Hash": "ecf4edb46db40b5132295c0291d62fb65d6759a9eedfa4d5d612dd5ec54a6b38"}}`),
 					Header:     header,
 				})
-				require.NoError(t, err)
-				require.Equal(t, http.StatusBadRequest, res0.Response.StatusCode)
 				require.Equal(t, `{"errors":[{"message":"persisted query not found","extensions":{"code":"PERSISTED_QUERY_NOT_FOUND"}}]}`, res0.Body)
 			})
 		})
@@ -174,11 +168,9 @@ func TestAutomaticPersistedQueries(t *testing.T) {
 					},
 				},
 			}, func(t *testing.T, xEnv *testenv.Environment) {
-				res, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
+				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
 					Extensions: []byte(`{"persistedQuery": {"version": 1, "sha256Hash": "does-not-exist"}}`),
 				})
-				require.NoError(t, err)
-				require.Equal(t, http.StatusBadRequest, res.Response.StatusCode)
 				require.Equal(t, `{"errors":[{"message":"persisted query not found","extensions":{"code":"PERSISTED_QUERY_NOT_FOUND"}}]}`, res.Body)
 			})
 		})
@@ -210,12 +202,10 @@ func TestAutomaticPersistedQueries(t *testing.T) {
 			}, func(t *testing.T, xEnv *testenv.Environment) {
 				header := make(http.Header)
 				header.Add("graphql-client-name", "my-client")
-				res0, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
+				res0 := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
 					Extensions: []byte(`{"persistedQuery": {"version": 1, "sha256Hash": "ecf4edb46db40b5132295c0291d62fb65d6759a9eedfa4d5d612dd5ec54a6b38"}}`),
 					Header:     header,
 				})
-				require.NoError(t, err)
-				require.Equal(t, http.StatusBadRequest, res0.Response.StatusCode)
 				require.Equal(t, `{"errors":[{"message":"persisted query not found","extensions":{"code":"PERSISTED_QUERY_NOT_FOUND"}}]}`, res0.Body)
 
 				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
@@ -273,12 +263,10 @@ func TestAutomaticPersistedQueries(t *testing.T) {
 
 				time.Sleep(3 * time.Second)
 
-				res0, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
+				res0 := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
 					Extensions: []byte(`{"persistedQuery": {"version": 1, "sha256Hash": "ecf4edb46db40b5132295c0291d62fb65d6759a9eedfa4d5d612dd5ec54a6b38"}}`),
 					Header:     header,
 				})
-				require.NoError(t, err)
-				require.Equal(t, http.StatusBadRequest, res0.Response.StatusCode)
 				require.Equal(t, `{"errors":[{"message":"persisted query not found","extensions":{"code":"PERSISTED_QUERY_NOT_FOUND"}}]}`, res0.Body)
 			})
 		})
@@ -358,14 +346,11 @@ func BenchmarkAutomaticPersistedQueriesCacheEnabled(b *testing.B) {
 	}, func(b *testing.B, xEnv *testenv.Environment) {
 		header := make(http.Header)
 		header.Add("graphql-client-name", "my-client")
-		res, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
+		res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
 			Query:      `{ employees { details { forename location { ...CountryFields } maritalStatus middlename nationality pastLocations { country { ...CountryFields } name type } pets { class gender name ...AlligatorFields ...CatFields ...DogFields ...MouseFields ...PonyFields } surname } } } fragment CountryFields on Country { key { name } } fragment AlligatorFields on Alligator { __typename class dangerous gender name } fragment CatFields on Cat { __typename class gender name type } fragment DogFields on Dog { __typename breed class gender name } fragment MouseFields on Mouse { __typename class gender name } fragment PonyFields on Pony { __typename class gender name }`,
 			Extensions: []byte(`{"persistedQuery": {"version": 1, "sha256Hash": "fb51f4141cc4f185fedc9956ae9e047b193edb196c6c095af8be785011a7c2ff"}}`),
 			Header:     header,
 		})
-		if err != nil {
-			b.Fatal(err)
-		}
 		if res.Body != expected {
 			b.Fatalf("unexpected response: %s", res.Body)
 		}
@@ -373,14 +358,11 @@ func BenchmarkAutomaticPersistedQueriesCacheEnabled(b *testing.B) {
 			for pb.Next() {
 				header := make(http.Header)
 				header.Add("graphql-client-name", "my-client")
-				res, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
+				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
 					Query:      `{ employees { details { forename location { ...CountryFields } maritalStatus middlename nationality pastLocations { country { ...CountryFields } name type } pets { class gender name ...AlligatorFields ...CatFields ...DogFields ...MouseFields ...PonyFields } surname } } } fragment CountryFields on Country { key { name } } fragment AlligatorFields on Alligator { __typename class dangerous gender name } fragment CatFields on Cat { __typename class gender name type } fragment DogFields on Dog { __typename breed class gender name } fragment MouseFields on Mouse { __typename class gender name } fragment PonyFields on Pony { __typename class gender name }`,
 					Extensions: []byte(`{"persistedQuery": {"version": 1, "sha256Hash": "fb51f4141cc4f185fedc9956ae9e047b193edb196c6c095af8be785011a7c2ff"}}`),
 					Header:     header,
 				})
-				if err != nil {
-					b.Fatal(err)
-				}
 				if res.Body != expected {
 					b.Fatalf("unexpected response: %s", res.Body)
 				}

--- a/router-tests/persisted_operations_over_get_test.go
+++ b/router-tests/persisted_operations_over_get_test.go
@@ -24,7 +24,7 @@ func TestPersistedOperationOverGET(t *testing.T) {
 				Header:     header,
 			})
 			require.NoError(t, err)
-			require.Equal(t, http.StatusBadRequest, res.Response.StatusCode)
+			require.Equal(t, http.StatusOK, res.Response.StatusCode)
 			require.Equal(t, `{"errors":[{"message":"persisted query not found","extensions":{"code":"PERSISTED_QUERY_NOT_FOUND"}}]}`, res.Body)
 		})
 	})
@@ -92,7 +92,7 @@ func TestAutomatedPersistedQueriesOverGET(t *testing.T) {
 				Header:     header,
 			})
 			require.NoError(t, err)
-			require.Equal(t, http.StatusBadRequest, res.Response.StatusCode)
+			require.Equal(t, http.StatusOK, res.Response.StatusCode)
 			require.Equal(t, `{"errors":[{"message":"persisted query not found","extensions":{"code":"PERSISTED_QUERY_NOT_FOUND"}}]}`, res.Body)
 		})
 	})
@@ -114,7 +114,7 @@ func TestAutomatedPersistedQueriesOverGET(t *testing.T) {
 				Header:     header,
 			})
 			require.NoError(t, err0)
-			require.Equal(t, http.StatusBadRequest, res0.Response.StatusCode)
+			require.Equal(t, http.StatusOK, res0.Response.StatusCode)
 			require.Equal(t, `{"errors":[{"message":"persisted query not found","extensions":{"code":"PERSISTED_QUERY_NOT_FOUND"}}]}`, res0.Body)
 
 			res1, err1 := xEnv.MakeGraphQLRequestOverGET(testenv.GraphQLRequest{

--- a/router-tests/persisted_operations_test.go
+++ b/router-tests/persisted_operations_test.go
@@ -18,11 +18,9 @@ func TestPersistedOperationNotFound(t *testing.T) {
 	t.Parallel()
 
 	testenv.Run(t, &testenv.Config{}, func(t *testing.T, xEnv *testenv.Environment) {
-		res, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
+		res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
 			Extensions: []byte(`{"persistedQuery": {"version": 1, "sha256Hash": "does-not-exist"}}`),
 		})
-		require.NoError(t, err)
-		require.Equal(t, http.StatusBadRequest, res.Response.StatusCode)
 		require.Equal(t, `{"errors":[{"message":"persisted query not found","extensions":{"code":"PERSISTED_QUERY_NOT_FOUND"}}]}`, res.Body)
 	})
 }
@@ -137,6 +135,19 @@ func TestPersistedOperationsCache(t *testing.T) {
 		require.Equal(t, `{"data":{"employees":[{"details":{"pets":null}},{"details":{"pets":null}},{"details":{"pets":[{"name":"Snappy","__typename":"Alligator"}]}},{"details":{"pets":[{"name":"Abby","__typename":"Dog","breed":"GOLDEN_RETRIEVER","class":"MAMMAL","gender":"FEMALE"},{"name":"Survivor","__typename":"Pony"}]}},{"details":{"pets":[{"name":"Blotch","__typename":"Cat","class":"MAMMAL","gender":"FEMALE","type":"STREET"},{"name":"Grayone","__typename":"Cat","class":"MAMMAL","gender":"MALE","type":"STREET"},{"name":"Rusty","__typename":"Cat","class":"MAMMAL","gender":"MALE","type":"STREET"},{"name":"Manya","__typename":"Cat","class":"MAMMAL","gender":"FEMALE","type":"HOME"},{"name":"Peach","__typename":"Cat","class":"MAMMAL","gender":"MALE","type":"STREET"},{"name":"Panda","__typename":"Cat","class":"MAMMAL","gender":"MALE","type":"HOME"},{"name":"Mommy","__typename":"Cat","class":"MAMMAL","gender":"FEMALE","type":"STREET"},{"name":"Terry","__typename":"Cat","class":"MAMMAL","gender":"FEMALE","type":"HOME"},{"name":"Tilda","__typename":"Cat","class":"MAMMAL","gender":"FEMALE","type":"HOME"},{"name":"Vasya","__typename":"Cat","class":"MAMMAL","gender":"MALE","type":"HOME"}]}},{"details":{"pets":null}},{"details":{"pets":null}},{"details":{"pets":[{"name":"Vanson","__typename":"Mouse"}]}},{"details":{"pets":null}},{"details":{"pets":[{"name":"Pepper","__typename":"Cat","class":"MAMMAL","gender":"FEMALE","type":"HOME"}]}}]}}`, res.Body)
 		require.Equal(t, "HIT", res.Response.Header.Get(core.PersistedOperationCacheHeader))
 		require.Equal(t, "HIT", res.Response.Header.Get(core.ExecutionPlanCacheHeader))
+
+		header = make(http.Header)
+		header.Add("graphql-client-name", "not-my-client")
+		res, err = xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
+			OperationName: []byte(`"Employees"`),
+			Extensions:    []byte(`{"persistedQuery": {"version": 1, "sha256Hash": "2267510fb4289672bea757e862d6b00e83db5d3cbbcfb15260601b6f29bb2b8f"}}`),
+			Header:        header,
+			Variables:     []byte(`{"withAligators": false,"withCats": true,"skipDogs": false,"skipMouses": true}`),
+		})
+		require.NoError(t, err)
+		require.Equal(t, `{"errors":[{"message":"persisted query not found","extensions":{"code":"PERSISTED_QUERY_NOT_FOUND"}}]}`, res.Body)
+		require.Equal(t, "", res.Response.Header.Get(core.PersistedOperationCacheHeader))
+		require.Equal(t, "", res.Response.Header.Get(core.ExecutionPlanCacheHeader))
 	}
 
 	retrieveNumberOfCDNRequests := func(t *testing.T, cdnURL string) int {
@@ -156,7 +167,7 @@ func TestPersistedOperationsCache(t *testing.T) {
 		testenv.Run(t, &testenv.Config{}, func(t *testing.T, xEnv *testenv.Environment) {
 			sendTwoRequests(t, xEnv)
 			numberOfCDNRequests := retrieveNumberOfCDNRequests(t, xEnv.CDN.URL)
-			require.Equal(t, 1, numberOfCDNRequests)
+			require.Equal(t, 2, numberOfCDNRequests)
 		})
 	})
 
@@ -170,7 +181,7 @@ func TestPersistedOperationsCache(t *testing.T) {
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			sendTwoRequests(t, xEnv)
 			numberOfCDNRequests := retrieveNumberOfCDNRequests(t, xEnv.CDN.URL)
-			require.Equal(t, 2, numberOfCDNRequests)
+			require.Equal(t, 3, numberOfCDNRequests)
 		})
 	})
 }

--- a/router/core/errors.go
+++ b/router/core/errors.go
@@ -281,8 +281,8 @@ func writeOperationError(r *http.Request, w http.ResponseWriter, requestLogger *
 	case errors.As(err, &httpErr):
 		writeRequestErrors(r, w, httpErr.StatusCode(), requestErrorsFromHttpError(httpErr), requestLogger)
 	case errors.As(err, &poNotFoundErr):
-		newErr := NewHttpGraphqlError("persisted query not found", "PERSISTED_QUERY_NOT_FOUND", http.StatusBadRequest)
-		writeRequestErrors(r, w, http.StatusBadRequest, requestErrorsFromHttpError(newErr), requestLogger)
+		newErr := NewHttpGraphqlError("persisted query not found", "PERSISTED_QUERY_NOT_FOUND", http.StatusOK)
+		writeRequestErrors(r, w, http.StatusOK, requestErrorsFromHttpError(newErr), requestLogger)
 	case errors.As(err, &reportErr):
 		report := reportErr.Report()
 		logInternalErrorsFromReport(reportErr.Report(), requestLogger)

--- a/router/core/graphql_prehandler.go
+++ b/router/core/graphql_prehandler.go
@@ -576,7 +576,7 @@ func (h *PreHandler) handleOperation(req *http.Request, buf *bytes.Buffer, varia
 		trace.WithAttributes(requestContext.telemetry.traceAttrs...),
 	)
 
-	cached, err := operationKit.NormalizeOperation(isApq)
+	cached, err := operationKit.NormalizeOperation(requestContext.operation.clientInfo.Name, isApq)
 	if err != nil {
 		rtrace.AttachErrToSpan(engineNormalizeSpan, err)
 

--- a/router/core/websocket.go
+++ b/router/core/websocket.go
@@ -803,7 +803,7 @@ func (h *WebSocketConnectionHandler) parseAndPlan(payload []byte) (*ParsedOperat
 
 	startNormalization := time.Now()
 
-	if _, err := operationKit.NormalizeOperation(isApq); err != nil {
+	if _, err := operationKit.NormalizeOperation(h.clientInfo.Name, isApq); err != nil {
 		opContext.normalizationTime = time.Since(startNormalization)
 		return nil, nil, err
 	}


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

## Motivation and Context

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please describe in detail the impact of this change. Attach screenshots if applicable.
-->

Previous PRs added APQ, and affected persisted operations. This PR makes two changes: 
* It closes #1179, ensuring that different client names can't access different users persisted operations
* It ensures that even when a persisted operation isn't found, it'll return 200, since it's a well formed GraphQL query

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->