### PR TITLE
fix(cli): resolve broken console outputs

### DIFF
--- a/cli/src/commands/contract/commands/create.ts
+++ b/cli/src/commands/contract/commands/create.ts
@@ -134,7 +134,8 @@ export default (opts: BaseCommandOptions) => {
         if (resp.response?.details) {
           console.error(pc.red(pc.bold(resp.response?.details)));
         }
-        process.exit(1);
+        process.exitCode = 1;
+        return;
       }
     }
 

--- a/cli/src/commands/contract/commands/update.ts
+++ b/cli/src/commands/contract/commands/update.ts
@@ -131,7 +131,8 @@ export default (opts: BaseCommandOptions) => {
         if (resp.response?.details) {
           console.error(pc.red(pc.bold(resp.response?.details)));
         }
-        process.exit(1);
+        process.exitCode = 1;
+        return;
       }
     }
 

--- a/cli/src/commands/feature-flag/commands/create.ts
+++ b/cli/src/commands/feature-flag/commands/create.ts
@@ -76,7 +76,9 @@ export default (opts: BaseCommandOptions) => {
         suppressWarnings: options.suppressWarnings,
       });
     } catch {
-      process.exit(1);
+      process.exitCode = 1;
+      // eslint-disable-next-line no-useless-return
+      return;
     }
   });
 

--- a/cli/src/commands/feature-flag/commands/delete.ts
+++ b/cli/src/commands/feature-flag/commands/delete.ts
@@ -23,7 +23,8 @@ export default (opts: BaseCommandOptions) => {
         message: `Are you sure you want to delete the feature flag "${name}"?`,
       });
       if (!deletionConfirmed.confirmDeletion) {
-        process.exit(1);
+        process.exitCode = 1;
+        return;
       }
     }
 
@@ -61,7 +62,9 @@ export default (opts: BaseCommandOptions) => {
         suppressWarnings: options.suppressWarnings,
       });
     } catch {
-      process.exit(1);
+      process.exitCode = 1;
+      // eslint-disable-next-line no-useless-return
+      return;
     }
   });
 

--- a/cli/src/commands/feature-flag/commands/disable.ts
+++ b/cli/src/commands/feature-flag/commands/disable.ts
@@ -53,7 +53,9 @@ export default (opts: BaseCommandOptions) => {
         suppressWarnings: options.suppressWarnings,
       });
     } catch {
-      process.exit(1);
+      process.exitCode = 1;
+      // eslint-disable-next-line no-useless-return
+      return;
     }
   });
 

--- a/cli/src/commands/feature-flag/commands/enable.ts
+++ b/cli/src/commands/feature-flag/commands/enable.ts
@@ -53,7 +53,9 @@ export default (opts: BaseCommandOptions) => {
         suppressWarnings: options.suppressWarnings,
       });
     } catch {
-      process.exit(1);
+      process.exitCode = 1;
+      // eslint-disable-next-line no-useless-return
+      return;
     }
   });
 

--- a/cli/src/commands/feature-flag/commands/update.ts
+++ b/cli/src/commands/feature-flag/commands/update.ts
@@ -82,7 +82,9 @@ export default (opts: BaseCommandOptions) => {
         suppressWarnings: options.suppressWarnings,
       });
     } catch {
-      process.exit(1);
+      process.exitCode = 1;
+      // eslint-disable-next-line no-useless-return
+      return;
     }
   });
 

--- a/cli/src/commands/feature-subgraph/commands/create.ts
+++ b/cli/src/commands/feature-subgraph/commands/create.ts
@@ -80,7 +80,9 @@ export default (opts: BaseCommandOptions) => {
       if (resp.response?.details) {
         console.log(pc.red(pc.bold(resp.response?.details)));
       }
-      process.exit(1);
+      process.exitCode = 1;
+      // eslint-disable-next-line no-useless-return
+      return;
     }
   });
 

--- a/cli/src/commands/feature-subgraph/commands/publish.ts
+++ b/cli/src/commands/feature-subgraph/commands/publish.ts
@@ -236,7 +236,9 @@ export default (opts: BaseCommandOptions) => {
             program.error(pc.red(pc.bold(resp.response?.details)));
           }
         }
-        process.exit(1);
+        process.exitCode = 1;
+        // eslint-disable-next-line no-useless-return
+        return;
       }
     }
   });

--- a/cli/src/commands/graph/common/fetch-schema.ts
+++ b/cli/src/commands/graph/common/fetch-schema.ts
@@ -31,7 +31,8 @@ export default (opts: CommonGraphCommandOptions) => {
       if (resp.response?.details) {
         console.log(pc.red(pc.bold(resp.response?.details)));
       }
-      process.exit(1);
+      process.exitCode = 1;
+      return;
     }
 
     if (options.out) {

--- a/cli/src/commands/graph/common/version/commands/set.ts
+++ b/cli/src/commands/graph/common/version/commands/set.ts
@@ -34,7 +34,8 @@ export default (opts: CommonGraphCommandOptions) => {
 
     if (!response.response) {
       spinner.fail(`Failed to set router compatibility version for ${graphType} "${pc.bold(name)}".`);
-      process.exit(1);
+      process.exitCode = 1;
+      return;
     }
 
     if (response.response.code === EnumStatusCode.ERR_NOT_FOUND) {

--- a/cli/src/commands/graph/federated-graph/commands/check.ts
+++ b/cli/src/commands/graph/federated-graph/commands/check.ts
@@ -110,7 +110,9 @@ export default (opts: BaseCommandOptions) => {
     }
 
     if (!success) {
-      process.exit(1);
+      process.exitCode = 1;
+      // eslint-disable-next-line no-useless-return
+      return;
     }
   });
 

--- a/cli/src/commands/graph/federated-graph/commands/create.ts
+++ b/cli/src/commands/graph/federated-graph/commands/create.ts
@@ -134,7 +134,8 @@ export default (opts: BaseCommandOptions) => {
         if (resp.response?.details) {
           console.error(pc.red(pc.bold(resp.response?.details)));
         }
-        process.exit(1);
+        process.exitCode = 1;
+        return;
       }
     }
 

--- a/cli/src/commands/graph/federated-graph/commands/delete.ts
+++ b/cli/src/commands/graph/federated-graph/commands/delete.ts
@@ -20,7 +20,8 @@ export default (opts: BaseCommandOptions) => {
         message: 'Are you sure you want to delete this federated graph?',
       });
       if (!deletionConfirmed.confirmDeletion) {
-        process.exit(1);
+        process.exitCode = 1;
+        return;
       }
     }
 
@@ -42,7 +43,9 @@ export default (opts: BaseCommandOptions) => {
       if (resp.response?.details) {
         console.log(pc.red(pc.bold(resp.response?.details)));
       }
-      process.exit(1);
+      process.exitCode = 1;
+      // eslint-disable-next-line no-useless-return
+      return;
     }
   });
 

--- a/cli/src/commands/graph/federated-graph/commands/fetch.ts
+++ b/cli/src/commands/graph/federated-graph/commands/fetch.ts
@@ -170,7 +170,9 @@ rover supergraph compose --config '${join(basePath, `rover-composition.yaml`)}' 
       if (e.message) {
         console.error(pc.red(e.message));
       }
-      process.exit(1);
+      process.exitCode = 1;
+      // eslint-disable-next-line no-useless-return
+      return;
     }
   });
 

--- a/cli/src/commands/graph/federated-graph/commands/list.ts
+++ b/cli/src/commands/graph/federated-graph/commands/list.ts
@@ -64,7 +64,7 @@ export default (opts: BaseCommandOptions) => {
       } else {
         console.log('No federated graphs found');
       }
-      process.exit(0);
+      return;
     }
 
     if (options.out) {
@@ -81,7 +81,7 @@ export default (opts: BaseCommandOptions) => {
           }) satisfies OutputFile[number],
       );
       await writeFile(resolve(options.out), JSON.stringify(output));
-      process.exit(0);
+      return;
     }
 
     if (options.raw) {

--- a/cli/src/commands/graph/federated-graph/commands/list.ts
+++ b/cli/src/commands/graph/federated-graph/commands/list.ts
@@ -85,12 +85,12 @@ export default (opts: BaseCommandOptions) => {
     }
 
     if (options.raw) {
-      console.log(pc.yellow('Please use the --json option. The --raw option is deprecated.'));
+      console.warn(pc.yellow('Please use the --json option. The --raw option is deprecated.'));
     }
 
     if (options.raw || options.json) {
       console.log(JSON.stringify(filteredGraphs));
-      process.exit(0);
+      return;
     }
 
     const graphsTable = new Table({

--- a/cli/src/commands/graph/federated-graph/commands/move.ts
+++ b/cli/src/commands/graph/federated-graph/commands/move.ts
@@ -95,7 +95,8 @@ export default (opts: BaseCommandOptions) => {
         if (resp.response?.details) {
           console.error(pc.red(pc.bold(resp.response?.details)));
         }
-        process.exit(1);
+        process.exitCode = 1;
+        return;
       }
     }
 

--- a/cli/src/commands/graph/federated-graph/commands/update.ts
+++ b/cli/src/commands/graph/federated-graph/commands/update.ts
@@ -134,7 +134,8 @@ export default (opts: BaseCommandOptions) => {
         if (resp.response?.details) {
           console.log(pc.red(pc.bold(resp.response?.details)));
         }
-        process.exit(1);
+        process.exitCode = 1;
+        return;
       }
     }
 

--- a/cli/src/commands/graph/monograph/commands/check.ts
+++ b/cli/src/commands/graph/monograph/commands/check.ts
@@ -72,7 +72,9 @@ export default (opts: BaseCommandOptions) => {
     const success = handleCheckResult(resp);
 
     if (!success && !ignoreErrorsDueToGitHubIntegration) {
-      process.exit(1);
+      process.exitCode = 1;
+      // eslint-disable-next-line no-useless-return
+      return;
     }
   });
 

--- a/cli/src/commands/graph/monograph/commands/create.ts
+++ b/cli/src/commands/graph/monograph/commands/create.ts
@@ -85,7 +85,9 @@ export default (opts: BaseCommandOptions) => {
       if (resp.response?.details) {
         console.log(pc.red(pc.bold(resp.response?.details)));
       }
-      process.exit(1);
+      process.exitCode = 1;
+      // eslint-disable-next-line no-useless-return
+      return;
     }
   });
 

--- a/cli/src/commands/graph/monograph/commands/delete.ts
+++ b/cli/src/commands/graph/monograph/commands/delete.ts
@@ -20,7 +20,8 @@ export default (opts: BaseCommandOptions) => {
         message: 'Are you sure you want to delete this monograph?',
       });
       if (!deletionConfirmed.confirmDeletion) {
-        process.exit(1);
+        process.exitCode = 1;
+        return;
       }
     }
 

--- a/cli/src/commands/graph/monograph/commands/list.ts
+++ b/cli/src/commands/graph/monograph/commands/list.ts
@@ -85,7 +85,7 @@ export default (opts: BaseCommandOptions) => {
     }
 
     if (options.raw || options.json) {
-      console.log(filteredGraphs);
+      console.log(JSON.stringify(filteredGraphs));
       return;
     }
 

--- a/cli/src/commands/graph/monograph/commands/list.ts
+++ b/cli/src/commands/graph/monograph/commands/list.ts
@@ -81,12 +81,12 @@ export default (opts: BaseCommandOptions) => {
     }
 
     if (options.raw) {
-      console.log(pc.yellow('Please use the --json option. The --raw option is deprecated.'));
+      console.warn(pc.yellow('Please use the --json option. The --raw option is deprecated.'));
     }
 
     if (options.raw || options.json) {
       console.log(filteredGraphs);
-      process.exit(0);
+      return;
     }
 
     const graphsTable = new Table({

--- a/cli/src/commands/graph/monograph/commands/list.ts
+++ b/cli/src/commands/graph/monograph/commands/list.ts
@@ -62,7 +62,7 @@ export default (opts: BaseCommandOptions) => {
       } else {
         console.log('No monographs found');
       }
-      process.exit(0);
+      return;
     }
 
     if (options.out) {
@@ -77,7 +77,7 @@ export default (opts: BaseCommandOptions) => {
           }) satisfies OutputFile[number],
       );
       await writeFile(resolve(options.out), JSON.stringify(output));
-      process.exit(0);
+      return;
     }
 
     if (options.raw) {

--- a/cli/src/commands/graph/monograph/commands/migrate.ts
+++ b/cli/src/commands/graph/monograph/commands/migrate.ts
@@ -18,7 +18,8 @@ export default (opts: BaseCommandOptions) => {
       message: 'This action is irreversible. Are you sure you want to migrate this monograph?',
     });
     if (!inquiry.confirmMigration) {
-      process.exit(1);
+      process.exitCode = 1;
+      return;
     }
 
     const spinner = ora('Monograph is being migrated...').start();

--- a/cli/src/commands/graph/monograph/commands/publish.ts
+++ b/cli/src/commands/graph/monograph/commands/publish.ts
@@ -129,7 +129,8 @@ export default (opts: BaseCommandOptions) => {
         if (resp.response?.details) {
           console.log(pc.red(pc.bold(resp.response?.details)));
         }
-        process.exit(1);
+        process.exitCode = 1;
+        return;
       }
     }
 

--- a/cli/src/commands/graph/monograph/commands/update.ts
+++ b/cli/src/commands/graph/monograph/commands/update.ts
@@ -89,7 +89,9 @@ export default (opts: BaseCommandOptions) => {
       if (resp.response?.details) {
         console.log(pc.red(pc.bold(resp.response?.details)));
       }
-      process.exit(1);
+      process.exitCode = 1;
+      // eslint-disable-next-line no-useless-return
+      return;
     }
   });
 

--- a/cli/src/commands/namespace/commands/delete.ts
+++ b/cli/src/commands/namespace/commands/delete.ts
@@ -18,7 +18,8 @@ export default (opts: BaseCommandOptions) => {
         message: 'All resources within the namespace will be deleted. Are you sure you want to proceed?',
       });
       if (!deletionConfirmed.confirmDeletion) {
-        process.exit(1);
+        process.exitCode = 1;
+        return;
       }
     }
 

--- a/cli/src/commands/namespace/commands/list.ts
+++ b/cli/src/commands/namespace/commands/list.ts
@@ -42,7 +42,7 @@ export default (opts: BaseCommandOptions) => {
     }
 
     if (options.raw) {
-      console.log(pc.yellow('Please use the --json option. The --raw option is deprecated.'));
+      console.warn(pc.yellow('Please use the --json option. The --raw option is deprecated.'));
     }
 
     if (options.raw || options.json) {

--- a/cli/src/commands/router/commands/cache/commands/push.ts
+++ b/cli/src/commands/router/commands/cache/commands/push.ts
@@ -77,7 +77,9 @@ export default (opts: BaseCommandOptions) => {
       if (result.response?.details) {
         console.error(pc.red(pc.bold(result.response?.details)));
       }
-      process.exit(1);
+      process.exitCode = 1;
+      // eslint-disable-next-line no-useless-return
+      return;
     }
   });
   return command;

--- a/cli/src/commands/router/commands/compose.ts
+++ b/cli/src/commands/router/commands/compose.ts
@@ -121,7 +121,8 @@ export default (opts: BaseCommandOptions) => {
         compositionErrorsTable.push([compositionError.message]);
       }
       console.log(compositionErrorsTable.toString());
-      process.exit(1);
+      process.exitCode = 1;
+      return;
     }
 
     if (!options.suppressWarnings && result.warnings.length > 0) {

--- a/cli/src/commands/router/commands/fetch.ts
+++ b/cli/src/commands/router/commands/fetch.ts
@@ -45,7 +45,8 @@ export default (opts: BaseCommandOptions) => {
       if (resp.response?.details) {
         console.log(pc.red(pc.bold(resp.response?.details)));
       }
-      process.exit(1);
+      process.exitCode = 1;
+      return;
     }
 
     let decoded: GraphToken;
@@ -82,14 +83,16 @@ export default (opts: BaseCommandOptions) => {
       const signature = response.headers.get('X-Signature-SHA256');
       if (!signature) {
         console.log(pc.red('You provided a signature key, but the router config does not have a signature header.'));
-        process.exit(1);
+        process.exitCode = 1;
+        return;
       }
 
       const hash = await makeSignature(body, options.graphSignKey);
 
       if (!safeCompare(hash, signature)) {
         console.log(pc.red('The signature of the router config does not match the provided signature key.'));
-        process.exit(1);
+        process.exitCode = 1;
+        return;
       }
 
       if (options.out) {

--- a/cli/src/commands/router/commands/token/commands/create.ts
+++ b/cli/src/commands/router/commands/token/commands/create.ts
@@ -49,7 +49,9 @@ export default (opts: BaseCommandOptions) => {
       if (resp.response?.details) {
         console.log(pc.red(pc.bold(resp.response?.details)));
       }
-      process.exit(1);
+      process.exitCode = 1;
+      // eslint-disable-next-line no-useless-return
+      return;
     }
   });
 

--- a/cli/src/commands/router/commands/token/commands/delete.ts
+++ b/cli/src/commands/router/commands/token/commands/delete.ts
@@ -23,7 +23,8 @@ export default (opts: BaseCommandOptions) => {
         message: 'Are you sure you want to delete this router token?',
       });
       if (!deletionConfirmed.confirmDeletion) {
-        process.exit(1);
+        process.exitCode = 1;
+        return;
       }
     }
     const resp = await opts.client.platform.deleteRouterToken(
@@ -44,7 +45,9 @@ export default (opts: BaseCommandOptions) => {
       if (resp.response?.details) {
         console.log(pc.red(pc.bold(resp.response?.details)));
       }
-      process.exit(1);
+      process.exitCode = 1;
+      // eslint-disable-next-line no-useless-return
+      return;
     }
   });
 

--- a/cli/src/commands/router/commands/token/commands/list.ts
+++ b/cli/src/commands/router/commands/token/commands/list.ts
@@ -31,7 +31,7 @@ export default (opts: BaseCommandOptions) => {
 
     if (resp.tokens.length === 0) {
       console.log('No router tokens for the given graph found');
-      process.exit(0);
+      return;
     }
 
     const tokensTable = new Table({

--- a/cli/src/commands/subgraph/commands/check.ts
+++ b/cli/src/commands/subgraph/commands/check.ts
@@ -71,7 +71,9 @@ export default (opts: BaseCommandOptions) => {
     const success = handleCheckResult(resp);
 
     if (!success && !ignoreErrorsDueToGitHubIntegration) {
-      process.exit(1);
+      process.exitCode = 1;
+      // eslint-disable-next-line no-useless-return
+      return;
     }
   });
 

--- a/cli/src/commands/subgraph/commands/create.ts
+++ b/cli/src/commands/subgraph/commands/create.ts
@@ -101,7 +101,9 @@ export default (opts: BaseCommandOptions) => {
       if (resp.response?.details) {
         console.log(pc.red(pc.bold(resp.response?.details)));
       }
-      process.exit(1);
+      process.exitCode = 1;
+      // eslint-disable-next-line no-useless-return
+      return;
     }
   });
 

--- a/cli/src/commands/subgraph/commands/delete.ts
+++ b/cli/src/commands/subgraph/commands/delete.ts
@@ -22,7 +22,8 @@ export default (opts: BaseCommandOptions) => {
         message: `Are you sure you want to delete the subgraph "${name}"?`,
       });
       if (!deletionConfirmed.confirmDeletion) {
-        process.exit(1);
+        process.exitCode = 1;
+        return;
       }
     }
 
@@ -112,7 +113,8 @@ export default (opts: BaseCommandOptions) => {
         if (resp.response?.details) {
           console.log(pc.red(pc.bold(resp.response?.details)));
         }
-        process.exit(1);
+        process.exitCode = 1;
+        return;
       }
     }
 

--- a/cli/src/commands/subgraph/commands/fetch.ts
+++ b/cli/src/commands/subgraph/commands/fetch.ts
@@ -62,7 +62,8 @@ export default (opts: BaseCommandOptions) => {
       if (response?.details) {
         console.log(pc.red(pc.bold(response?.details)));
       }
-      process.exit(1);
+      process.exitCode = 1;
+      return;
     }
 
     if (options.out) {

--- a/cli/src/commands/subgraph/commands/fix.ts
+++ b/cli/src/commands/subgraph/commands/fix.ts
@@ -55,7 +55,8 @@ export default (opts: BaseCommandOptions) => {
         console.log(pc.red(pc.bold(resp.response?.details)));
       }
       console.log(logSymbols.error + pc.red(' Schema fix failed.'));
-      process.exit(1);
+      process.exitCode = 1;
+      return;
     }
 
     if (!resp.modified) {

--- a/cli/src/commands/subgraph/commands/list.ts
+++ b/cli/src/commands/subgraph/commands/list.ts
@@ -61,12 +61,12 @@ export default (opts: BaseCommandOptions) => {
     }
 
     if (options.raw) {
-      console.log(pc.yellow('Please use the --json option. The --raw option is deprecated.'));
+      console.warn(pc.yellow('Please use the --json option. The --raw option is deprecated.'));
     }
 
     if (options.raw || options.json) {
       console.log(JSON.stringify(resp.graphs));
-      process.exit(0);
+      return;
     }
 
     const graphsTable = new Table({

--- a/cli/src/commands/subgraph/commands/list.ts
+++ b/cli/src/commands/subgraph/commands/list.ts
@@ -43,7 +43,7 @@ export default (opts: BaseCommandOptions) => {
 
     if (resp.graphs.length === 0) {
       console.log('No subgraphs found');
-      process.exit(0);
+      return;
     }
 
     if (options.out) {
@@ -57,7 +57,7 @@ export default (opts: BaseCommandOptions) => {
           }) as OutputFile[number],
       );
       await writeFile(resolve(options.out), JSON.stringify(output));
-      process.exit(0);
+      return;
     }
 
     if (options.raw) {

--- a/cli/src/commands/subgraph/commands/move.ts
+++ b/cli/src/commands/subgraph/commands/move.ts
@@ -96,7 +96,8 @@ export default (opts: BaseCommandOptions) => {
         if (resp.response?.details) {
           console.error(pc.red(pc.bold(resp.response?.details)));
         }
-        process.exit(1);
+        process.exitCode = 1;
+        return;
       }
     }
 

--- a/cli/src/commands/subgraph/commands/publish.ts
+++ b/cli/src/commands/subgraph/commands/publish.ts
@@ -197,7 +197,8 @@ export default (opts: BaseCommandOptions) => {
         if (resp.response?.details) {
           console.error(pc.red(pc.bold(resp.response?.details)));
         }
-        process.exit(1);
+        process.exitCode = 1;
+        return;
       }
     }
 

--- a/cli/src/commands/subgraph/commands/update.ts
+++ b/cli/src/commands/subgraph/commands/update.ts
@@ -171,7 +171,8 @@ export default (opts: BaseCommandOptions) => {
         if (resp.response?.details) {
           console.log(pc.red(pc.bold(resp.response?.details)));
         }
-        process.exit(1);
+        process.exitCode = 1;
+        return;
       }
     }
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -30,5 +30,6 @@ Please try the below steps to solve the issue
       borderStyle: 'round',
     }),
   );
-  process.exit(1);
+
+  process.exitCode = 1;
 }

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -230,7 +230,7 @@ export const checkForUpdates = async () => {
 Changelog: https://github.com/wundergraph/cosmo/releases/tag/wgc@${latestVersion}
 Run npm i -g wgc@latest`;
 
-    console.log(
+    console.warn(
       boxen(message, {
         padding: 1,
         margin: 1,


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

## Motivation and Context

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please describe in detail the impact of this change. Attach screenshots if applicable.
-->

This PR fixes two issues

**Writing to stderr**
Writing to stderr, we have changed console.log to console.warn. `console.warn` in nodejs is just an alias for `console.error` which writes to stderr. When we write to stderr anytime data gets piped to a different source, only the stdout is piped. Write now messages like deprecation messages get piped out because they are printed to stdout, this will change it to stderr then.

**Cleaning up process.exit**
When we use process.exit it means that any async processes wont get to run on the event loop, because console.log can be async this means that the everything might not get written to stdout. The workaround is either keep process.exit and use process.stdout.write, and set a callback, which we wait until is run before exiting the process. However we opted to simply do an early return. The nodejs docs itself suggests this approach.
We can look at removing process.exit separately if needed
See More Here: https://nodejs.org/api/process.html#processexitcode

I cleaned up all the process.exit functions, and I manually tested each file that was modified for the code path it was modified (i.e. verifying the early returns), this was mostly for the error paths since it was mainly `exit(1)`s, but tested the happy path for the `exit(0)`s.

On a seperate note, I saw that program.error of the commander library also internally calls process.exit, but we can look at refactoring this out later (if it even makes sense)

## Checklist

- [x] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->