### PR TITLE
ci: optimize bun binaries and put experimental in the name

### DIFF
--- a/.github/workflows/cli-binary-release.yaml
+++ b/.github/workflows/cli-binary-release.yaml
@@ -21,9 +21,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      
+
       - uses: oven-sh/setup-bun@v2
-    
+
       - uses: ./.github/actions/node
 
       - name: Install dependencies
@@ -35,21 +35,23 @@ jobs:
       - uses: winterjung/split@v2
         id: split
         with:
-          separator: "@"
-          msg: "${{ github.event.release.tag_name }}"
+          separator: '@'
+          msg: '${{ github.event.release.tag_name }}'
 
-      - name: "Build wgc binary"
+      - name: 'Build wgc binary'
         working-directory: cli
         run: bun build --compile --minify --sourcemap --target ${{ matrix.target }} src/index.ts --outfile out/wgc-experimental-${{ steps.split.outputs._1 }}-${{ matrix.target }}
 
-      - name: "Gzip wgc binary"
+      - name: 'Gzip wgc binary'
         working-directory: cli
         shell: bash
+        # the '*' here is needed to catch `.exe` files for Windows builds, if we ever add them
         run: gzip -9 -v out/wgc-experimental-${{ steps.split.outputs._1 }}-${{ matrix.target }}*
 
-      - name: "Upload build to release"
+      - name: 'Upload build to release'
         working-directory: cli
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
+        # the '*' here is needed to catch `.exe` files for Windows builds, if we ever add them
         run: gh release upload ${{ github.event.release.tag_name }} out/wgc-experimental-${{ steps.split.outputs._1 }}-${{ matrix.target }}*.gz --clobber

--- a/.github/workflows/cli-binary-release.yaml
+++ b/.github/workflows/cli-binary-release.yaml
@@ -38,16 +38,18 @@ jobs:
           separator: "@"
           msg: "${{ github.event.release.tag_name }}"
 
-      - name: Set BUILD_TIME env
-        run: echo BUILD_TIME=$(date -u +'%Y-%m-%dT%H:%M:%SZ') >> ${GITHUB_ENV}
-
       - name: "Build wgc binary"
         working-directory: cli
-        run: bun build --compile --target ${{ matrix.target }} src/index.ts --outfile out/wgc-${{ steps.split.outputs._1 }}-${{ matrix.target }}
+        run: bun build --compile --minify --sourcemap --target ${{ matrix.target }} src/index.ts --outfile out/wgc-experimental-${{ steps.split.outputs._1 }}-${{ matrix.target }}
+
+      - name: "Gzip wgc binary"
+        working-directory: cli
+        shell: bash
+        run: gzip -9 -v out/wgc-experimental-${{ steps.split.outputs._1 }}-${{ matrix.target }}*
 
       - name: "Upload build to release"
         working-directory: cli
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
-        run: gh release upload ${{ github.event.release.tag_name }} out/wgc-${{ steps.split.outputs._1 }}-${{ matrix.target }} --clobber
+        run: gh release upload ${{ github.event.release.tag_name }} out/wgc-experimental-${{ steps.split.outputs._1 }}-${{ matrix.target }}*.gz --clobber


### PR DESCRIPTION
- Gzips the built binaries for artifact size optimization
- Added `experimental` to released filenames