### PR TITLE
feat: enables the full cosmo docker example to be built upon the latest rel…

### DIFF
--- a/examples/full-cosmo-docker/README.md
+++ b/examples/full-cosmo-docker/README.md
@@ -16,7 +16,7 @@ This example demonstrates how to run the entire Cosmo platform locally with Dock
 1. Start the platform:
 
 ```shell
-./start.sh
+./start.sh --last-release
 ```
 
 2. Navigate to the [Studio Playground](http://localhost:3000/wundergraph/default/graph/mygraph/playground) and login before with the default credentials:
@@ -43,4 +43,4 @@ query MyEmployees {
 }
 ```
 
-After you are done, you can clean up the demo by running `./destroy.sh`.
+After you are done, you can clean up the demo by running `./destroy.sh --last-release`.

--- a/examples/full-cosmo-docker/destroy.sh
+++ b/examples/full-cosmo-docker/destroy.sh
@@ -1,4 +1,15 @@
 #!/bin/bash
 set -e
 
+file_path="current_commit.hash"
+if [[ "$1" == "--last-release" ]] && [ -f "$file_path" ]; then
+    current_commit=$(cat "$file_path")  # Use $file variable here
+    rm -f "$file_path"
+fi
+
 cd ../.. && make full-demo-down
+
+if [[ "$1" == "--last-release" ]] && (( ${#current_commit} > 0 )); then
+    # Restoring code: Checkout to the current commit
+    git checkout "$current_commit"
+fi

--- a/examples/full-cosmo-docker/start.sh
+++ b/examples/full-cosmo-docker/start.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
 set -e
 
+file_path="current_commit.hash"
+if [[ "$1" == "--last-release" ]]; then
+    current_commit=$(git rev-parse HEAD)
+
+    latest_tag=$(git tag --sort=-v:refname | head -n 1)
+    latest_release_commit=$(git rev-list -n 1 "$latest_tag")
+
+    # Checkout the code at the last release
+    git checkout "$latest_release_commit"
+
+    echo $current_commit > "$file_path"
+    current=$(cat current_commit.hash)
+fi
+
 cd ../.. && make full-demo-up


### PR DESCRIPTION
## Motivation and Context

The full cosmo docker example currently builds some images using the latest code, which may introduce instability due to untested changes. This PR modifies the example to use the last released code version for building images, ensuring greater stability and reliability.

To maintain flexibility, the --last-release flag has been added. When this flag is provided, the example will explicitly use the last released version. Otherwise, the current behavior is preserved.

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [x] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).
