### PR TITLE
fix: add edfs to the demo environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -212,6 +212,7 @@ services:
     networks:
       - primary
     profiles:
+      - dev
       - edfs
 
   redis:
@@ -260,6 +261,7 @@ services:
       ALLOW_PLAINTEXT_LISTENER: yes
       KAFKA_KRAFT_CLUSTER_ID: XkpGZQ27R3eTl3OdTm2LYA # 16 byte base64-encoded UUID
     profiles:
+      - dev
       - edfs
 
 # This network is shared between this file and docker-compose.full.yml to

--- a/router/.env.example
+++ b/router/.env.example
@@ -8,6 +8,7 @@ DEV_MODE=true
 GRAPH_API_TOKEN=<generated_with_wgc>
 CDN_URL=http://127.0.0.1:11000
 NATS_URL=nats://localhost:4222
+CONFIG_PATH=demo.config.yaml
 #CONFIG_PATH=debug.config.yaml
 #GRAPH_CONFIG_SIGN_KEY=7kZKCz7DaLpvHKtaFEupDsBvDD9EEmUB
 

--- a/router/demo.config.yaml
+++ b/router/demo.config.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=./pkg/config/config.schema.json
+
+# See pkg/config/config.go for the full list of configuration options.
+# This file is used for the demo environment
+
+version: "1"
+
+events:
+  providers:
+    nats:
+      - id: default
+        url: "nats://localhost:4222"
+      - id: my-nats
+        url: "nats://localhost:4222"
+    kafka:
+      - id: my-kafka
+        brokers:
+          - "localhost:9092"


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

## Motivation and Context

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please describe in detail the impact of this change. Attach screenshots if applicable.
-->
Since the last change that checks for edfs providers, the demo environment would not work by default. 
So we have to add the configuration and services needed by the router to work properly.

## Checklist

- [X] I have discussed my proposed changes in an issue and have received approval to proceed.
- [X] I have followed the coding standards of the project.
- [X] Tests or benchmarks have been added or updated.
- [X] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [X] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->