### PR TITLE
fix(router): write proper line endings and header for multipart

### DIFF
--- a/router-tests/events/kafka_events_test.go
+++ b/router-tests/events/kafka_events_test.go
@@ -422,6 +422,7 @@ func TestKafkaEvents(t *testing.T) {
 		}
 
 		assertMultipartPrefix := func(t *testing.T, reader *bufio.Reader) {
+			assertLineEquals(t, reader, "")
 			assertLineEquals(t, reader, "--graphql")
 			assertLineEquals(t, reader, "Content-Type: application/json")
 			assertLineEquals(t, reader, "")

--- a/router-tests/events/nats_events_test.go
+++ b/router-tests/events/nats_events_test.go
@@ -285,6 +285,7 @@ func TestNatsEvents(t *testing.T) {
 		}
 
 		assertMultipartPrefix := func(t *testing.T, reader *bufio.Reader) {
+			assertLineEquals(t, reader, "")
 			assertLineEquals(t, reader, "--graphql")
 			assertLineEquals(t, reader, "Content-Type: application/json")
 			assertLineEquals(t, reader, "")
@@ -322,7 +323,7 @@ func TestNatsEvents(t *testing.T) {
 					require.Equal(t, http.StatusOK, resp.StatusCode)
 					defer resp.Body.Close()
 
-					require.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+					require.Equal(t, "multipart/mixed; boundary=graphql", resp.Header.Get("Content-Type"))
 					require.Equal(t, "no-cache", resp.Header.Get("Cache-Control"))
 					require.Equal(t, "no", resp.Header.Get("X-Accel-Buffering"))
 

--- a/router/core/flushwriter.go
+++ b/router/core/flushwriter.go
@@ -20,6 +20,7 @@ const (
 	jsonContent          = "application/json"
 	sseMimeType          = "text/event-stream"
 	heartbeat            = "{}"
+	multipartContent     = multipartMime + "; boundary=" + multipartBoundary
 )
 
 type HttpFlushWriter struct {
@@ -165,7 +166,7 @@ func setSubscriptionHeaders(wgParams SubscriptionParams, r *http.Request, w http
 	}
 
 	if wgParams.UseMultipart {
-		w.Header().Set("Content-Type", jsonContent)
+		w.Header().Set("Content-Type", multipartContent)
 		if r.ProtoMajor == 1 {
 			w.Header().Set("Transfer-Encoding", "chunked")
 		}
@@ -206,7 +207,7 @@ func GetWriterPrefix(sse bool, multipart bool) string {
 	if sse {
 		flushBreak = "event: next\ndata: "
 	} else if multipart {
-		flushBreak = "--" + multipartBoundary + "\nContent-Type: " + jsonContent + "\n\n"
+		flushBreak = "\r\n--" + multipartBoundary + "\nContent-Type: " + jsonContent + "\r\n\r\n"
 	}
 
 	return flushBreak


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

## Motivation and Context

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please describe in detail the impact of this change. Attach screenshots if applicable.
-->

Users noted that mutlipart subscriptions weren't working with Apollo Client. This PR fixes two issues with the current multipart subscription, in order to fix it: 
*. It changes the main Content-Type header to `multipart/mixed; boundary=graphql`, to fit with the [W3 RFC](https://www.w3.org/Protocols/rfc1341/7_2_Multipart.html) requirements (and the client's explicit parsing)
* It changes the line endings before the message to be `/r/n` instead of just `/n`, to fit with the RFC's explicit use of CRLF. 

### Using it with a client: 
```
const { ApolloClient, InMemoryCache, HttpLink} = require('@apollo/client');
const gql = require('graphql-tag');

// Define your subscription query
const SUBSCRIPTION_QUERY = `
  subscription Test {
    countFor(count: 5)
  }
`;

// HTTP link for queries and mutations
const httpLink = new HttpLink({
  uri: 'http://localhost:3002/graphql',
  headers: {
    Accept: 'multipart/mixed;subscriptionSpec="1.0", application/json',
  },
});

// Create the Apollo Client
const client = new ApolloClient({
  link: httpLink,
  cache: new InMemoryCache(),
});

// Execute the subscription
const testSubscription = () => {
  const observable = client.subscribe({
    query: gql(SUBSCRIPTION_QUERY),
  });

  // Listen for incoming data
  observable.subscribe({
    next(data) {
      console.log('Subscription data:', data);
    },
    error(err) {
      if (err?.message === 'internal system error') {
        console.log("system error, ignore")
      } else {
        console.error('Subscription error:', err);
      }
    },
    complete() {
      console.log('Subscription completed');
    },
  });
};

// Start the test
console.log("hello world")
testSubscription();
```

prints:
```
hello world
Subscription data: { data: { countFor: 0 } }
Subscription data: { data: { countFor: 1 } }
Subscription data: { data: { countFor: 2 } }
Subscription data: { data: { countFor: 3 } }
Subscription data: { data: { countFor: 4 } }
Subscription data: { data: { countFor: 5 } }
Subscription completed
```

### Using with curl
```
❯ curl -i -H "Accept: multipart/mixed" -X POST http://localhost:3002/graphql -d '{"query": "subscription { countFor(count: 2) }"}'
HTTP/1.1 200 OK
Cache-Control: no-cache
Connection: keep-alive
Content-Type: multipart/mixed; boundary=graphql
Vary: Accept-Encoding
X-Accel-Buffering: no
Date: Mon, 20 Jan 2025 07:30:54 GMT
Transfer-Encoding: chunked


--graphql
Content-Type: application/json

{"payload":{"data":{"countFor":0}}}

--graphql
Content-Type: application/json

{"payload":{"data":{"countFor":1}}}

--graphql
Content-Type: application/json

{"payload":{"data":{"countFor":2}}}

--graphql
Content-Type: application/json

{"payload":{"errors":[{"message":"internal system error"}],"data":null}}
--graphql--
```


## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->