### PR TITLE
feat: apollo router compatibility options + router-like invalid vars

### DIFF
--- a/router-tests/apollo_compatibility_test.go
+++ b/router-tests/apollo_compatibility_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/wundergraph/cosmo/router/pkg/config"
 )
 
-func TestApolloRouterCompatability(t *testing.T) {
+func TestApolloRouterCompatibility(t *testing.T) {
 	t.Parallel()
 
 	t.Run("enable replace invalid variable error", func(t *testing.T) {

--- a/router-tests/apollo_compatibility_test.go
+++ b/router-tests/apollo_compatibility_test.go
@@ -14,7 +14,32 @@ import (
 	"github.com/wundergraph/cosmo/router/pkg/config"
 )
 
-func TestApolloCompatibility(t *testing.T) {
+func TestApolloRouterCompatability(t *testing.T) {
+	t.Parallel()
+
+	t.Run("enable replace invalid variable error", func(t *testing.T) {
+		t.Parallel()
+		testenv.Run(t, &testenv.Config{
+			RouterOptions: []core.Option{
+				core.WithApolloRouterCompatibilityFlags(config.ApolloRouterCompatibilityFlags{
+					ReplaceInvalidVarErrors: config.ApolloRouterCompatibilityReplaceInvalidVarErrors{
+						Enabled: true,
+					},
+				}),
+			},
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			res, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
+				Query:     `query FloatQuery($arg: Float) { floatField(arg: $arg) }`,
+				Variables: json.RawMessage(`{"arg":"INVALID"}`),
+			})
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusOK, res.Response.StatusCode)
+			assert.Equal(t, `{"errors":[{"message":"invalid type for variable: 'arg'","extensions":{"code":"VALIDATION_INVALID_TYPE_VARIABLE"}}]}`, res.Body)
+		})
+	})
+}
+
+func TestApolloGatewayCompatibility(t *testing.T) {
 	t.Parallel()
 
 	t.Run("enable all", func(t *testing.T) {

--- a/router-tests/go.mod
+++ b/router-tests/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/twmb/franz-go/pkg/kadm v1.11.0
 	github.com/wundergraph/cosmo/demo v0.0.0-20250213151749-f4c692434ef1
 	github.com/wundergraph/cosmo/router v0.0.0-20250213151749-f4c692434ef1
-	github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.153
+	github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.154
 	go.opentelemetry.io/otel v1.28.0
 	go.opentelemetry.io/otel/sdk v1.28.0
 	go.opentelemetry.io/otel/sdk/metric v1.28.0

--- a/router-tests/go.mod
+++ b/router-tests/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/twmb/franz-go/pkg/kadm v1.11.0
 	github.com/wundergraph/cosmo/demo v0.0.0-20250213151749-f4c692434ef1
 	github.com/wundergraph/cosmo/router v0.0.0-20250213151749-f4c692434ef1
-	github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.152
+	github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.153
 	go.opentelemetry.io/otel v1.28.0
 	go.opentelemetry.io/otel/sdk v1.28.0
 	go.opentelemetry.io/otel/sdk/metric v1.28.0

--- a/router-tests/go.sum
+++ b/router-tests/go.sum
@@ -335,8 +335,6 @@ github.com/wundergraph/astjson v0.0.0-20250106123708-be463c97e083 h1:8/D7f8gKxTB
 github.com/wundergraph/astjson v0.0.0-20250106123708-be463c97e083/go.mod h1:eOTL6acwctsN4F3b7YE+eE2t8zcJ/doLm9sZzsxxxrE=
 github.com/wundergraph/consul/sdk v0.0.0-20250204115147-ed842a8fd301 h1:EzfKHQoTjFDDcgaECCCR2aTePqMu9QBmPbyhqIYOhV0=
 github.com/wundergraph/consul/sdk v0.0.0-20250204115147-ed842a8fd301/go.mod h1:wxI0Nak5dI5RvJuzGyiEK4nZj0O9X+Aw6U0tC1wPKq0=
-github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.152 h1:s2QRv/cx6WGsb8V8Kb2uD1D5oWIV6s9HPxbbSzBbuT0=
-github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.152/go.mod h1:B7eV0Qh8Lop9QzIOQcsvKp3S0ejfC6mgyWoJnI917yQ=
 github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.153 h1:YOVmy8FMmU6HDASoy1hTIPm9wZLy3JpPQ4AWWPsdTXc=
 github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.153/go.mod h1:B7eV0Qh8Lop9QzIOQcsvKp3S0ejfC6mgyWoJnI917yQ=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=

--- a/router-tests/go.sum
+++ b/router-tests/go.sum
@@ -335,8 +335,8 @@ github.com/wundergraph/astjson v0.0.0-20250106123708-be463c97e083 h1:8/D7f8gKxTB
 github.com/wundergraph/astjson v0.0.0-20250106123708-be463c97e083/go.mod h1:eOTL6acwctsN4F3b7YE+eE2t8zcJ/doLm9sZzsxxxrE=
 github.com/wundergraph/consul/sdk v0.0.0-20250204115147-ed842a8fd301 h1:EzfKHQoTjFDDcgaECCCR2aTePqMu9QBmPbyhqIYOhV0=
 github.com/wundergraph/consul/sdk v0.0.0-20250204115147-ed842a8fd301/go.mod h1:wxI0Nak5dI5RvJuzGyiEK4nZj0O9X+Aw6U0tC1wPKq0=
-github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.153 h1:YOVmy8FMmU6HDASoy1hTIPm9wZLy3JpPQ4AWWPsdTXc=
-github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.153/go.mod h1:B7eV0Qh8Lop9QzIOQcsvKp3S0ejfC6mgyWoJnI917yQ=
+github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.154 h1:fed/UUZ26+aQ8yNFgbUfsz83/a3NABGxiu4S/Ecazug=
+github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.154/go.mod h1:B7eV0Qh8Lop9QzIOQcsvKp3S0ejfC6mgyWoJnI917yQ=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb h1:zGWFAtiMcyryUHoUjUJX0/lt1H2+i2Ka2n+D3DImSNo=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=

--- a/router-tests/go.sum
+++ b/router-tests/go.sum
@@ -337,6 +337,8 @@ github.com/wundergraph/consul/sdk v0.0.0-20250204115147-ed842a8fd301 h1:EzfKHQoT
 github.com/wundergraph/consul/sdk v0.0.0-20250204115147-ed842a8fd301/go.mod h1:wxI0Nak5dI5RvJuzGyiEK4nZj0O9X+Aw6U0tC1wPKq0=
 github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.152 h1:s2QRv/cx6WGsb8V8Kb2uD1D5oWIV6s9HPxbbSzBbuT0=
 github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.152/go.mod h1:B7eV0Qh8Lop9QzIOQcsvKp3S0ejfC6mgyWoJnI917yQ=
+github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.153 h1:YOVmy8FMmU6HDASoy1hTIPm9wZLy3JpPQ4AWWPsdTXc=
+github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.153/go.mod h1:B7eV0Qh8Lop9QzIOQcsvKp3S0ejfC6mgyWoJnI917yQ=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb h1:zGWFAtiMcyryUHoUjUJX0/lt1H2+i2Ka2n+D3DImSNo=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=

--- a/router/cmd/instance.go
+++ b/router/cmd/instance.go
@@ -72,6 +72,7 @@ func NewRouter(ctx context.Context, params Params, additionalOptions ...core.Opt
 		core.WithPersistedOperationsConfig(cfg.PersistedOperationsConfig),
 		core.WithAutomatedPersistedQueriesConfig(cfg.AutomaticPersistedQueries),
 		core.WithApolloCompatibilityFlagsConfig(cfg.ApolloCompatibilityFlags),
+		core.WithApolloRouterCompatibilityFlags(cfg.ApolloRouterCompatabilityFlags),
 		core.WithStorageProviders(cfg.StorageProviders),
 		core.WithGraphQLPath(cfg.GraphQLPath),
 		core.WithModulesConfig(cfg.Modules),

--- a/router/cmd/instance.go
+++ b/router/cmd/instance.go
@@ -72,7 +72,7 @@ func NewRouter(ctx context.Context, params Params, additionalOptions ...core.Opt
 		core.WithPersistedOperationsConfig(cfg.PersistedOperationsConfig),
 		core.WithAutomatedPersistedQueriesConfig(cfg.AutomaticPersistedQueries),
 		core.WithApolloCompatibilityFlagsConfig(cfg.ApolloCompatibilityFlags),
-		core.WithApolloRouterCompatibilityFlags(cfg.ApolloRouterCompatabilityFlags),
+		core.WithApolloRouterCompatibilityFlags(cfg.ApolloRouterCompatibilityFlags),
 		core.WithStorageProviders(cfg.StorageProviders),
 		core.WithGraphQLPath(cfg.GraphQLPath),
 		core.WithModulesConfig(cfg.Modules),

--- a/router/core/graph_server.go
+++ b/router/core/graph_server.go
@@ -914,6 +914,7 @@ func (s *graphServer) buildGraphMux(ctx context.Context,
 		ParseKitPoolSize:                    s.engineExecutionConfiguration.ParseKitPoolSize,
 		IntrospectionEnabled:                s.Config.introspection,
 		ApolloCompatibilityFlags:            s.apolloCompatibilityFlags,
+		ApolloRouterCompatibilityFlags:      s.apolloRouterCompatibilityFlags,
 	})
 	operationPlanner := NewOperationPlanner(executor, gm.planCache)
 

--- a/router/core/operation_processor.go
+++ b/router/core/operation_processor.go
@@ -37,9 +37,11 @@ import (
 	"github.com/wundergraph/cosmo/router/pkg/config"
 )
 
-// staticOperationName is used to replace the operation name in the document when generating the operation ID
-// this ensures that the operation ID is the same for the same operation regardless of the operation name
-var staticOperationName = []byte("O")
+var (
+	// staticOperationName is used to replace the operation name in the document when generating the operation ID
+	// this ensures that the operation ID is the same for the same operation regardless of the operation name
+	staticOperationName = []byte("O")
+)
 
 type ParsedOperation struct {
 	// ID represents a unique-ish ID for the operation calculated by hashing
@@ -87,7 +89,9 @@ func (e invalidExtensionsTypeError) ExtensionCode() string {
 	return ""
 }
 
-var _ HttpError = invalidExtensionsTypeError(0)
+var (
+	_ HttpError = invalidExtensionsTypeError(0)
+)
 
 type OperationProcessorOptions struct {
 	Executor                            *Executor
@@ -219,6 +223,7 @@ func (o *OperationKit) Free() {
 // It follows the GraphQL over HTTP specification for GET requests https://graphql.github.io/graphql-over-http/draft/#sec-GET
 // We always compact the variables and extensions to ensure that we produce easy to parse JSON for the engine
 func (o *OperationKit) UnmarshalOperationFromURL(url *url.URL) error {
+
 	values := url.Query()
 
 	query := values.Get("query")
@@ -433,8 +438,8 @@ const (
 )
 
 func (o *OperationKit) isIntrospectionQuery() (result bool, err error) {
-	operationDefinitionRef := ast.InvalidRef
-	possibleOperationDefinitionRefs := make([]int, 0)
+	var operationDefinitionRef = ast.InvalidRef
+	var possibleOperationDefinitionRefs = make([]int, 0)
 
 	for i := 0; i < len(o.kit.doc.RootNodes); i++ {
 		if o.kit.doc.RootNodes[i].Kind == ast.NodeKindOperationDefinition {
@@ -517,6 +522,7 @@ func (o *OperationKit) Parse() error {
 
 	if !o.introspectionEnabled {
 		isIntrospection, err := o.isIntrospectionQuery()
+
 		if err != nil {
 			return &httpGraphqlError{
 				message:    "could not determine if operation was an introspection query",
@@ -672,6 +678,7 @@ type ComplexityCacheEntry struct {
 }
 
 func (o *OperationKit) normalizeNonPersistedOperation() (cached bool, err error) {
+
 	skipIncludeVariableNames := o.skipIncludeVariableNames()
 	cacheKey := o.normalizationCacheKey(skipIncludeVariableNames)
 	if o.cache != nil && o.cache.normalizationCache != nil {
@@ -859,6 +866,7 @@ func (o *OperationKit) RemapVariables(disabled bool) error {
 }
 
 func (o *OperationKit) loadPersistedOperationFromCache(clientName string) (ok bool, includeOpName bool, err error) {
+
 	if o.cache == nil || o.cache.persistedOperationNormalizationCache == nil {
 		return false, false, nil
 	}
@@ -1112,7 +1120,9 @@ func (o *OperationKit) runComplexityComparisons(complexityLimitConfig *config.Co
 	return nil
 }
 
-var literalIF = []byte("if")
+var (
+	literalIF = []byte("if")
+)
 
 func (o *OperationKit) skipIncludeVariableNames() []string {
 	if len(o.kit.doc.Directives) == 0 {

--- a/router/core/operation_processor.go
+++ b/router/core/operation_processor.go
@@ -1168,7 +1168,7 @@ func createParseKit(i int, options *parseKitOptions) *parseKit {
 			ApolloCompatibilityFlags: apollocompatibility.Flags{
 				ReplaceInvalidVarError: options.apolloCompatibilityFlags.ReplaceInvalidVarErrors.Enabled,
 			},
-			ApolloRouterCompatabilityFlags: apollocompatibility.ApolloRouterFlags{
+			ApolloRouterCompatibilityFlags: apollocompatibility.ApolloRouterFlags{
 				ReplaceInvalidVarError: options.apolloRouterCompatibilityFlags.ReplaceInvalidVarErrors.Enabled,
 			},
 		}),

--- a/router/core/router.go
+++ b/router/core/router.go
@@ -186,6 +186,7 @@ type (
 		persistedOperationsConfig       config.PersistedOperationsConfig
 		automaticPersistedQueriesConfig config.AutomaticPersistedQueriesConfig
 		apolloCompatibilityFlags        config.ApolloCompatibilityFlags
+		apolloRouterCompatibilityFlags  config.ApolloRouterCompatibilityFlags
 		storageProviders                config.StorageProviders
 		eventsConfig                    config.EventsConfiguration
 		prometheusServer                *http.Server
@@ -1825,6 +1826,12 @@ func WithApolloCompatibilityFlagsConfig(cfg config.ApolloCompatibilityFlags) Opt
 			cfg.ReplaceValidationErrorStatus.Enabled = true
 		}
 		r.apolloCompatibilityFlags = cfg
+	}
+}
+
+func WithApolloRouterCompatibilityFlags(cfg config.ApolloRouterCompatibilityFlags) Option {
+	return func(r *Router) {
+		r.apolloRouterCompatibilityFlags = cfg
 	}
 }
 

--- a/router/go.mod
+++ b/router/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/tidwall/gjson v1.18.0
 	github.com/tidwall/sjson v1.2.5
 	github.com/twmb/franz-go v1.16.1
-	github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.152
+	github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.153
 	// Do not upgrade, it renames attributes we rely on
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.46.1
 	go.opentelemetry.io/contrib/propagators/b3 v1.23.0
@@ -150,4 +150,4 @@ require (
 // Remember you can use Go workspaces to avoid using replace directives in multiple go.mod files
 // Use what is best for your personal workflow. See CONTRIBUTING.md for more information
 
-//replace github.com/wundergraph/graphql-go-tools/v2 => ../../graphql-go-tools/v2
+// replace github.com/wundergraph/graphql-go-tools/v2 => ../../graphql-go-tools/v2

--- a/router/go.mod
+++ b/router/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/tidwall/gjson v1.18.0
 	github.com/tidwall/sjson v1.2.5
 	github.com/twmb/franz-go v1.16.1
-	github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.153
+	github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.154
 	// Do not upgrade, it renames attributes we rely on
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.46.1
 	go.opentelemetry.io/contrib/propagators/b3 v1.23.0

--- a/router/go.sum
+++ b/router/go.sum
@@ -279,8 +279,8 @@ github.com/vektah/gqlparser/v2 v2.5.16 h1:1gcmLTvs3JLKXckwCwlUagVn/IlV2bwqle0vJ0
 github.com/vektah/gqlparser/v2 v2.5.16/go.mod h1:1lz1OeCqgQbQepsGxPVywrjdBHW2T08PUS3pJqepRww=
 github.com/wundergraph/astjson v0.0.0-20250106123708-be463c97e083 h1:8/D7f8gKxTBjW+SZK4mhxTTBVpxcqeBgWF1Rfmltbfk=
 github.com/wundergraph/astjson v0.0.0-20250106123708-be463c97e083/go.mod h1:eOTL6acwctsN4F3b7YE+eE2t8zcJ/doLm9sZzsxxxrE=
-github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.153 h1:YOVmy8FMmU6HDASoy1hTIPm9wZLy3JpPQ4AWWPsdTXc=
-github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.153/go.mod h1:B7eV0Qh8Lop9QzIOQcsvKp3S0ejfC6mgyWoJnI917yQ=
+github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.154 h1:fed/UUZ26+aQ8yNFgbUfsz83/a3NABGxiu4S/Ecazug=
+github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.154/go.mod h1:B7eV0Qh8Lop9QzIOQcsvKp3S0ejfC6mgyWoJnI917yQ=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
 github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=

--- a/router/go.sum
+++ b/router/go.sum
@@ -279,8 +279,6 @@ github.com/vektah/gqlparser/v2 v2.5.16 h1:1gcmLTvs3JLKXckwCwlUagVn/IlV2bwqle0vJ0
 github.com/vektah/gqlparser/v2 v2.5.16/go.mod h1:1lz1OeCqgQbQepsGxPVywrjdBHW2T08PUS3pJqepRww=
 github.com/wundergraph/astjson v0.0.0-20250106123708-be463c97e083 h1:8/D7f8gKxTBjW+SZK4mhxTTBVpxcqeBgWF1Rfmltbfk=
 github.com/wundergraph/astjson v0.0.0-20250106123708-be463c97e083/go.mod h1:eOTL6acwctsN4F3b7YE+eE2t8zcJ/doLm9sZzsxxxrE=
-github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.151 h1:gLE6iYQyPO1ib53nLjlo5s/9g8pTgenCPmF5bSvF7zE=
-github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.151/go.mod h1:B7eV0Qh8Lop9QzIOQcsvKp3S0ejfC6mgyWoJnI917yQ=
 github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.153 h1:YOVmy8FMmU6HDASoy1hTIPm9wZLy3JpPQ4AWWPsdTXc=
 github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.153/go.mod h1:B7eV0Qh8Lop9QzIOQcsvKp3S0ejfC6mgyWoJnI917yQ=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=

--- a/router/go.sum
+++ b/router/go.sum
@@ -279,8 +279,10 @@ github.com/vektah/gqlparser/v2 v2.5.16 h1:1gcmLTvs3JLKXckwCwlUagVn/IlV2bwqle0vJ0
 github.com/vektah/gqlparser/v2 v2.5.16/go.mod h1:1lz1OeCqgQbQepsGxPVywrjdBHW2T08PUS3pJqepRww=
 github.com/wundergraph/astjson v0.0.0-20250106123708-be463c97e083 h1:8/D7f8gKxTBjW+SZK4mhxTTBVpxcqeBgWF1Rfmltbfk=
 github.com/wundergraph/astjson v0.0.0-20250106123708-be463c97e083/go.mod h1:eOTL6acwctsN4F3b7YE+eE2t8zcJ/doLm9sZzsxxxrE=
-github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.152 h1:s2QRv/cx6WGsb8V8Kb2uD1D5oWIV6s9HPxbbSzBbuT0=
-github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.152/go.mod h1:B7eV0Qh8Lop9QzIOQcsvKp3S0ejfC6mgyWoJnI917yQ=
+github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.151 h1:gLE6iYQyPO1ib53nLjlo5s/9g8pTgenCPmF5bSvF7zE=
+github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.151/go.mod h1:B7eV0Qh8Lop9QzIOQcsvKp3S0ejfC6mgyWoJnI917yQ=
+github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.153 h1:YOVmy8FMmU6HDASoy1hTIPm9wZLy3JpPQ4AWWPsdTXc=
+github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.153/go.mod h1:B7eV0Qh8Lop9QzIOQcsvKp3S0ejfC6mgyWoJnI917yQ=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
 github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=

--- a/router/pkg/config/config.go
+++ b/router/pkg/config/config.go
@@ -885,7 +885,7 @@ type Config struct {
 	PersistedOperationsConfig      PersistedOperationsConfig       `yaml:"persisted_operations"`
 	AutomaticPersistedQueries      AutomaticPersistedQueriesConfig `yaml:"automatic_persisted_queries"`
 	ApolloCompatibilityFlags       ApolloCompatibilityFlags        `yaml:"apollo_compatibility_flags"`
-	ApolloRouterCompatabilityFlags ApolloRouterCompatibilityFlags  `yaml:"apollo_router_compatability_flags"`
+	ApolloRouterCompatibilityFlags ApolloRouterCompatibilityFlags  `yaml:"apollo_router_Compatibility_flags"`
 	ClientHeader                   ClientHeader                    `yaml:"client_header"`
 }
 

--- a/router/pkg/config/config.go
+++ b/router/pkg/config/config.go
@@ -794,6 +794,14 @@ type ApolloCompatibilityReplaceValidationErrorStatus struct {
 	Enabled bool `yaml:"enabled" envDefault:"false" env:"APOLLO_COMPATIBILITY_REPLACE_VALIDATION_ERROR_STATUS_ENABLED"`
 }
 
+type ApolloRouterCompatibilityFlags struct {
+	ReplaceInvalidVarErrors ApolloRouterCompatibilityReplaceInvalidVarErrors `yaml:"replace_invalid_var_errors"`
+}
+
+type ApolloRouterCompatibilityReplaceInvalidVarErrors struct {
+	Enabled bool `yaml:"enabled" envDefault:"false" env:"APOLLO_ROUTER_COMPATIBILITY_REPLACE_INVALID_VAR_ERRORS_ENABLED"`
+}
+
 type CacheWarmupSource struct {
 	Filesystem *CacheWarmupFileSystemSource `yaml:"filesystem,omitempty"`
 }
@@ -872,12 +880,13 @@ type Config struct {
 
 	SubgraphErrorPropagation SubgraphErrorPropagationConfiguration `yaml:"subgraph_error_propagation"`
 
-	StorageProviders          StorageProviders                `yaml:"storage_providers"`
-	ExecutionConfig           ExecutionConfig                 `yaml:"execution_config"`
-	PersistedOperationsConfig PersistedOperationsConfig       `yaml:"persisted_operations"`
-	AutomaticPersistedQueries AutomaticPersistedQueriesConfig `yaml:"automatic_persisted_queries"`
-	ApolloCompatibilityFlags  ApolloCompatibilityFlags        `yaml:"apollo_compatibility_flags"`
-	ClientHeader              ClientHeader                    `yaml:"client_header"`
+	StorageProviders               StorageProviders                `yaml:"storage_providers"`
+	ExecutionConfig                ExecutionConfig                 `yaml:"execution_config"`
+	PersistedOperationsConfig      PersistedOperationsConfig       `yaml:"persisted_operations"`
+	AutomaticPersistedQueries      AutomaticPersistedQueriesConfig `yaml:"automatic_persisted_queries"`
+	ApolloCompatibilityFlags       ApolloCompatibilityFlags        `yaml:"apollo_compatibility_flags"`
+	ApolloRouterCompatabilityFlags ApolloRouterCompatibilityFlags  `yaml:"apollo_router_compatability_flags"`
+	ClientHeader                   ClientHeader                    `yaml:"client_header"`
 }
 
 type PlaygroundConfig struct {

--- a/router/pkg/config/config.schema.json
+++ b/router/pkg/config/config.schema.json
@@ -2396,6 +2396,24 @@
         }
       }
     },
+    "apollo_router_compatibility_flags": {
+      "type": "object",
+      "description": "To enable full compatibility with Apollo Router you can enable certain compatibility flags, allowing you to use Cosmo Router as a drop-in replacement for Apollo Router",
+      "additionalProperties": false,
+      "properties": {
+        "replace_invalid_var_errors": {
+          "type": "object",
+          "description": "Produces the same error (message, extension code but not status code) as Apollo Router when an invalid variable is supplied.",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        }
+      }
+    },
     "client_header": {
       "type": "object",
       "description": "The configuration to set custom client name and version header.",

--- a/router/pkg/config/testdata/config_defaults.json
+++ b/router/pkg/config/testdata/config_defaults.json
@@ -413,7 +413,7 @@
       "Enabled": false
     }
   },
-  "ApolloRouterCompatabilityFlags": {
+  "ApolloRouterCompatibilityFlags": {
     "ReplaceInvalidVarErrors": {
       "Enabled": false
     }

--- a/router/pkg/config/testdata/config_defaults.json
+++ b/router/pkg/config/testdata/config_defaults.json
@@ -413,6 +413,11 @@
       "Enabled": false
     }
   },
+  "ApolloRouterCompatabilityFlags": {
+    "ReplaceInvalidVarErrors": {
+      "Enabled": false
+    }
+  },
   "ClientHeader": {
     "Name": "",
     "Version": ""

--- a/router/pkg/config/testdata/config_full.json
+++ b/router/pkg/config/testdata/config_full.json
@@ -700,6 +700,11 @@
       "Enabled": false
     }
   },
+  "ApolloRouterCompatabilityFlags": {
+    "ReplaceInvalidVarErrors": {
+      "Enabled": false
+    }
+  },
   "ClientHeader": {
     "Name": "Client-Name",
     "Version": "Client_Version"

--- a/router/pkg/config/testdata/config_full.json
+++ b/router/pkg/config/testdata/config_full.json
@@ -700,7 +700,7 @@
       "Enabled": false
     }
   },
-  "ApolloRouterCompatabilityFlags": {
+  "ApolloRouterCompatibilityFlags": {
     "ReplaceInvalidVarErrors": {
       "Enabled": false
     }


### PR DESCRIPTION
## Motivation and Context

- Updates `graphql-go-tools` to [v2.0.0-rc.154](https://github.com/wundergraph/graphql-go-tools/releases/tag/v2.0.0-rc.154), incorporating Apollo Router compatibility options
- Adds a new config section `apollo_router_compatability_flags` that includes the option `replace_invalid_var_errors` which enables Cosmo/Router to return Apollo Router-like errors instead of Apollo Gateway-like or standard.
- Adds a new E2E test for this behavior
- [New docs](https://app.gitbook.com/o/AGsPMiPE3xradDAKeJYL/s/f2zpPO8tcaY6tJoaEebc/~/changes/SM1MfIihDRSR5SsqEeMG/router/configuration)

## Checklist

- [x] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [x] Tests or benchmarks have been added or updated.
- [x] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Example Config

```yaml
version: "1"

apollo_router_compatibility_flags:
    replace_invalid_var_errors:
        enabled: true
```