### PR TITLE
feat: tolerate initial JWK error

### DIFF
--- a/.github/actions/build-push-image/action.yaml
+++ b/.github/actions/build-push-image/action.yaml
@@ -79,9 +79,6 @@ runs:
 
     - name: Build & Push Docker Image
       uses: docker/build-push-action@v6
-      env:
-        DOCKER_BUILD_SUMMARY: false
-        DOCKER_BUILD_RECORD_UPLOAD: false
       with:
         # This is a limitation of GitHub. Only organization members can push to GitHub Container Registry
         # For now, we will disable the push to the GitHub Container Registry for external contributors

--- a/router-tests/authentication_test.go
+++ b/router-tests/authentication_test.go
@@ -2,6 +2,7 @@ package integration_test
 
 import (
 	"bytes"
+	"go.uber.org/zap"
 	"io"
 	"net/http"
 	"strings"
@@ -29,7 +30,7 @@ func configureAuth(t *testing.T) ([]authentication.Authenticator, *jwks.Server) 
 	authServer, err := jwks.NewServer(t)
 	require.NoError(t, err)
 	t.Cleanup(authServer.Close)
-	tokenDecoder, _ := authentication.NewJwksTokenDecoder(authServer.JWKSURL(), time.Second*5)
+	tokenDecoder, _ := authentication.NewJwksTokenDecoder(zap.NewNop(), authServer.JWKSURL(), time.Second*5)
 	authOptions := authentication.HttpHeaderAuthenticatorOptions{
 		Name:         jwksName,
 		URL:          authServer.JWKSURL(),
@@ -613,7 +614,7 @@ func TestAuthenticationWithCustomHeaders(t *testing.T) {
 	authServer, err := jwks.NewServer(t)
 	require.NoError(t, err)
 	t.Cleanup(authServer.Close)
-	tokenDecoder, _ := authentication.NewJwksTokenDecoder(authServer.JWKSURL(), time.Second*5)
+	tokenDecoder, _ := authentication.NewJwksTokenDecoder(zap.NewNop(), authServer.JWKSURL(), time.Second*5)
 	authOptions := authentication.HttpHeaderAuthenticatorOptions{
 		Name:                jwksName,
 		URL:                 authServer.JWKSURL(),
@@ -748,7 +749,7 @@ func TestAuthenticationMultipleProviders(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(authServer2.Close)
 
-	tokenDecoder1, _ := authentication.NewJwksTokenDecoder(authServer1.JWKSURL(), time.Second*5)
+	tokenDecoder1, _ := authentication.NewJwksTokenDecoder(zap.NewNop(), authServer1.JWKSURL(), time.Second*5)
 	authenticator1HeaderValuePrefixes := []string{"Bearer"}
 	authenticator1, err := authentication.NewHttpHeaderAuthenticator(authentication.HttpHeaderAuthenticatorOptions{
 		Name:                "1",
@@ -758,7 +759,7 @@ func TestAuthenticationMultipleProviders(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	tokenDecoder2, _ := authentication.NewJwksTokenDecoder(authServer2.JWKSURL(), time.Second*5)
+	tokenDecoder2, _ := authentication.NewJwksTokenDecoder(zap.NewNop(), authServer2.JWKSURL(), time.Second*5)
 	authenticator2HeaderValuePrefixes := []string{"", "Bearer", "Token"}
 	authenticator2, err := authentication.NewHttpHeaderAuthenticator(authentication.HttpHeaderAuthenticatorOptions{
 		Name:                "2",
@@ -858,7 +859,7 @@ func TestAuthenticationOverWebsocket(t *testing.T) {
 	require.NoError(t, err)
 	defer authServer.Close()
 
-	tokenDecoder, _ := authentication.NewJwksTokenDecoder(authServer.JWKSURL(), time.Second*5)
+	tokenDecoder, _ := authentication.NewJwksTokenDecoder(zap.NewNop(), authServer.JWKSURL(), time.Second*5)
 	jwksOpts := authentication.HttpHeaderAuthenticatorOptions{
 		Name:         jwksName,
 		URL:          authServer.JWKSURL(),

--- a/router-tests/modules/set_scopes_test.go
+++ b/router-tests/modules/set_scopes_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/wundergraph/cosmo/router/core"
 	"github.com/wundergraph/cosmo/router/pkg/authentication"
 	"github.com/wundergraph/cosmo/router/pkg/config"
+	"go.uber.org/zap"
 	"io"
 	"net/http"
 	"strings"
@@ -26,7 +27,7 @@ func configureAuth(t *testing.T) ([]authentication.Authenticator, *jwks.Server) 
 	authServer, err := jwks.NewServer(t)
 	require.NoError(t, err)
 	t.Cleanup(authServer.Close)
-	tokenDecoder, _ := authentication.NewJwksTokenDecoder(authServer.JWKSURL(), time.Second*5)
+	tokenDecoder, _ := authentication.NewJwksTokenDecoder(zap.NewNop(), authServer.JWKSURL(), time.Second*5)
 	authOptions := authentication.HttpHeaderAuthenticatorOptions{
 		Name:         jwksName,
 		URL:          authServer.JWKSURL(),

--- a/router-tests/websocket_test.go
+++ b/router-tests/websocket_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"go.uber.org/zap"
 	"io"
 	"math/big"
 	"net"
@@ -73,7 +74,7 @@ func TestWebSockets(t *testing.T) {
 		authServer, err := jwks.NewServer(t)
 		require.NoError(t, err)
 		t.Cleanup(authServer.Close)
-		tokenDecoder, _ := authentication.NewJwksTokenDecoder(authServer.JWKSURL(), time.Second*5)
+		tokenDecoder, _ := authentication.NewJwksTokenDecoder(zap.NewNop(), authServer.JWKSURL(), time.Second*5)
 		authOptions := authentication.HttpHeaderAuthenticatorOptions{
 			Name:         jwksName,
 			URL:          authServer.JWKSURL(),
@@ -123,7 +124,7 @@ func TestWebSockets(t *testing.T) {
 		authServer, err := jwks.NewServer(t)
 		require.NoError(t, err)
 		t.Cleanup(authServer.Close)
-		tokenDecoder, _ := authentication.NewJwksTokenDecoder(authServer.JWKSURL(), time.Second*5)
+		tokenDecoder, _ := authentication.NewJwksTokenDecoder(zap.NewNop(), authServer.JWKSURL(), time.Second*5)
 		authOptions := authentication.HttpHeaderAuthenticatorOptions{
 			Name:         jwksName,
 			URL:          authServer.JWKSURL(),
@@ -173,7 +174,7 @@ func TestWebSockets(t *testing.T) {
 		authServer, err := jwks.NewServer(t)
 		require.NoError(t, err)
 		t.Cleanup(authServer.Close)
-		tokenDecoder, _ := authentication.NewJwksTokenDecoder(authServer.JWKSURL(), time.Second*5)
+		tokenDecoder, _ := authentication.NewJwksTokenDecoder(zap.NewNop(), authServer.JWKSURL(), time.Second*5)
 		authOptions := authentication.HttpHeaderAuthenticatorOptions{
 			Name:         jwksName,
 			URL:          authServer.JWKSURL(),
@@ -232,7 +233,7 @@ func TestWebSockets(t *testing.T) {
 		authServer, err := jwks.NewServer(t)
 		require.NoError(t, err)
 		t.Cleanup(authServer.Close)
-		tokenDecoder, _ := authentication.NewJwksTokenDecoder(authServer.JWKSURL(), time.Second*5)
+		tokenDecoder, _ := authentication.NewJwksTokenDecoder(zap.NewNop(), authServer.JWKSURL(), time.Second*5)
 		authOptions := authentication.HttpHeaderAuthenticatorOptions{
 			Name:         jwksName,
 			URL:          authServer.JWKSURL(),
@@ -290,7 +291,7 @@ func TestWebSockets(t *testing.T) {
 		authServer, err := jwks.NewServer(t)
 		require.NoError(t, err)
 		t.Cleanup(authServer.Close)
-		tokenDecoder, _ := authentication.NewJwksTokenDecoder(authServer.JWKSURL(), time.Second*5)
+		tokenDecoder, _ := authentication.NewJwksTokenDecoder(zap.NewNop(), authServer.JWKSURL(), time.Second*5)
 		authOptions := authentication.WebsocketInitialPayloadAuthenticatorOptions{
 			TokenDecoder: tokenDecoder,
 			Key:          "Authorization",
@@ -351,7 +352,7 @@ func TestWebSockets(t *testing.T) {
 		authServer, err := jwks.NewServer(t)
 		require.NoError(t, err)
 		t.Cleanup(authServer.Close)
-		tokenDecoder, _ := authentication.NewJwksTokenDecoder(authServer.JWKSURL(), time.Second*5)
+		tokenDecoder, _ := authentication.NewJwksTokenDecoder(zap.NewNop(), authServer.JWKSURL(), time.Second*5)
 		authOptions := authentication.WebsocketInitialPayloadAuthenticatorOptions{
 			TokenDecoder: tokenDecoder,
 			Key:          "Authorization",
@@ -400,7 +401,7 @@ func TestWebSockets(t *testing.T) {
 		authServer, err := jwks.NewServer(t)
 		require.NoError(t, err)
 		t.Cleanup(authServer.Close)
-		tokenDecoder, _ := authentication.NewJwksTokenDecoder(authServer.JWKSURL(), time.Second*5)
+		tokenDecoder, _ := authentication.NewJwksTokenDecoder(zap.NewNop(), authServer.JWKSURL(), time.Second*5)
 		authOptions := authentication.WebsocketInitialPayloadAuthenticatorOptions{
 			TokenDecoder: tokenDecoder,
 			Key:          "Authorization",

--- a/router/cmd/instance.go
+++ b/router/cmd/instance.go
@@ -65,7 +65,7 @@ func NewRouter(params Params, additionalOptions ...core.Option) (*core.Router, e
 			tokenDecoder, err := authentication.NewJwksTokenDecoder(providerLogger, auth.JWKS.URL, auth.JWKS.RefreshInterval)
 			if err != nil {
 				providerLogger.Error("Could not create JWKS token decoder", zap.Error(err))
-				continue
+				return nil, err
 			}
 			opts := authentication.HttpHeaderAuthenticatorOptions{
 				Name:                name,
@@ -77,7 +77,7 @@ func NewRouter(params Params, additionalOptions ...core.Option) (*core.Router, e
 			authenticator, err := authentication.NewHttpHeaderAuthenticator(opts)
 			if err != nil {
 				providerLogger.Error("Could not create HttpHeader authenticator", zap.Error(err))
-				continue
+				return nil, err
 			}
 			authenticators = append(authenticators, authenticator)
 
@@ -90,7 +90,7 @@ func NewRouter(params Params, additionalOptions ...core.Option) (*core.Router, e
 				authenticator, err = authentication.NewWebsocketInitialPayloadAuthenticator(opts)
 				if err != nil {
 					providerLogger.Error("Could not create WebsocketInitialPayload authenticator", zap.Error(err))
-					continue
+					return nil, err
 				}
 				authenticators = append(authenticators, authenticator)
 			}

--- a/router/cmd/instance.go
+++ b/router/cmd/instance.go
@@ -76,7 +76,8 @@ func NewRouter(params Params, additionalOptions ...core.Option) (*core.Router, e
 			}
 			authenticator, err := authentication.NewHttpHeaderAuthenticator(opts)
 			if err != nil {
-				providerLogger.Fatal("Could not create HttpHeader authenticator", zap.Error(err))
+				providerLogger.Error("Could not create HttpHeader authenticator", zap.Error(err))
+				continue
 			}
 			authenticators = append(authenticators, authenticator)
 
@@ -88,7 +89,8 @@ func NewRouter(params Params, additionalOptions ...core.Option) (*core.Router, e
 				}
 				authenticator, err = authentication.NewWebsocketInitialPayloadAuthenticator(opts)
 				if err != nil {
-					providerLogger.Fatal("Could not create WebsocketInitialPayload authenticator", zap.Error(err))
+					providerLogger.Error("Could not create WebsocketInitialPayload authenticator", zap.Error(err))
+					continue
 				}
 				authenticators = append(authenticators, authenticator)
 			}

--- a/router/pkg/authentication/jwks_token_decoder.go
+++ b/router/pkg/authentication/jwks_token_decoder.go
@@ -37,7 +37,7 @@ func NewJwksTokenDecoder(logger *zap.Logger, url string, refreshInterval time.Du
 		// Allow the JWKS to be empty initially, but it can recover on refresh.
 		TolerateInitialJWKHTTPError: true,
 		RefreshErrorHandler: func(err error) {
-			logger.Error("Could not refresh JWKS. The JWKS will be empty until the next refresh.", zap.Error(err))
+			logger.Error("Could not refresh JWKS. Trying again in the next interval.", zap.Error(err))
 		},
 	})
 	if err != nil {

--- a/router/pkg/authentication/jwks_token_decoder.go
+++ b/router/pkg/authentication/jwks_token_decoder.go
@@ -37,7 +37,7 @@ func NewJwksTokenDecoder(logger *zap.Logger, url string, refreshInterval time.Du
 		// Allow the JWKS to be empty initially, but it can recover on refresh.
 		TolerateInitialJWKHTTPError: true,
 		RefreshErrorHandler: func(err error) {
-			logger.Error("Could not refresh JWKS", zap.Error(err))
+			logger.Error("Could not refresh JWKS. The JWKS will be empty until the next refresh.", zap.Error(err))
 		},
 	})
 	if err != nil {

--- a/router/pkg/authentication/jwks_token_decoder.go
+++ b/router/pkg/authentication/jwks_token_decoder.go
@@ -37,7 +37,11 @@ func NewJwksTokenDecoder(logger *zap.Logger, url string, refreshInterval time.Du
 		// Allow the JWKS to be empty initially, but it can recover on refresh.
 		TolerateInitialJWKHTTPError: true,
 		RefreshErrorHandler: func(err error) {
-			logger.Error("Could not refresh JWKS. Trying again in the next interval.", zap.Error(err))
+			logger.Error("Could not refresh JWKS. Trying again in the next interval.",
+				zap.Error(err),
+				zap.String("url", url),
+				zap.String("interval", refreshInterval.String()),
+			)
 		},
 	})
 	if err != nil {

--- a/router/pkg/authentication/jwks_token_decoder.go
+++ b/router/pkg/authentication/jwks_token_decoder.go
@@ -2,6 +2,7 @@ package authentication
 
 import (
 	"fmt"
+	"go.uber.org/zap"
 	"time"
 
 	"github.com/MicahParks/keyfunc/v2"
@@ -29,10 +30,15 @@ func (j *jwksTokenDecoder) Decode(tokenString string) (Claims, error) {
 	return Claims(claims), nil
 }
 
-func NewJwksTokenDecoder(url string, refreshInterval time.Duration) (TokenDecoder, error) {
+func NewJwksTokenDecoder(logger *zap.Logger, url string, refreshInterval time.Duration) (TokenDecoder, error) {
 
 	jwks, err := keyfunc.Get(url, keyfunc.Options{
 		RefreshInterval: refreshInterval,
+		// Allow the JWKS to be empty initially, but it can recover on refresh.
+		TolerateInitialJWKHTTPError: true,
+		RefreshErrorHandler: func(err error) {
+			logger.Error("Could not refresh JWKS", zap.Error(err))
+		},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error initializing JWKS from %q: %w", url, err)


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

## Motivation and Context

It can't be always guaranteed that the JWK server is up and ready when the router starts. This is in particular true when the JWK is served from a sidecar. This PR allows the initial JWK refresh to fail. All errors are logged.

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please describe in detail the impact of this change. Attach screenshots if applicable.
-->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->