### PR TITLE
fix: webhooks shot when schema is unchanged

### DIFF
--- a/controlplane/src/core/bufservices/federated-graph/updateFederatedGraph.ts
+++ b/controlplane/src/core/bufservices/federated-graph/updateFederatedGraph.ts
@@ -161,25 +161,28 @@ export function updateFederatedGraph(
       targetNamespaceDisplayName: federatedGraph.namespace,
     });
 
-    orgWebhooks.send(
-      {
-        eventName: OrganizationEventName.FEDERATED_GRAPH_SCHEMA_UPDATED,
-        payload: {
-          federated_graph: {
-            id: federatedGraph.id,
-            name: federatedGraph.name,
-            namespace: federatedGraph.namespace,
+    // Send webhook event only when we update label matchers because this causes schema update
+    if (req.labelMatchers.length > 0 || req.unsetLabelMatchers) {
+      orgWebhooks.send(
+        {
+          eventName: OrganizationEventName.FEDERATED_GRAPH_SCHEMA_UPDATED,
+          payload: {
+            federated_graph: {
+              id: federatedGraph.id,
+              name: federatedGraph.name,
+              namespace: federatedGraph.namespace,
+            },
+            organization: {
+              id: authContext.organizationId,
+              slug: authContext.organizationSlug,
+            },
+            errors: compositionErrors.length > 0 || deploymentErrors.length > 0,
+            actor_id: authContext.userId,
           },
-          organization: {
-            id: authContext.organizationId,
-            slug: authContext.organizationSlug,
-          },
-          errors: compositionErrors.length > 0 || deploymentErrors.length > 0,
-          actor_id: authContext.userId,
         },
-      },
-      authContext.userId,
-    );
+        authContext.userId,
+      );
+    }
 
     if (compositionErrors.length > 0) {
       return {


### PR DESCRIPTION
## Motivation and Context

Federated graph update command used to shoot webhook on updating things that do not perform schema updates

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->