### PR TITLE
test: run kafka as github CI service instead of container

### DIFF
--- a/.github/workflows/router-ci.yaml
+++ b/.github/workflows/router-ci.yaml
@@ -2,12 +2,12 @@ name: Router CI
 on:
   pull_request:
     paths:
-      - "composition-go/**/*"
-      - "demo/**/*"
-      - "router/**/*"
-      - "router-tests/**/*"
-      - "connect/**/*"
-      - ".github/workflows/router-ci.yaml"
+      - 'composition-go/**/*'
+      - 'demo/**/*'
+      - 'router/**/*'
+      - 'router-tests/**/*'
+      - 'connect/**/*'
+      - '.github/workflows/router-ci.yaml'
 
 concurrency:
   group: ${{github.workflow}}-${{github.head_ref}}
@@ -150,6 +150,22 @@ jobs:
           password: ${{secrets.DOCKER_PASSWORD}}
         ports:
           - 6379:6379
+      kafka:
+        image: bitnami/kafka:3.7.0
+        env:
+          KAFKA_ENABLE_KRAFT: yes
+          KAFKA_CFG_PROCESS_ROLES: controller,broker
+          KAFKA_CFG_CONTROLLER_LISTENER_NAMES: CONTROLLER
+          KAFKA_CFG_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
+          KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+          KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: 1@localhost:9093
+          KAFKA_CFG_TRANSACTION_PARTITION_VERIFICATION_ENABLE: false
+          KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+          KAFKA_CFG_NODE_ID: 1
+          ALLOW_PLAINTEXT_LISTENER: yes
+          KAFKA_KRAFT_CLUSTER_ID: XkpGZQ27R3eTl3OdTm2LYA # 16 byte base64-encoded UUID
+        ports:
+          - '9092:9092'
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/go
@@ -205,14 +221,14 @@ jobs:
           dockerfile: router/Dockerfile
           token: ${{secrets.GITHUB_TOKEN}}
           image_name: router
-          image_description: "Cosmo Router"
+          image_description: 'Cosmo Router'
           image_platforms: 'linux/amd64'
           load_Image: 'true'
           push: 'false'
 
       - uses: ./.github/actions/image-scan
         with:
-          name: "Router"
+          name: 'Router'
           github_token: ${{secrets.GITHUB_TOKEN}}
           image_ref: 'ghcr.io/wundergraph/cosmo/router:sha-${{ github.sha }}'
 
@@ -233,4 +249,4 @@ jobs:
           dockerfile: router/Dockerfile
           token: ${{secrets.GITHUB_TOKEN}}
           image_name: router
-          image_description: "Cosmo Router"
+          image_description: 'Cosmo Router'

--- a/router-tests/testenv/testenv.go
+++ b/router-tests/testenv/testenv.go
@@ -366,6 +366,16 @@ func createTestEnv(t testing.TB, cfg *Config) (*Environment, error) {
 	if cfg.EnableKafka {
 		if os.Getenv("CI") == "true" {
 			cfg.KafkaSeeds = []string{"localhost:9092"}
+
+			client, err := kgo.NewClient(
+				kgo.SeedBrokers(cfg.KafkaSeeds...),
+			)
+			if err != nil {
+				return nil, err
+			}
+
+			kafkaClient = client
+			kafkaAdminClient = kadm.NewClient(kafkaClient)
 		} else {
 			kafkaStarted.Add(1)
 			go func() {

--- a/router-tests/testenv/testenv.go
+++ b/router-tests/testenv/testenv.go
@@ -364,6 +364,10 @@ func createTestEnv(t testing.TB, cfg *Config) (*Environment, error) {
 	}
 
 	if cfg.EnableKafka {
+		// Depending on whether or not we are in CI e.g. Github Actions, we
+		// either start a kafka container or use the one provided by the CI
+		// This is faster in GHA due to pitiful DIND speed, and helps prevent timeout
+		// related errors (for now)
 		if os.Getenv("CI") == "true" {
 			cfg.KafkaSeeds = []string{"localhost:9092"}
 


### PR DESCRIPTION
- patch for seemingly load related integration test failures perhaps as a result of all the new CLI tests
- runs kafka as github CI service instead of container for the time being
- kafka service configuration is transplanted from the `docker-compose.yml` file

I intend to find a nicer solution soon.