### PR TITLE
feat: add ApolloCompatibilitySkipEnumValueValidation

### DIFF
--- a/router/core/executor.go
+++ b/router/core/executor.go
@@ -95,6 +95,9 @@ func (b *ExecutorConfigurationBuilder) Build(ctx context.Context, opts *Executor
 	if opts.ApolloCompatibilityFlags.ReplaceInvalidVarErrors.Enabled {
 		options.ResolvableOptions.ApolloCompatibilityReplaceInvalidVarError = true
 	}
+	if opts.ApolloCompatibilityFlags.SkipEnumValueValidation.Enabled {
+		options.ResolvableOptions.ApolloCompatibilitySkipEnumValueValidation = true
+	}
 
 	switch opts.RouterEngineConfig.SubgraphErrorPropagation.Mode {
 	case config.SubgraphErrorPropagationModePassthrough:

--- a/router/core/router.go
+++ b/router/core/router.go
@@ -1752,6 +1752,7 @@ func WithApolloCompatibilityFlagsConfig(cfg config.ApolloCompatibilityFlags) Opt
 			cfg.SuppressFetchErrors.Enabled = true
 			cfg.ReplaceUndefinedOpFieldErrors.Enabled = true
 			cfg.ReplaceInvalidVarErrors.Enabled = true
+			cfg.SkipEnumValueValidation.Enabled = true
 		}
 		r.apolloCompatibilityFlags = cfg
 	}

--- a/router/pkg/config/config.go
+++ b/router/pkg/config/config.go
@@ -739,6 +739,7 @@ type ApolloCompatibilityFlags struct {
 	SuppressFetchErrors           ApolloCompatibilitySuppressFetchErrors           `yaml:"suppress_fetch_errors"`
 	ReplaceUndefinedOpFieldErrors ApolloCompatibilityReplaceUndefinedOpFieldErrors `yaml:"replace_undefined_op_field_errors"`
 	ReplaceInvalidVarErrors       ApolloCompatibilityReplaceInvalidVarErrors       `yaml:"replace_invalid_var_errors"`
+	SkipEnumValueValidation       ApolloCompatibilitySkipEnumValueValidation       `yaml:"skip_enum_value_validation"`
 }
 
 type ApolloCompatibilityValueCompletion struct {
@@ -764,6 +765,10 @@ type ApolloCompatibilityReplaceUndefinedOpFieldErrors struct {
 
 type ApolloCompatibilityReplaceInvalidVarErrors struct {
 	Enabled bool `yaml:"enabled" envDefault:"false" env:"APOLLO_COMPATIBILITY_REPLACE_INVALID_VAR_ERRORS_ENABLED"`
+}
+
+type ApolloCompatibilitySkipEnumValueValidation struct {
+	Enabled bool `yaml:"enabled" envDefault:"false" env:"APOLLO_COMPATIBILITY_SKIP_ENUM_VALUE_VALIDATION_ENABLED"`
 }
 
 type CacheWarmupSource struct {

--- a/router/pkg/config/config.schema.json
+++ b/router/pkg/config/config.schema.json
@@ -2366,6 +2366,17 @@
               "default": false
             }
           }
+        },
+        "skip_enum_value_validation": {
+          "type": "object",
+          "description": "Skips the GraphQL scheme's exact check of Enums, allowing the value to be thrown as a string.",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false
+            }
+          }
         }
       }
     },


### PR DESCRIPTION
## Motivation and Context

Need to support ApolloCompatibilitySkipEnumValueValidation opts in graphql go tools https://github.com/wundergraph/graphql-go-tools/pull/1031