### PR TITLE
fix: bump timeout in server to address responseheadertimeout flake

### DIFF
--- a/router/core/timout_transport_test.go
+++ b/router/core/timout_transport_test.go
@@ -102,13 +102,13 @@ func TestTimeoutTransport(t *testing.T) {
 		transportOpts := &SubgraphTransportOptions{
 			SubgraphMap: map[string]*TransportTimeoutOptions{
 				testSubgraphKey: {
-					ResponseHeaderTimeout: 3 * time.Millisecond,
+					ResponseHeaderTimeout: 10 * time.Millisecond,
 				},
 			},
 		}
 
 		headerTimeoutServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			time.Sleep(5 * time.Millisecond) // Delayed header response
+			time.Sleep(50 * time.Millisecond) // Delayed header response
 			w.WriteHeader(http.StatusOK)
 		}))
 		defer headerTimeoutServer.Close()


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

## Motivation and Context

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please describe in detail the impact of this change. Attach screenshots if applicable.
-->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->