### PR TITLE
fix(router): use valid format for graphql operation

### DIFF
--- a/router-tests/go.mod
+++ b/router-tests/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/twmb/franz-go/pkg/kadm v1.11.0
 	github.com/wundergraph/cosmo/demo v0.0.0-20241118164309-37af7e49ffff
 	github.com/wundergraph/cosmo/router v0.0.0-20241118164309-37af7e49ffff
-	github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.128
+	github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.129
 	go.opentelemetry.io/otel v1.28.0
 	go.opentelemetry.io/otel/sdk v1.28.0
 	go.opentelemetry.io/otel/sdk/metric v1.28.0

--- a/router-tests/go.sum
+++ b/router-tests/go.sum
@@ -350,8 +350,8 @@ github.com/vektah/gqlparser/v2 v2.5.16 h1:1gcmLTvs3JLKXckwCwlUagVn/IlV2bwqle0vJ0
 github.com/vektah/gqlparser/v2 v2.5.16/go.mod h1:1lz1OeCqgQbQepsGxPVywrjdBHW2T08PUS3pJqepRww=
 github.com/wundergraph/astjson v0.0.0-20241108124845-44485579ffa5 h1:rc+IQxG3rrAXEjBywirkzhKkyCKvXLGQXABVD8GiUtU=
 github.com/wundergraph/astjson v0.0.0-20241108124845-44485579ffa5/go.mod h1:eOTL6acwctsN4F3b7YE+eE2t8zcJ/doLm9sZzsxxxrE=
-github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.128 h1:0qFNHSFjXLBOEeeaIY8Pa5usEW//yTQY3ahIQnPouG8=
-github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.128/go.mod h1:s4r/lhVEU5s0c6tCgpR0hK6FHEmX0cbrKcMU1pMc/ZI=
+github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.129 h1:TnW4GYiUqJgZ0P5wQW1ByHkorE4qKuhTdnyhiCwoSZw=
+github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.129/go.mod h1:s4r/lhVEU5s0c6tCgpR0hK6FHEmX0cbrKcMU1pMc/ZI=
 github.com/xrash/smetrics v0.0.0-20240312152122-5f08fbb34913 h1:+qGGcbkzsfDQNPPe9UDgpxAWQrhbbBXOYJFQDq/dtJw=
 github.com/xrash/smetrics v0.0.0-20240312152122-5f08fbb34913/go.mod h1:4aEEwZQutDLsQv2Deui4iYQ6DWTxR14g6m8Wv88+Xqk=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/router-tests/testdata/fixtures/query_plans/response_with_query_plan_operation_name_sanitized.json
+++ b/router-tests/testdata/fixtures/query_plans/response_with_query_plan_operation_name_sanitized.json
@@ -1,0 +1,147 @@
+{
+  "data": {
+    "products": [
+      {
+        "__typename": "Consultancy",
+        "lead": {
+          "__typename": "Employee",
+          "id": 1,
+          "derivedMood": "HAPPY"
+        },
+        "isLeadAvailable": false
+      },
+      {
+        "__typename": "Cosmo"
+      },
+      {
+        "__typename": "SDK"
+      }
+    ]
+  },
+  "extensions": {
+    "queryPlan": {
+      "version": "1",
+      "kind": "Sequence",
+      "children": [
+        {
+          "kind": "Single",
+          "fetch": {
+            "kind": "Single",
+            "subgraphName": "employees",
+            "subgraphId": "0",
+            "fetchId": 0,
+            "query": "query Requires__employees__0 {\n    products {\n        __typename\n        ... on Consultancy {\n            lead {\n                __typename\n                id\n            }\n            __typename\n            upc\n        }\n    }\n}"
+          }
+        },
+        {
+          "kind": "Parallel",
+          "children": [
+            {
+              "kind": "Single",
+              "fetch": {
+                "kind": "BatchEntity",
+                "path": "products.@.lead",
+                "subgraphName": "--_$mo\u0026o-d_-$-_-",
+                "subgraphId": "6",
+                "fetchId": 1,
+                "dependsOnFetchIds": [
+                  0
+                ],
+                "representations": [
+                  {
+                    "kind": "@key",
+                    "typeName": "Employee",
+                    "fragment": "fragment Key on Employee {\n    __typename\n    id\n}"
+                  }
+                ],
+                "query": "query Requires__mo_o_d__1($representations: [_Any!]!){\n    _entities(representations: $representations){\n        ... on Employee {\n            __typename\n            currentMood\n        }\n    }\n}"
+              }
+            },
+            {
+              "kind": "Single",
+              "fetch": {
+                "kind": "BatchEntity",
+                "path": "products.@.lead",
+                "subgraphName": "--_$av_ai-la%bi$lit-y_-$-_-",
+                "subgraphId": "5",
+                "fetchId": 2,
+                "dependsOnFetchIds": [
+                  0
+                ],
+                "representations": [
+                  {
+                    "kind": "@key",
+                    "typeName": "Employee",
+                    "fragment": "fragment Key on Employee {\n    __typename\n    id\n}"
+                  }
+                ],
+                "query": "query Requires__av_ai_la_bi_lit_y__2($representations: [_Any!]!){\n    _entities(representations: $representations){\n        ... on Employee {\n            __typename\n            isAvailable\n        }\n    }\n}"
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Parallel",
+          "children": [
+            {
+              "kind": "Single",
+              "fetch": {
+                "kind": "BatchEntity",
+                "path": "products.@.lead",
+                "subgraphName": "employees",
+                "subgraphId": "0",
+                "fetchId": 3,
+                "dependsOnFetchIds": [
+                  0,
+                  1
+                ],
+                "representations": [
+                  {
+                    "kind": "@requires",
+                    "typeName": "Employee",
+                    "fieldName": "derivedMood",
+                    "fragment": "fragment Requires_for_derivedMood on Employee {\n    currentMood\n}"
+                  },
+                  {
+                    "kind": "@key",
+                    "typeName": "Employee",
+                    "fragment": "fragment Key on Employee {\n    __typename\n    id\n}"
+                  }
+                ],
+                "query": "query Requires__employees__3($representations: [_Any!]!){\n    _entities(representations: $representations){\n        ... on Employee {\n            __typename\n            derivedMood\n        }\n    }\n}"
+              }
+            },
+            {
+              "kind": "Single",
+              "fetch": {
+                "kind": "BatchEntity",
+                "path": "products",
+                "subgraphName": "employees",
+                "subgraphId": "0",
+                "fetchId": 4,
+                "dependsOnFetchIds": [
+                  0,
+                  2
+                ],
+                "representations": [
+                  {
+                    "kind": "@requires",
+                    "typeName": "Consultancy",
+                    "fieldName": "isLeadAvailable",
+                    "fragment": "fragment Requires_for_isLeadAvailable on Consultancy {\n    lead {\n        isAvailable\n    }\n}"
+                  },
+                  {
+                    "kind": "@key",
+                    "typeName": "Consultancy",
+                    "fragment": "fragment Key on Consultancy {\n    __typename\n    upc\n}"
+                  }
+                ],
+                "query": "query Requires__employees__4($representations: [_Any!]!){\n    _entities(representations: $representations){\n        ... on Consultancy {\n            __typename\n            isLeadAvailable\n        }\n    }\n}"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/router-tests/testdata/fixtures/query_plans/response_with_query_plan_operation_name_sanitized_no_data.json
+++ b/router-tests/testdata/fixtures/query_plans/response_with_query_plan_operation_name_sanitized_no_data.json
@@ -1,0 +1,220 @@
+{
+  "data": null,
+  "extensions": {
+    "queryPlan": {
+      "version": "1",
+      "kind": "Sequence",
+      "children": [
+        {
+          "kind": "Single",
+          "fetch": {
+            "kind": "Single",
+            "subgraphName": "employees",
+            "subgraphId": "0",
+            "fetchId": 0,
+            "query": "query Requires__employees__0 {\n    products {\n        __typename\n        ... on Consultancy {\n            lead {\n                __typename\n                id\n            }\n            __typename\n            upc\n        }\n    }\n}"
+          }
+        },
+        {
+          "kind": "Parallel",
+          "children": [
+            {
+              "kind": "Single",
+              "fetch": {
+                "kind": "BatchEntity",
+                "path": "products.@.lead",
+                "subgraphName": "--_$mo\u0026o-d_-$-_-",
+                "subgraphId": "6",
+                "fetchId": 1,
+                "dependsOnFetchIds": [
+                  0
+                ],
+                "representations": [
+                  {
+                    "kind": "@key",
+                    "typeName": "Employee",
+                    "fragment": "fragment Key on Employee {\n    __typename\n    id\n}"
+                  }
+                ],
+                "query": "query Requires__mo_o_d__1($representations: [_Any!]!){\n    _entities(representations: $representations){\n        ... on Employee {\n            __typename\n            currentMood\n        }\n    }\n}"
+              }
+            },
+            {
+              "kind": "Single",
+              "fetch": {
+                "kind": "BatchEntity",
+                "path": "products.@.lead",
+                "subgraphName": "--_$av_ai-la%bi$lit-y_-$-_-",
+                "subgraphId": "5",
+                "fetchId": 2,
+                "dependsOnFetchIds": [
+                  0
+                ],
+                "representations": [
+                  {
+                    "kind": "@key",
+                    "typeName": "Employee",
+                    "fragment": "fragment Key on Employee {\n    __typename\n    id\n}"
+                  }
+                ],
+                "query": "query Requires__av_ai_la_bi_lit_y__2($representations: [_Any!]!){\n    _entities(representations: $representations){\n        ... on Employee {\n            __typename\n            isAvailable\n        }\n    }\n}"
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Parallel",
+          "children": [
+            {
+              "kind": "Single",
+              "fetch": {
+                "kind": "BatchEntity",
+                "path": "products.@.lead",
+                "subgraphName": "employees",
+                "subgraphId": "0",
+                "fetchId": 3,
+                "dependsOnFetchIds": [
+                  0,
+                  1
+                ],
+                "representations": [
+                  {
+                    "kind": "@requires",
+                    "typeName": "Employee",
+                    "fieldName": "derivedMood",
+                    "fragment": "fragment Requires_for_derivedMood on Employee {\n    currentMood\n}"
+                  },
+                  {
+                    "kind": "@key",
+                    "typeName": "Employee",
+                    "fragment": "fragment Key on Employee {\n    __typename\n    id\n}"
+                  }
+                ],
+                "query": "query Requires__employees__3($representations: [_Any!]!){\n    _entities(representations: $representations){\n        ... on Employee {\n            __typename\n            derivedMood\n        }\n    }\n}"
+              }
+            },
+            {
+              "kind": "Single",
+              "fetch": {
+                "kind": "BatchEntity",
+                "path": "products",
+                "subgraphName": "employees",
+                "subgraphId": "0",
+                "fetchId": 4,
+                "dependsOnFetchIds": [
+                  0,
+                  2
+                ],
+                "representations": [
+                  {
+                    "kind": "@requires",
+                    "typeName": "Consultancy",
+                    "fieldName": "isLeadAvailable",
+                    "fragment": "fragment Requires_for_isLeadAvailable on Consultancy {\n    lead {\n        isAvailable\n    }\n}"
+                  },
+                  {
+                    "kind": "@key",
+                    "typeName": "Consultancy",
+                    "fragment": "fragment Key on Consultancy {\n    __typename\n    upc\n}"
+                  }
+                ],
+                "query": "query Requires__employees__4($representations: [_Any!]!){\n    _entities(representations: $representations){\n        ... on Consultancy {\n            __typename\n            isLeadAvailable\n        }\n    }\n}"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "trace": {
+      "version": "1",
+      "info": {
+        "trace_start_time": "",
+        "trace_start_unix": 0,
+        "parse_stats": {
+          "duration_nanoseconds": 5,
+          "duration_pretty": "5ns",
+          "duration_since_start_nanoseconds": 5,
+          "duration_since_start_pretty": "5ns"
+        },
+        "normalize_stats": {
+          "duration_nanoseconds": 5,
+          "duration_pretty": "5ns",
+          "duration_since_start_nanoseconds": 10,
+          "duration_since_start_pretty": "10ns"
+        },
+        "validate_stats": {
+          "duration_nanoseconds": 5,
+          "duration_pretty": "5ns",
+          "duration_since_start_nanoseconds": 15,
+          "duration_since_start_pretty": "15ns"
+        },
+        "planner_stats": {
+          "duration_nanoseconds": 5,
+          "duration_pretty": "5ns",
+          "duration_since_start_nanoseconds": 20,
+          "duration_since_start_pretty": "20ns"
+        }
+      },
+      "fetches": {
+        "kind": "Sequence",
+        "children": [
+          {
+            "kind": "Single",
+            "fetch": {
+              "kind": "Single",
+              "path": "",
+              "source_id": "0",
+              "source_name": "employees"
+            }
+          },
+          {
+            "kind": "Parallel",
+            "children": [
+              {
+                "kind": "Single",
+                "fetch": {
+                  "kind": "BatchEntity",
+                  "path": "products.@.lead",
+                  "source_id": "6",
+                  "source_name": "--_$mo\u0026o-d_-$-_-"
+                }
+              },
+              {
+                "kind": "Single",
+                "fetch": {
+                  "kind": "BatchEntity",
+                  "path": "products.@.lead",
+                  "source_id": "5",
+                  "source_name": "--_$av_ai-la%bi$lit-y_-$-_-"
+                }
+              }
+            ]
+          },
+          {
+            "kind": "Parallel",
+            "children": [
+              {
+                "kind": "Single",
+                "fetch": {
+                  "kind": "BatchEntity",
+                  "path": "products.@.lead",
+                  "source_id": "0",
+                  "source_name": "employees"
+                }
+              },
+              {
+                "kind": "Single",
+                "fetch": {
+                  "kind": "BatchEntity",
+                  "path": "products",
+                  "source_id": "0",
+                  "source_name": "employees"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/router/go.mod
+++ b/router/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/tidwall/gjson v1.18.0
 	github.com/tidwall/sjson v1.2.5
 	github.com/twmb/franz-go v1.16.1
-	github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.128
+	github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.129
 	// Do not upgrade, it renames attributes we rely on
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.46.1
 	go.opentelemetry.io/contrib/propagators/b3 v1.23.0

--- a/router/go.sum
+++ b/router/go.sum
@@ -268,8 +268,8 @@ github.com/vektah/gqlparser/v2 v2.5.16 h1:1gcmLTvs3JLKXckwCwlUagVn/IlV2bwqle0vJ0
 github.com/vektah/gqlparser/v2 v2.5.16/go.mod h1:1lz1OeCqgQbQepsGxPVywrjdBHW2T08PUS3pJqepRww=
 github.com/wundergraph/astjson v0.0.0-20241108124845-44485579ffa5 h1:rc+IQxG3rrAXEjBywirkzhKkyCKvXLGQXABVD8GiUtU=
 github.com/wundergraph/astjson v0.0.0-20241108124845-44485579ffa5/go.mod h1:eOTL6acwctsN4F3b7YE+eE2t8zcJ/doLm9sZzsxxxrE=
-github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.128 h1:0qFNHSFjXLBOEeeaIY8Pa5usEW//yTQY3ahIQnPouG8=
-github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.128/go.mod h1:s4r/lhVEU5s0c6tCgpR0hK6FHEmX0cbrKcMU1pMc/ZI=
+github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.129 h1:TnW4GYiUqJgZ0P5wQW1ByHkorE4qKuhTdnyhiCwoSZw=
+github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.129/go.mod h1:s4r/lhVEU5s0c6tCgpR0hK6FHEmX0cbrKcMU1pMc/ZI=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.46.1 h1:aFJWCqJMNjENlcleuuOkGAPH82y0yULBScfXcIEdS24=

--- a/router/pkg/config/config.go
+++ b/router/pkg/config/config.go
@@ -320,7 +320,7 @@ type EngineExecutionConfiguration struct {
 	EnableValidationCache                  bool                     `envDefault:"true" env:"ENGINE_ENABLE_VALIDATION_CACHE" yaml:"enable_validation_cache"`
 	ValidationCacheSize                    int64                    `envDefault:"10240" env:"ENGINE_VALIDATION_CACHE_SIZE" yaml:"validation_cache_size,omitempty"`
 	ResolverMaxRecyclableParserSize        int                      `envDefault:"32768" env:"ENGINE_RESOLVER_MAX_RECYCLABLE_PARSER_SIZE" yaml:"resolver_max_recyclable_parser_size,omitempty"`
-	EnableSubgraphFetchOperationName       bool                     `envDefault:"false" env:"ENGINE_ENABLE_SUBGRAPH_FETCH_OPERATION_NAME" yaml:"enable_subgraph_fetch_operation_name"`
+	EnableSubgraphFetchOperationName       bool                     `envDefault:"true" env:"ENGINE_ENABLE_SUBGRAPH_FETCH_OPERATION_NAME" yaml:"enable_subgraph_fetch_operation_name"`
 }
 
 type SecurityConfiguration struct {

--- a/router/pkg/config/config.schema.json
+++ b/router/pkg/config/config.schema.json
@@ -2030,7 +2030,7 @@
         },
         "enable_subgraph_fetch_operation_name": {
             "type": "boolean",
-            "default": false,
+            "default": true,
             "description": "Enable appending the operation name to subgraph fetches. This will ensure that the operation name will be included in the corresponding subgraph requests using the following format: $operationName__$subgraphName__$sequenceID."
         }
       }

--- a/router/pkg/config/testdata/config_defaults.json
+++ b/router/pkg/config/testdata/config_defaults.json
@@ -244,7 +244,7 @@
     "EnableValidationCache": true,
     "ValidationCacheSize": 10240,
     "ResolverMaxRecyclableParserSize": 32768,
-    "EnableSubgraphFetchOperationName": false
+    "EnableSubgraphFetchOperationName": true
   },
   "WebSocket": {
     "Enabled": true,


### PR DESCRIPTION
## Motivation and Context

Subgraph names can contain characters which are not valid for using the fetch operation name format. This PR updates the engine version which makes sure to sanitize the operation name during the planning phase.

## Related Engine Release 

https://github.com/wundergraph/graphql-go-tools/releases/tag/v2.0.0-rc.129

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->