### PR TITLE
fix(router): ensure subgraph access logs handles null requests/errors

### DIFF
--- a/router-tests/go.mod
+++ b/router-tests/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/twmb/franz-go/pkg/kadm v1.11.0
 	github.com/wundergraph/cosmo/demo v0.0.0-20241210060746-91245ea676ff
 	github.com/wundergraph/cosmo/router v0.0.0-20241210060746-91245ea676ff
-	github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.134
+	github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.136
 	go.opentelemetry.io/otel v1.28.0
 	go.opentelemetry.io/otel/sdk v1.28.0
 	go.opentelemetry.io/otel/sdk/metric v1.28.0

--- a/router-tests/go.sum
+++ b/router-tests/go.sum
@@ -350,8 +350,8 @@ github.com/vektah/gqlparser/v2 v2.5.16 h1:1gcmLTvs3JLKXckwCwlUagVn/IlV2bwqle0vJ0
 github.com/vektah/gqlparser/v2 v2.5.16/go.mod h1:1lz1OeCqgQbQepsGxPVywrjdBHW2T08PUS3pJqepRww=
 github.com/wundergraph/astjson v0.0.0-20241210135722-15ca0ac078f8 h1:D0Pw/sly2S9gt63BVlTAfHZG8h98h1AsELOuMgydDt0=
 github.com/wundergraph/astjson v0.0.0-20241210135722-15ca0ac078f8/go.mod h1:eOTL6acwctsN4F3b7YE+eE2t8zcJ/doLm9sZzsxxxrE=
-github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.134 h1:7YjoZo/OgEm7RhojETdyP3B0zcR6H1o4ZwBO9r+7J+8=
-github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.134/go.mod h1:xQLII50+GThIafwHGzeOVLsobqpAAB4WA/M9S+HTzxo=
+github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.136 h1:DrQIzB1uO7W85Nf04h3HCPlKrE+D+bs1fR4LvxCQLgE=
+github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.136/go.mod h1:xQLII50+GThIafwHGzeOVLsobqpAAB4WA/M9S+HTzxo=
 github.com/xrash/smetrics v0.0.0-20240312152122-5f08fbb34913 h1:+qGGcbkzsfDQNPPe9UDgpxAWQrhbbBXOYJFQDq/dtJw=
 github.com/xrash/smetrics v0.0.0-20240312152122-5f08fbb34913/go.mod h1:4aEEwZQutDLsQv2Deui4iYQ6DWTxR14g6m8Wv88+Xqk=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/router-tests/structured_logging_test.go
+++ b/router-tests/structured_logging_test.go
@@ -52,6 +52,102 @@ func (m MyPanicModule) Module() core.ModuleInfo {
 	}
 }
 
+var (
+	allSubgraphLogs = []config.CustomAttribute{
+		{
+			Key:     "service_name",
+			Default: "",
+			ValueFrom: &config.CustomDynamicAttribute{
+				RequestHeader: "service-name",
+			},
+		},
+		{
+			Key:     "response_header",
+			Default: "",
+			ValueFrom: &config.CustomDynamicAttribute{
+				ResponseHeader: "response-header-name",
+			},
+		},
+		{
+			Key:     "operation_name",
+			Default: "",
+			ValueFrom: &config.CustomDynamicAttribute{
+				ContextField: core.ContextFieldOperationName,
+			},
+		},
+		{
+			Key:     "operation_type",
+			Default: "",
+			ValueFrom: &config.CustomDynamicAttribute{
+				ContextField: core.ContextFieldOperationType,
+			},
+		},
+		{
+			Key:     "operation_hash",
+			Default: "",
+			ValueFrom: &config.CustomDynamicAttribute{
+				ContextField: core.ContextFieldOperationHash,
+			},
+		},
+		{
+			Key:     "operation_persisted_hash",
+			Default: "",
+			ValueFrom: &config.CustomDynamicAttribute{
+				ContextField: core.ContextFieldPersistedOperationSha256,
+			},
+		},
+		{
+			Key:     "operation_sha256",
+			Default: "",
+			ValueFrom: &config.CustomDynamicAttribute{
+				ContextField: core.ContextFieldOperationSha256,
+			},
+		},
+		{
+			Key:     "response_error_message",
+			Default: "",
+			ValueFrom: &config.CustomDynamicAttribute{
+				ContextField: core.ContextFieldResponseErrorMessage,
+			},
+		},
+		{
+			Key:     "parsed_time",
+			Default: "",
+			ValueFrom: &config.CustomDynamicAttribute{
+				ContextField: core.ContextFieldOperationParsingTime,
+			},
+		},
+		{
+			Key:     "validation_time",
+			Default: "",
+			ValueFrom: &config.CustomDynamicAttribute{
+				ContextField: core.ContextFieldOperationValidationTime,
+			},
+		},
+		{
+			Key:     "planned_time",
+			Default: "",
+			ValueFrom: &config.CustomDynamicAttribute{
+				ContextField: core.ContextFieldOperationPlanningTime,
+			},
+		},
+		{
+			Key:     "normalized_time",
+			Default: "",
+			ValueFrom: &config.CustomDynamicAttribute{
+				ContextField: core.ContextFieldOperationNormalizationTime,
+			},
+		},
+		{
+			Key:     "request_error",
+			Default: "",
+			ValueFrom: &config.CustomDynamicAttribute{
+				ContextField: core.ContextFieldRequestError,
+			},
+		},
+	}
+)
+
 func TestRouterStartLogs(t *testing.T) {
 	t.Parallel()
 
@@ -140,8 +236,8 @@ func TestAccessLogsFileOutput(t *testing.T) {
 		t.Run("Simple", func(t *testing.T) {
 			t.Parallel()
 
-			fp := filepath.Join(os.TempDir(), "access.log")
-			f, err := logging.NewLogFile(filepath.Join(os.TempDir(), "access.log"))
+			fp := filepath.Join(t.TempDir(), "access.log")
+			f, err := logging.NewLogFile(fp)
 			require.NoError(t, err)
 
 			t.Cleanup(func() {
@@ -1297,99 +1393,7 @@ func TestAccessLogs(t *testing.T) {
 
 			testenv.Run(t, &testenv.Config{
 				SubgraphAccessLogsEnabled: true,
-				SubgraphAccessLogFields: []config.CustomAttribute{
-					{
-						Key:     "service_name",
-						Default: "",
-						ValueFrom: &config.CustomDynamicAttribute{
-							RequestHeader: "service-name",
-						},
-					},
-					{
-						Key:     "response_header",
-						Default: "",
-						ValueFrom: &config.CustomDynamicAttribute{
-							ResponseHeader: "response-header-name",
-						},
-					},
-					{
-						Key:     "operation_name",
-						Default: "",
-						ValueFrom: &config.CustomDynamicAttribute{
-							ContextField: core.ContextFieldOperationName,
-						},
-					},
-					{
-						Key:     "operation_type",
-						Default: "",
-						ValueFrom: &config.CustomDynamicAttribute{
-							ContextField: core.ContextFieldOperationType,
-						},
-					},
-					{
-						Key:     "operation_hash",
-						Default: "",
-						ValueFrom: &config.CustomDynamicAttribute{
-							ContextField: core.ContextFieldOperationHash,
-						},
-					},
-					{
-						Key:     "operation_persisted_hash",
-						Default: "",
-						ValueFrom: &config.CustomDynamicAttribute{
-							ContextField: core.ContextFieldPersistedOperationSha256,
-						},
-					},
-					{
-						Key:     "operation_sha256",
-						Default: "",
-						ValueFrom: &config.CustomDynamicAttribute{
-							ContextField: core.ContextFieldOperationSha256,
-						},
-					},
-					{
-						Key:     "response_error_message",
-						Default: "",
-						ValueFrom: &config.CustomDynamicAttribute{
-							ContextField: core.ContextFieldResponseErrorMessage,
-						},
-					},
-					{
-						Key:     "parsed_time",
-						Default: "",
-						ValueFrom: &config.CustomDynamicAttribute{
-							ContextField: core.ContextFieldOperationParsingTime,
-						},
-					},
-					{
-						Key:     "validation_time",
-						Default: "",
-						ValueFrom: &config.CustomDynamicAttribute{
-							ContextField: core.ContextFieldOperationValidationTime,
-						},
-					},
-					{
-						Key:     "planned_time",
-						Default: "",
-						ValueFrom: &config.CustomDynamicAttribute{
-							ContextField: core.ContextFieldOperationPlanningTime,
-						},
-					},
-					{
-						Key:     "normalized_time",
-						Default: "",
-						ValueFrom: &config.CustomDynamicAttribute{
-							ContextField: core.ContextFieldOperationNormalizationTime,
-						},
-					},
-					{
-						Key:     "request_error",
-						Default: "",
-						ValueFrom: &config.CustomDynamicAttribute{
-							ContextField: core.ContextFieldRequestError,
-						},
-					},
-				},
+				SubgraphAccessLogFields:   allSubgraphLogs,
 				LogObservation: testenv.LogObservationConfig{
 					Enabled:  true,
 					LogLevel: zapcore.InfoLevel,
@@ -1483,99 +1487,7 @@ func TestAccessLogs(t *testing.T) {
 						},
 					},
 				},
-				SubgraphAccessLogFields: []config.CustomAttribute{
-					{
-						Key:     "service_name",
-						Default: "",
-						ValueFrom: &config.CustomDynamicAttribute{
-							RequestHeader: "service-name",
-						},
-					},
-					{
-						Key:     "response_header",
-						Default: "",
-						ValueFrom: &config.CustomDynamicAttribute{
-							ResponseHeader: "response-header-name",
-						},
-					},
-					{
-						Key:     "operation_name",
-						Default: "",
-						ValueFrom: &config.CustomDynamicAttribute{
-							ContextField: core.ContextFieldOperationName,
-						},
-					},
-					{
-						Key:     "operation_type",
-						Default: "",
-						ValueFrom: &config.CustomDynamicAttribute{
-							ContextField: core.ContextFieldOperationType,
-						},
-					},
-					{
-						Key:     "operation_hash",
-						Default: "",
-						ValueFrom: &config.CustomDynamicAttribute{
-							ContextField: core.ContextFieldOperationHash,
-						},
-					},
-					{
-						Key:     "operation_persisted_hash",
-						Default: "",
-						ValueFrom: &config.CustomDynamicAttribute{
-							ContextField: core.ContextFieldPersistedOperationSha256,
-						},
-					},
-					{
-						Key:     "operation_sha256",
-						Default: "",
-						ValueFrom: &config.CustomDynamicAttribute{
-							ContextField: core.ContextFieldOperationSha256,
-						},
-					},
-					{
-						Key:     "response_error_message",
-						Default: "",
-						ValueFrom: &config.CustomDynamicAttribute{
-							ContextField: core.ContextFieldResponseErrorMessage,
-						},
-					},
-					{
-						Key:     "parsed_time",
-						Default: "",
-						ValueFrom: &config.CustomDynamicAttribute{
-							ContextField: core.ContextFieldOperationParsingTime,
-						},
-					},
-					{
-						Key:     "validation_time",
-						Default: "",
-						ValueFrom: &config.CustomDynamicAttribute{
-							ContextField: core.ContextFieldOperationValidationTime,
-						},
-					},
-					{
-						Key:     "planned_time",
-						Default: "",
-						ValueFrom: &config.CustomDynamicAttribute{
-							ContextField: core.ContextFieldOperationPlanningTime,
-						},
-					},
-					{
-						Key:     "normalized_time",
-						Default: "",
-						ValueFrom: &config.CustomDynamicAttribute{
-							ContextField: core.ContextFieldOperationNormalizationTime,
-						},
-					},
-					{
-						Key:     "request_error",
-						Default: "",
-						ValueFrom: &config.CustomDynamicAttribute{
-							ContextField: core.ContextFieldRequestError,
-						},
-					},
-				},
+				SubgraphAccessLogFields: allSubgraphLogs,
 				LogObservation: testenv.LogObservationConfig{
 					Enabled:  true,
 					LogLevel: zapcore.InfoLevel,
@@ -1836,6 +1748,119 @@ func TestAccessLogs(t *testing.T) {
 					"hostname",
 				}
 				checkValues(t, requestContext1, expectedValues1, additionalExpectedKeys1)
+			})
+		})
+
+		t.Run("handles unresponsive subgraph errors gracefully", func(t *testing.T) {
+			t.Parallel()
+
+			testenv.Run(t, &testenv.Config{
+				SubgraphAccessLogsEnabled: true,
+				ModifySubgraphErrorPropagation: func(cfg *config.SubgraphErrorPropagationConfiguration) {
+					cfg.Enabled = false
+					cfg.Mode = config.SubgraphErrorPropagationModeWrapped
+				},
+				Subgraphs: testenv.SubgraphsConfig{
+					Products: testenv.SubgraphConfig{
+						CloseOnStart: true,
+					},
+				},
+				AccessLogFields: []config.CustomAttribute{
+					{
+						Key:     "request_error",
+						Default: "",
+						ValueFrom: &config.CustomDynamicAttribute{
+							ContextField: core.ContextFieldRequestError,
+						},
+					},
+				},
+				SubgraphAccessLogFields: allSubgraphLogs,
+				LogObservation: testenv.LogObservationConfig{
+					Enabled:  true,
+					LogLevel: zapcore.InfoLevel,
+				},
+				RouterOptions: []core.Option{
+					core.WithHeaderRules(config.HeaderRules{
+						All: &config.GlobalHeaderRule{
+							Request: []*config.RequestHeaderRule{
+								{
+									Operation: config.HeaderRuleOperationPropagate,
+									Named:     "service-name",
+								},
+							},
+						},
+					}),
+				},
+			}, func(t *testing.T, xEnv *testenv.Environment) {
+				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+					Query:  `query employees { employees { id details { forename surname } notes } }`,
+					Header: map[string][]string{"service-name": {"service-name"}},
+				})
+				require.Equal(t, `{"errors":[{"message":"Failed to fetch from Subgraph 'products' at Path 'employees'."}],"data":{"employees":[{"id":1,"details":{"forename":"Jens","surname":"Neuse"},"notes":null},{"id":2,"details":{"forename":"Dustin","surname":"Deus"},"notes":null},{"id":3,"details":{"forename":"Stefan","surname":"Avram"},"notes":null},{"id":4,"details":{"forename":"Björn","surname":"Schwenzer"},"notes":null},{"id":5,"details":{"forename":"Sergiy","surname":"Petrunin"},"notes":null},{"id":7,"details":{"forename":"Suvij","surname":"Surya"},"notes":null},{"id":8,"details":{"forename":"Nithin","surname":"Kumar"},"notes":null},{"id":10,"details":{"forename":"Eelco","surname":"Wiersma"},"notes":null},{"id":11,"details":{"forename":"Alexandra","surname":"Neuse"},"notes":null},{"id":12,"details":{"forename":"David","surname":"Stutt"},"notes":null}]}}`, res.Body)
+				logEntries := xEnv.Observer().All()
+				require.Len(t, logEntries, 12)
+				requestLog := xEnv.Observer().FilterMessage("/graphql")
+				require.Equal(t, requestLog.Len(), 3)
+
+				employeeContext := requestLog.All()[0].ContextMap()
+				employeeSubgraphVals := map[string]interface{}{
+					"log_type":         "client/subgraph",
+					"subgraph_name":    "employees",
+					"subgraph_id":      "0",
+					"status":           int64(200),
+					"method":           "POST",
+					"path":             "/graphql",
+					"query":            "", // http query is empty
+					"ip":               "[REDACTED]",
+					"service_name":     "service-name",                                                     // From request header
+					"operation_hash":   "13939103824696605913",                                             // From context
+					"operation_sha256": "049efe2ebbdf2e4845e69f69cb7965963b118612a6247ab6d91b1961ea0158dc", // From context
+					"operation_name":   "employees",                                                        // From context
+					"operation_type":   "query",                                                            // From context
+				}
+				additionalExpectedKeys := []string{
+					"user_agent", "latency", "config_version", "request_id", "pid", "hostname", "normalized_time", "parsed_time", "planned_time", "validation_time", "trace_id", "url",
+				}
+				checkValues(t, employeeContext, employeeSubgraphVals, additionalExpectedKeys)
+
+				productContext := requestLog.All()[1].ContextMap()
+				productSubgraphVals := map[string]interface{}{
+					"log_type":         "client/subgraph",
+					"subgraph_name":    "products",
+					"subgraph_id":      "3",
+					"status":           int64(0),
+					"method":           "POST",
+					"path":             "/graphql",
+					"query":            "", // http query is empty
+					"ip":               "[REDACTED]",
+					"service_name":     "service-name",                                                     // From request header
+					"operation_hash":   "13939103824696605913",                                             // From context
+					"operation_sha256": "049efe2ebbdf2e4845e69f69cb7965963b118612a6247ab6d91b1961ea0158dc", // From context
+					"operation_name":   "employees",                                                        // From context
+					"operation_type":   "query",                                                            // From context
+					"request_error":    true,                                                               // From context
+				}
+				checkValues(t, productContext, productSubgraphVals, append(additionalExpectedKeys, "response_error_message"))
+
+				graphContext := requestLog.All()[2].ContextMap()
+				graphVals := map[string]interface{}{
+					"log_type":      "request",
+					"status":        int64(200),
+					"method":        "POST",
+					"path":          "/graphql",
+					"query":         "",
+					"ip":            "[REDACTED]",
+					"request_error": true, // From context
+				}
+				graphKeys := []string{
+					"user_agent",
+					"latency",
+					"config_version",
+					"request_id",
+					"pid",
+					"hostname",
+				}
+				checkValues(t, graphContext, graphVals, graphKeys)
 			})
 		})
 	})

--- a/router/core/engine_loader_hooks.go
+++ b/router/core/engine_loader_hooks.go
@@ -143,12 +143,12 @@ func (f *engineLoaderHooks) OnFinished(ctx context.Context, ds resolve.DataSourc
 		}
 		path := ds.Name
 		if responseInfo.Request != nil {
-			fields = append(fields, f.accessLogger.GetRequestFields(responseInfo, fields)...)
+			fields = append(fields, f.accessLogger.RequestFields(responseInfo, fields)...)
 			if responseInfo.Request.URL != nil {
 				path = responseInfo.Request.URL.Path
 			}
 		}
-		f.accessLogger.WriteLog(path, fields)
+		f.accessLogger.Info(path, fields...)
 	}
 
 	if responseInfo.Err != nil {

--- a/router/core/engine_loader_hooks.go
+++ b/router/core/engine_loader_hooks.go
@@ -141,10 +141,14 @@ func (f *engineLoaderHooks) OnFinished(ctx context.Context, ds resolve.DataSourc
 			zap.Int("status", responseInfo.StatusCode),
 			zap.Duration("latency", latency),
 		}
-		if responseInfo.Request != nil && responseInfo.Request.URL != nil {
-			fields = append(fields, zap.String("url", responseInfo.Request.URL.String()))
+		path := ds.Name
+		if responseInfo.Request != nil {
+			fields = append(fields, f.accessLogger.GetRequestFields(responseInfo, fields)...)
+			if responseInfo.Request.URL != nil {
+				path = responseInfo.Request.URL.Path
+			}
 		}
-		f.accessLogger.WriteRequestLog(responseInfo, fields)
+		f.accessLogger.WriteLog(path, fields)
 	}
 
 	if responseInfo.Err != nil {

--- a/router/core/engine_loader_hooks.go
+++ b/router/core/engine_loader_hooks.go
@@ -148,7 +148,7 @@ func (f *engineLoaderHooks) OnFinished(ctx context.Context, ds resolve.DataSourc
 				path = responseInfo.Request.URL.Path
 			}
 		}
-		f.accessLogger.Info(path, fields...)
+		f.accessLogger.Info(path, fields)
 	}
 
 	if responseInfo.Err != nil {

--- a/router/core/request_context_fields.go
+++ b/router/core/request_context_fields.go
@@ -69,6 +69,10 @@ func NewDurationLogField(val time.Duration, attribute config.CustomAttribute) za
 }
 
 func AccessLogsFieldHandler(attributes []config.CustomAttribute, err any, request *http.Request, responseHeader *http.Header) []zapcore.Field {
+	if request == nil {
+		return nil
+	}
+
 	reqContext := getRequestContext(request.Context())
 
 	resFields := make([]zapcore.Field, 0, len(attributes))

--- a/router/go.mod
+++ b/router/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/tidwall/gjson v1.18.0
 	github.com/tidwall/sjson v1.2.5
 	github.com/twmb/franz-go v1.16.1
-	github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.134
+	github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.136
 	// Do not upgrade, it renames attributes we rely on
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.46.1
 	go.opentelemetry.io/contrib/propagators/b3 v1.23.0

--- a/router/go.sum
+++ b/router/go.sum
@@ -268,8 +268,8 @@ github.com/vektah/gqlparser/v2 v2.5.16 h1:1gcmLTvs3JLKXckwCwlUagVn/IlV2bwqle0vJ0
 github.com/vektah/gqlparser/v2 v2.5.16/go.mod h1:1lz1OeCqgQbQepsGxPVywrjdBHW2T08PUS3pJqepRww=
 github.com/wundergraph/astjson v0.0.0-20241210135722-15ca0ac078f8 h1:D0Pw/sly2S9gt63BVlTAfHZG8h98h1AsELOuMgydDt0=
 github.com/wundergraph/astjson v0.0.0-20241210135722-15ca0ac078f8/go.mod h1:eOTL6acwctsN4F3b7YE+eE2t8zcJ/doLm9sZzsxxxrE=
-github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.134 h1:7YjoZo/OgEm7RhojETdyP3B0zcR6H1o4ZwBO9r+7J+8=
-github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.134/go.mod h1:xQLII50+GThIafwHGzeOVLsobqpAAB4WA/M9S+HTzxo=
+github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.136 h1:DrQIzB1uO7W85Nf04h3HCPlKrE+D+bs1fR4LvxCQLgE=
+github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.136/go.mod h1:xQLII50+GThIafwHGzeOVLsobqpAAB4WA/M9S+HTzxo=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.46.1 h1:aFJWCqJMNjENlcleuuOkGAPH82y0yULBScfXcIEdS24=

--- a/router/internal/requestlogger/subgraphlogger.go
+++ b/router/internal/requestlogger/subgraphlogger.go
@@ -43,22 +43,22 @@ func NewSubgraphAccessLogger(logger *zap.Logger, opts SubgraphOptions) *Subgraph
 	}
 }
 
-func (h *SubgraphAccessLogger) WriteRequestLog(respInfo *resolve.ResponseInfo, subgraphFields []zap.Field) {
-	if respInfo == nil || respInfo.Request == nil {
-		return
+func (h *SubgraphAccessLogger) GetRequestFields(respInfo *resolve.ResponseInfo, subgraphFields []zap.Field) []zap.Field {
+	if respInfo == nil {
+		return []zap.Field{}
 	}
 
-	path := ""
-	if respInfo.Request.URL != nil {
-		path = respInfo.Request.URL.Path
-	}
 	fields := h.accessLogger.getRequestFields(respInfo.Request)
+	if respInfo.Request != nil && respInfo.Request.URL != nil {
+		fields = append(fields, zap.String("url", respInfo.Request.URL.String()))
+	}
 	if h.accessLogger.fieldsHandler != nil {
 		fields = append(fields, h.accessLogger.fieldsHandler(h.accessLogger.attributes, respInfo.Err, respInfo.Request, &respInfo.ResponseHeaders)...)
 	}
 
-	if len(subgraphFields) > 0 {
-		fields = append(fields, subgraphFields...)
-	}
-	h.logger.Info(path, fields...)
+	return fields
+}
+
+func (h *SubgraphAccessLogger) WriteLog(message string, fields []zap.Field) {
+	h.logger.Info(message, fields...)
 }

--- a/router/internal/requestlogger/subgraphlogger.go
+++ b/router/internal/requestlogger/subgraphlogger.go
@@ -43,7 +43,7 @@ func NewSubgraphAccessLogger(logger *zap.Logger, opts SubgraphOptions) *Subgraph
 	}
 }
 
-func (h *SubgraphAccessLogger) GetRequestFields(respInfo *resolve.ResponseInfo, subgraphFields []zap.Field) []zap.Field {
+func (h *SubgraphAccessLogger) RequestFields(respInfo *resolve.ResponseInfo, subgraphFields []zap.Field) []zap.Field {
 	if respInfo == nil {
 		return []zap.Field{}
 	}
@@ -59,6 +59,6 @@ func (h *SubgraphAccessLogger) GetRequestFields(respInfo *resolve.ResponseInfo, 
 	return fields
 }
 
-func (h *SubgraphAccessLogger) WriteLog(message string, fields []zap.Field) {
+func (h *SubgraphAccessLogger) Info(message string, fields ...zap.Field) {
 	h.logger.Info(message, fields...)
 }

--- a/router/internal/requestlogger/subgraphlogger.go
+++ b/router/internal/requestlogger/subgraphlogger.go
@@ -44,11 +44,14 @@ func NewSubgraphAccessLogger(logger *zap.Logger, opts SubgraphOptions) *Subgraph
 }
 
 func (h *SubgraphAccessLogger) WriteRequestLog(respInfo *resolve.ResponseInfo, subgraphFields []zap.Field) {
-	if respInfo == nil {
+	if respInfo == nil || respInfo.Request == nil {
 		return
 	}
 
-	path := respInfo.Request.URL.Path
+	path := ""
+	if respInfo.Request.URL != nil {
+		path = respInfo.Request.URL.Path
+	}
 	fields := h.accessLogger.getRequestFields(respInfo.Request)
 	if h.accessLogger.fieldsHandler != nil {
 		fields = append(fields, h.accessLogger.fieldsHandler(h.accessLogger.attributes, respInfo.Err, respInfo.Request, &respInfo.ResponseHeaders)...)

--- a/router/internal/requestlogger/subgraphlogger.go
+++ b/router/internal/requestlogger/subgraphlogger.go
@@ -59,6 +59,6 @@ func (h *SubgraphAccessLogger) RequestFields(respInfo *resolve.ResponseInfo, sub
 	return fields
 }
 
-func (h *SubgraphAccessLogger) Info(message string, fields ...zap.Field) {
+func (h *SubgraphAccessLogger) Info(message string, fields []zap.Field) {
 	h.logger.Info(message, fields...)
 }

--- a/router/internal/requestlogger/subgraphlogger_test.go
+++ b/router/internal/requestlogger/subgraphlogger_test.go
@@ -25,12 +25,12 @@ func TestSubgraphAccessLogger(t *testing.T) {
 		subgraphLogger := requestlogger.NewSubgraphAccessLogger(l, requestlogger.SubgraphOptions{})
 		req, err := http.NewRequest("POST", "http://localhost:3002/graphql", nil)
 		require.NoError(t, err)
-		subgraphLogger.WriteLog("", subgraphLogger.GetRequestFields(&resolve.ResponseInfo{
+		subgraphLogger.Info("", subgraphLogger.RequestFields(&resolve.ResponseInfo{
 			StatusCode:      200,
 			Err:             nil,
 			Request:         req,
 			ResponseHeaders: nil,
-		}, nil))
+		}, nil)...)
 
 		require.Equal(t, 1, logObserver.Len())
 		requestContext := logObserver.All()[0].ContextMap()
@@ -54,12 +54,12 @@ func TestSubgraphAccessLogger(t *testing.T) {
 		req, err := http.NewRequest("POST", "http://localhost:3002/graphql", nil)
 		req.RemoteAddr = "my-test"
 		require.NoError(t, err)
-		subgraphLogger.WriteLog("", subgraphLogger.GetRequestFields(&resolve.ResponseInfo{
+		subgraphLogger.Info("", subgraphLogger.RequestFields(&resolve.ResponseInfo{
 			StatusCode:      200,
 			Err:             nil,
 			Request:         req,
 			ResponseHeaders: nil,
-		}, nil))
+		}, nil)...)
 
 		require.Equal(t, 1, logObserver.Len())
 		requestContext := logObserver.All()[0].ContextMap()
@@ -88,12 +88,12 @@ func TestSubgraphAccessLogger(t *testing.T) {
 		req, err := http.NewRequest("POST", "http://localhost:3002/graphql", nil)
 		req.RemoteAddr = "my-test"
 		require.NoError(t, err)
-		subgraphLogger.WriteLog("", subgraphLogger.GetRequestFields(&resolve.ResponseInfo{
+		subgraphLogger.Info("", subgraphLogger.RequestFields(&resolve.ResponseInfo{
 			StatusCode:      200,
 			Err:             nil,
 			Request:         req,
 			ResponseHeaders: nil,
-		}, nil))
+		}, nil)...)
 
 		require.Equal(t, 1, logObserver.Len())
 		requestContext := logObserver.All()[0].ContextMap()
@@ -122,12 +122,12 @@ func TestSubgraphAccessLogger(t *testing.T) {
 		req, err := http.NewRequest("POST", "http://localhost:3002/graphql", nil)
 		req.RemoteAddr = "my-test"
 		require.NoError(t, err)
-		subgraphLogger.WriteLog("", subgraphLogger.GetRequestFields(&resolve.ResponseInfo{
+		subgraphLogger.Info("", subgraphLogger.RequestFields(&resolve.ResponseInfo{
 			StatusCode:      200,
 			Err:             nil,
 			Request:         req,
 			ResponseHeaders: nil,
-		}, nil))
+		}, nil)...)
 
 		require.Equal(t, 1, logObserver.Len())
 		requestContext := logObserver.All()[0].ContextMap()
@@ -168,14 +168,14 @@ func TestSubgraphAccessLogger(t *testing.T) {
 		req.Header.Add("test-header", "test-value")
 
 		require.NoError(t, err)
-		subgraphLogger.WriteLog("", subgraphLogger.GetRequestFields(&resolve.ResponseInfo{
+		subgraphLogger.Info("", subgraphLogger.RequestFields(&resolve.ResponseInfo{
 			StatusCode: 200,
 			Err:        nil,
 			Request:    req,
 			ResponseHeaders: map[string][]string{
 				"Test-Response-Header": {"test-response-value"},
 			},
-		}, nil))
+		}, nil)...)
 
 		require.Equal(t, 1, logObserver.Len())
 		requestContext := logObserver.All()[0].ContextMap()
@@ -227,14 +227,14 @@ func TestSubgraphAccessLogger(t *testing.T) {
 			},
 		})
 
-		subgraphLogger.WriteLog("subgraph error", subgraphLogger.GetRequestFields(&resolve.ResponseInfo{
+		subgraphLogger.Info("subgraph error", subgraphLogger.RequestFields(&resolve.ResponseInfo{
 			StatusCode: 200,
 			Err:        errors.New("my-test-error"),
 			Request:    nil,
 			ResponseHeaders: map[string][]string{
 				"Test-Response-Header": {"test-response-value"},
 			},
-		}, nil))
+		}, nil)...)
 
 		require.Equal(t, 1, logObserver.Len())
 		requestContext := logObserver.All()[0].ContextMap()

--- a/router/internal/requestlogger/subgraphlogger_test.go
+++ b/router/internal/requestlogger/subgraphlogger_test.go
@@ -30,7 +30,7 @@ func TestSubgraphAccessLogger(t *testing.T) {
 			Err:             nil,
 			Request:         req,
 			ResponseHeaders: nil,
-		}, nil)...)
+		}, nil))
 
 		require.Equal(t, 1, logObserver.Len())
 		requestContext := logObserver.All()[0].ContextMap()
@@ -59,7 +59,7 @@ func TestSubgraphAccessLogger(t *testing.T) {
 			Err:             nil,
 			Request:         req,
 			ResponseHeaders: nil,
-		}, nil)...)
+		}, nil))
 
 		require.Equal(t, 1, logObserver.Len())
 		requestContext := logObserver.All()[0].ContextMap()
@@ -93,7 +93,7 @@ func TestSubgraphAccessLogger(t *testing.T) {
 			Err:             nil,
 			Request:         req,
 			ResponseHeaders: nil,
-		}, nil)...)
+		}, nil))
 
 		require.Equal(t, 1, logObserver.Len())
 		requestContext := logObserver.All()[0].ContextMap()
@@ -127,7 +127,7 @@ func TestSubgraphAccessLogger(t *testing.T) {
 			Err:             nil,
 			Request:         req,
 			ResponseHeaders: nil,
-		}, nil)...)
+		}, nil))
 
 		require.Equal(t, 1, logObserver.Len())
 		requestContext := logObserver.All()[0].ContextMap()
@@ -175,7 +175,7 @@ func TestSubgraphAccessLogger(t *testing.T) {
 			ResponseHeaders: map[string][]string{
 				"Test-Response-Header": {"test-response-value"},
 			},
-		}, nil)...)
+		}, nil))
 
 		require.Equal(t, 1, logObserver.Len())
 		requestContext := logObserver.All()[0].ContextMap()
@@ -234,7 +234,7 @@ func TestSubgraphAccessLogger(t *testing.T) {
 			ResponseHeaders: map[string][]string{
 				"Test-Response-Header": {"test-response-value"},
 			},
-		}, nil)...)
+		}, nil))
 
 		require.Equal(t, 1, logObserver.Len())
 		requestContext := logObserver.All()[0].ContextMap()

--- a/router/internal/requestlogger/subgraphlogger_test.go
+++ b/router/internal/requestlogger/subgraphlogger_test.go
@@ -1,6 +1,7 @@
 package requestlogger_test
 
 import (
+	"errors"
 	"github.com/stretchr/testify/require"
 	"github.com/wundergraph/cosmo/router/core"
 	"github.com/wundergraph/cosmo/router/internal/requestlogger"
@@ -40,7 +41,7 @@ func TestSubgraphAccessLogger(t *testing.T) {
 			"query":    "",
 			"ip":       "",
 		}
-		additionalExpectedKeys := []string{"user_agent", "hostname", "pid"}
+		additionalExpectedKeys := []string{"user_agent", "hostname", "pid", "url"}
 		checkValues(t, requestContext, expectedValues, additionalExpectedKeys)
 	})
 
@@ -69,7 +70,7 @@ func TestSubgraphAccessLogger(t *testing.T) {
 			"query":    "",
 			"ip":       "my-test",
 		}
-		additionalExpectedKeys := []string{"user_agent", "hostname", "pid"}
+		additionalExpectedKeys := []string{"user_agent", "hostname", "pid", "url"}
 		checkValues(t, requestContext, expectedValues, additionalExpectedKeys)
 	})
 
@@ -103,7 +104,7 @@ func TestSubgraphAccessLogger(t *testing.T) {
 			"query":    "",
 			"ip":       "[REDACTED]",
 		}
-		additionalExpectedKeys := []string{"user_agent", "hostname", "pid"}
+		additionalExpectedKeys := []string{"user_agent", "hostname", "pid", "url"}
 		checkValues(t, requestContext, expectedValues, additionalExpectedKeys)
 	})
 
@@ -137,7 +138,7 @@ func TestSubgraphAccessLogger(t *testing.T) {
 			"query":    "",
 			"ip":       "6d792d74657374e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 		}
-		additionalExpectedKeys := []string{"user_agent", "hostname", "pid"}
+		additionalExpectedKeys := []string{"user_agent", "hostname", "pid", "url"}
 		checkValues(t, requestContext, expectedValues, additionalExpectedKeys)
 	})
 
@@ -187,7 +188,7 @@ func TestSubgraphAccessLogger(t *testing.T) {
 			"test":          "test-value",
 			"test-response": "test-response-value",
 		}
-		additionalExpectedKeys := []string{"user_agent", "request_id", "hostname", "pid"}
+		additionalExpectedKeys := []string{"user_agent", "request_id", "hostname", "pid", "url"}
 		checkValues(t, requestContext, expectedValues, additionalExpectedKeys)
 	})
 
@@ -211,12 +212,24 @@ func TestSubgraphAccessLogger(t *testing.T) {
 						ResponseHeader: "test-response-header",
 					},
 				},
+				{
+					Key: "request-error",
+					ValueFrom: &config.CustomDynamicAttribute{
+						ContextField: core.ContextFieldRequestError,
+					},
+				},
+				{
+					Key: "request-error-msg",
+					ValueFrom: &config.CustomDynamicAttribute{
+						ContextField: core.ContextFieldResponseErrorMessage,
+					},
+				},
 			},
 		})
 
 		subgraphLogger.WriteLog("subgraph error", subgraphLogger.GetRequestFields(&resolve.ResponseInfo{
 			StatusCode: 200,
-			Err:        nil,
+			Err:        errors.New("my-test-error"),
 			Request:    nil,
 			ResponseHeaders: map[string][]string{
 				"Test-Response-Header": {"test-response-value"},
@@ -226,7 +239,10 @@ func TestSubgraphAccessLogger(t *testing.T) {
 		require.Equal(t, 1, logObserver.Len())
 		requestContext := logObserver.All()[0].ContextMap()
 		expectedValues := map[string]interface{}{
-			"log_type": "client/subgraph",
+			"log_type":          "client/subgraph",
+			"request-error":     true,
+			"request-error-msg": "my-test-error",
+			"test-response":     "test-response-value",
 		}
 		additionalExpectedKeys := []string{"hostname", "pid"}
 		checkValues(t, requestContext, expectedValues, additionalExpectedKeys)


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

## Motivation and Context

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please describe in detail the impact of this change. Attach screenshots if applicable.
-->

There was a null pointer when consumers would encounter a subgraph with a null request (which can happen in error cases). This PR makes the code much more resilient, and adds tests to ensure that nil pointers are handled gracefully.

Resolves ENG-6173
## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->