### PR TITLE
feat: allow to configure MaxSubscriptionWorkers

### DIFF
--- a/router/core/executor.go
+++ b/router/core/executor.go
@@ -78,6 +78,7 @@ func (b *ExecutorConfigurationBuilder) Build(ctx context.Context, opts *Executor
 		AllowedSubgraphErrorFields:         opts.RouterEngineConfig.SubgraphErrorPropagation.AllowedFields,
 		MaxRecyclableParserSize:            opts.RouterEngineConfig.Execution.ResolverMaxRecyclableParserSize,
 		MultipartSubHeartbeatInterval:      opts.HeartbeatInterval,
+		MaxSubscriptionWorkers:             opts.RouterEngineConfig.Execution.MaxSubscriptionWorkers,
 	}
 
 	if opts.ApolloCompatibilityFlags.ValueCompletion.Enabled {

--- a/router/pkg/config/config.go
+++ b/router/pkg/config/config.go
@@ -338,6 +338,7 @@ type EngineExecutionConfiguration struct {
 	ValidationCacheSize                    int64                    `envDefault:"1024" env:"ENGINE_VALIDATION_CACHE_SIZE" yaml:"validation_cache_size,omitempty"`
 	ResolverMaxRecyclableParserSize        int                      `envDefault:"32768" env:"ENGINE_RESOLVER_MAX_RECYCLABLE_PARSER_SIZE" yaml:"resolver_max_recyclable_parser_size,omitempty"`
 	EnableSubgraphFetchOperationName       bool                     `envDefault:"false" env:"ENGINE_ENABLE_SUBGRAPH_FETCH_OPERATION_NAME" yaml:"enable_subgraph_fetch_operation_name"`
+	MaxSubscriptionWorkers                 int                      `envDefault:"1024" env:"ENGINE_MAX_SUBSCRIPTION_WORKERS" yaml:"max_subscription_workers,omitempty"`
 }
 
 type BlockOperationConfiguration struct {

--- a/router/pkg/config/config.schema.json
+++ b/router/pkg/config/config.schema.json
@@ -2261,6 +2261,11 @@
           "type": "boolean",
           "default": false,
           "description": "Enable appending the operation name to subgraph fetches. This will ensure that the operation name will be included in the corresponding subgraph requests using the following format: $operationName__$subgraphName__$sequenceID."
+        },
+        "max_subscription_workers": {
+          "type": "integer",
+          "default": 1024,
+          "description": "The maximum number of subscription workers. This configuration effectively limits the number of concurrent subscriptions that can be processed by a single instance of the router."
         }
       }
     },

--- a/router/pkg/config/fixtures/full.yaml
+++ b/router/pkg/config/fixtures/full.yaml
@@ -266,6 +266,7 @@ engine:
   websocket_client_read_timeout: "5s"
   execution_plan_cache_size: 1024
   resolver_max_recyclable_parser_size: 4096
+  max_subscription_workers: 2048
   debug:
     report_websocket_connections: false
     report_memory_usage: false

--- a/router/pkg/config/testdata/config_defaults.json
+++ b/router/pkg/config/testdata/config_defaults.json
@@ -291,7 +291,8 @@
     "EnableValidationCache": true,
     "ValidationCacheSize": 1024,
     "ResolverMaxRecyclableParserSize": 32768,
-    "EnableSubgraphFetchOperationName": false
+    "EnableSubgraphFetchOperationName": false,
+    "MaxSubscriptionWorkers": 1024
   },
   "WebSocket": {
     "Enabled": true,

--- a/router/pkg/config/testdata/config_full.json
+++ b/router/pkg/config/testdata/config_full.json
@@ -532,7 +532,8 @@
     "EnableValidationCache": true,
     "ValidationCacheSize": 1024,
     "ResolverMaxRecyclableParserSize": 4096,
-    "EnableSubgraphFetchOperationName": true
+    "EnableSubgraphFetchOperationName": true,
+    "MaxSubscriptionWorkers": 2048
   },
   "WebSocket": {
     "Enabled": true,


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

## Motivation and Context

The subscriptions are limited to a fix 1024 concurrent workers but, some customers needed this value to be configurable.
Also, I found out that the subscriptions after the 1024th got stuck unwittingly to the client, so I also added a timeout to how long try to get the semaphore.

## Checklist

- [-] I have discussed my proposed changes in an issue and have received approval to proceed.
- [X] I have followed the coding standards of the project.
- [-] Tests or benchmarks have been added or updated.
- [X] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs) (https://app.gitbook.com/o/AGsPMiPE3xradDAKeJYL/s/f2zpPO8tcaY6tJoaEebc/~/changes/f20uqVAbrDidcqyKX1i1/router/configuration).
- [X] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->