### PR TITLE
feat: include client schema in the output of federated-graph fetch command

### DIFF
--- a/cli/src/commands/graph/federated-graph/commands/fetch.ts
+++ b/cli/src/commands/graph/federated-graph/commands/fetch.ts
@@ -4,7 +4,7 @@ import yaml from 'js-yaml';
 import { join, resolve } from 'pathe';
 import pc from 'picocolors';
 import { BaseCommandOptions } from '../../../../core/types/types.js';
-import { fetchRouterConfig, getFederatedGraphSDL, getSubgraphSDL, getSubgraphsOfFedGraph } from '../utils.js';
+import { fetchRouterConfig, getFederatedGraphSchemas, getSubgraphSDL, getSubgraphsOfFedGraph } from '../utils.js';
 
 export default (opts: BaseCommandOptions) => {
   const cmd = new Command('fetch');
@@ -23,7 +23,11 @@ export default (opts: BaseCommandOptions) => {
 
   cmd.action(async (name, options) => {
     try {
-      const fedGraphSDL = await getFederatedGraphSDL({ client: opts.client, name, namespace: options.namespace });
+      const fedGraphSchemas = await getFederatedGraphSchemas({
+        client: opts.client,
+        name,
+        namespace: options.namespace,
+      });
 
       const basePath = resolve(options.out, `${name}${options.namespace ? `-${options.namespace}` : ''}`);
       const superGraphPath = join(basePath, '/supergraph/');
@@ -47,7 +51,11 @@ export default (opts: BaseCommandOptions) => {
       });
       writeFileSync(join(superGraphPath, `cosmoConfig.json`), routerConfig);
 
-      writeFileSync(join(superGraphPath, `cosmoSchema.graphql`), fedGraphSDL);
+      writeFileSync(join(superGraphPath, `cosmoSchema.graphql`), fedGraphSchemas.sdl);
+
+      if (fedGraphSchemas.clientSchema) {
+        writeFileSync(join(superGraphPath, `cosmoClientSchema.graphql`), fedGraphSchemas.clientSchema);
+      }
 
       const subgraphs = await getSubgraphsOfFedGraph({ client: opts.client, name, namespace: options.namespace });
 

--- a/cli/src/commands/graph/federated-graph/utils.ts
+++ b/cli/src/commands/graph/federated-graph/utils.ts
@@ -118,7 +118,7 @@ export const getSubgraphsOfFedGraph = async ({
   });
 };
 
-export const getFederatedGraphSDL = async ({
+export const getFederatedGraphSchemas = async ({
   client,
   name,
   namespace,
@@ -145,9 +145,10 @@ export const getFederatedGraphSDL = async ({
     );
   }
 
-  const sdl = await resp.sdl;
-
-  return sdl;
+  return {
+    sdl: resp.sdl,
+    clientSchema: resp.clientSchema,
+  };
 };
 
 // Returns the latest valid schema version of a subgraph that was composed to form the provided federated graph.


### PR DESCRIPTION
This PR adds the client schema of the federated graph in the output of `wgc federated-graph fetch` command.

## Checklist

- [x] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).