### PR TITLE
fix: use gauge for server.uptime metric

### DIFF
--- a/router-tests/telemetry/telemetry_test.go
+++ b/router-tests/telemetry/telemetry_test.go
@@ -2605,7 +2605,7 @@ func TestRuntimeTelemetry(t *testing.T) {
 
 			metricServerUptime := getMetricByName(runtimeScope, "server.uptime")
 			require.NotNil(t, metricServerUptime)
-			metricServerUptimeDataType := metricServerUptime.Data.(metricdata.Sum[int64])
+			metricServerUptimeDataType := metricServerUptime.Data.(metricdata.Gauge[int64])
 			require.Len(t, metricServerUptimeDataType.DataPoints, 1)
 			serverUptimeMetric := metricdata.Metrics{
 				Name:        "server.uptime",

--- a/router-tests/telemetry/telemetry_test.go
+++ b/router-tests/telemetry/telemetry_test.go
@@ -2611,9 +2611,7 @@ func TestRuntimeTelemetry(t *testing.T) {
 				Name:        "server.uptime",
 				Description: "Seconds since the server started. Resets between router config changes.",
 				Unit:        "s",
-				Data: metricdata.Sum[int64]{
-					Temporality: metricdata.CumulativeTemporality,
-					IsMonotonic: true,
+				Data: metricdata.Gauge[int64]{
 					DataPoints: []metricdata.DataPoint[int64]{
 						{
 							Attributes: attribute.NewSet(

--- a/router/pkg/metric/router_runtime_metrics.go
+++ b/router/pkg/metric/router_runtime_metrics.go
@@ -189,7 +189,7 @@ func (r *RuntimeMetrics) Start() error {
 		return err
 	}
 
-	serverUptime, err := r.meter.Int64ObservableCounter(
+	serverUptime, err := r.meter.Int64ObservableGauge(
 		"server.uptime",
 		otelmetric.WithUnit("s"),
 		otelmetric.WithDescription("Seconds since the server started. Resets between router config changes."),


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

## Motivation and Context

This PR change the server uptime metric from type counter to gauge. Counter was not correct because we are not interested in the aggregation but in the last value.

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please describe in detail the impact of this change. Attach screenshots if applicable.
-->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->