### PR TITLE
fix: ensure that apq alone (without persistent operations enabled) works

### DIFF
--- a/router-tests/automatic_persisted_queries_test.go
+++ b/router-tests/automatic_persisted_queries_test.go
@@ -23,6 +23,9 @@ func TestAutomaticPersistedQueries(t *testing.T) {
 
 		t.Run("Sha without query fails", func(t *testing.T) {
 			testenv.Run(t, &testenv.Config{
+				RouterOptions: []core.Option{
+					core.WithGraphApiToken(""),
+				},
 				ApqConfig: config.AutomaticPersistedQueriesConfig{
 					Enabled: true,
 				},
@@ -36,6 +39,11 @@ func TestAutomaticPersistedQueries(t *testing.T) {
 
 		t.Run("Sha with query works", func(t *testing.T) {
 			testenv.Run(t, &testenv.Config{
+				RouterOptions: []core.Option{
+					// This ensures that no CDN client for persistent operations is created, so we can verify that
+					// APQ alone (without persistent operation support setup) works as expected.
+					core.WithGraphApiToken(""),
+				},
 				ApqConfig: config.AutomaticPersistedQueriesConfig{
 					Enabled: true,
 					Cache: config.AutomaticPersistedQueriesCacheConfig{

--- a/router/internal/persistedoperation/client.go
+++ b/router/internal/persistedoperation/client.go
@@ -78,6 +78,11 @@ func (c client) PersistedOperation(ctx context.Context, clientName string, sha25
 		return data, false, nil
 	}
 
+	if c.providerClient == nil {
+		// This can happen if we are using APQ client, without any persisted operation client. Otherwise, we should have a provider client and shouldn't reach here.
+		return nil, c.apqClient != nil, nil
+	}
+
 	content, _, err := c.providerClient.PersistedOperation(ctx, clientName, sha256Hash)
 	if errors.As(err, &PoNotFoundErr) && c.apqClient != nil {
 		// This could well be the first time a client is requesting an APQ operation and the query is attached to the request. Return without error here, and we'll verify the operation later.


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

## Motivation and Context

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please describe in detail the impact of this change. Attach screenshots if applicable.
-->

Previous efforts to add APQ in (#1346) failed to fully verify that APQ works even when persistent operations aren't set up, based on complexity in the test environment/router setup. This PR adds the required test, and fixes the null pointer bug that had existed prior. 

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->