### PR TITLE
feat(router): add configurable connection limits for each subgraph

### DIFF
--- a/router/core/router.go
+++ b/router/core/router.go
@@ -6,13 +6,14 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	rd "github.com/wundergraph/cosmo/router/internal/persistedoperation/operationstorage/redis"
 	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"sync"
 	"time"
+
+	rd "github.com/wundergraph/cosmo/router/internal/persistedoperation/operationstorage/redis"
 
 	"connectrpc.com/connect"
 	"github.com/mitchellh/mapstructure"
@@ -85,7 +86,7 @@ type (
 		proxy             ProxyFunc
 	}
 
-	TransportTimeoutOptions struct {
+	TransportRequestOptions struct {
 		RequestTimeout         time.Duration
 		ResponseHeaderTimeout  time.Duration
 		ExpectContinueTimeout  time.Duration
@@ -93,11 +94,15 @@ type (
 		DialTimeout            time.Duration
 		TLSHandshakeTimeout    time.Duration
 		KeepAliveProbeInterval time.Duration
+
+		MaxConnsPerHost     int
+		MaxIdleConns        int
+		MaxIdleConnsPerHost int
 	}
 
 	SubgraphTransportOptions struct {
-		TransportTimeoutOptions
-		SubgraphMap map[string]*TransportTimeoutOptions
+		TransportRequestOptions
+		SubgraphMap map[string]*TransportRequestOptions
 	}
 
 	GraphQLMetricsConfig struct {
@@ -1659,8 +1664,8 @@ func DefaultFileUploadConfig() *config.FileUpload {
 	}
 }
 
-func NewTransportTimeoutOptions(cfg config.GlobalSubgraphRequestRule) TransportTimeoutOptions {
-	return TransportTimeoutOptions{
+func NewTransportRequestOptions(cfg config.GlobalSubgraphRequestRule) TransportRequestOptions {
+	return TransportRequestOptions{
 		RequestTimeout:         cfg.RequestTimeout,
 		ResponseHeaderTimeout:  cfg.ResponseHeaderTimeout,
 		ExpectContinueTimeout:  cfg.ExpectContinueTimeout,
@@ -1668,17 +1673,21 @@ func NewTransportTimeoutOptions(cfg config.GlobalSubgraphRequestRule) TransportT
 		DialTimeout:            cfg.DialTimeout,
 		TLSHandshakeTimeout:    cfg.TLSHandshakeTimeout,
 		KeepAliveProbeInterval: cfg.KeepAliveProbeInterval,
+
+		MaxConnsPerHost:     cfg.MaxConnsPerHost,
+		MaxIdleConns:        cfg.MaxIdleConns,
+		MaxIdleConnsPerHost: cfg.MaxIdleConnsPerHost,
 	}
 }
 
 func NewSubgraphTransportOptions(cfg config.TrafficShapingRules) *SubgraphTransportOptions {
 	base := &SubgraphTransportOptions{
-		TransportTimeoutOptions: NewTransportTimeoutOptions(cfg.All),
-		SubgraphMap:             map[string]*TransportTimeoutOptions{},
+		TransportRequestOptions: NewTransportRequestOptions(cfg.All),
+		SubgraphMap:             map[string]*TransportRequestOptions{},
 	}
 
 	for k, v := range cfg.Subgraphs {
-		opts := NewTransportTimeoutOptions(*v)
+		opts := NewTransportRequestOptions(*v)
 		base.SubgraphMap[k] = &opts
 	}
 
@@ -1687,7 +1696,7 @@ func NewSubgraphTransportOptions(cfg config.TrafficShapingRules) *SubgraphTransp
 
 func DefaultSubgraphTransportOptions() *SubgraphTransportOptions {
 	return &SubgraphTransportOptions{
-		TransportTimeoutOptions: TransportTimeoutOptions{
+		TransportRequestOptions: TransportRequestOptions{
 			RequestTimeout:         60 * time.Second,
 			TLSHandshakeTimeout:    10 * time.Second,
 			ResponseHeaderTimeout:  0 * time.Second,
@@ -1695,8 +1704,12 @@ func DefaultSubgraphTransportOptions() *SubgraphTransportOptions {
 			KeepAliveProbeInterval: 30 * time.Second,
 			KeepAliveIdleTimeout:   0 * time.Second,
 			DialTimeout:            30 * time.Second,
+
+			MaxConnsPerHost:     100,
+			MaxIdleConns:        1024,
+			MaxIdleConnsPerHost: 20,
 		},
-		SubgraphMap: map[string]*TransportTimeoutOptions{},
+		SubgraphMap: map[string]*TransportRequestOptions{},
 	}
 }
 
@@ -1826,7 +1839,7 @@ func WithCacheWarmupConfig(cfg *config.CacheWarmupConfiguration) Option {
 
 type ProxyFunc func(req *http.Request) (*url.URL, error)
 
-func newHTTPTransport(opts TransportTimeoutOptions, proxy ProxyFunc) *http.Transport {
+func newHTTPTransport(opts TransportRequestOptions, proxy ProxyFunc) *http.Transport {
 	dialer := &net.Dialer{
 		Timeout:   opts.DialTimeout,
 		KeepAlive: opts.KeepAliveProbeInterval,
@@ -1839,13 +1852,13 @@ func newHTTPTransport(opts TransportTimeoutOptions, proxy ProxyFunc) *http.Trans
 		},
 		// The defaults value 0 = unbounded.
 		// We set to some value to prevent resource exhaustion e.g max requests and ports.
-		MaxConnsPerHost: 100,
+		MaxConnsPerHost: opts.MaxConnsPerHost,
 		// The defaults value 0 = unbounded. 100 is used by the default go transport.
 		// This value should be significant higher than MaxIdleConnsPerHost.
-		MaxIdleConns: 1024,
+		MaxIdleConns: opts.MaxIdleConns,
 		// The default value is 2. Such a low limit will open and close connections too often.
 		// Details: https://gitlab.com/gitlab-org/gitlab-pages/-/merge_requests/274
-		MaxIdleConnsPerHost: 20,
+		MaxIdleConnsPerHost: opts.MaxIdleConnsPerHost,
 		ForceAttemptHTTP2:   true,
 		IdleConnTimeout:     opts.KeepAliveIdleTimeout,
 		// Set more timeouts https://gitlab.com/gitlab-org/gitlab-pages/-/issues/495

--- a/router/core/subgraph_transport_test.go
+++ b/router/core/subgraph_transport_test.go
@@ -52,7 +52,7 @@ func TestTimeoutTransport(t *testing.T) {
 		t.Parallel()
 
 		transportOpts := &SubgraphTransportOptions{
-			SubgraphMap: map[string]*TransportTimeoutOptions{
+			SubgraphMap: map[string]*TransportRequestOptions{
 				testSubgraphKey: {
 					ResponseHeaderTimeout: 100 * time.Millisecond,
 				},
@@ -89,7 +89,7 @@ func TestTimeoutTransport(t *testing.T) {
 		t.Parallel()
 
 		transportOpts := &SubgraphTransportOptions{
-			SubgraphMap: map[string]*TransportTimeoutOptions{
+			SubgraphMap: map[string]*TransportRequestOptions{
 				testSubgraphKey: {
 					TLSHandshakeTimeout: 2 * time.Millisecond,
 				},
@@ -127,7 +127,7 @@ func TestTimeoutTransport(t *testing.T) {
 		t.Parallel()
 
 		transportOpts := &SubgraphTransportOptions{
-			SubgraphMap: map[string]*TransportTimeoutOptions{
+			SubgraphMap: map[string]*TransportRequestOptions{
 				testSubgraphKey: {
 					DialTimeout: 1 * time.Millisecond,
 				},

--- a/router/pkg/config/config.go
+++ b/router/pkg/config/config.go
@@ -174,6 +174,11 @@ type GlobalSubgraphRequestRule struct {
 	TLSHandshakeTimeout    time.Duration `yaml:"tls_handshake_timeout,omitempty" envDefault:"10s"`
 	KeepAliveIdleTimeout   time.Duration `yaml:"keep_alive_idle_timeout,omitempty" envDefault:"0s"`
 	KeepAliveProbeInterval time.Duration `yaml:"keep_alive_probe_interval,omitempty" envDefault:"30s"`
+
+	// Connection configuration
+	MaxConnsPerHost     int `yaml:"max_conns_per_host,omitempty" envDefault:"100"`
+	MaxIdleConns        int `yaml:"max_idle_conns,omitempty" envDefault:"1024"`
+	MaxIdleConnsPerHost int `yaml:"max_idle_conns_per_host,omitempty" envDefault:"20"`
 }
 
 type SubgraphTrafficRequestRule struct {

--- a/router/pkg/config/config.schema.json
+++ b/router/pkg/config/config.schema.json
@@ -2430,6 +2430,21 @@
           },
           "description": "The keep alive probe interval. The period is specified as a string with a number and a unit, e.g. 10ms, 1s, 1m, 1h. The supported units are 'ms', 's', 'm', 'h'."
         },
+        "max_idle_conns": {
+          "type": "integer",
+          "default": 1024,
+          "description": "MaxIdleConns controls the maximum number of idle (keep-alive) connections across all hosts. Zero means no limit"
+        },
+        "max_conns_per_host": {
+          "type": "integer",
+          "default": 100,
+          "description": "MaxConnsPerHost limits the total number of connections per host, including connections in the dialing, active, and idle states. Zero means no limit."
+        },
+        "max_idle_conns_per_host": {
+          "type": "integer",
+          "default": 20,
+          "description": "MaxIdleConnsPerHost, if non-zero, controls the maximum idle (keep-alive) connections to keep per-host. Zero will default to 2"
+        },
         "retry": {
           "type": "object",
           "description": "The retry configuration. The retry configuration is used to configure the retry behavior for the subgraphs requests. See https://cosmo-docs.wundergraph.com/router/traffic-shaping#automatic-retry for more information.",

--- a/router/pkg/config/config.schema.json
+++ b/router/pkg/config/config.schema.json
@@ -562,7 +562,7 @@
           "description": "The configuration for the router access logs",
           "properties": {
             "fields": {
-              "$ref": "#/definitions/context_fields"
+              "$ref": "#/$defs/context_fields"
             }
           }
         },
@@ -579,7 +579,7 @@
             "fields": {
               "allOf": [
                 {
-                  "$ref": "#/definitions/context_fields"
+                  "$ref": "#/$defs/context_fields"
                 },
                 {
                   "items": {
@@ -1254,13 +1254,13 @@
         "all": {
           "type": "object",
           "description": "The configuration for all subgraphs. The configuration is used to configure the traffic shaping for all subgraphs.",
-          "$ref": "#/definitions/traffic_shaping_subgraph_request_rule"
+          "$ref": "#/$defs/traffic_shaping_subgraph_request_rule"
         },
         "subgraphs": {
           "type": "object",
           "description": "The configuration to control traffic shaping for specific subgraphs.",
           "additionalProperties": {
-            "$ref": "#/definitions/traffic_shaping_subgraph_request_rule"
+            "$ref": "#/$defs/traffic_shaping_subgraph_request_rule"
           }
         }
       }
@@ -1278,10 +1278,10 @@
               "items": {
                 "oneOf": [
                   {
-                    "$ref": "#/definitions/traffic_shaping_header_rule"
+                    "$ref": "#/$defs/traffic_shaping_header_rule"
                   },
                   {
-                    "$ref": "#/definitions/set_header_rule"
+                    "$ref": "#/$defs/set_header_rule"
                   }
                 ]
               }
@@ -1291,10 +1291,10 @@
               "items": {
                 "oneOf": [
                   {
-                    "$ref": "#/definitions/traffic_shaping_header_response_rule"
+                    "$ref": "#/$defs/traffic_shaping_header_response_rule"
                   },
                   {
-                    "$ref": "#/definitions/set_header_rule"
+                    "$ref": "#/$defs/set_header_rule"
                   }
                 ]
               }
@@ -1312,10 +1312,10 @@
                 "items": {
                   "oneOf": [
                     {
-                      "$ref": "#/definitions/traffic_shaping_header_rule"
+                      "$ref": "#/$defs/traffic_shaping_header_rule"
                     },
                     {
-                      "$ref": "#/definitions/set_header_rule"
+                      "$ref": "#/$defs/set_header_rule"
                     }
                   ]
                 }
@@ -1325,10 +1325,10 @@
                 "items": {
                   "oneOf": [
                     {
-                      "$ref": "#/definitions/traffic_shaping_header_response_rule"
+                      "$ref": "#/$defs/traffic_shaping_header_response_rule"
                     },
                     {
-                      "$ref": "#/definitions/set_header_rule"
+                      "$ref": "#/$defs/set_header_rule"
                     }
                   ]
                 }
@@ -2385,7 +2385,7 @@
       }
     }
   },
-  "definitions": {
+  "$defs": {
     "traffic_shaping_subgraph_request_rule": {
       "type": "object",
       "additionalProperties": false,

--- a/router/pkg/config/testdata/config_defaults.json
+++ b/router/pkg/config/testdata/config_defaults.json
@@ -121,7 +121,10 @@
       "ExpectContinueTimeout": 0,
       "TLSHandshakeTimeout": 10000000000,
       "KeepAliveIdleTimeout": 0,
-      "KeepAliveProbeInterval": 30000000000
+      "KeepAliveProbeInterval": 30000000000,
+      "MaxConnsPerHost": 100,
+      "MaxIdleConns": 1024,
+      "MaxIdleConnsPerHost": 20
     },
     "Router": {
       "MaxRequestBodyBytes": 5000000,

--- a/router/pkg/config/testdata/config_full.json
+++ b/router/pkg/config/testdata/config_full.json
@@ -245,7 +245,10 @@
       "ExpectContinueTimeout": 0,
       "TLSHandshakeTimeout": 0,
       "KeepAliveIdleTimeout": 0,
-      "KeepAliveProbeInterval": 30000000000
+      "KeepAliveProbeInterval": 30000000000,
+      "MaxConnsPerHost": 100,
+      "MaxIdleConns": 1024,
+      "MaxIdleConnsPerHost": 20
     },
     "Router": {
       "MaxRequestBodyBytes": 5000000,
@@ -267,7 +270,10 @@
         "ExpectContinueTimeout": 0,
         "TLSHandshakeTimeout": 0,
         "KeepAliveIdleTimeout": 0,
-        "KeepAliveProbeInterval": 0
+        "KeepAliveProbeInterval": 0,
+        "MaxConnsPerHost": 0,
+        "MaxIdleConns": 0,
+        "MaxIdleConnsPerHost": 0
       }
     }
   },


### PR DESCRIPTION
- **feat(router): add configurable connection limits for each subgraph**
- **test: update snapshots**

<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

## Motivation and Context

Users want to configure connection limits for the router, including per-subgraph values. 

## Checklist

- [X] I have discussed my proposed changes in an issue and have received approval to proceed.
- [X] I have followed the coding standards of the project.
- [x] Tests or benchmarks have been added or updated.
- [x] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

Example config utilizing this feature:

```yaml
traffic_shaping:
  all:
    max_idle_conns: 1024
    max_conns_per_host: 100
    max_idle_conns_per_host: 20
  subgraphs:
    employees:
      max_idle_conns: 4096
      max_conns_per_host: 400
      max_idle_conns_per_host: 80
 ```