### PR TITLE
fix: include changedTypes in the list of changes displayed in the slack notification

### DIFF
--- a/controlplane/src/core/webhooks/OrganizationWebhookService.ts
+++ b/controlplane/src/core/webhooks/OrganizationWebhookService.ts
@@ -264,6 +264,32 @@ export class OrganizationWebhookService {
             return tempData;
           }
 
+          if (changedChanges.length > 0) {
+            tempData.attachments.unshift({
+              color: '#8D879D',
+              blocks: [
+                {
+                  type: 'rich_text',
+                  elements: [
+                    {
+                      type: 'rich_text_list',
+                      style: 'bullet',
+                      elements: changedChanges.map((r) => ({
+                        type: 'rich_text_section',
+                        elements: [
+                          {
+                            type: 'text',
+                            text: r.changeMessage,
+                          },
+                        ],
+                      })),
+                    },
+                  ],
+                },
+              ],
+            });
+          }
+
           if (removedChanges.length > 0) {
             tempData.attachments.unshift({
               color: '#e11d48',
@@ -289,6 +315,7 @@ export class OrganizationWebhookService {
               ],
             });
           }
+
           if (addedChanges.length > 0) {
             tempData.attachments.unshift({
               color: '#22c55e',


### PR DESCRIPTION
This PR adds the missing changes with the change type "CHANGED" in the Slack notification.

## Checklist

- [x] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).
