### PR TITLE
feat: initial access log improvements

### DIFF
--- a/router-tests/structured_logging_test.go
+++ b/router-tests/structured_logging_test.go
@@ -188,7 +188,7 @@ func TestAccessLogsFileOutput(t *testing.T) {
 				}
 				additionalExpectedKeys1 := []string{
 					"time", "hostname", "pid", "latency",
-					"user_agent", "config_version", "request_id", "trace_id",
+					"user_agent", "config_version", "request_id", "trace_id", "url",
 				}
 				checkValues(t, logEntry, expectedValues1, additionalExpectedKeys1)
 			})
@@ -1059,7 +1059,7 @@ func TestAccessLogs(t *testing.T) {
 				additionalExpectedKeys := []string{
 					"user_agent", "latency", "config_version", "request_id", "pid", "hostname",
 				}
-				checkValues(t, requestContext, expectedValues, append(additionalExpectedKeys, "trace_id"))
+				checkValues(t, requestContext, expectedValues, append(additionalExpectedKeys, "trace_id", "url"))
 
 				requestContext1 := requestLog.All()[1].ContextMap()
 				expectedValues1 := map[string]interface{}{
@@ -1109,7 +1109,7 @@ func TestAccessLogs(t *testing.T) {
 				additionalExpectedKeys := []string{
 					"user_agent", "latency", "config_version", "request_id", "pid", "hostname", "trace_id",
 				}
-				checkValues(t, requestContext, expectedValues, additionalExpectedKeys)
+				checkValues(t, requestContext, expectedValues, append(additionalExpectedKeys, "url"))
 
 				requestContext1 := requestLog.All()[1].ContextMap()
 				expectedValues1 := map[string]interface{}{
@@ -1212,7 +1212,7 @@ func TestAccessLogs(t *testing.T) {
 					"ip":            "[REDACTED]",
 				}
 				additionalExpectedKeys := []string{
-					"user_agent", "latency", "config_version", "request_id", "pid", "hostname", "trace_id",
+					"user_agent", "latency", "config_version", "request_id", "pid", "hostname", "trace_id", "url",
 				}
 				checkValues(t, requestContext, expectedValues, additionalExpectedKeys)
 
@@ -1390,7 +1390,7 @@ func TestAccessLogs(t *testing.T) {
 					"operation_type":   "query",                                                            // From context
 				}
 				additionalExpectedKeys := []string{
-					"user_agent", "latency", "config_version", "request_id", "pid", "hostname", "normalized_time", "parsed_time", "planned_time", "validation_time", "trace_id",
+					"user_agent", "latency", "config_version", "request_id", "pid", "hostname", "normalized_time", "parsed_time", "planned_time", "validation_time", "trace_id", "url",
 				}
 				checkValues(t, requestContext, expectedValues, additionalExpectedKeys)
 
@@ -1561,7 +1561,7 @@ func TestAccessLogs(t *testing.T) {
 					"operation_type":   "query",                                                            // From context
 				}
 				additionalExpectedKeys := []string{
-					"user_agent", "latency", "config_version", "request_id", "pid", "hostname", "normalized_time", "parsed_time", "planned_time", "validation_time", "trace_id",
+					"user_agent", "latency", "config_version", "request_id", "pid", "hostname", "normalized_time", "parsed_time", "planned_time", "validation_time", "trace_id", "url",
 				}
 				checkValues(t, employeeContext, employeeSubgraphVals, additionalExpectedKeys)
 
@@ -1742,7 +1742,7 @@ func TestAccessLogs(t *testing.T) {
 					"operation_type":           "query",                                                            // From context
 				}
 				additionalExpectedKeys := []string{
-					"user_agent", "latency", "config_version", "request_id", "pid", "hostname", "normalized_time", "parsed_time", "planned_time", "validation_time", "trace_id",
+					"user_agent", "latency", "config_version", "request_id", "pid", "hostname", "normalized_time", "parsed_time", "planned_time", "validation_time", "trace_id", "url",
 				}
 				checkValues(t, requestContext, expectedValues, additionalExpectedKeys)
 

--- a/router/core/engine_loader_hooks.go
+++ b/router/core/engine_loader_hooks.go
@@ -132,6 +132,9 @@ func (f *engineLoaderHooks) OnFinished(ctx context.Context, ds resolve.DataSourc
 		if responseInfo.Err != nil {
 			fields = append(fields, zap.Any("error", responseInfo.Err))
 		}
+		if responseInfo.Request != nil && responseInfo.Request.URL != nil {
+			fields = append(fields, zap.String("url", responseInfo.Request.URL.String()))
+		}
 		f.accessLogger.WriteRequestLog(responseInfo, fields)
 	}
 

--- a/router/pkg/config/config.schema.json
+++ b/router/pkg/config/config.schema.json
@@ -2335,6 +2335,10 @@
                 "type": "string",
                 "description": "The name of the request header from which to extract the value. The value is only extracted when a request context is available otherwise the default value is used."
               },
+              "response_header": {
+                "type": "string",
+                "description": "The name of the response header from which to extract the value. The value is only extracted for subgraph access logs"
+              },
               "context_field": {
                 "type": "string",
                 "description": "The field name of the context from which to extract the value. The value is only extracted when a context is available otherwise the default value is used.",

--- a/router/pkg/config/fixtures/full.yaml
+++ b/router/pkg/config/fixtures/full.yaml
@@ -42,6 +42,20 @@ cors:
   allow_credentials: true
   max_age: 5m
 
+access_logs:
+  enabled: true
+  router:
+    fields:
+      - key: "hello"
+        value_from:
+          context_field: "operation_name"
+  subgraphs:
+    enabled: true
+    fields:
+      - key: "response_field"
+        value_from:
+          response_header: "X-Response-Field"
+
 compliance:
   anonymize_ip:
     enabled: true

--- a/router/pkg/config/testdata/config_full.json
+++ b/router/pkg/config/testdata/config_full.json
@@ -267,11 +267,31 @@
       }
     },
     "Router": {
-      "Fields": null
+      "Fields": [
+        {
+          "Key": "hello",
+          "Default": "",
+          "ValueFrom": {
+            "RequestHeader": "",
+            "ContextField": "operation_name",
+            "ResponseHeader": ""
+          }
+        }
+      ]
     },
     "Subgraphs": {
-      "Enabled": false,
-      "Fields": null
+      "Enabled": true,
+      "Fields": [
+        {
+          "Key": "response_field",
+          "Default": "",
+          "ValueFrom": {
+            "RequestHeader": "",
+            "ContextField": "",
+            "ResponseHeader": "X-Response-Field"
+          }
+        }
+      ]
     }
   },
   "ListenAddr": "localhost:3002",


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

## Motivation and Context
This PR adds two necessary access logs improvements:
* Enabling subgraph response header custom values (which had previously been let out of the config)
* Adding the subgraph url into the access log

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please describe in detail the impact of this change. Attach screenshots if applicable.
-->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->