### PR TITLE
feat(engine): apollo router compatible non-2XX response errors

### DIFF
--- a/demo/go.mod
+++ b/demo/go.mod
@@ -11,8 +11,8 @@ require (
 	github.com/rs/cors v1.11.0
 	github.com/vektah/gqlparser/v2 v2.5.21
 	github.com/wundergraph/cosmo/composition-go v0.0.0-20240124120900-5effe48a4a1d
-	github.com/wundergraph/cosmo/router v0.0.0-20250214150441-4e73ca7eb147
-	github.com/wundergraph/cosmo/router-tests v0.0.0-20250214150441-4e73ca7eb147
+	github.com/wundergraph/cosmo/router v0.0.0-20250218093943-e5b2167f65c7
+	github.com/wundergraph/cosmo/router-tests v0.0.0-20250218093943-e5b2167f65c7
 	github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.155
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.46.1
 	go.opentelemetry.io/otel v1.28.0

--- a/demo/go.mod
+++ b/demo/go.mod
@@ -11,8 +11,8 @@ require (
 	github.com/rs/cors v1.11.0
 	github.com/vektah/gqlparser/v2 v2.5.21
 	github.com/wundergraph/cosmo/composition-go v0.0.0-20240124120900-5effe48a4a1d
-	github.com/wundergraph/cosmo/router v0.0.0-20250213114402-18a18b4245cf
-	github.com/wundergraph/cosmo/router-tests v0.0.0-20250213114402-18a18b4245cf
+	github.com/wundergraph/cosmo/router v0.0.0-20250214150441-4e73ca7eb147
+	github.com/wundergraph/cosmo/router-tests v0.0.0-20250214150441-4e73ca7eb147
 	github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.155
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.46.1
 	go.opentelemetry.io/otel v1.28.0

--- a/demo/go.sum
+++ b/demo/go.sum
@@ -357,10 +357,10 @@ github.com/wundergraph/astjson v0.0.0-20250106123708-be463c97e083 h1:8/D7f8gKxTB
 github.com/wundergraph/astjson v0.0.0-20250106123708-be463c97e083/go.mod h1:eOTL6acwctsN4F3b7YE+eE2t8zcJ/doLm9sZzsxxxrE=
 github.com/wundergraph/cosmo/composition-go v0.0.0-20240124120900-5effe48a4a1d h1:NEUrhuqOaTO1dpW8pz2tu6dKbQAqFvgiF/m4NXdzZm0=
 github.com/wundergraph/cosmo/composition-go v0.0.0-20240124120900-5effe48a4a1d/go.mod h1:9I3gPMAlAY+m1/cFL20iN7XHTyuZd3VT5ijccdU/FsI=
-github.com/wundergraph/cosmo/router v0.0.0-20250214150441-4e73ca7eb147 h1:8N+M2lqrWON+Zj6c3noqoZawOUjT+JtBL7/XJQuL6Ck=
-github.com/wundergraph/cosmo/router v0.0.0-20250214150441-4e73ca7eb147/go.mod h1:3csm8whpHCXgpQKrT86sZJSuN8eUU3CkXKSBBjfD+7Y=
-github.com/wundergraph/cosmo/router-tests v0.0.0-20250214150441-4e73ca7eb147 h1:tHr1fnuNgNKiHHihyn1p8xVjUn4CnGA6L6xP5hRF5XU=
-github.com/wundergraph/cosmo/router-tests v0.0.0-20250214150441-4e73ca7eb147/go.mod h1:3/gv1m42t6KuQxqQUvWSijc/TI+yKbsSF/CdwaBtLmk=
+github.com/wundergraph/cosmo/router v0.0.0-20250218093943-e5b2167f65c7 h1:+kwYDe0/Tm10VTTAgGFXoeVHCnQVwPuKsHijtZKMD4Q=
+github.com/wundergraph/cosmo/router v0.0.0-20250218093943-e5b2167f65c7/go.mod h1:fegv/vONTxD6SRweTJyQSBALVvyst1zI6DOhPj1vJsQ=
+github.com/wundergraph/cosmo/router-tests v0.0.0-20250218093943-e5b2167f65c7 h1:xWDcFs4dCLKgu6ZxW8ADeywL5B8vSLLdZEM8htitzDY=
+github.com/wundergraph/cosmo/router-tests v0.0.0-20250218093943-e5b2167f65c7/go.mod h1:M9w5UOrQkB86E4ZYoLFhvl+04U83B4zm5r2TFtobHxc=
 github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.155 h1:+ygDhCfLCwDE1aL+2wjtU0PfrMJ9f9ZLb0Lm0w5W7Is=
 github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.155/go.mod h1:B7eV0Qh8Lop9QzIOQcsvKp3S0ejfC6mgyWoJnI917yQ=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=

--- a/demo/go.sum
+++ b/demo/go.sum
@@ -357,10 +357,10 @@ github.com/wundergraph/astjson v0.0.0-20250106123708-be463c97e083 h1:8/D7f8gKxTB
 github.com/wundergraph/astjson v0.0.0-20250106123708-be463c97e083/go.mod h1:eOTL6acwctsN4F3b7YE+eE2t8zcJ/doLm9sZzsxxxrE=
 github.com/wundergraph/cosmo/composition-go v0.0.0-20240124120900-5effe48a4a1d h1:NEUrhuqOaTO1dpW8pz2tu6dKbQAqFvgiF/m4NXdzZm0=
 github.com/wundergraph/cosmo/composition-go v0.0.0-20240124120900-5effe48a4a1d/go.mod h1:9I3gPMAlAY+m1/cFL20iN7XHTyuZd3VT5ijccdU/FsI=
-github.com/wundergraph/cosmo/router v0.0.0-20250213114402-18a18b4245cf h1:b8iIJ8gyCwi0KRNq63DNrVKlF/kaEi7/FBHJzYdMYF0=
-github.com/wundergraph/cosmo/router v0.0.0-20250213114402-18a18b4245cf/go.mod h1:WJ0QwGSdRTUBMD8V6an0jgf21KTJF8SgbnueG0zPnMU=
-github.com/wundergraph/cosmo/router-tests v0.0.0-20250213114402-18a18b4245cf h1:HsdrXGJGHkKJ8x9WNcRgd4TJgex3QuoIVBcxnl9cMCA=
-github.com/wundergraph/cosmo/router-tests v0.0.0-20250213114402-18a18b4245cf/go.mod h1:PAAQGsfQMSwbC3ThZxUTTH3oi+YxraRIJPcWMQkzJ9Y=
+github.com/wundergraph/cosmo/router v0.0.0-20250214150441-4e73ca7eb147 h1:8N+M2lqrWON+Zj6c3noqoZawOUjT+JtBL7/XJQuL6Ck=
+github.com/wundergraph/cosmo/router v0.0.0-20250214150441-4e73ca7eb147/go.mod h1:3csm8whpHCXgpQKrT86sZJSuN8eUU3CkXKSBBjfD+7Y=
+github.com/wundergraph/cosmo/router-tests v0.0.0-20250214150441-4e73ca7eb147 h1:tHr1fnuNgNKiHHihyn1p8xVjUn4CnGA6L6xP5hRF5XU=
+github.com/wundergraph/cosmo/router-tests v0.0.0-20250214150441-4e73ca7eb147/go.mod h1:3/gv1m42t6KuQxqQUvWSijc/TI+yKbsSF/CdwaBtLmk=
 github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.155 h1:+ygDhCfLCwDE1aL+2wjtU0PfrMJ9f9ZLb0Lm0w5W7Is=
 github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.155/go.mod h1:B7eV0Qh8Lop9QzIOQcsvKp3S0ejfC6mgyWoJnI917yQ=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=

--- a/router-tests/apollo_compatibility_test.go
+++ b/router-tests/apollo_compatibility_test.go
@@ -34,7 +34,16 @@ func TestApolloRouterCompatibility(t *testing.T) {
 			})
 			require.NoError(t, err)
 			assert.Equal(t, http.StatusOK, res.Response.StatusCode)
-			assert.Equal(t, `{"errors":[{"message":"invalid type for variable: 'arg'","extensions":{"code":"VALIDATION_INVALID_TYPE_VARIABLE"}}]}`, res.Body)
+			assert.JSONEq(t, `{
+				"errors": [
+					{
+						"message": "invalid type for variable: 'arg'",
+						"extensions": {
+							"code": "VALIDATION_INVALID_TYPE_VARIABLE"
+						}
+					}
+				]
+			}`, res.Body)
 		})
 	})
 
@@ -60,7 +69,235 @@ func TestApolloRouterCompatibility(t *testing.T) {
 			})
 			require.NoError(t, err)
 			assert.Equal(t, http.StatusBadRequest, res.Response.StatusCode)
-			assert.Equal(t, `{"errors":[{"message":"invalid type for variable: 'arg'","extensions":{"code":"VALIDATION_INVALID_TYPE_VARIABLE"}}]}`, res.Body)
+			assert.JSONEq(t, `{
+				"errors": [
+					{
+						"message": "invalid type for variable: 'arg'",
+						"extensions": {
+							"code": "VALIDATION_INVALID_TYPE_VARIABLE"
+						}
+					}
+				]
+			}`, res.Body)
+		})
+	})
+
+	t.Run("enable subrequest http error compatibility with error propagation disabled", func(t *testing.T) {
+		t.Parallel()
+		testenv.Run(t, &testenv.Config{
+			RouterOptions: []core.Option{
+				core.WithApolloRouterCompatibilityFlags(config.ApolloRouterCompatibilityFlags{
+					SubrequestHTTPError: config.ApolloRouterCompatibilitySubrequestHTTPError{
+						Enabled: true,
+					},
+				}),
+				core.WithSubgraphErrorPropagation(config.SubgraphErrorPropagationConfiguration{
+					Enabled: false,
+				}),
+			},
+			Subgraphs: testenv.SubgraphsConfig{
+				Test1: testenv.SubgraphConfig{
+					Middleware: func(handler http.Handler) http.Handler {
+						return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+							w.WriteHeader(http.StatusForbidden)
+							w.Header().Set("Content-Type", "application/json")
+							_ = json.NewEncoder(w).Encode(map[string]interface{}{
+								"errors": []map[string]interface{}{
+									{
+										"message": "Unknown access token",
+										"extensions": map[string]interface{}{
+											"code": "UNAUTHENTICATED",
+										},
+									},
+								},
+							})
+						})
+					},
+				},
+			},
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			res, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
+				Query:     `query FloatQuery($arg: Float) { floatField(arg: $arg) }`,
+				Variables: json.RawMessage(`{"arg": 2.5}`),
+			})
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusOK, res.Response.StatusCode)
+			assert.JSONEq(t, `{
+				"errors": [
+					{
+						"message": "HTTP fetch failed from 'test1': 403: Forbidden",
+						"path": [],
+						"extensions": {
+							"code": "SUBREQUEST_HTTP_ERROR",
+							"service": "test1",
+							"reason": "403: Forbidden",
+							"http": {
+								"status": 403
+							}
+						}
+					},
+					{
+						"message": "Failed to fetch from Subgraph 'test1'."
+					}
+				],
+				"data": {
+					"floatField": null
+				}
+			}`, res.Body)
+		})
+	})
+
+	t.Run("enable subrequest http error compatibility with subgraph error propagation enabled", func(t *testing.T) {
+		t.Parallel()
+		testenv.Run(t, &testenv.Config{
+			RouterOptions: []core.Option{
+				core.WithApolloRouterCompatibilityFlags(config.ApolloRouterCompatibilityFlags{
+					SubrequestHTTPError: config.ApolloRouterCompatibilitySubrequestHTTPError{
+						Enabled: true,
+					},
+				}),
+				core.WithSubgraphErrorPropagation(config.SubgraphErrorPropagationConfiguration{
+					Enabled:                true,
+					Mode:                   "pass-through",
+					AllowedExtensionFields: []string{"code"},
+				}),
+			},
+			Subgraphs: testenv.SubgraphsConfig{
+				Test1: testenv.SubgraphConfig{
+					Middleware: func(handler http.Handler) http.Handler {
+						return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+							w.WriteHeader(http.StatusForbidden)
+							w.Header().Set("Content-Type", "application/json")
+							_ = json.NewEncoder(w).Encode(map[string]interface{}{
+								"errors": []map[string]interface{}{
+									{
+										"message": "Unknown access token",
+										"extensions": map[string]interface{}{
+											"code": "UNAUTHENTICATED",
+										},
+									},
+								},
+							})
+						})
+					},
+				},
+			},
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			res, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
+				Query:     `query FloatQuery($arg: Float) { floatField(arg: $arg) }`,
+				Variables: json.RawMessage(`{"arg": 2.5}`),
+			})
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusOK, res.Response.StatusCode)
+			assert.JSONEq(t, `{
+				"errors": [
+					{
+						"message": "HTTP fetch failed from 'test1': 403: Forbidden",
+						"path": [],
+						"extensions": {
+							"code": "SUBREQUEST_HTTP_ERROR",
+							"service": "test1",
+							"reason": "403: Forbidden",
+							"http": {
+								"status": 403
+							}
+						}
+					},
+					{
+						"message": "Unknown access token",
+						"extensions": {
+							"code": "UNAUTHENTICATED"
+						}
+					}
+				],
+				"data": {
+					"floatField": null
+				}
+			}`, res.Body)
+		})
+	})
+
+	t.Run("disable subrequest http error compatibility", func(t *testing.T) {
+		t.Parallel()
+		testenv.Run(t, &testenv.Config{
+			RouterOptions: []core.Option{
+				core.WithApolloRouterCompatibilityFlags(config.ApolloRouterCompatibilityFlags{
+					SubrequestHTTPError: config.ApolloRouterCompatibilitySubrequestHTTPError{
+						Enabled: false,
+					},
+				}),
+			},
+			Subgraphs: testenv.SubgraphsConfig{
+				Test1: testenv.SubgraphConfig{
+					Middleware: func(handler http.Handler) http.Handler {
+						return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+							w.WriteHeader(http.StatusForbidden)
+						})
+					},
+				},
+			},
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			res, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
+				Query:     `query FloatQuery($arg: Float) { floatField(arg: $arg) }`,
+				Variables: json.RawMessage(`{"arg": 2.5}`),
+			})
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusOK, res.Response.StatusCode)
+			assert.JSONEq(t, `{
+				"errors": [
+					{
+						"message": "Failed to fetch from Subgraph 'test1', Reason: empty response.",
+						"extensions": {
+							"statusCode": 403
+						}
+					}
+				],
+				"data": {
+					"floatField": null
+				}
+			}`, res.Body)
+		})
+	})
+
+	t.Run("enable subrequest http error compatibility and return non-error code", func(t *testing.T) {
+		t.Parallel()
+		testenv.Run(t, &testenv.Config{
+			RouterOptions: []core.Option{
+				core.WithApolloRouterCompatibilityFlags(config.ApolloRouterCompatibilityFlags{
+					SubrequestHTTPError: config.ApolloRouterCompatibilitySubrequestHTTPError{
+						Enabled: true,
+					},
+				}),
+			},
+			Subgraphs: testenv.SubgraphsConfig{
+				Test1: testenv.SubgraphConfig{
+					Middleware: func(handler http.Handler) http.Handler {
+						return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+							w.WriteHeader(http.StatusOK)
+						})
+					},
+				},
+			},
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			res, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
+				Query:     `query FloatQuery($arg: Float) { floatField(arg: $arg) }`,
+				Variables: json.RawMessage(`{"arg": 2.5}`),
+			})
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusOK, res.Response.StatusCode)
+			assert.JSONEq(t, `{
+				"errors": [
+					{
+						"message": "Failed to fetch from Subgraph 'test1', Reason: empty response.",
+						"extensions": {
+							"statusCode": 200
+						}
+					}
+				],
+				"data": {
+					"floatField": null
+				}
+			}`, res.Body)
 		})
 	})
 }

--- a/router-tests/go.mod
+++ b/router-tests/go.mod
@@ -23,9 +23,9 @@ require (
 	github.com/tidwall/gjson v1.18.0
 	github.com/twmb/franz-go v1.16.1
 	github.com/twmb/franz-go/pkg/kadm v1.11.0
-	github.com/wundergraph/cosmo/demo v0.0.0-20250213151749-f4c692434ef1
-	github.com/wundergraph/cosmo/router v0.0.0-20250213151749-f4c692434ef1
-	github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.155
+	github.com/wundergraph/cosmo/demo v0.0.0-20250215214155-40cfc416cc28
+	github.com/wundergraph/cosmo/router v0.0.0-20250215214155-40cfc416cc28
+	github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.156
 	go.opentelemetry.io/otel v1.28.0
 	go.opentelemetry.io/otel/sdk v1.28.0
 	go.opentelemetry.io/otel/sdk/metric v1.28.0

--- a/router-tests/go.mod
+++ b/router-tests/go.mod
@@ -23,8 +23,8 @@ require (
 	github.com/tidwall/gjson v1.18.0
 	github.com/twmb/franz-go v1.16.1
 	github.com/twmb/franz-go/pkg/kadm v1.11.0
-	github.com/wundergraph/cosmo/demo v0.0.0-20250215214155-40cfc416cc28
-	github.com/wundergraph/cosmo/router v0.0.0-20250215214155-40cfc416cc28
+	github.com/wundergraph/cosmo/demo v0.0.0-20250218124445-6709220e2efe
+	github.com/wundergraph/cosmo/router v0.0.0-20250218124445-6709220e2efe
 	github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.156
 	go.opentelemetry.io/otel v1.28.0
 	go.opentelemetry.io/otel/sdk v1.28.0

--- a/router-tests/go.sum
+++ b/router-tests/go.sum
@@ -335,8 +335,8 @@ github.com/wundergraph/astjson v0.0.0-20250106123708-be463c97e083 h1:8/D7f8gKxTB
 github.com/wundergraph/astjson v0.0.0-20250106123708-be463c97e083/go.mod h1:eOTL6acwctsN4F3b7YE+eE2t8zcJ/doLm9sZzsxxxrE=
 github.com/wundergraph/consul/sdk v0.0.0-20250204115147-ed842a8fd301 h1:EzfKHQoTjFDDcgaECCCR2aTePqMu9QBmPbyhqIYOhV0=
 github.com/wundergraph/consul/sdk v0.0.0-20250204115147-ed842a8fd301/go.mod h1:wxI0Nak5dI5RvJuzGyiEK4nZj0O9X+Aw6U0tC1wPKq0=
-github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.155 h1:+ygDhCfLCwDE1aL+2wjtU0PfrMJ9f9ZLb0Lm0w5W7Is=
-github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.155/go.mod h1:B7eV0Qh8Lop9QzIOQcsvKp3S0ejfC6mgyWoJnI917yQ=
+github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.156 h1:OFc0aBKNYav0uZb72WjLNkHaE/onc+joeSTxCnZKdlI=
+github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.156/go.mod h1:B7eV0Qh8Lop9QzIOQcsvKp3S0ejfC6mgyWoJnI917yQ=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb h1:zGWFAtiMcyryUHoUjUJX0/lt1H2+i2Ka2n+D3DImSNo=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=

--- a/router/core/executor.go
+++ b/router/core/executor.go
@@ -48,13 +48,14 @@ type Executor struct {
 }
 
 type ExecutorBuildOptions struct {
-	EngineConfig             *nodev1.EngineConfiguration
-	Subgraphs                []*nodev1.Subgraph
-	RouterEngineConfig       *RouterEngineConfiguration
-	PubSubProviders          *EnginePubSubProviders
-	Reporter                 resolve.Reporter
-	ApolloCompatibilityFlags config.ApolloCompatibilityFlags
-	HeartbeatInterval        time.Duration
+	EngineConfig                   *nodev1.EngineConfiguration
+	Subgraphs                      []*nodev1.Subgraph
+	RouterEngineConfig             *RouterEngineConfiguration
+	PubSubProviders                *EnginePubSubProviders
+	Reporter                       resolve.Reporter
+	ApolloCompatibilityFlags       config.ApolloCompatibilityFlags
+	ApolloRouterCompatibilityFlags config.ApolloRouterCompatibilityFlags
+	HeartbeatInterval              time.Duration
 }
 
 func (b *ExecutorConfigurationBuilder) Build(ctx context.Context, opts *ExecutorBuildOptions) (*Executor, error) {
@@ -94,6 +95,10 @@ func (b *ExecutorConfigurationBuilder) Build(ctx context.Context, opts *Executor
 	}
 	if opts.ApolloCompatibilityFlags.ReplaceInvalidVarErrors.Enabled {
 		options.ResolvableOptions.ApolloCompatibilityReplaceInvalidVarError = true
+	}
+
+	if opts.ApolloRouterCompatibilityFlags.SubrequestHTTPError.Enabled {
+		options.ResolvableOptions.ApolloRouterCompatibilitySubrequestHTTPError = true
 	}
 
 	switch opts.RouterEngineConfig.SubgraphErrorPropagation.Mode {

--- a/router/core/graph_server.go
+++ b/router/core/graph_server.go
@@ -887,13 +887,14 @@ func (s *graphServer) buildGraphMux(ctx context.Context,
 	executor, err := ecb.Build(
 		ctx,
 		&ExecutorBuildOptions{
-			EngineConfig:             engineConfig,
-			Subgraphs:                configSubgraphs,
-			RouterEngineConfig:       routerEngineConfig,
-			PubSubProviders:          s.pubSubProviders,
-			Reporter:                 s.engineStats,
-			ApolloCompatibilityFlags: s.apolloCompatibilityFlags,
-			HeartbeatInterval:        s.multipartHeartbeatInterval,
+			EngineConfig:                   engineConfig,
+			Subgraphs:                      configSubgraphs,
+			RouterEngineConfig:             routerEngineConfig,
+			PubSubProviders:                s.pubSubProviders,
+			Reporter:                       s.engineStats,
+			ApolloCompatibilityFlags:       s.apolloCompatibilityFlags,
+			ApolloRouterCompatibilityFlags: s.apolloRouterCompatibilityFlags,
+			HeartbeatInterval:              s.multipartHeartbeatInterval,
 		},
 	)
 	if err != nil {

--- a/router/go.mod
+++ b/router/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/tidwall/gjson v1.18.0
 	github.com/tidwall/sjson v1.2.5
 	github.com/twmb/franz-go v1.16.1
-	github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.155
+	github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.156
 	// Do not upgrade, it renames attributes we rely on
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.46.1
 	go.opentelemetry.io/contrib/propagators/b3 v1.23.0

--- a/router/go.sum
+++ b/router/go.sum
@@ -279,8 +279,8 @@ github.com/vektah/gqlparser/v2 v2.5.16 h1:1gcmLTvs3JLKXckwCwlUagVn/IlV2bwqle0vJ0
 github.com/vektah/gqlparser/v2 v2.5.16/go.mod h1:1lz1OeCqgQbQepsGxPVywrjdBHW2T08PUS3pJqepRww=
 github.com/wundergraph/astjson v0.0.0-20250106123708-be463c97e083 h1:8/D7f8gKxTBjW+SZK4mhxTTBVpxcqeBgWF1Rfmltbfk=
 github.com/wundergraph/astjson v0.0.0-20250106123708-be463c97e083/go.mod h1:eOTL6acwctsN4F3b7YE+eE2t8zcJ/doLm9sZzsxxxrE=
-github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.155 h1:+ygDhCfLCwDE1aL+2wjtU0PfrMJ9f9ZLb0Lm0w5W7Is=
-github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.155/go.mod h1:B7eV0Qh8Lop9QzIOQcsvKp3S0ejfC6mgyWoJnI917yQ=
+github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.156 h1:OFc0aBKNYav0uZb72WjLNkHaE/onc+joeSTxCnZKdlI=
+github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.156/go.mod h1:B7eV0Qh8Lop9QzIOQcsvKp3S0ejfC6mgyWoJnI917yQ=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
 github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=

--- a/router/pkg/config/config.go
+++ b/router/pkg/config/config.go
@@ -796,10 +796,15 @@ type ApolloCompatibilityReplaceValidationErrorStatus struct {
 
 type ApolloRouterCompatibilityFlags struct {
 	ReplaceInvalidVarErrors ApolloRouterCompatibilityReplaceInvalidVarErrors `yaml:"replace_invalid_var_errors"`
+	SubrequestHTTPError     ApolloRouterCompatibilitySubrequestHTTPError     `yaml:"subrequest_http_error"`
 }
 
 type ApolloRouterCompatibilityReplaceInvalidVarErrors struct {
 	Enabled bool `yaml:"enabled" envDefault:"false" env:"APOLLO_ROUTER_COMPATIBILITY_REPLACE_INVALID_VAR_ERRORS_ENABLED"`
+}
+
+type ApolloRouterCompatibilitySubrequestHTTPError struct {
+	Enabled bool `yaml:"enabled" envDefault:"false" env:"APOLLO_ROUTER_COMPATIBILITY_SUBREQUEST_HTTP_ERROR_ENABLED"`
 }
 
 type CacheWarmupSource struct {
@@ -882,7 +887,7 @@ type Config struct {
 
 	StorageProviders               StorageProviders                `yaml:"storage_providers"`
 	ExecutionConfig                ExecutionConfig                 `yaml:"execution_config"`
-	PersistedOperationsConfig      PersistedOperationsConfig       `yaml:"persisted_operations"`
+	PersistedOperationsConfig      PersistedOperationsConfig       `yaml:"persisted_operations,omitempty"`
 	AutomaticPersistedQueries      AutomaticPersistedQueriesConfig `yaml:"automatic_persisted_queries"`
 	ApolloCompatibilityFlags       ApolloCompatibilityFlags        `yaml:"apollo_compatibility_flags"`
 	ApolloRouterCompatibilityFlags ApolloRouterCompatibilityFlags  `yaml:"apollo_router_compatibility_flags"`

--- a/router/pkg/config/config.go
+++ b/router/pkg/config/config.go
@@ -887,7 +887,7 @@ type Config struct {
 
 	StorageProviders               StorageProviders                `yaml:"storage_providers"`
 	ExecutionConfig                ExecutionConfig                 `yaml:"execution_config"`
-	PersistedOperationsConfig      PersistedOperationsConfig       `yaml:"persisted_operations,omitempty"`
+	PersistedOperationsConfig      PersistedOperationsConfig       `yaml:"persisted_operations"`
 	AutomaticPersistedQueries      AutomaticPersistedQueriesConfig `yaml:"automatic_persisted_queries"`
 	ApolloCompatibilityFlags       ApolloCompatibilityFlags        `yaml:"apollo_compatibility_flags"`
 	ApolloRouterCompatibilityFlags ApolloRouterCompatibilityFlags  `yaml:"apollo_router_compatibility_flags"`

--- a/router/pkg/config/config.schema.json
+++ b/router/pkg/config/config.schema.json
@@ -2411,6 +2411,17 @@
               "default": false
             }
           }
+        },
+        "subrequest_http_error": {
+          "type": "object",
+          "description": "Prepends an additional error when subgraph HTTP response code is non-2XX, similar to Apollo Router.",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false
+            }
+          }
         }
       }
     },

--- a/router/pkg/config/testdata/config_defaults.json
+++ b/router/pkg/config/testdata/config_defaults.json
@@ -416,6 +416,9 @@
   "ApolloRouterCompatibilityFlags": {
     "ReplaceInvalidVarErrors": {
       "Enabled": false
+    },
+    "SubrequestHTTPError": {
+      "Enabled": false
     }
   },
   "ClientHeader": {

--- a/router/pkg/config/testdata/config_full.json
+++ b/router/pkg/config/testdata/config_full.json
@@ -703,6 +703,9 @@
   "ApolloRouterCompatibilityFlags": {
     "ReplaceInvalidVarErrors": {
       "Enabled": false
+    },
+    "SubrequestHTTPError": {
+      "Enabled": false
     }
   },
   "ClientHeader": {


### PR DESCRIPTION
## Motivation and Context

- Adds config option `/apollo_router_compatibility_flags/subrequest_http_error/enabled` which enables Apollo Router like behaviour when subgraphs return non-2XX http status.
- Bumps `graphql-go-tools` to (v2.0.0-rc.156)[https://github.com/wundergraph/graphql-go-tools/releases/tag/v2.0.0-rc.156] to support this functionality

## Checklist

- [x] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [x] Tests or benchmarks have been added or updated.
- [x] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## `graphql-go-tools` changelog [2.0.0-rc.156](https://github.com/wundergraph/graphql-go-tools/compare/v2.0.0-rc.155...v2.0.0-rc.156) (2025-02-18)

### Features

* apollo-router-like non-ok http status errors ([#1072](https://github.com/wundergraph/graphql-go-tools/issues/1072)) ([e685c29](https://github.com/wundergraph/graphql-go-tools/commit/e685c29331c0d1879ff8e099d4441047fbddf054))