### PR TITLE
fix: panic when normalizing multi operation documents

### DIFF
--- a/router-tests/normalization_cache_test.go
+++ b/router-tests/normalization_cache_test.go
@@ -67,7 +67,7 @@ func TestNormalizationCache(t *testing.T) {
 func TestNormalizationCacheWithMultiOperationDocument(t *testing.T) {
 	t.Parallel()
 
-	t.Run("Should identify correct document after fully normalization", func(t *testing.T) {
+	t.Run("Should identify correct document after removing unused operations during normalization", func(t *testing.T) {
 
 		document := `query A {
   a: employee(id: 1) {

--- a/router-tests/normalization_cache_test.go
+++ b/router-tests/normalization_cache_test.go
@@ -64,6 +64,73 @@ func TestNormalizationCache(t *testing.T) {
 	})
 }
 
+func TestNormalizationCacheWithMultiOperationDocument(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Should identify correct document after fully normalization", func(t *testing.T) {
+
+		document := `query A {
+  a: employee(id: 1) {
+    id
+    details {
+      pets {
+        name
+      }
+    }
+  }
+}
+
+query B ($id: Int!) {
+  b: employee(id: $id) {
+    id
+    details {
+      pets {
+        name
+      }
+    }
+  }
+}`
+
+		testenv.Run(t, &testenv.Config{}, func(t *testing.T, xEnv *testenv.Environment) {
+			res, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
+				OperationName: []byte(`"A"`),
+				Query:         document,
+				Variables:     []byte(`{"id": 1234}`),
+			})
+			require.NoError(t, err)
+			require.Equal(t, "MISS", res.Response.Header.Get(core.NormalizationCacheHeader))
+			require.Equal(t, `{"data":{"a":{"id":1,"details":{"pets":null}}}}`, res.Body)
+
+			res, err = xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
+				OperationName: []byte(`"A"`),
+				Query:         document,
+				Variables:     []byte(`{"id": 12345}`),
+			})
+			require.NoError(t, err)
+			require.Equal(t, "HIT", res.Response.Header.Get(core.NormalizationCacheHeader))
+			require.Equal(t, `{"data":{"a":{"id":1,"details":{"pets":null}}}}`, res.Body)
+
+			res, err = xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
+				OperationName: []byte(`"B"`),
+				Query:         document,
+				Variables:     []byte(`{"id": 1}`),
+			})
+			require.NoError(t, err)
+			require.Equal(t, "MISS", res.Response.Header.Get(core.NormalizationCacheHeader))
+			require.Equal(t, `{"data":{"b":{"id":1,"details":{"pets":null}}}}`, res.Body)
+
+			res, err = xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
+				OperationName: []byte(`"B"`),
+				Query:         document,
+				Variables:     []byte(`{"id": 3}`),
+			})
+			require.NoError(t, err)
+			require.Equal(t, "HIT", res.Response.Header.Get(core.NormalizationCacheHeader))
+			require.Equal(t, `{"data":{"b":{"id":3,"details":{"pets":[{"name":"Snappy"}]}}}}`, res.Body)
+		})
+	})
+}
+
 func TestDefaultValuesForSkipInclude(t *testing.T) {
 	t.Parallel()
 

--- a/router-tests/persisted_operations_test.go
+++ b/router-tests/persisted_operations_test.go
@@ -95,6 +95,62 @@ func TestPersistedOperationPOExtensionNotTransmittedToSubgraph(t *testing.T) {
 	})
 }
 
+func TestPersistedNormalizationCacheWithMultiOperationDocument(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Should identify correct document after removing unused operations during normalization", func(t *testing.T) {
+
+		testenv.Run(t, &testenv.Config{}, func(t *testing.T, xEnv *testenv.Environment) {
+			header := make(http.Header)
+			header.Add("graphql-client-name", "my-client")
+			res, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
+				OperationName: []byte(`"A"`),
+				Extensions:    []byte(`{"persistedQuery": {"version": 1, "sha256Hash": "724399f210ef3f16e6e5427a70bb9609ecea7297e99c3e9241d5912d04eabe60"}}`),
+				Header:        header,
+			})
+			require.NoError(t, err)
+			require.Equal(t, "MISS", res.Response.Header.Get(core.PersistedOperationCacheHeader))
+			require.Equal(t, "MISS", res.Response.Header.Get(core.ExecutionPlanCacheHeader))
+
+			header = make(http.Header)
+			header.Add("graphql-client-name", "my-client")
+			res, err = xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
+				OperationName: []byte(`"A"`),
+				Extensions:    []byte(`{"persistedQuery": {"version": 1, "sha256Hash": "724399f210ef3f16e6e5427a70bb9609ecea7297e99c3e9241d5912d04eabe60"}}`),
+				Header:        header,
+			})
+			require.NoError(t, err)
+			require.Equal(t, "HIT", res.Response.Header.Get(core.PersistedOperationCacheHeader))
+			require.Equal(t, "HIT", res.Response.Header.Get(core.ExecutionPlanCacheHeader))
+
+			header = make(http.Header)
+			header.Add("graphql-client-name", "my-client")
+			res, err = xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
+				OperationName: []byte(`"B"`),
+				Variables:     []byte(`{"id": 1}`),
+				Extensions:    []byte(`{"persistedQuery": {"version": 1, "sha256Hash": "724399f210ef3f16e6e5427a70bb9609ecea7297e99c3e9241d5912d04eabe60"}}`),
+				Header:        header,
+			})
+			require.NoError(t, err)
+			require.Equal(t, "MISS", res.Response.Header.Get(core.PersistedOperationCacheHeader))
+			require.Equal(t, "MISS", res.Response.Header.Get(core.ExecutionPlanCacheHeader))
+
+			header = make(http.Header)
+			header.Add("graphql-client-name", "my-client")
+			res, err = xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
+				OperationName: []byte(`"B"`),
+				Variables:     []byte(`{"id": 1}`),
+				Extensions:    []byte(`{"persistedQuery": {"version": 1, "sha256Hash": "724399f210ef3f16e6e5427a70bb9609ecea7297e99c3e9241d5912d04eabe60"}}`),
+				Header:        header,
+			})
+			require.NoError(t, err)
+			require.Equal(t, "HIT", res.Response.Header.Get(core.PersistedOperationCacheHeader))
+			require.Equal(t, "HIT", res.Response.Header.Get(core.ExecutionPlanCacheHeader))
+		})
+	})
+
+}
+
 func TestPersistedOperationsCache(t *testing.T) {
 	t.Parallel()
 

--- a/router-tests/persisted_operations_test.go
+++ b/router-tests/persisted_operations_test.go
@@ -109,6 +109,7 @@ func TestPersistedNormalizationCacheWithMultiOperationDocument(t *testing.T) {
 				Header:        header,
 			})
 			require.NoError(t, err)
+			require.Equal(t, `{"data":{"a":{"id":1,"details":{"pets":null}}}}`, res.Body)
 			require.Equal(t, "MISS", res.Response.Header.Get(core.PersistedOperationCacheHeader))
 			require.Equal(t, "MISS", res.Response.Header.Get(core.ExecutionPlanCacheHeader))
 
@@ -120,6 +121,7 @@ func TestPersistedNormalizationCacheWithMultiOperationDocument(t *testing.T) {
 				Header:        header,
 			})
 			require.NoError(t, err)
+			require.Equal(t, `{"data":{"a":{"id":1,"details":{"pets":null}}}}`, res.Body)
 			require.Equal(t, "HIT", res.Response.Header.Get(core.PersistedOperationCacheHeader))
 			require.Equal(t, "HIT", res.Response.Header.Get(core.ExecutionPlanCacheHeader))
 
@@ -132,6 +134,7 @@ func TestPersistedNormalizationCacheWithMultiOperationDocument(t *testing.T) {
 				Header:        header,
 			})
 			require.NoError(t, err)
+			require.Equal(t, `{"data":{"b":{"id":1,"details":{"pets":null}}}}`, res.Body)
 			require.Equal(t, "MISS", res.Response.Header.Get(core.PersistedOperationCacheHeader))
 			require.Equal(t, "MISS", res.Response.Header.Get(core.ExecutionPlanCacheHeader))
 
@@ -144,6 +147,7 @@ func TestPersistedNormalizationCacheWithMultiOperationDocument(t *testing.T) {
 				Header:        header,
 			})
 			require.NoError(t, err)
+			require.Equal(t, `{"data":{"b":{"id":1,"details":{"pets":null}}}}`, res.Body)
 			require.Equal(t, "HIT", res.Response.Header.Get(core.PersistedOperationCacheHeader))
 			require.Equal(t, "HIT", res.Response.Header.Get(core.ExecutionPlanCacheHeader))
 		})

--- a/router-tests/testdata/cdn/organization/graph/operations/my-client/dc67510fb4289672bea757e862d6b00e83db5d3cbbcfb15260601b6f29bb2b8f.json
+++ b/router-tests/testdata/cdn/organization/graph/operations/my-client/dc67510fb4289672bea757e862d6b00e83db5d3cbbcfb15260601b6f29bb2b8f.json
@@ -1,4 +1,0 @@
-{
-    "version": 1,
-    "body": "query Employees {\n  employees {\n    id\n    }\n}"
-}

--- a/router-tests/testenv/testdata/cdn/organization/graph/operations/my-client/724399f210ef3f16e6e5427a70bb9609ecea7297e99c3e9241d5912d04eabe60.json
+++ b/router-tests/testenv/testdata/cdn/organization/graph/operations/my-client/724399f210ef3f16e6e5427a70bb9609ecea7297e99c3e9241d5912d04eabe60.json
@@ -1,0 +1,1 @@
+{"version":1,"body":"query A {\n  a: employee(id: 1) {\n    id\n    details {\n      pets {\n        name\n      }\n    }\n  }\n}\n\nquery B ($id: Int!) {\n  b: employee(id: $id) {\n    id\n    details {\n      pets {\n        name\n      }\n    }\n  }\n}"}

--- a/router/core/operation_processor.go
+++ b/router/core/operation_processor.go
@@ -757,6 +757,13 @@ func (o *OperationKit) NormalizeVariables() error {
 		}
 	}
 
+	// Assuming the user sends a multi-operation document
+	// During normalization, we removed the unused operations from the document
+	// This will always lead to operation definitions of a length of 1 even when multiple operations are sent
+	if o.parsedOperation.NormalizationCacheHit {
+		o.operationDefinitionRef = 0
+	}
+
 	// Print the operation without the operation name to get the pure normalized form
 	// Afterward we can calculate the operation ID that is used as a stable identifier for analytics
 
@@ -870,7 +877,7 @@ func (o *OperationKit) savePersistedOperationToCache(clientName string, isApq bo
 		operationID:              o.parsedOperation.InternalID,
 		normalizedRepresentation: o.parsedOperation.NormalizedRepresentation,
 		operationType:            o.parsedOperation.Type,
-		operationDefinitionRef:   o.operationDefinitionRef,
+		operationDefinitionRef:   0,
 	}
 
 	if isApq {

--- a/router/core/operation_processor.go
+++ b/router/core/operation_processor.go
@@ -877,7 +877,7 @@ func (o *OperationKit) savePersistedOperationToCache(clientName string, isApq bo
 		operationID:              o.parsedOperation.InternalID,
 		normalizedRepresentation: o.parsedOperation.NormalizedRepresentation,
 		operationType:            o.parsedOperation.Type,
-		operationDefinitionRef:   0,
+		operationDefinitionRef:   o.operationDefinitionRef,
 	}
 
 	if isApq {

--- a/router/core/operation_processor.go
+++ b/router/core/operation_processor.go
@@ -797,11 +797,6 @@ func (o *OperationKit) NormalizeVariables() error {
 
 	o.kit.normalizedOperation.Reset()
 
-	// Reset the operation name to the original name and print the operation again
-	// to get the final normalized form of the operation
-
-	o.kit.doc.OperationDefinitions[o.operationDefinitionRef].Name = o.originalOperationNameRef
-
 	err = o.kit.printer.Print(o.kit.doc, o.kit.normalizedOperation)
 	if err != nil {
 		return err

--- a/router/core/operation_processor.go
+++ b/router/core/operation_processor.go
@@ -832,7 +832,9 @@ func (o *OperationKit) loadPersistedOperationFromCache(clientName string) (ok bo
 	o.parsedOperation.InternalID = entry.operationID
 	o.parsedOperation.NormalizedRepresentation = entry.normalizedRepresentation
 	o.parsedOperation.Type = entry.operationType
-	o.operationDefinitionRef = entry.operationDefinitionRef
+	//  We will always only have a single operation definition in the document
+	// Because we removed the unused operations during normalization
+	o.operationDefinitionRef = 0
 	err = o.setAndParseOperationDoc()
 	if err != nil {
 		return false, err


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

## Motivation and Context

During improving the normalization logic, we didn't consider multi operation documents. 

Details: When a user hits the cache with a multi operation document, we only store the used operation in the cache. Therefore all places has to reference this document instead of using the index from the original operation document.

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please describe in detail the impact of this change. Attach screenshots if applicable.
-->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->