### PR TITLE
fix(router): remove wildcard from router graphql path

### DIFF
--- a/router-tests/graphql_over_get_test.go
+++ b/router-tests/graphql_over_get_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/wundergraph/cosmo/router-tests/testenv"
+	"github.com/wundergraph/cosmo/router/core"
 )
 
 func TestOperationsOverGET(t *testing.T) {
@@ -52,6 +53,97 @@ func TestOperationsOverGET(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, http.StatusMethodNotAllowed, res.Response.StatusCode)
 			require.Equal(t, `{"errors":[{"message":"Mutations can only be sent over HTTP POST"}]}`, res.Body)
+		})
+	})
+
+	t.Run("Query should be successful with custom path", func(t *testing.T) {
+		t.Parallel()
+
+		testenv.Run(t, &testenv.Config{
+			OverrideGraphQLPath: "/custom-graphql",
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			res, err := xEnv.MakeGraphQLRequestOverGET(testenv.GraphQLRequest{
+				OperationName: []byte(`Employees`),
+				Query:         `query Employees { employees { id } }`,
+			})
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, res.Response.StatusCode)
+			require.Equal(t, `{"data":{"employees":[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5},{"id":7},{"id":8},{"id":10},{"id":11},{"id":12}]}}`, res.Body)
+		})
+	})
+
+	t.Run("Mutation should not be allowed with custom path", func(t *testing.T) {
+		t.Parallel()
+
+		testenv.Run(t, &testenv.Config{
+			OverrideGraphQLPath: "/custom-graphql",
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			res, err := xEnv.MakeGraphQLRequestOverGET(testenv.GraphQLRequest{
+				OperationName: []byte(`updateEmployeeTag`),
+				Query:         "mutation updateEmployeeTag {\n  updateEmployeeTag(id: 10, tag: \"dd\") {\n    id\n  }\n}",
+			})
+			require.NoError(t, err)
+			require.Equal(t, http.StatusMethodNotAllowed, res.Response.StatusCode)
+			require.Equal(t, `{"errors":[{"message":"Mutations can only be sent over HTTP POST"}]}`, res.Body)
+		})
+	})
+
+	t.Run("Should return 404 for unknown path", func(t *testing.T) {
+		t.Parallel()
+
+		testenv.Run(t, &testenv.Config{
+			RouterOptions: []core.Option{
+				core.WithGraphQLPath("/custom-graphql"),
+			},
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			// Default path for creating requests ist /graphql if not updated with `OverrideGraphQLPath`
+			res, err := xEnv.MakeGraphQLRequestOverGET(testenv.GraphQLRequest{
+				OperationName: []byte(`Employees`),
+				Query:         `query Employees { employees { id } }`,
+			})
+
+			require.NoError(t, err)
+			require.Equal(t, http.StatusNotFound, res.Response.StatusCode)
+		})
+	})
+
+	t.Run("Should not create wildcard for root path", func(t *testing.T) {
+		t.Parallel()
+
+		testenv.Run(t, &testenv.Config{
+			RouterOptions: []core.Option{
+				core.WithGraphQLPath("/"),
+			},
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			// Default path for creating requests ist /graphql if not updated with `OverrideGraphQLPath`
+			res, err := xEnv.MakeGraphQLRequestOverGET(testenv.GraphQLRequest{
+				OperationName: []byte(`Employees`),
+				Query:         `query Employees { employees { id } }`,
+			})
+
+			require.NoError(t, err)
+			require.Equal(t, http.StatusNotFound, res.Response.StatusCode)
+		})
+	})
+
+	t.Run("Should allow to create wildcard path", func(t *testing.T) {
+		t.Parallel()
+
+		testenv.Run(t, &testenv.Config{
+			RouterOptions: []core.Option{
+				core.WithGraphQLPath("/*"),
+			},
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			// Default path for creating requests ist /graphql if not updated with `OverrideGraphQLPath`
+			res, err := xEnv.MakeGraphQLRequestOverGET(testenv.GraphQLRequest{
+				OperationName: []byte(`Employees`),
+				Query:         `query Employees { employees { id } }`,
+			})
+
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, res.Response.StatusCode)
+			require.Equal(t, `{"data":{"employees":[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5},{"id":7},{"id":8},{"id":10},{"id":11},{"id":12}]}}`, res.Body)
+
 		})
 	})
 }
@@ -115,6 +207,50 @@ func TestSubscriptionOverGET(t *testing.T) {
 		}
 
 		testenv.Run(t, &testenv.Config{}, func(t *testing.T, xEnv *testenv.Environment) {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			var wg sync.WaitGroup
+			wg.Add(2)
+
+			go xEnv.GraphQLSubscriptionOverSSEWithQueryParam(ctx, testenv.GraphQLRequest{
+				OperationName: []byte(`CurrentTime`),
+				Query:         `subscription CurrentTime { currentTime { unixTime timeStamp }}`,
+				Header: map[string][]string{
+					"Content-Type":  {"application/json"},
+					"Connection":    {"keep-alive"},
+					"Cache-Control": {"no-cache"},
+				},
+			}, func(data string) {
+				defer wg.Done()
+
+				var payload currentTimePayload
+				err := json.Unmarshal([]byte(data), &payload)
+				require.NoError(t, err)
+
+				require.NotZero(t, payload.Data.CurrentTime.UnixTime)
+				require.NotEmpty(t, payload.Data.CurrentTime.Timestamp)
+			})
+
+			wg.Wait()
+		})
+	})
+
+	t.Run("should create subscription for custom graphql path", func(t *testing.T) {
+		t.Parallel()
+
+		type currentTimePayload struct {
+			Data struct {
+				CurrentTime struct {
+					UnixTime  float64 `json:"unixTime"`
+					Timestamp string  `json:"timestamp"`
+				} `json:"currentTime"`
+			} `json:"data"`
+		}
+
+		testenv.Run(t, &testenv.Config{
+			OverrideGraphQLPath: "/custom-graphql",
+		}, func(t *testing.T, xEnv *testenv.Environment) {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
 

--- a/router-tests/graphql_over_get_test.go
+++ b/router-tests/graphql_over_get_test.go
@@ -3,7 +3,6 @@ package integration
 import (
 	"context"
 	"encoding/json"
-	"golang.org/x/net/html"
 	"net/http"
 	"sync"
 	"testing"
@@ -12,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/wundergraph/cosmo/router-tests/testenv"
 	"github.com/wundergraph/cosmo/router/core"
+	"golang.org/x/net/html"
 )
 
 func TestOperationsOverGET(t *testing.T) {

--- a/router-tests/graphql_over_get_test.go
+++ b/router-tests/graphql_over_get_test.go
@@ -96,7 +96,7 @@ func TestOperationsOverGET(t *testing.T) {
 				core.WithGraphQLPath("/custom-graphql"),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
-			// Default path for creating requests ist /graphql if not updated with `OverrideGraphQLPath`
+			// Default path for creating requests is /graphql if not updated with `OverrideGraphQLPath`
 			res, err := xEnv.MakeGraphQLRequestOverGET(testenv.GraphQLRequest{
 				OperationName: []byte(`Employees`),
 				Query:         `query Employees { employees { id } }`,
@@ -115,7 +115,7 @@ func TestOperationsOverGET(t *testing.T) {
 				core.WithGraphQLPath("/"),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
-			// Default path for creating requests ist /graphql if not updated with `OverrideGraphQLPath`
+			// Default path for creating requests is /graphql if not updated with `OverrideGraphQLPath`
 			res, err := xEnv.MakeGraphQLRequestOverGET(testenv.GraphQLRequest{
 				OperationName: []byte(`Employees`),
 				Query:         `query Employees { employees { id } }`,
@@ -134,7 +134,7 @@ func TestOperationsOverGET(t *testing.T) {
 				core.WithGraphQLPath("/*"),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
-			// Default path for creating requests ist /graphql if not updated with `OverrideGraphQLPath`
+			// Default path for creating requests is /graphql if not updated with `OverrideGraphQLPath`
 			res, err := xEnv.MakeGraphQLRequestOverGET(testenv.GraphQLRequest{
 				OperationName: []byte(`Employees`),
 				Query:         `query Employees { employees { id } }`,

--- a/router/core/graph_server.go
+++ b/router/core/graph_server.go
@@ -221,11 +221,11 @@ func newGraphServer(ctx context.Context, r *Router, routerConfig *nodev1.RouterC
 		})
 
 		// Mount the feature flag handler. It calls the base mux if no feature flag is set.
-		cr.Mount(r.graphqlPath, multiGraphHandler)
+		cr.Handle(r.graphqlPath, multiGraphHandler)
 
 		if r.webSocketConfiguration != nil && r.webSocketConfiguration.Enabled && r.webSocketConfiguration.AbsintheProtocol.Enabled {
 			// Mount the Absinthe protocol handler for WebSockets
-			httpRouter.Mount(r.webSocketConfiguration.AbsintheProtocol.HandlerPath, multiGraphHandler)
+			httpRouter.Handle(r.webSocketConfiguration.AbsintheProtocol.HandlerPath, multiGraphHandler)
 		}
 	})
 
@@ -1081,9 +1081,9 @@ func (s *graphServer) buildGraphMux(ctx context.Context,
 	httpRouter.Use(s.routerMiddlewares...)
 
 	// GraphQL over POST
-	httpRouter.Post("/", graphqlHandler.ServeHTTP)
+	httpRouter.Post(s.graphqlPath, graphqlHandler.ServeHTTP)
 	// GraphQL over GET
-	httpRouter.Get("/", graphqlHandler.ServeHTTP)
+	httpRouter.Get(s.graphqlPath, graphqlHandler.ServeHTTP)
 
 	gm.mux = httpRouter
 


### PR DESCRIPTION
## Motivation and Context

`Mount()` appends a wildcard `*` to the graphql endpoint. We want to make sure we only hit the endpoint on the configured path. Wildcard url paths should not be taken into account and any other path than the configured paths should return 404.

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->