### PR TITLE
feat: set the scopes on request without authentication

### DIFF
--- a/router-tests/modules/custom-set-auth-scopes/module.go
+++ b/router-tests/modules/custom-set-auth-scopes/module.go
@@ -1,0 +1,48 @@
+package custom_set_auth_scopes
+
+import (
+	"net/http"
+
+	"github.com/wundergraph/cosmo/router/core"
+	"go.uber.org/zap"
+)
+
+func init() {
+	// Register your module here
+	core.RegisterModule(&SetAuthenticationScopesModule{})
+}
+
+const myModuleID = "setAuthenticationScopesModule"
+
+// SetAuthenticationScopesModule is a simple module that has access to the GraphQL operation and adds custom scopes to the response
+type SetAuthenticationScopesModule struct {
+	Value  uint64   `mapstructure:"value"`
+	Scopes []string `mapstructure:"scopes"`
+	Logger *zap.Logger
+}
+
+func (m *SetAuthenticationScopesModule) Middleware(ctx core.RequestContext, next http.Handler) {
+	if m.Scopes != nil {
+		ctx.SetAuthenticationScopes(m.Scopes)
+	}
+
+	// Call the next handler in the chain or return early by calling w.Write()
+	next.ServeHTTP(ctx.ResponseWriter(), ctx.Request())
+}
+
+func (m *SetAuthenticationScopesModule) Module() core.ModuleInfo {
+	return core.ModuleInfo{
+		// This is the ID of your module, it must be unique
+		ID: myModuleID,
+		// The priority of your module, lower numbers are executed first
+		Priority: 2,
+		New: func() core.Module {
+			return &SetAuthenticationScopesModule{}
+		},
+	}
+}
+
+// Interface guard
+var (
+	_ core.RouterMiddlewareHandler = (*SetAuthenticationScopesModule)(nil)
+)

--- a/router-tests/modules/custom-set-auth-scopes/module.go
+++ b/router-tests/modules/custom-set-auth-scopes/module.go
@@ -7,11 +7,6 @@ import (
 	"go.uber.org/zap"
 )
 
-func init() {
-	// Register your module here
-	core.RegisterModule(&SetAuthenticationScopesModule{})
-}
-
 const myModuleID = "setAuthenticationScopesModule"
 
 // SetAuthenticationScopesModule is a simple module that has access to the GraphQL operation and adds custom scopes to the response

--- a/router-tests/modules/custom-set-scopes/module.go
+++ b/router-tests/modules/custom-set-scopes/module.go
@@ -7,11 +7,6 @@ import (
 	"go.uber.org/zap"
 )
 
-func init() {
-	// Register your module here
-	core.RegisterModule(&SetScopesModule{})
-}
-
 const myModuleID = "setScopesModule"
 
 // SetScopesModule is a simple module that has access to the GraphQL operation and adds custom scopes to the response

--- a/router-tests/modules/custom-trace-propagator/module.go
+++ b/router-tests/modules/custom-trace-propagator/module.go
@@ -11,11 +11,6 @@ import (
 	"github.com/wundergraph/cosmo/router/core"
 )
 
-func init() {
-	// Register your module here
-	core.RegisterModule(&CustomTracePropagatorModule{})
-}
-
 const myModuleID = "tracePropagatorModule"
 
 // CustomTracePropagatorModule is a simple module that provides a custom trace propagator for the router

--- a/router-tests/modules/custom_trace_propagator_test.go
+++ b/router-tests/modules/custom_trace_propagator_test.go
@@ -42,6 +42,7 @@ func TestModuleCustomPropagator(t *testing.T) {
 			},
 			RouterOptions: []core.Option{
 				core.WithModulesConfig(cfg.Modules),
+				core.WithCustomModules(&module.MyModule{}, &custom_trace_propagator.CustomTracePropagatorModule{}),
 				core.WithTracing(&rtrace.Config{
 					Enabled: true,
 				}),

--- a/router-tests/modules/module_test.go
+++ b/router-tests/modules/module_test.go
@@ -2,12 +2,13 @@ package module_test
 
 import (
 	"encoding/json"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wundergraph/cosmo/router-tests/testenv"
 	"github.com/wundergraph/cosmo/router/pkg/trace/tracetest"
 	"go.uber.org/zap/zapcore"
-	"testing"
 
 	"github.com/wundergraph/cosmo/router/cmd/custom/module"
 	"github.com/wundergraph/cosmo/router/core"
@@ -27,6 +28,7 @@ func TestModuleSetCustomHeader(t *testing.T) {
 	testenv.Run(t, &testenv.Config{
 		RouterOptions: []core.Option{
 			core.WithModulesConfig(cfg.Modules),
+			core.WithCustomModules(&module.MyModule{}),
 		},
 	}, func(t *testing.T, xEnv *testenv.Environment) {
 		res, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
@@ -56,6 +58,7 @@ func TestCustomModuleLogs(t *testing.T) {
 	testenv.Run(t, &testenv.Config{
 		RouterOptions: []core.Option{
 			core.WithModulesConfig(cfg.Modules),
+			core.WithCustomModules(&module.MyModule{}),
 		},
 		LogObservation: testenv.LogObservationConfig{
 			Enabled:  true,

--- a/router-tests/modules/set_authentication_scopes_test.go
+++ b/router-tests/modules/set_authentication_scopes_test.go
@@ -1,0 +1,147 @@
+package module_test
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	setScopesModule "github.com/wundergraph/cosmo/router-tests/modules/custom-set-auth-scopes"
+	verifyScopes "github.com/wundergraph/cosmo/router-tests/modules/verify-scopes"
+	"github.com/wundergraph/cosmo/router-tests/testenv"
+	"github.com/wundergraph/cosmo/router/cmd/custom/module"
+	"github.com/wundergraph/cosmo/router/core"
+	"github.com/wundergraph/cosmo/router/pkg/config"
+)
+
+func TestCustomModuleSetAuthenticationScopes(t *testing.T) {
+	t.Run("it can set scopes and request passes on authenticated request", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := config.Config{
+			Graph: config.Graph{},
+			Modules: map[string]interface{}{
+				"myModule": module.MyModule{
+					Value: 1,
+				},
+				"setAuthenticationScopesModule": setScopesModule.SetAuthenticationScopesModule{
+					Value:  2,
+					Scopes: []string{"read:employee", "read:private"},
+				},
+				"verifyScopesModule": verifyScopes.VerifyScopesModule{
+					Value:  3,
+					Scopes: []string{"read:employee", "read:private"},
+				},
+			},
+		}
+		authenticators, authServer := configureAuth(t)
+		testenv.Run(t, &testenv.Config{
+			RouterOptions: []core.Option{
+				core.WithAccessController(core.NewAccessController(authenticators, false)),
+				core.WithModulesConfig(cfg.Modules),
+			},
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			// Operations with a token should succeed
+			token, err := authServer.Token(nil)
+			require.NoError(t, err)
+			header := http.Header{
+				"Authorization": []string{"Bearer " + token},
+			}
+			res, err := xEnv.MakeRequest(http.MethodPost, "/graphql", header, strings.NewReader(employeesQueryRequiringClaims))
+			require.NoError(t, err)
+			defer res.Body.Close()
+			require.Equal(t, http.StatusOK, res.StatusCode)
+			require.Equal(t, jwksName, res.Header.Get(xAuthenticatedByHeader))
+			data, err := io.ReadAll(res.Body)
+			require.NoError(t, err)
+			require.Equal(t, `{"data":{"employees":[{"id":1,"startDate":"January 2020"},{"id":2,"startDate":"July 2022"},{"id":3,"startDate":"June 2021"},{"id":4,"startDate":"July 2022"},{"id":5,"startDate":"July 2022"},{"id":7,"startDate":"September 2022"},{"id":8,"startDate":"September 2022"},{"id":10,"startDate":"November 2022"},{"id":11,"startDate":"November 2022"},{"id":12,"startDate":"December 2022"}]}}`, string(data))
+		})
+	})
+
+	t.Run("should fail with authorization error because module didn't set the necessary scopes to execute the query", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := config.Config{
+			Graph: config.Graph{},
+			Modules: map[string]interface{}{
+				"myModule": module.MyModule{
+					Value: 1,
+				},
+				"setAuthenticationScopesModule": setScopesModule.SetAuthenticationScopesModule{
+					Value:  2,
+					Scopes: []string{"read:employee"},
+				},
+				"verifyScopesModule": verifyScopes.VerifyScopesModule{
+					Value:  3,
+					Scopes: []string{"read:employee"},
+				},
+			},
+		}
+		authenticators, authServer := configureAuth(t)
+		testenv.Run(t, &testenv.Config{
+			RouterOptions: []core.Option{
+				core.WithAccessController(core.NewAccessController(authenticators, false)),
+				core.WithModulesConfig(cfg.Modules),
+			},
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			// Operations with a token should succeed
+			token, err := authServer.Token(map[string]any{
+				"scope": "read:employee read:private",
+			})
+			require.NoError(t, err)
+			header := http.Header{
+				"Authorization": []string{"Bearer " + token},
+			}
+			res, err := xEnv.MakeRequest(http.MethodPost, "/graphql", header, strings.NewReader(employeesQueryRequiringClaims))
+			require.NoError(t, err)
+			defer res.Body.Close()
+			require.Equal(t, http.StatusOK, res.StatusCode)
+			require.Equal(t, jwksName, res.Header.Get(xAuthenticatedByHeader))
+			data, err := io.ReadAll(res.Body)
+			require.NoError(t, err)
+			require.Equal(t, `{"errors":[{"message":"Unauthorized to load field 'Query.employees.startDate', Reason: missing required scopes.","path":["employees",0,"startDate"]},{"message":"Unauthorized to load field 'Query.employees.startDate', Reason: missing required scopes.","path":["employees",1,"startDate"]},{"message":"Unauthorized to load field 'Query.employees.startDate', Reason: missing required scopes.","path":["employees",2,"startDate"]},{"message":"Unauthorized to load field 'Query.employees.startDate', Reason: missing required scopes.","path":["employees",3,"startDate"]},{"message":"Unauthorized to load field 'Query.employees.startDate', Reason: missing required scopes.","path":["employees",4,"startDate"]},{"message":"Unauthorized to load field 'Query.employees.startDate', Reason: missing required scopes.","path":["employees",5,"startDate"]},{"message":"Unauthorized to load field 'Query.employees.startDate', Reason: missing required scopes.","path":["employees",6,"startDate"]},{"message":"Unauthorized to load field 'Query.employees.startDate', Reason: missing required scopes.","path":["employees",7,"startDate"]},{"message":"Unauthorized to load field 'Query.employees.startDate', Reason: missing required scopes.","path":["employees",8,"startDate"]},{"message":"Unauthorized to load field 'Query.employees.startDate', Reason: missing required scopes.","path":["employees",9,"startDate"]}],"data":{"employees":[null,null,null,null,null,null,null,null,null,null]},"extensions":{"authorization":{"missingScopes":[{"coordinate":{"typeName":"Employee","fieldName":"startDate"},"required":[["read:employee","read:private"],["read:all"]]}],"actualScopes":["read:employee"]}}}`, string(data))
+		})
+	})
+
+	t.Run("it can set scopes and request passes on not authenticated request", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := config.Config{
+			Graph: config.Graph{},
+			Modules: map[string]interface{}{
+				"myModule": module.MyModule{
+					Value: 1,
+				},
+				"setAuthenticationScopesModule": setScopesModule.SetAuthenticationScopesModule{
+					Value:  2,
+					Scopes: []string{"read:employee", "read:private"},
+				},
+				"verifyScopesModule": verifyScopes.VerifyScopesModule{
+					Value:  3,
+					Scopes: []string{"read:employee", "read:private"},
+				},
+			},
+		}
+		_, authServer := configureAuth(t)
+		testenv.Run(t, &testenv.Config{
+			RouterOptions: []core.Option{
+				core.WithModulesConfig(cfg.Modules),
+			},
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			// Operations with a token should succeed
+			token, err := authServer.Token(nil)
+			require.NoError(t, err)
+			header := http.Header{
+				"Authorization": []string{"Bearer " + token},
+			}
+			res, err := xEnv.MakeRequest(http.MethodPost, "/graphql", header, strings.NewReader(employeesQueryRequiringClaims))
+			require.NoError(t, err)
+			defer res.Body.Close()
+			require.Equal(t, http.StatusOK, res.StatusCode)
+			data, err := io.ReadAll(res.Body)
+			require.NoError(t, err)
+			require.Equal(t, `{"data":{"employees":[{"id":1,"startDate":"January 2020"},{"id":2,"startDate":"July 2022"},{"id":3,"startDate":"June 2021"},{"id":4,"startDate":"July 2022"},{"id":5,"startDate":"July 2022"},{"id":7,"startDate":"September 2022"},{"id":8,"startDate":"September 2022"},{"id":10,"startDate":"November 2022"},{"id":11,"startDate":"November 2022"},{"id":12,"startDate":"December 2022"}]}}`, string(data))
+		})
+	})
+}

--- a/router-tests/modules/set_authentication_scopes_test.go
+++ b/router-tests/modules/set_authentication_scopes_test.go
@@ -10,21 +10,17 @@ import (
 	setScopesModule "github.com/wundergraph/cosmo/router-tests/modules/custom-set-auth-scopes"
 	verifyScopes "github.com/wundergraph/cosmo/router-tests/modules/verify-scopes"
 	"github.com/wundergraph/cosmo/router-tests/testenv"
-	"github.com/wundergraph/cosmo/router/cmd/custom/module"
 	"github.com/wundergraph/cosmo/router/core"
 	"github.com/wundergraph/cosmo/router/pkg/config"
 )
 
 func TestCustomModuleSetAuthenticationScopes(t *testing.T) {
-	t.Run("it can set scopes and request passes on authenticated request", func(t *testing.T) {
+	t.Run("it can set scopes and request passes on authenticated request without scopes", func(t *testing.T) {
 		t.Parallel()
 
 		cfg := config.Config{
 			Graph: config.Graph{},
 			Modules: map[string]interface{}{
-				"myModule": module.MyModule{
-					Value: 1,
-				},
 				"setAuthenticationScopesModule": setScopesModule.SetAuthenticationScopesModule{
 					Value:  2,
 					Scopes: []string{"read:employee", "read:private"},
@@ -40,10 +36,54 @@ func TestCustomModuleSetAuthenticationScopes(t *testing.T) {
 			RouterOptions: []core.Option{
 				core.WithAccessController(core.NewAccessController(authenticators, false)),
 				core.WithModulesConfig(cfg.Modules),
+				core.WithCustomModules(&setScopesModule.SetAuthenticationScopesModule{}, &verifyScopes.VerifyScopesModule{}),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			// Operations with a token should succeed
 			token, err := authServer.Token(nil)
+			require.NoError(t, err)
+			header := http.Header{
+				"Authorization": []string{"Bearer " + token},
+			}
+			res, err := xEnv.MakeRequest(http.MethodPost, "/graphql", header, strings.NewReader(employeesQueryRequiringClaims))
+			require.NoError(t, err)
+			defer res.Body.Close()
+			require.Equal(t, http.StatusOK, res.StatusCode)
+			require.Equal(t, jwksName, res.Header.Get(xAuthenticatedByHeader))
+			data, err := io.ReadAll(res.Body)
+			require.NoError(t, err)
+			require.Equal(t, `{"data":{"employees":[{"id":1,"startDate":"January 2020"},{"id":2,"startDate":"July 2022"},{"id":3,"startDate":"June 2021"},{"id":4,"startDate":"July 2022"},{"id":5,"startDate":"July 2022"},{"id":7,"startDate":"September 2022"},{"id":8,"startDate":"September 2022"},{"id":10,"startDate":"November 2022"},{"id":11,"startDate":"November 2022"},{"id":12,"startDate":"December 2022"}]}}`, string(data))
+		})
+	})
+
+	t.Run("it can set scopes and request passes on authenticated request with scopes", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := config.Config{
+			Graph: config.Graph{},
+			Modules: map[string]interface{}{
+				"setAuthenticationScopesModule": setScopesModule.SetAuthenticationScopesModule{
+					Value:  2,
+					Scopes: []string{"read:employee", "read:private"},
+				},
+				"verifyScopesModule": verifyScopes.VerifyScopesModule{
+					Value:  3,
+					Scopes: []string{"read:employee", "read:private"},
+				},
+			},
+		}
+		authenticators, authServer := configureAuth(t)
+		testenv.Run(t, &testenv.Config{
+			RouterOptions: []core.Option{
+				core.WithAccessController(core.NewAccessController(authenticators, false)),
+				core.WithModulesConfig(cfg.Modules),
+				core.WithCustomModules(&setScopesModule.SetAuthenticationScopesModule{}, &verifyScopes.VerifyScopesModule{}),
+			},
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			// Operations with a token should succeed
+			token, err := authServer.Token(map[string]any{
+				"scope": "read:employee2 read:private2",
+			})
 			require.NoError(t, err)
 			header := http.Header{
 				"Authorization": []string{"Bearer " + token},
@@ -65,9 +105,6 @@ func TestCustomModuleSetAuthenticationScopes(t *testing.T) {
 		cfg := config.Config{
 			Graph: config.Graph{},
 			Modules: map[string]interface{}{
-				"myModule": module.MyModule{
-					Value: 1,
-				},
 				"setAuthenticationScopesModule": setScopesModule.SetAuthenticationScopesModule{
 					Value:  2,
 					Scopes: []string{"read:employee"},
@@ -83,6 +120,7 @@ func TestCustomModuleSetAuthenticationScopes(t *testing.T) {
 			RouterOptions: []core.Option{
 				core.WithAccessController(core.NewAccessController(authenticators, false)),
 				core.WithModulesConfig(cfg.Modules),
+				core.WithCustomModules(&setScopesModule.SetAuthenticationScopesModule{}, &verifyScopes.VerifyScopesModule{}),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			// Operations with a token should succeed
@@ -110,9 +148,6 @@ func TestCustomModuleSetAuthenticationScopes(t *testing.T) {
 		cfg := config.Config{
 			Graph: config.Graph{},
 			Modules: map[string]interface{}{
-				"myModule": module.MyModule{
-					Value: 1,
-				},
 				"setAuthenticationScopesModule": setScopesModule.SetAuthenticationScopesModule{
 					Value:  2,
 					Scopes: []string{"read:employee", "read:private"},
@@ -127,6 +162,7 @@ func TestCustomModuleSetAuthenticationScopes(t *testing.T) {
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
 				core.WithModulesConfig(cfg.Modules),
+				core.WithCustomModules(&setScopesModule.SetAuthenticationScopesModule{}, &verifyScopes.VerifyScopesModule{}),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			// Operations with a token should succeed

--- a/router-tests/modules/set_scopes_test.go
+++ b/router-tests/modules/set_scopes_test.go
@@ -1,6 +1,12 @@
 package module_test
 
 import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/stretchr/testify/require"
 	integration "github.com/wundergraph/cosmo/router-tests"
 	"github.com/wundergraph/cosmo/router-tests/jwks"
@@ -11,11 +17,6 @@ import (
 	"github.com/wundergraph/cosmo/router/pkg/authentication"
 	"github.com/wundergraph/cosmo/router/pkg/config"
 	"go.uber.org/zap"
-	"io"
-	"net/http"
-	"strings"
-	"testing"
-	"time"
 )
 
 const (
@@ -64,6 +65,7 @@ func TestCustomModuleSetScopes(t *testing.T) {
 			RouterOptions: []core.Option{
 				core.WithAccessController(core.NewAccessController(authenticators, false)),
 				core.WithModulesConfig(cfg.Modules),
+				core.WithCustomModules(&module.MyModule{}, &setScopesModule.SetScopesModule{}),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			// Operations with a token should succeed
@@ -103,6 +105,7 @@ func TestCustomModuleSetScopes(t *testing.T) {
 			RouterOptions: []core.Option{
 				core.WithAccessController(core.NewAccessController(authenticators, false)),
 				core.WithModulesConfig(cfg.Modules),
+				core.WithCustomModules(&module.MyModule{}, &setScopesModule.SetScopesModule{}),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			// Operations with a token should succeed

--- a/router-tests/modules/verify-scopes/module.go
+++ b/router-tests/modules/verify-scopes/module.go
@@ -24,7 +24,7 @@ type VerifyScopesModule struct {
 
 func (m *VerifyScopesModule) Middleware(ctx core.RequestContext, next http.Handler) {
 	auth := ctx.Authentication()
-	if m.Scopes != nil && slices.Compare(m.Scopes, auth.Scopes()) != 0 {
+	if m.Scopes != nil && (auth == nil || slices.Compare(m.Scopes, auth.Scopes()) != 0) {
 		ctx.ResponseWriter().WriteHeader(http.StatusBadRequest)
 		next.ServeHTTP(ctx.ResponseWriter(), ctx.Request())
 		return

--- a/router-tests/modules/verify-scopes/module.go
+++ b/router-tests/modules/verify-scopes/module.go
@@ -1,0 +1,52 @@
+package verify_scopes
+
+import (
+	"net/http"
+	"slices"
+
+	"github.com/wundergraph/cosmo/router/core"
+	"go.uber.org/zap"
+)
+
+func init() {
+	// Register your module here
+	core.RegisterModule(&VerifyScopesModule{})
+}
+
+const myModuleID = "verifyScopesModule"
+
+// VerifyScopesModule is a simple module that has access to the GraphQL operation and adds custom scopes to the response
+type VerifyScopesModule struct {
+	Value  uint64   `mapstructure:"value"`
+	Scopes []string `mapstructure:"scopes"`
+	Logger *zap.Logger
+}
+
+func (m *VerifyScopesModule) Middleware(ctx core.RequestContext, next http.Handler) {
+	auth := ctx.Authentication()
+	if m.Scopes != nil && slices.Compare(m.Scopes, auth.Scopes()) != 0 {
+		ctx.ResponseWriter().WriteHeader(http.StatusBadRequest)
+		next.ServeHTTP(ctx.ResponseWriter(), ctx.Request())
+		return
+	}
+
+	// Call the next handler in the chain or return early by calling w.Write()
+	next.ServeHTTP(ctx.ResponseWriter(), ctx.Request())
+}
+
+func (m *VerifyScopesModule) Module() core.ModuleInfo {
+	return core.ModuleInfo{
+		// This is the ID of your module, it must be unique
+		ID: myModuleID,
+		// The priority of your module, lower numbers are executed first
+		Priority: 5,
+		New: func() core.Module {
+			return &VerifyScopesModule{}
+		},
+	}
+}
+
+// Interface guard
+var (
+	_ core.RouterMiddlewareHandler = (*VerifyScopesModule)(nil)
+)

--- a/router-tests/modules/verify-scopes/module.go
+++ b/router-tests/modules/verify-scopes/module.go
@@ -8,11 +8,6 @@ import (
 	"go.uber.org/zap"
 )
 
-func init() {
-	// Register your module here
-	core.RegisterModule(&VerifyScopesModule{})
-}
-
 const myModuleID = "verifyScopesModule"
 
 // VerifyScopesModule is a simple module that has access to the GraphQL operation and adds custom scopes to the response

--- a/router/cmd/custom/module/module.go
+++ b/router/cmd/custom/module/module.go
@@ -8,11 +8,6 @@ import (
 	"go.uber.org/zap"
 )
 
-func init() {
-	// Register your module here
-	core.RegisterModule(&MyModule{})
-}
-
 const myModuleID = "myModule"
 
 // MyModule is a simple module that has access to the GraphQL operation and add a header to the response

--- a/router/core/context.go
+++ b/router/core/context.go
@@ -448,9 +448,9 @@ func (c *requestContext) SetAuthenticationScopes(scopes []string) {
 	auth := authentication.FromContext(c.request.Context())
 	if auth == nil {
 		auth = authentication.NewEmptyAuthentication()
+		c.request = c.request.WithContext(authentication.NewContext(c.request.Context(), auth))
 	}
 	auth.SetScopes(scopes)
-	c.request = c.request.WithContext(authentication.NewContext(c.request.Context(), auth))
 }
 
 type OperationContext interface {

--- a/router/core/context.go
+++ b/router/core/context.go
@@ -129,6 +129,10 @@ type RequestContext interface {
 
 	// Authentication returns the authentication information for the request, if any
 	Authentication() authentication.Authentication
+
+	// SetAuthenticationScopes sets the scopes for the request on Authentication
+	// If Authentication is not set, it will be initialized with the scopes
+	SetAuthenticationScopes(scopes []string)
 }
 
 var metricAttrsPool = sync.Pool{
@@ -438,6 +442,15 @@ func (c *requestContext) SubgraphByID(subgraphID string) *Subgraph {
 
 func (c *requestContext) Authentication() authentication.Authentication {
 	return authentication.FromContext(c.request.Context())
+}
+
+func (c *requestContext) SetAuthenticationScopes(scopes []string) {
+	auth := authentication.FromContext(c.request.Context())
+	if auth == nil {
+		auth = authentication.NewEmptyAuthentication()
+	}
+	auth.SetScopes(scopes)
+	c.request = c.request.WithContext(authentication.NewContext(c.request.Context(), auth))
 }
 
 type OperationContext interface {

--- a/router/pkg/authentication/authentication.go
+++ b/router/pkg/authentication/authentication.go
@@ -109,3 +109,7 @@ func Authenticate(ctx context.Context, authenticators []Authenticator, p Provide
 	// even if to claims were found.
 	return nil, joinedErrors
 }
+
+func NewEmptyAuthentication() Authentication {
+	return &authentication{}
+}


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

## Motivation and Context

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please describe in detail the impact of this change. Attach screenshots if applicable.
-->
Some customers need to set the scopes on a request without authentication. This is not possible right now because you need the authentication object to be initialized to set the scopes inside of it.

In this PR I added the method `SetAuthenticationScopes` to the context to make it possible to set scopes on a request with or without authentication.

I had to remove the registration of the test custom modules to avoid interference between them.

## Checklist

- [X] I have discussed my proposed changes in an issue and have received approval to proceed.
- [X] I have followed the coding standards of the project.
- [X] Tests or benchmarks have been added or updated.
- [x] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [X] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->