### PR TITLE
feat(router): enable setting request header from context

### DIFF
--- a/router-tests/headers_test.go
+++ b/router-tests/headers_test.go
@@ -88,8 +88,8 @@ func TestForwardHeaders(t *testing.T) {
 					All: &config.GlobalHeaderRule{
 						Request: []*config.RequestHeaderRule{
 							{
-								Operation: config.HeaderRuleOperationPropagate,
-								Named:     headerName,
+								Operation: config.HeaderRuleOperationSet,
+								Name:      headerName,
 								ValueFrom: &config.CustomDynamicAttribute{
 									ContextField: contextField,
 								}}}}})}

--- a/router-tests/headers_test.go
+++ b/router-tests/headers_test.go
@@ -111,7 +111,7 @@ func TestForwardHeaders(t *testing.T) {
 				})
 		})
 
-		t.Run("explicit header overwrites dynamic header", func(t *testing.T) {
+		t.Run("propagated header overwrites explicit header", func(t *testing.T) {
 			t.Parallel()
 
 			testenv.Run(t, &testenv.Config{
@@ -124,7 +124,7 @@ func TestForwardHeaders(t *testing.T) {
 						opNameHeader: "not-myQuery",
 					})
 					require.NoError(t, err)
-					headerVal := "not-myQuery"
+					headerVal := "myQuery"
 					require.Equal(t, `{"data":{"headerValue":"`+headerVal+`"}}`, res.Body)
 				})
 		})

--- a/router-tests/headers_test.go
+++ b/router-tests/headers_test.go
@@ -111,7 +111,7 @@ func TestForwardHeaders(t *testing.T) {
 				})
 		})
 
-		t.Run("propagated header overwrites explicit header", func(t *testing.T) {
+		t.Run("set dynamic header overwrites explicit header", func(t *testing.T) {
 			t.Parallel()
 
 			testenv.Run(t, &testenv.Config{

--- a/router-tests/headers_test.go
+++ b/router-tests/headers_test.go
@@ -81,7 +81,7 @@ func TestForwardHeaders(t *testing.T) {
 		})
 	})
 
-	t.Run("PropagateHeadersFromContext", func(t *testing.T) {
+	t.Run("SetHeadersFromContext", func(t *testing.T) {
 		setRequestDynamicAttribute := func(headerName, contextField string) []core.Option {
 			return []core.Option{
 				core.WithHeaderRules(config.HeaderRules{

--- a/router-tests/headers_test.go
+++ b/router-tests/headers_test.go
@@ -110,6 +110,24 @@ func TestForwardHeaders(t *testing.T) {
 					require.Equal(t, `{"data":{"headerValue":"`+headerVal+`"}}`, res.Body)
 				})
 		})
+
+		t.Run("explicit header overwrites dynamic header", func(t *testing.T) {
+			t.Parallel()
+
+			testenv.Run(t, &testenv.Config{
+				RouterOptions: setRequestDynamicAttribute(opNameHeader, core.ContextFieldOperationName),
+			},
+				func(t *testing.T, xEnv *testenv.Environment) {
+					res, err := xEnv.MakeGraphQLRequestWithHeaders(testenv.GraphQLRequest{
+						Query: `query myQuery { headerValue(name:"` + opNameHeader + `") }`,
+					}, map[string]string{
+						opNameHeader: "not-myQuery",
+					})
+					require.NoError(t, err)
+					headerVal := "not-myQuery"
+					require.Equal(t, `{"data":{"headerValue":"`+headerVal+`"}}`, res.Body)
+				})
+		})
 	})
 
 	t.Run("HTTP with client extension", func(t *testing.T) {

--- a/router/core/header_rule_engine.go
+++ b/router/core/header_rule_engine.go
@@ -397,6 +397,12 @@ func (h *HeaderPropagation) applyRequestRule(ctx RequestContext, request *http.R
 			request.Header.Set(rule.Named, ctx.Request().Header.Get(rule.Named))
 		} else if rule.Default != "" {
 			request.Header.Set(rule.Named, rule.Default)
+		} else if rule.ValueFrom.ContextField != "" {
+			val := GetCustomDynamicAttributeValue(rule.ValueFrom, ctx)
+			value = fmt.Sprintf("%v", val)
+			if value != "" {
+				request.Header.Set(rule.Named, value)
+			}
 		}
 
 		return

--- a/router/core/header_rule_engine.go
+++ b/router/core/header_rule_engine.go
@@ -392,17 +392,20 @@ func (h *HeaderPropagation) applyRequestRule(ctx RequestContext, request *http.R
 			return
 		}
 
+		if rule.ValueFrom != nil && rule.ValueFrom.ContextField != "" {
+			val := getCustomDynamicAttributeValue(rule.ValueFrom, getRequestContext(request.Context()))
+			value := fmt.Sprintf("%v", val)
+			if value != "" {
+				request.Header.Set(rule.Named, value)
+			}
+			return
+		}
+
 		value := ctx.Request().Header.Get(rule.Named)
 		if value != "" {
 			request.Header.Set(rule.Named, ctx.Request().Header.Get(rule.Named))
 		} else if rule.Default != "" {
 			request.Header.Set(rule.Named, rule.Default)
-		} else if rule.ValueFrom != nil && rule.ValueFrom.ContextField != "" {
-			val := getCustomDynamicAttributeValue(rule.ValueFrom, getRequestContext(request.Context()))
-			value = fmt.Sprintf("%v", val)
-			if value != "" {
-				request.Header.Set(rule.Named, value)
-			}
 		}
 
 		return

--- a/router/core/header_rule_engine.go
+++ b/router/core/header_rule_engine.go
@@ -397,7 +397,7 @@ func (h *HeaderPropagation) applyRequestRule(ctx RequestContext, request *http.R
 			request.Header.Set(rule.Named, ctx.Request().Header.Get(rule.Named))
 		} else if rule.Default != "" {
 			request.Header.Set(rule.Named, rule.Default)
-		} else if rule.ValueFrom.ContextField != "" {
+		} else if rule.ValueFrom != nil && rule.ValueFrom.ContextField != "" {
 			val := GetCustomDynamicAttributeValue(rule.ValueFrom, ctx)
 			value = fmt.Sprintf("%v", val)
 			if value != "" {

--- a/router/core/header_rule_engine.go
+++ b/router/core/header_rule_engine.go
@@ -398,7 +398,7 @@ func (h *HeaderPropagation) applyRequestRule(ctx RequestContext, request *http.R
 		} else if rule.Default != "" {
 			request.Header.Set(rule.Named, rule.Default)
 		} else if rule.ValueFrom != nil && rule.ValueFrom.ContextField != "" {
-			val := GetCustomDynamicAttributeValue(rule.ValueFrom, ctx)
+			val := getCustomDynamicAttributeValue(rule.ValueFrom, getRequestContext(request.Context()))
 			value = fmt.Sprintf("%v", val)
 			if value != "" {
 				request.Header.Set(rule.Named, value)

--- a/router/core/request_context_fields.go
+++ b/router/core/request_context_fields.go
@@ -104,13 +104,16 @@ func GetCustomDynamicAttributeValue(attribute *config.CustomDynamicAttribute, re
 			return op.sha256Hash
 		}
 	case ContextFieldOperationHash:
+		if opOk && op.hash != 0 {
+			return strconv.FormatUint(op.hash, 10)
+		}
 		return operation.Hash()
 	case ContextFieldPersistedOperationSha256:
 		if opOk {
 			return op.persistedID
 		}
 	case ContextFieldResponseErrorMessage:
-		if reqOk {
+		if reqOk && reqContext.error != nil {
 			return reqContext.error.Error()
 		}
 	case ContextFieldOperationServices:

--- a/router/pkg/config/config.go
+++ b/router/pkg/config/config.go
@@ -221,14 +221,14 @@ type RequestHeaderRule struct {
 	Rename string `yaml:"rename,omitempty"`
 	// Default is the default value to set if the header is not present
 	Default string `yaml:"default"`
-	// ValueFrom is the context field to get the value from, in propagating to subgraphs
-	ValueFrom *CustomDynamicAttribute `yaml:"value_from,omitempty"`
 
 	// Set header options
 	// Name is the name of the header to set
 	Name string `yaml:"name"`
 	// Value is the value of the header to set
 	Value string `yaml:"value"`
+	// ValueFrom is the context field to get the value from, in propagating to subgraphs
+	ValueFrom *CustomDynamicAttribute `yaml:"value_from,omitempty"`
 }
 
 func (r *RequestHeaderRule) GetOperation() HeaderRuleOperation {

--- a/router/pkg/config/config.go
+++ b/router/pkg/config/config.go
@@ -239,9 +239,6 @@ func (r *RequestHeaderRule) GetMatching() string {
 	return r.Matching
 }
 
-type HeaderValueFrom struct {
-	ContextField string `yaml:"context_field,omitempty"`
-}
 type ResponseHeaderRuleAlgorithm string
 
 const (

--- a/router/pkg/config/config.go
+++ b/router/pkg/config/config.go
@@ -30,8 +30,8 @@ type CustomStaticAttribute struct {
 }
 
 type CustomDynamicAttribute struct {
-	RequestHeader string `yaml:"request_header"`
-	ContextField  string `yaml:"context_field"`
+	RequestHeader string `yaml:"request_header,omitempty"`
+	ContextField  string `yaml:"context_field,omitempty"`
 }
 
 type CustomAttribute struct {
@@ -221,6 +221,8 @@ type RequestHeaderRule struct {
 	Rename string `yaml:"rename,omitempty"`
 	// Default is the default value to set if the header is not present
 	Default string `yaml:"default"`
+	// ValueFrom is the context field to get the value from, in propagating to subgraphs
+	ValueFrom *CustomDynamicAttribute `yaml:"value_from,omitempty"`
 
 	// Set header options
 	// Name is the name of the header to set
@@ -237,6 +239,9 @@ func (r *RequestHeaderRule) GetMatching() string {
 	return r.Matching
 }
 
+type HeaderValueFrom struct {
+	ContextField string `yaml:"context_field,omitempty"`
+}
 type ResponseHeaderRuleAlgorithm string
 
 const (

--- a/router/pkg/config/config.schema.json
+++ b/router/pkg/config/config.schema.json
@@ -2104,21 +2104,8 @@
               "type": "string",
               "description": "The field name of the context from which to extract the value. The value is only extracted when a context is available otherwise the default value is used.",
               "enum": [
-                "operation_name",
-                "operation_type",
-                "operation_service_names",
-                "operation_hash",
-                "persisted_operation_sha256",
-                "operation_sha256",
-                "response_error_message",
-                "graphql_error_codes",
-                "graphql_error_service_names",
-                "operation_parsing_time",
-                "operation_validation_time",
-                "operation_planning_time",
-                "operation_normalization_time"
+                "operation_name"
               ]
-
             }
           }
         }

--- a/router/pkg/config/config.schema.json
+++ b/router/pkg/config/config.schema.json
@@ -2093,6 +2093,34 @@
           "type": "string",
           "examples": ["default-value"],
           "description": "The default value of the header in case it is not present in the request."
+        },
+        "value_from": {
+          "type": "object",
+          "description": "The configuration for the value from. The value from is used to extract a value from a request context and propagate it to subgraphs,",
+          "additionalProperties": false,
+          "required": ["context_field"],
+          "properties": {
+            "context_field": {
+              "type": "string",
+              "description": "The field name of the context from which to extract the value. The value is only extracted when a context is available otherwise the default value is used.",
+              "enum": [
+                "operation_name",
+                "operation_type",
+                "operation_service_names",
+                "operation_hash",
+                "persisted_operation_sha256",
+                "operation_sha256",
+                "response_error_message",
+                "graphql_error_codes",
+                "graphql_error_service_names",
+                "operation_parsing_time",
+                "operation_validation_time",
+                "operation_planning_time",
+                "operation_normalization_time"
+              ]
+
+            }
+          }
         }
       },
       "required": ["op"]

--- a/router/pkg/config/config.schema.json
+++ b/router/pkg/config/config.schema.json
@@ -2093,21 +2093,6 @@
           "type": "string",
           "examples": ["default-value"],
           "description": "The default value of the header in case it is not present in the request."
-        },
-        "value_from": {
-          "type": "object",
-          "description": "The configuration for the value from. The value from is used to extract a value from a request context and propagate it to subgraphs,",
-          "additionalProperties": false,
-          "required": ["context_field"],
-          "properties": {
-            "context_field": {
-              "type": "string",
-              "description": "The field name of the context from which to extract the value. The value is only extracted when a context is available otherwise the default value is used.",
-              "enum": [
-                "operation_name"
-              ]
-            }
-          }
         }
       },
       "required": ["op"]
@@ -2171,9 +2156,24 @@
           "type": "string",
           "examples": ["My-Secret-Value"],
           "description": "The value to set for the header. This can include environment variables."
+        },
+        "value_from": {
+          "type": "object",
+          "description": "The configuration for the value from. The value from is used to extract a value from a request context and propagate it to subgraphs. This is currently only valid in requests",
+          "additionalProperties": false,
+          "required": ["context_field"],
+          "properties": {
+            "context_field": {
+              "type": "string",
+              "description": "The field name of the context from which to extract the value. The value is only extracted when a context is available otherwise the default value is used.",
+              "enum": [
+                "operation_name"
+              ]
+            }
+          }
         }
       },
-      "required": ["op", "name", "value"]
+      "required": ["op", "name"]
     }
   }
 }

--- a/router/pkg/config/fixtures/full.yaml
+++ b/router/pkg/config/fixtures/full.yaml
@@ -164,8 +164,8 @@ headers:
       - op: "set"
         name: "X-API-Key"
         value: "some-secret"
-      - op: "propagate"
-        named: "x-operation-name"
+      - op: "set"
+        name: "x-operation-name"
         value_from:
           context_field: "operation_name"
     response:

--- a/router/pkg/config/fixtures/full.yaml
+++ b/router/pkg/config/fixtures/full.yaml
@@ -164,6 +164,10 @@ headers:
       - op: "set"
         name: "X-API-Key"
         value: "some-secret"
+      - op: "propagate"
+        named: "x-operation-name"
+        value_from:
+          context_field: "operation_name"
     response:
       - op: "propagate"
         algorithm: "append"

--- a/router/pkg/config/testdata/config_full.json
+++ b/router/pkg/config/testdata/config_full.json
@@ -131,9 +131,9 @@
           "Named": "X-Test-Header",
           "Rename": "",
           "Default": "",
-          "ValueFrom": null,
           "Name": "",
-          "Value": ""
+          "Value": "",
+          "ValueFrom": null
         },
         {
           "Operation": "propagate",
@@ -141,9 +141,9 @@
           "Named": "",
           "Rename": "",
           "Default": "",
-          "ValueFrom": null,
           "Name": "",
-          "Value": ""
+          "Value": "",
+          "ValueFrom": null
         },
         {
           "Operation": "propagate",
@@ -151,9 +151,9 @@
           "Named": "X-User-Id",
           "Rename": "",
           "Default": "123",
-          "ValueFrom": null,
           "Name": "",
-          "Value": ""
+          "Value": "",
+          "ValueFrom": null
         },
         {
           "Operation": "set",
@@ -161,22 +161,22 @@
           "Named": "",
           "Rename": "",
           "Default": "",
-          "ValueFrom": null,
           "Name": "X-API-Key",
-          "Value": "some-secret"
+          "Value": "some-secret",
+          "ValueFrom": null
         },
         {
-          "Operation": "propagate",
+          "Operation": "set",
           "Matching": "",
-          "Named": "x-operation-name",
+          "Named": "",
           "Rename": "",
           "Default": "",
+          "Name": "x-operation-name",
+          "Value": "",
           "ValueFrom": {
             "RequestHeader": "",
             "ContextField": "operation_name"
-          },
-          "Name": "",
-          "Value": ""
+          }
         }
       ],
       "Response": [
@@ -201,9 +201,9 @@
             "Named": "Subgraph-Secret",
             "Rename": "",
             "Default": "some-secret",
-            "ValueFrom": null,
             "Name": "",
-            "Value": ""
+            "Value": "",
+            "ValueFrom": null
           }
         ],
         "Response": [

--- a/router/pkg/config/testdata/config_full.json
+++ b/router/pkg/config/testdata/config_full.json
@@ -131,6 +131,7 @@
           "Named": "X-Test-Header",
           "Rename": "",
           "Default": "",
+          "ValueFrom": null,
           "Name": "",
           "Value": ""
         },
@@ -140,6 +141,7 @@
           "Named": "",
           "Rename": "",
           "Default": "",
+          "ValueFrom": null,
           "Name": "",
           "Value": ""
         },
@@ -149,6 +151,7 @@
           "Named": "X-User-Id",
           "Rename": "",
           "Default": "123",
+          "ValueFrom": null,
           "Name": "",
           "Value": ""
         },
@@ -158,8 +161,22 @@
           "Named": "",
           "Rename": "",
           "Default": "",
+          "ValueFrom": null,
           "Name": "X-API-Key",
           "Value": "some-secret"
+        },
+        {
+          "Operation": "propagate",
+          "Matching": "",
+          "Named": "x-operation-name",
+          "Rename": "",
+          "Default": "",
+          "ValueFrom": {
+            "RequestHeader": "",
+            "ContextField": "operation_name"
+          },
+          "Name": "",
+          "Value": ""
         }
       ],
       "Response": [
@@ -184,6 +201,7 @@
             "Named": "Subgraph-Secret",
             "Rename": "",
             "Default": "some-secret",
+            "ValueFrom": null,
             "Name": "",
             "Value": ""
           }


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

## Motivation and Context

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please describe in detail the impact of this change. Attach screenshots if applicable.
-->

This, as similar work to #1203, enables users to propagate request headers from a subset of request context elements, such as operation name

```
headers:
  all:
    request:
      -  operation: "set"
          name: x-operation-name
          value_from: # New
             context_field: operation_name
```

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->