### PR TITLE
feat(router): add request_error boolean field to access logs

### DIFF
--- a/router-tests/structured_logging_test.go
+++ b/router-tests/structured_logging_test.go
@@ -1645,7 +1645,6 @@ func TestAccessLogs(t *testing.T) {
 					"path":                   "/graphql",
 					"query":                  "", // http query is empty
 					"ip":                     "[REDACTED]",
-					"error":                  "Failed to fetch from Subgraph 'products' at Path: 'employees'.",   // Automatically added from error
 					"service_name":           "service-name",                                                     // From request header
 					"response_error_message": "Failed to fetch from Subgraph 'products' at Path: 'employees'.",   // From context
 					"operation_hash":         "16884868987896027258",                                             // From context

--- a/router-tests/structured_logging_test.go
+++ b/router-tests/structured_logging_test.go
@@ -328,6 +328,13 @@ func TestAccessLogs(t *testing.T) {
 						ContextField: core.ContextFieldOperationValidationTime,
 					},
 				},
+				{
+					Key:     "failed",
+					Default: "",
+					ValueFrom: &config.CustomDynamicAttribute{
+						ContextField: core.ContextFieldRequestFailed,
+					},
+				},
 			},
 			LogObservation: testenv.LogObservationConfig{
 				Enabled:  true,
@@ -530,6 +537,13 @@ func TestAccessLogs(t *testing.T) {
 						ContextField: core.ContextFieldOperationValidationTime,
 					},
 				},
+				{
+					Key:     "failed",
+					Default: "",
+					ValueFrom: &config.CustomDynamicAttribute{
+						ContextField: core.ContextFieldRequestFailed,
+					},
+				},
 			},
 			NoRetryClient: true,
 			RouterOptions: []core.Option{
@@ -567,6 +581,7 @@ func TestAccessLogs(t *testing.T) {
 				"user_agent":    "Go-http-client/1.1",
 				"service_name":  "service-name", // From header
 				"error_message": "unexpected token - got: EOF want one of: [RBRACE IDENT SPREAD]",
+				"failed":        true,
 			}
 			additionalExpectedKeys := []string{
 				"latency",
@@ -641,6 +656,13 @@ func TestAccessLogs(t *testing.T) {
 						ContextField: core.ContextFieldOperationValidationTime,
 					},
 				},
+				{
+					Key:     "failed",
+					Default: "",
+					ValueFrom: &config.CustomDynamicAttribute{
+						ContextField: core.ContextFieldRequestFailed,
+					},
+				},
 			},
 			NoRetryClient: true,
 			RouterOptions: []core.Option{
@@ -681,6 +703,7 @@ func TestAccessLogs(t *testing.T) {
 				"operation_name": "employees",    // From context
 				"error_message":  "field: notExists not defined on type: Query",
 				"operation_hash": "10501571900000980785",
+				"failed":         true,
 			}
 			additionalExpectedKeys := []string{
 				"latency",
@@ -757,6 +780,13 @@ func TestAccessLogs(t *testing.T) {
 						ContextField: core.ContextFieldOperationValidationTime,
 					},
 				},
+				{
+					Key:     "failed",
+					Default: "",
+					ValueFrom: &config.CustomDynamicAttribute{
+						ContextField: core.ContextFieldRequestFailed,
+					},
+				},
 			},
 			NoRetryClient: true,
 			RouterOptions: []core.Option{
@@ -807,6 +837,7 @@ func TestAccessLogs(t *testing.T) {
 				"operation_name": "employees",            // From context
 				"operation_type": "query",                // From context
 				"error_message":  "implement me",
+				"failed":         true,
 			}
 			additionalExpectedKeys := []string{
 				"latency",
@@ -885,6 +916,13 @@ func TestAccessLogs(t *testing.T) {
 						ContextField: core.ContextFieldOperationValidationTime,
 					},
 				},
+				{
+					Key:     "failed",
+					Default: "",
+					ValueFrom: &config.CustomDynamicAttribute{
+						ContextField: core.ContextFieldRequestFailed,
+					},
+				},
 			},
 			NoRetryClient: true,
 			RouterOptions: []core.Option{
@@ -936,6 +974,7 @@ func TestAccessLogs(t *testing.T) {
 				"operation_name": "employees",            // From context
 				"operation_type": "query",                // From context
 				"error_message":  "implement me",
+				"failed":         true,
 			}
 			additionalExpectedKeys := []string{
 				"latency",
@@ -971,6 +1010,13 @@ func TestAccessLogs(t *testing.T) {
 					Default: "",
 					ValueFrom: &config.CustomDynamicAttribute{
 						ContextField: core.ContextFieldGraphQLErrorServices,
+					},
+				},
+				{
+					Key:     "failed",
+					Default: "",
+					ValueFrom: &config.CustomDynamicAttribute{
+						ContextField: core.ContextFieldRequestFailed,
 					},
 				},
 			},
@@ -1013,6 +1059,7 @@ func TestAccessLogs(t *testing.T) {
 				"user_agent":    "Go-http-client/1.1",
 				"error_codes":   []interface{}{"UNAUTHORIZED"},
 				"service_names": []interface{}{"products"},
+				"failed":        true,
 			}
 			additionalExpectedKeys := []string{
 				"latency",
@@ -1335,6 +1382,13 @@ func TestAccessLogs(t *testing.T) {
 							ContextField: core.ContextFieldOperationNormalizationTime,
 						},
 					},
+					{
+						Key:     "failed",
+						Default: "",
+						ValueFrom: &config.CustomDynamicAttribute{
+							ContextField: core.ContextFieldRequestFailed,
+						},
+					},
 				},
 				LogObservation: testenv.LogObservationConfig{
 					Enabled:  true,
@@ -1420,6 +1474,15 @@ func TestAccessLogs(t *testing.T) {
 
 			testenv.Run(t, &testenv.Config{
 				SubgraphAccessLogsEnabled: true,
+				AccessLogFields: []config.CustomAttribute{
+					{
+						Key:     "failed",
+						Default: "",
+						ValueFrom: &config.CustomDynamicAttribute{
+							ContextField: core.ContextFieldRequestFailed,
+						},
+					},
+				},
 				SubgraphAccessLogFields: []config.CustomAttribute{
 					{
 						Key:     "service_name",
@@ -1505,6 +1568,13 @@ func TestAccessLogs(t *testing.T) {
 							ContextField: core.ContextFieldOperationNormalizationTime,
 						},
 					},
+					{
+						Key:     "failed",
+						Default: "",
+						ValueFrom: &config.CustomDynamicAttribute{
+							ContextField: core.ContextFieldRequestFailed,
+						},
+					},
 				},
 				LogObservation: testenv.LogObservationConfig{
 					Enabled:  true,
@@ -1567,20 +1637,22 @@ func TestAccessLogs(t *testing.T) {
 
 				productContext := requestLog.All()[1].ContextMap()
 				productSubgraphVals := map[string]interface{}{
-					"log_type":         "client/subgraph",
-					"subgraph_name":    "products",
-					"subgraph_id":      "3",
-					"status":           int64(403),
-					"method":           "POST",
-					"path":             "/graphql",
-					"query":            "", // http query is empty
-					"ip":               "[REDACTED]",
-					"service_name":     "service-name",                                                     // From request header
-					"error":            "Failed to fetch from Subgraph 'products' at Path: 'employees'.",   // From context
-					"operation_hash":   "16884868987896027258",                                             // From context
-					"operation_sha256": "049efe2ebbdf2e4845e69f69cb7965963b118612a6247ab6d91b1961ea0158dc", // From context
-					"operation_name":   "employees",                                                        // From context
-					"operation_type":   "query",                                                            // From context
+					"log_type":               "client/subgraph",
+					"subgraph_name":          "products",
+					"subgraph_id":            "3",
+					"status":                 int64(403),
+					"method":                 "POST",
+					"path":                   "/graphql",
+					"query":                  "", // http query is empty
+					"ip":                     "[REDACTED]",
+					"error":                  "Failed to fetch from Subgraph 'products' at Path: 'employees'.",   // Automatically added from error
+					"service_name":           "service-name",                                                     // From request header
+					"response_error_message": "Failed to fetch from Subgraph 'products' at Path: 'employees'.",   // From context
+					"operation_hash":         "16884868987896027258",                                             // From context
+					"operation_sha256":       "049efe2ebbdf2e4845e69f69cb7965963b118612a6247ab6d91b1961ea0158dc", // From context
+					"operation_name":         "employees",                                                        // From context
+					"operation_type":         "query",                                                            // From context
+					"failed":                 true,                                                               // From context
 				}
 				checkValues(t, productContext, productSubgraphVals, additionalExpectedKeys)
 
@@ -1592,6 +1664,7 @@ func TestAccessLogs(t *testing.T) {
 					"path":     "/graphql",
 					"query":    "",
 					"ip":       "[REDACTED]",
+					"failed":   true, // From context
 				}
 				graphKeys := []string{
 					"user_agent",

--- a/router-tests/structured_logging_test.go
+++ b/router-tests/structured_logging_test.go
@@ -329,10 +329,10 @@ func TestAccessLogs(t *testing.T) {
 					},
 				},
 				{
-					Key:     "failed",
+					Key:     "request.error",
 					Default: "",
 					ValueFrom: &config.CustomDynamicAttribute{
-						ContextField: core.ContextFieldRequestFailed,
+						ContextField: core.ContextFieldRequestError,
 					},
 				},
 			},
@@ -538,10 +538,10 @@ func TestAccessLogs(t *testing.T) {
 					},
 				},
 				{
-					Key:     "failed",
+					Key:     "request.error",
 					Default: "",
 					ValueFrom: &config.CustomDynamicAttribute{
-						ContextField: core.ContextFieldRequestFailed,
+						ContextField: core.ContextFieldRequestError,
 					},
 				},
 			},
@@ -581,7 +581,7 @@ func TestAccessLogs(t *testing.T) {
 				"user_agent":    "Go-http-client/1.1",
 				"service_name":  "service-name", // From header
 				"error_message": "unexpected token - got: EOF want one of: [RBRACE IDENT SPREAD]",
-				"failed":        true,
+				"request.error": true,
 			}
 			additionalExpectedKeys := []string{
 				"latency",
@@ -657,10 +657,10 @@ func TestAccessLogs(t *testing.T) {
 					},
 				},
 				{
-					Key:     "failed",
+					Key:     "request.error",
 					Default: "",
 					ValueFrom: &config.CustomDynamicAttribute{
-						ContextField: core.ContextFieldRequestFailed,
+						ContextField: core.ContextFieldRequestError,
 					},
 				},
 			},
@@ -703,7 +703,7 @@ func TestAccessLogs(t *testing.T) {
 				"operation_name": "employees",    // From context
 				"error_message":  "field: notExists not defined on type: Query",
 				"operation_hash": "10501571900000980785",
-				"failed":         true,
+				"request.error":  true,
 			}
 			additionalExpectedKeys := []string{
 				"latency",
@@ -781,10 +781,10 @@ func TestAccessLogs(t *testing.T) {
 					},
 				},
 				{
-					Key:     "failed",
+					Key:     "request.error",
 					Default: "",
 					ValueFrom: &config.CustomDynamicAttribute{
-						ContextField: core.ContextFieldRequestFailed,
+						ContextField: core.ContextFieldRequestError,
 					},
 				},
 			},
@@ -837,7 +837,7 @@ func TestAccessLogs(t *testing.T) {
 				"operation_name": "employees",            // From context
 				"operation_type": "query",                // From context
 				"error_message":  "implement me",
-				"failed":         true,
+				"request.error":  true,
 			}
 			additionalExpectedKeys := []string{
 				"latency",
@@ -917,10 +917,10 @@ func TestAccessLogs(t *testing.T) {
 					},
 				},
 				{
-					Key:     "failed",
+					Key:     "request.error",
 					Default: "",
 					ValueFrom: &config.CustomDynamicAttribute{
-						ContextField: core.ContextFieldRequestFailed,
+						ContextField: core.ContextFieldRequestError,
 					},
 				},
 			},
@@ -974,7 +974,7 @@ func TestAccessLogs(t *testing.T) {
 				"operation_name": "employees",            // From context
 				"operation_type": "query",                // From context
 				"error_message":  "implement me",
-				"failed":         true,
+				"request.error":  true,
 			}
 			additionalExpectedKeys := []string{
 				"latency",
@@ -1013,10 +1013,10 @@ func TestAccessLogs(t *testing.T) {
 					},
 				},
 				{
-					Key:     "failed",
+					Key:     "request.error",
 					Default: "",
 					ValueFrom: &config.CustomDynamicAttribute{
-						ContextField: core.ContextFieldRequestFailed,
+						ContextField: core.ContextFieldRequestError,
 					},
 				},
 			},
@@ -1059,7 +1059,7 @@ func TestAccessLogs(t *testing.T) {
 				"user_agent":    "Go-http-client/1.1",
 				"error_codes":   []interface{}{"UNAUTHORIZED"},
 				"service_names": []interface{}{"products"},
-				"failed":        true,
+				"request.error": true,
 			}
 			additionalExpectedKeys := []string{
 				"latency",
@@ -1383,10 +1383,10 @@ func TestAccessLogs(t *testing.T) {
 						},
 					},
 					{
-						Key:     "failed",
+						Key:     "request.error",
 						Default: "",
 						ValueFrom: &config.CustomDynamicAttribute{
-							ContextField: core.ContextFieldRequestFailed,
+							ContextField: core.ContextFieldRequestError,
 						},
 					},
 				},
@@ -1476,10 +1476,10 @@ func TestAccessLogs(t *testing.T) {
 				SubgraphAccessLogsEnabled: true,
 				AccessLogFields: []config.CustomAttribute{
 					{
-						Key:     "failed",
+						Key:     "request.error",
 						Default: "",
 						ValueFrom: &config.CustomDynamicAttribute{
-							ContextField: core.ContextFieldRequestFailed,
+							ContextField: core.ContextFieldRequestError,
 						},
 					},
 				},
@@ -1569,10 +1569,10 @@ func TestAccessLogs(t *testing.T) {
 						},
 					},
 					{
-						Key:     "failed",
+						Key:     "request.error",
 						Default: "",
 						ValueFrom: &config.CustomDynamicAttribute{
-							ContextField: core.ContextFieldRequestFailed,
+							ContextField: core.ContextFieldRequestError,
 						},
 					},
 				},
@@ -1652,19 +1652,19 @@ func TestAccessLogs(t *testing.T) {
 					"operation_sha256":       "049efe2ebbdf2e4845e69f69cb7965963b118612a6247ab6d91b1961ea0158dc", // From context
 					"operation_name":         "employees",                                                        // From context
 					"operation_type":         "query",                                                            // From context
-					"failed":                 true,                                                               // From context
+					"request.error":          true,                                                               // From context
 				}
 				checkValues(t, productContext, productSubgraphVals, additionalExpectedKeys)
 
 				graphContext := requestLog.All()[2].ContextMap()
 				graphVals := map[string]interface{}{
-					"log_type": "request",
-					"status":   int64(200),
-					"method":   "POST",
-					"path":     "/graphql",
-					"query":    "",
-					"ip":       "[REDACTED]",
-					"failed":   true, // From context
+					"log_type":      "request",
+					"status":        int64(200),
+					"method":        "POST",
+					"path":          "/graphql",
+					"query":         "",
+					"ip":            "[REDACTED]",
+					"request.error": true, // From context
 				}
 				graphKeys := []string{
 					"user_agent",

--- a/router-tests/structured_logging_test.go
+++ b/router-tests/structured_logging_test.go
@@ -329,7 +329,7 @@ func TestAccessLogs(t *testing.T) {
 					},
 				},
 				{
-					Key:     "request.error",
+					Key:     "request_error",
 					Default: "",
 					ValueFrom: &config.CustomDynamicAttribute{
 						ContextField: core.ContextFieldRequestError,
@@ -538,7 +538,7 @@ func TestAccessLogs(t *testing.T) {
 					},
 				},
 				{
-					Key:     "request.error",
+					Key:     "request_error",
 					Default: "",
 					ValueFrom: &config.CustomDynamicAttribute{
 						ContextField: core.ContextFieldRequestError,
@@ -581,7 +581,7 @@ func TestAccessLogs(t *testing.T) {
 				"user_agent":    "Go-http-client/1.1",
 				"service_name":  "service-name", // From header
 				"error_message": "unexpected token - got: EOF want one of: [RBRACE IDENT SPREAD]",
-				"request.error": true,
+				"request_error": true,
 			}
 			additionalExpectedKeys := []string{
 				"latency",
@@ -657,7 +657,7 @@ func TestAccessLogs(t *testing.T) {
 					},
 				},
 				{
-					Key:     "request.error",
+					Key:     "request_error",
 					Default: "",
 					ValueFrom: &config.CustomDynamicAttribute{
 						ContextField: core.ContextFieldRequestError,
@@ -703,7 +703,7 @@ func TestAccessLogs(t *testing.T) {
 				"operation_name": "employees",    // From context
 				"error_message":  "field: notExists not defined on type: Query",
 				"operation_hash": "10501571900000980785",
-				"request.error":  true,
+				"request_error":  true,
 			}
 			additionalExpectedKeys := []string{
 				"latency",
@@ -781,7 +781,7 @@ func TestAccessLogs(t *testing.T) {
 					},
 				},
 				{
-					Key:     "request.error",
+					Key:     "request_error",
 					Default: "",
 					ValueFrom: &config.CustomDynamicAttribute{
 						ContextField: core.ContextFieldRequestError,
@@ -837,7 +837,7 @@ func TestAccessLogs(t *testing.T) {
 				"operation_name": "employees",            // From context
 				"operation_type": "query",                // From context
 				"error_message":  "implement me",
-				"request.error":  true,
+				"request_error":  true,
 			}
 			additionalExpectedKeys := []string{
 				"latency",
@@ -917,7 +917,7 @@ func TestAccessLogs(t *testing.T) {
 					},
 				},
 				{
-					Key:     "request.error",
+					Key:     "request_error",
 					Default: "",
 					ValueFrom: &config.CustomDynamicAttribute{
 						ContextField: core.ContextFieldRequestError,
@@ -974,7 +974,7 @@ func TestAccessLogs(t *testing.T) {
 				"operation_name": "employees",            // From context
 				"operation_type": "query",                // From context
 				"error_message":  "implement me",
-				"request.error":  true,
+				"request_error":  true,
 			}
 			additionalExpectedKeys := []string{
 				"latency",
@@ -1013,7 +1013,7 @@ func TestAccessLogs(t *testing.T) {
 					},
 				},
 				{
-					Key:     "request.error",
+					Key:     "request_error",
 					Default: "",
 					ValueFrom: &config.CustomDynamicAttribute{
 						ContextField: core.ContextFieldRequestError,
@@ -1059,7 +1059,7 @@ func TestAccessLogs(t *testing.T) {
 				"user_agent":    "Go-http-client/1.1",
 				"error_codes":   []interface{}{"UNAUTHORIZED"},
 				"service_names": []interface{}{"products"},
-				"request.error": true,
+				"request_error": true,
 			}
 			additionalExpectedKeys := []string{
 				"latency",
@@ -1383,7 +1383,7 @@ func TestAccessLogs(t *testing.T) {
 						},
 					},
 					{
-						Key:     "request.error",
+						Key:     "request_error",
 						Default: "",
 						ValueFrom: &config.CustomDynamicAttribute{
 							ContextField: core.ContextFieldRequestError,
@@ -1476,7 +1476,7 @@ func TestAccessLogs(t *testing.T) {
 				SubgraphAccessLogsEnabled: true,
 				AccessLogFields: []config.CustomAttribute{
 					{
-						Key:     "request.error",
+						Key:     "request_error",
 						Default: "",
 						ValueFrom: &config.CustomDynamicAttribute{
 							ContextField: core.ContextFieldRequestError,
@@ -1569,7 +1569,7 @@ func TestAccessLogs(t *testing.T) {
 						},
 					},
 					{
-						Key:     "request.error",
+						Key:     "request_error",
 						Default: "",
 						ValueFrom: &config.CustomDynamicAttribute{
 							ContextField: core.ContextFieldRequestError,
@@ -1652,7 +1652,7 @@ func TestAccessLogs(t *testing.T) {
 					"operation_sha256":       "049efe2ebbdf2e4845e69f69cb7965963b118612a6247ab6d91b1961ea0158dc", // From context
 					"operation_name":         "employees",                                                        // From context
 					"operation_type":         "query",                                                            // From context
-					"request.error":          true,                                                               // From context
+					"request_error":          true,                                                               // From context
 				}
 				checkValues(t, productContext, productSubgraphVals, additionalExpectedKeys)
 
@@ -1664,7 +1664,7 @@ func TestAccessLogs(t *testing.T) {
 					"path":          "/graphql",
 					"query":         "",
 					"ip":            "[REDACTED]",
-					"request.error": true, // From context
+					"request_error": true, // From context
 				}
 				graphKeys := []string{
 					"user_agent",

--- a/router/core/engine_loader_hooks.go
+++ b/router/core/engine_loader_hooks.go
@@ -129,9 +129,6 @@ func (f *engineLoaderHooks) OnFinished(ctx context.Context, ds resolve.DataSourc
 			zap.Int("status", responseInfo.StatusCode),
 			zap.Duration("latency", latency),
 		}
-		if responseInfo.Err != nil {
-			fields = append(fields, zap.Any("error", responseInfo.Err))
-		}
 		if responseInfo.Request != nil && responseInfo.Request.URL != nil {
 			fields = append(fields, zap.String("url", responseInfo.Request.URL.String()))
 		}

--- a/router/core/header_rule_engine.go
+++ b/router/core/header_rule_engine.go
@@ -352,7 +352,7 @@ func (h *HeaderPropagation) applyResponseRuleKeyValue(res *http.Response, propag
 func (h *HeaderPropagation) applyRequestRule(ctx RequestContext, request *http.Request, rule *config.RequestHeaderRule) {
 	if rule.Operation == config.HeaderRuleOperationSet {
 		if rule.ValueFrom != nil && rule.ValueFrom.ContextField != "" {
-			val := getCustomDynamicAttributeValue(rule.ValueFrom, getRequestContext(request.Context()))
+			val := getCustomDynamicAttributeValue(rule.ValueFrom, getRequestContext(request.Context()), nil)
 			value := fmt.Sprintf("%v", val)
 			if value != "" {
 				request.Header.Set(rule.Name, value)

--- a/router/internal/requestlogger/subgraphlogger.go
+++ b/router/internal/requestlogger/subgraphlogger.go
@@ -47,10 +47,11 @@ func (h *SubgraphAccessLogger) WriteRequestLog(respInfo *resolve.ResponseInfo, s
 	if respInfo == nil {
 		return
 	}
+
 	path := respInfo.Request.URL.Path
 	fields := h.accessLogger.getRequestFields(respInfo.Request)
 	if h.accessLogger.fieldsHandler != nil {
-		fields = append(fields, h.accessLogger.fieldsHandler(h.accessLogger.attributes, nil, respInfo.Request, &respInfo.ResponseHeaders)...)
+		fields = append(fields, h.accessLogger.fieldsHandler(h.accessLogger.attributes, respInfo.Err, respInfo.Request, &respInfo.ResponseHeaders)...)
 	}
 
 	if len(subgraphFields) > 0 {

--- a/router/pkg/config/config.schema.json
+++ b/router/pkg/config/config.schema.json
@@ -587,7 +587,9 @@
                               "operation_parsing_time",
                               "operation_validation_time",
                               "operation_planning_time",
-                              "operation_normalization_time"
+                              "operation_normalization_time",
+                              "request_error",
+                              "response_error_message"
                             ]
                           }
                         }
@@ -2349,6 +2351,7 @@
                   "operation_hash",
                   "persisted_operation_sha256",
                   "operation_sha256",
+                  "request_error",
                   "response_error_message",
                   "graphql_error_codes",
                   "graphql_error_service_names",


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

## Motivation and Context

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please describe in detail the impact of this change. Attach screenshots if applicable.
-->

With our work in adding access logs, we want to add a boolean field that users can watch to give them a simple indication if there was an error found in the request, whether a panic or a graphql error. It is also present in subgraph access logs, so it will exhibit which subgraph had the error

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->