### PR TITLE
feat(router): cookie header whitelist

### DIFF
--- a/router-tests/headers_test.go
+++ b/router-tests/headers_test.go
@@ -53,6 +53,122 @@ func TestForwardHeaders(t *testing.T) {
 		},
 	}
 
+	t.Run("cookie filtering should remove no cookies when not specified", func(t *testing.T) {
+		t.Parallel()
+
+		testenv.Run(t, &testenv.Config{
+			ModifyEngineExecutionConfiguration: func(cfg *config.EngineExecutionConfiguration) {
+				cfg.WebSocketClientReadTimeout = time.Millisecond * 10
+			},
+			RouterOptions: []core.Option{
+				core.WithHeaderRules(config.HeaderRules{
+					All: &config.GlobalHeaderRule{
+						Request: []*config.RequestHeaderRule{
+							{
+								Operation: config.HeaderRuleOperationPropagate,
+								Named:     "Cookie",
+							},
+						},
+					},
+				}),
+			},
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+				Cookies: []*http.Cookie{
+					{
+						Name:  "allowed",
+						Value: "allowed",
+					},
+					{
+						Name:  "allowed_as_well",
+						Value: "allowed",
+					},
+				},
+				Query: `query { headerValue(name:"Cookie") }`,
+			})
+			require.Equal(t, `{"data":{"headerValue":"allowed=allowed; allowed_as_well=allowed"}}`, res.Body)
+
+		})
+	})
+
+	t.Run("cookie filtering should remove no cookies when whitelist is empty", func(t *testing.T) {
+		t.Parallel()
+
+		testenv.Run(t, &testenv.Config{
+			ModifyEngineExecutionConfiguration: func(cfg *config.EngineExecutionConfiguration) {
+				cfg.WebSocketClientReadTimeout = time.Millisecond * 10
+			},
+			RouterOptions: []core.Option{
+				core.WithHeaderRules(config.HeaderRules{
+					CookieWhitelist: []string{},
+					All: &config.GlobalHeaderRule{
+						Request: []*config.RequestHeaderRule{
+							{
+								Operation: config.HeaderRuleOperationPropagate,
+								Named:     "Cookie",
+							},
+						},
+					},
+				}),
+			},
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+				Cookies: []*http.Cookie{
+					{
+						Name:  "allowed",
+						Value: "allowed",
+					},
+					{
+						Name:  "allowed_as_well",
+						Value: "allowed",
+					},
+				},
+				Query: `query { headerValue(name:"Cookie") }`,
+			})
+			require.Equal(t, `{"data":{"headerValue":"allowed=allowed; allowed_as_well=allowed"}}`, res.Body)
+
+		})
+	})
+
+	t.Run("cookie filtering should remove cookies not on the whitelist", func(t *testing.T) {
+		t.Parallel()
+
+		testenv.Run(t, &testenv.Config{
+			ModifyEngineExecutionConfiguration: func(cfg *config.EngineExecutionConfiguration) {
+				cfg.WebSocketClientReadTimeout = time.Millisecond * 10
+			},
+			RouterOptions: []core.Option{
+				core.WithHeaderRules(config.HeaderRules{
+					CookieWhitelist: []string{"allowed"},
+					All: &config.GlobalHeaderRule{
+						Request: []*config.RequestHeaderRule{
+							{
+								Operation: config.HeaderRuleOperationPropagate,
+								Named:     "Cookie",
+							},
+						},
+					},
+				}),
+			},
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+				Cookies: []*http.Cookie{
+					{
+						Name:  "allowed",
+						Value: "allowed",
+					},
+					{
+						Name:  "disallowed",
+						Value: "disallowed",
+					},
+				},
+				Query: `query { headerValue(name:"Cookie") }`,
+			})
+			require.Equal(t, `{"data":{"headerValue":"allowed=allowed"}}`, res.Body)
+
+		})
+	})
+
 	t.Run("HTTP", func(t *testing.T) {
 		t.Parallel()
 

--- a/router-tests/testenv/testenv.go
+++ b/router-tests/testenv/testenv.go
@@ -1241,6 +1241,7 @@ type GraphQLRequest struct {
 	OperationName json.RawMessage `json:"operationName,omitempty"`
 	Header        http.Header     `json:"-"`
 	Files         [][]byte        `json:"-"`
+	Cookies       []*http.Cookie  `json:"-"`
 }
 
 type TestResponse struct {
@@ -1299,6 +1300,13 @@ func (e *Environment) MakeGraphQLRequestWithContext(ctx context.Context, request
 	if request.Header != nil {
 		req.Header = request.Header
 	}
+
+	if request.Cookies != nil {
+		for _, c := range request.Cookies {
+			req.AddCookie(c)
+		}
+	}
+
 	req.Header.Set("Accept-Encoding", "identity")
 	return e.MakeGraphQLRequestRaw(req)
 }

--- a/router/core/graph_server.go
+++ b/router/core/graph_server.go
@@ -235,6 +235,8 @@ func newGraphServer(ctx context.Context, r *Router, routerConfig *nodev1.RouterC
 			return wrapper(h)
 		})
 
+		cr.Use(rmiddleware.CookieWhitelist(s.headerRules.CookieWhitelist))
+
 		// Mount the feature flag handler. It calls the base mux if no feature flag is set.
 		cr.Handle(r.graphqlPath, multiGraphHandler)
 

--- a/router/core/graph_server.go
+++ b/router/core/graph_server.go
@@ -235,7 +235,9 @@ func newGraphServer(ctx context.Context, r *Router, routerConfig *nodev1.RouterC
 			return wrapper(h)
 		})
 
-		cr.Use(rmiddleware.CookieWhitelist(s.headerRules.CookieWhitelist))
+		if s.headerRules != nil {
+			cr.Use(rmiddleware.CookieWhitelist(s.headerRules.CookieWhitelist))
+		}
 
 		// Mount the feature flag handler. It calls the base mux if no feature flag is set.
 		cr.Handle(r.graphqlPath, multiGraphHandler)

--- a/router/internal/middleware/cookie_filter.go
+++ b/router/internal/middleware/cookie_filter.go
@@ -1,0 +1,28 @@
+package middleware
+
+import (
+	"net/http"
+	"slices"
+)
+
+func CookieWhitelist(cookieWhitelist []string) func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(rw http.ResponseWriter, rr *http.Request) {
+			if len(cookieWhitelist) == 0 {
+				next.ServeHTTP(rw, rr)
+				return
+			}
+
+			cookies := rr.Cookies()
+			rr.Header.Del("Cookie")
+
+			for _, cookie := range cookies {
+				if slices.Contains(cookieWhitelist, cookie.Name) {
+					rr.AddCookie(cookie)
+				}
+			}
+
+			next.ServeHTTP(rw, rr)
+		})
+	}
+}

--- a/router/internal/middleware/cookie_filter_test.go
+++ b/router/internal/middleware/cookie_filter_test.go
@@ -1,0 +1,89 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCookieWhitelist(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should remove no cookies by default", func(t *testing.T) {
+		t.Parallel()
+
+		cookieWhitelist := []string{}
+		cookies := []*http.Cookie{
+			{
+				Name:  "allowed",
+				Value: "allowed",
+			},
+		}
+
+		recorder := httptest.NewRecorder()
+
+		filteredCookies := []*http.Cookie{}
+
+		next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			filteredCookies = r.Cookies()
+		})
+
+		req, err := http.NewRequest(http.MethodGet, "/", strings.NewReader("test"))
+		require.NoError(t, err)
+
+		for _, cookie := range cookies {
+			req.AddCookie(cookie)
+		}
+
+		CookieWhitelist(cookieWhitelist)(next).ServeHTTP(recorder, req)
+
+		require.Equal(t, http.StatusOK, recorder.Code)
+		require.Equal(t, cookies, filteredCookies)
+	})
+
+	t.Run("should only allow whitelisted cookies", func(t *testing.T) {
+		t.Parallel()
+
+		cookieWhitelist := []string{"allowed"}
+		cookies := []*http.Cookie{
+			{
+				Name:  "allowed",
+				Value: "allowed",
+			},
+			{
+				Name:  "disallowed",
+				Value: "disallowed",
+			},
+		}
+
+		expectedFilteredCookies := []*http.Cookie{
+			{
+				Name:  "allowed",
+				Value: "allowed",
+			},
+		}
+
+		recorder := httptest.NewRecorder()
+
+		filteredCookies := []*http.Cookie{}
+
+		next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			filteredCookies = r.Cookies()
+		})
+
+		req, err := http.NewRequest(http.MethodGet, "/", strings.NewReader("test"))
+		require.NoError(t, err)
+
+		for _, cookie := range cookies {
+			req.AddCookie(cookie)
+		}
+
+		CookieWhitelist(cookieWhitelist)(next).ServeHTTP(recorder, req)
+
+		require.Equal(t, http.StatusOK, recorder.Code)
+		require.Equal(t, expectedFilteredCookies, filteredCookies)
+	})
+}

--- a/router/pkg/config/config.go
+++ b/router/pkg/config/config.go
@@ -211,8 +211,9 @@ type CacheControlPolicy struct {
 
 type HeaderRules struct {
 	// All is a set of rules that apply to all requests
-	All       *GlobalHeaderRule            `yaml:"all,omitempty"`
-	Subgraphs map[string]*GlobalHeaderRule `yaml:"subgraphs,omitempty"`
+	All             *GlobalHeaderRule            `yaml:"all,omitempty"`
+	Subgraphs       map[string]*GlobalHeaderRule `yaml:"subgraphs,omitempty"`
+	CookieWhitelist []string                     `yaml:"cookie_whitelist,omitempty"`
 }
 
 type GlobalHeaderRule struct {

--- a/router/pkg/config/config.schema.json
+++ b/router/pkg/config/config.schema.json
@@ -1351,6 +1351,14 @@
               }
             }
           }
+        },
+        "cookie_whitelist": {
+          "type": "array",
+          "description": "A list of Cookie keys allowed to be forwarded to the subgraph. If the list is empty or unspecified, all cookies are forwarded. This option will do nothing if the 'Cookie' header is not propagated.",
+          "default": [],
+          "items": {
+            "type": "string"
+          }
         }
       }
     },

--- a/router/pkg/config/fixtures/full.yaml
+++ b/router/pkg/config/fixtures/full.yaml
@@ -211,6 +211,9 @@ headers:
         - op: "set"
           name: "X-Subgraph-Key"
           value: "some-subgraph-secret"
+  cookie_whitelist:
+    - "cookie1"
+    - "cookie2"
 
 # Authentication and Authorization
 # See https://cosmo-docs.wundergraph.com/router/authentication-and-authorization for more information

--- a/router/pkg/config/testdata/config_defaults.json
+++ b/router/pkg/config/testdata/config_defaults.json
@@ -104,7 +104,8 @@
   "Modules": null,
   "Headers": {
     "All": null,
-    "Subgraphs": null
+    "Subgraphs": null,
+    "CookieWhitelist": null
   },
   "TrafficShaping": {
     "All": {

--- a/router/pkg/config/testdata/config_full.json
+++ b/router/pkg/config/testdata/config_full.json
@@ -228,7 +228,11 @@
           }
         ]
       }
-    }
+    },
+    "CookieWhitelist": [
+      "cookie1",
+      "cookie2"
+    ]
   },
   "TrafficShaping": {
     "All": {


### PR DESCRIPTION
## Motivation and Context

- Adds config option `/headers/cookie_whitelist: []string` that represents a list of allowed cookie "keys" to be propagated by the router
- It achieves this by stripping unwanted headers off the request using standard HTTP middleware on the graph server
- An empty or unspecified value means allow all, users should just disable `Cookie` header propagation if they don't want any cookies
- This option will have little to no effect if `Cookie` is not a propagated header.
- `Cookie` being a `set` header should not be affected by this at all

## Checklist

- [x] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [x] Tests or benchmarks have been added or updated.
- [x] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).