### PR TITLE
feat: option to remove scopeinfo from prometheus metrics

### DIFF
--- a/router-tests/prometheus_test.go
+++ b/router-tests/prometheus_test.go
@@ -2986,25 +2986,12 @@ func TestPrometheus(t *testing.T) {
 
 			require.Len(t, requestsInFlightMetricsFiltered, 2)
 
-			require.NotContains(t, requestsInFlightMetricsFiltered[0].Label, &io_prometheus_client.LabelPair{
-				Name:  PointerOf("otel_scope_name"),
-				Value: PointerOf("cosmo.router.prometheus"),
-			})
-
-			require.NotContains(t, requestsInFlightMetricsFiltered[0].Label, &io_prometheus_client.LabelPair{
-				Name:  PointerOf("otel_scope_version"),
-				Value: PointerOf("0.0.1"),
-			})
-
-			require.NotContains(t, requestsInFlightMetricsFiltered[1].Label, &io_prometheus_client.LabelPair{
-				Name:  PointerOf("otel_scope_name"),
-				Value: PointerOf("cosmo.router.prometheus"),
-			})
-
-			require.NotContains(t, requestsInFlightMetricsFiltered[1].Label, &io_prometheus_client.LabelPair{
-				Name:  PointerOf("otel_scope_version"),
-				Value: PointerOf("0.0.1"),
-			})
+			for _, metric := range requestsInFlightMetricsFiltered {
+				for _, label := range metric.Label {
+					require.NotEqual(t, PointerOf("otel_scope_name"), label.Name, "otel_scope_name should not be present")
+					require.NotEqual(t, PointerOf("otel_scope_version"), label.Name, "otel_scope_version should not be present")
+				}
+			}
 		})
 	})
 

--- a/router-tests/prometheus_test.go
+++ b/router-tests/prometheus_test.go
@@ -50,8 +50,6 @@ func TestPrometheus(t *testing.T) {
 			requestTotalMetrics := requestTotal.GetMetric()
 
 			require.Len(t, requestTotalMetrics, 2)
-			require.Len(t, requestTotalMetrics[0].Label, 12)
-			require.Len(t, requestTotalMetrics[1].Label, 14)
 
 			require.Equal(t, []*io_prometheus_client.LabelPair{
 				{
@@ -167,8 +165,6 @@ func TestPrometheus(t *testing.T) {
 			requestsInFlightMetrics := requestsInFlight.GetMetric()
 
 			require.Len(t, requestsInFlightMetrics, 2)
-			require.Len(t, requestsInFlightMetrics[0].Label, 9)
-			require.Len(t, requestsInFlightMetrics[1].Label, 13)
 
 			require.Equal(t, []*io_prometheus_client.LabelPair{
 				{
@@ -268,8 +264,6 @@ func TestPrometheus(t *testing.T) {
 			requestDurationMetrics := requestDuration.GetMetric()
 
 			require.Len(t, requestDurationMetrics, 2)
-			require.Len(t, requestDurationMetrics[0].Label, 12)
-			require.Len(t, requestDurationMetrics[1].Label, 14)
 
 			require.Equal(t, []*io_prometheus_client.LabelPair{
 				{
@@ -385,8 +379,6 @@ func TestPrometheus(t *testing.T) {
 			responseContentLengthMetrics := responseContentLength.GetMetric()
 
 			require.Len(t, responseContentLengthMetrics, 2)
-			require.Len(t, responseContentLengthMetrics[0].Label, 12)
-			require.Len(t, responseContentLengthMetrics[1].Label, 14)
 
 			require.Equal(t, []*io_prometheus_client.LabelPair{
 				{
@@ -502,7 +494,6 @@ func TestPrometheus(t *testing.T) {
 			planningTimeMetrics := planningTime.GetMetric()
 
 			require.Len(t, planningTimeMetrics, 1)
-			require.Len(t, planningTimeMetrics[0].Label, 12)
 
 			require.Equal(t, []*io_prometheus_client.LabelPair{
 				{
@@ -613,8 +604,6 @@ func TestPrometheus(t *testing.T) {
 			requestTotalMetrics := requestTotal.GetMetric()
 
 			require.Len(t, requestTotalMetrics, 2)
-			require.Len(t, requestTotalMetrics[0].Label, 14)
-			require.Len(t, requestTotalMetrics[1].Label, 16)
 
 			require.Equal(t, []*io_prometheus_client.LabelPair{
 				{
@@ -746,8 +735,6 @@ func TestPrometheus(t *testing.T) {
 			requestsInFlightMetrics := requestsInFlight.GetMetric()
 
 			require.Len(t, requestsInFlightMetrics, 2)
-			require.Len(t, requestsInFlightMetrics[0].Label, 10)
-			require.Len(t, requestsInFlightMetrics[1].Label, 15)
 
 			require.Equal(t, []*io_prometheus_client.LabelPair{
 				{
@@ -859,8 +846,6 @@ func TestPrometheus(t *testing.T) {
 			requestDurationMetrics := requestDuration.GetMetric()
 
 			require.Len(t, requestDurationMetrics, 2)
-			require.Len(t, requestDurationMetrics[0].Label, 14)
-			require.Len(t, requestDurationMetrics[1].Label, 16)
 
 			require.Equal(t, []*io_prometheus_client.LabelPair{
 				{
@@ -992,8 +977,6 @@ func TestPrometheus(t *testing.T) {
 			responseContentLengthMetrics := responseContentLength.GetMetric()
 
 			require.Len(t, responseContentLengthMetrics, 2)
-			require.Len(t, responseContentLengthMetrics[0].Label, 14)
-			require.Len(t, responseContentLengthMetrics[1].Label, 16)
 
 			require.Equal(t, []*io_prometheus_client.LabelPair{
 				{
@@ -1170,8 +1153,6 @@ func TestPrometheus(t *testing.T) {
 			requestTotalMetrics := requestTotal.GetMetric()
 
 			require.Len(t, requestTotalMetrics, 2)
-			require.Len(t, requestTotalMetrics[0].Label, 13)
-			require.Len(t, requestTotalMetrics[1].Label, 15)
 
 			require.Equal(t, []*io_prometheus_client.LabelPair{
 				{
@@ -1295,8 +1276,6 @@ func TestPrometheus(t *testing.T) {
 			requestsInFlightMetrics := requestsInFlight.GetMetric()
 
 			require.Len(t, requestsInFlightMetrics, 2)
-			require.Len(t, requestsInFlightMetrics[0].Label, 10)
-			require.Len(t, requestsInFlightMetrics[1].Label, 14)
 
 			require.Equal(t, []*io_prometheus_client.LabelPair{
 				{
@@ -1404,8 +1383,6 @@ func TestPrometheus(t *testing.T) {
 			requestDurationMetrics := requestDuration.GetMetric()
 
 			require.Len(t, requestDurationMetrics, 2)
-			require.Len(t, requestDurationMetrics[0].Label, 13)
-			require.Len(t, requestDurationMetrics[1].Label, 15)
 
 			require.Equal(t, []*io_prometheus_client.LabelPair{
 				{
@@ -1529,8 +1506,6 @@ func TestPrometheus(t *testing.T) {
 			responseContentLengthMetrics := responseContentLength.GetMetric()
 
 			require.Len(t, responseContentLengthMetrics, 2)
-			require.Len(t, responseContentLengthMetrics[0].Label, 13)
-			require.Len(t, responseContentLengthMetrics[1].Label, 15)
 
 			require.Equal(t, []*io_prometheus_client.LabelPair{
 				{
@@ -1688,8 +1663,6 @@ func TestPrometheus(t *testing.T) {
 			totalRequestErrorsMetric := totalRequestsErrors.GetMetric()
 
 			require.Len(t, totalRequestErrorsMetric, 2)
-			require.Len(t, totalRequestErrorsMetric[0].Label, 12)
-			require.Len(t, totalRequestErrorsMetric[1].Label, 14)
 
 			// Error metric for the subgraph error
 			require.Equal(t, []*io_prometheus_client.LabelPair{
@@ -1873,10 +1846,6 @@ func TestPrometheus(t *testing.T) {
 			*/
 
 			require.Len(t, totalRequestErrorsMetric, 4)
-			require.Len(t, totalRequestErrorsMetric[0].Label, 13)
-			require.Len(t, totalRequestErrorsMetric[1].Label, 13)
-			require.Len(t, totalRequestErrorsMetric[2].Label, 15)
-			require.Len(t, totalRequestErrorsMetric[3].Label, 15)
 
 			require.Equal(t, []*io_prometheus_client.LabelPair{
 				{
@@ -2145,8 +2114,6 @@ func TestPrometheus(t *testing.T) {
 			requestTotalMetrics := requestTotal.GetMetric()
 
 			require.Len(t, requestTotalMetrics, 2)
-			require.Len(t, requestTotalMetrics[0].Label, 13)
-			require.Len(t, requestTotalMetrics[1].Label, 15)
 
 			require.Equal(t, []*io_prometheus_client.LabelPair{
 				{
@@ -2270,8 +2237,6 @@ func TestPrometheus(t *testing.T) {
 			requestsInFlightMetrics := requestsInFlight.GetMetric()
 
 			require.Len(t, requestsInFlightMetrics, 2)
-			require.Len(t, requestsInFlightMetrics[0].Label, 10)
-			require.Len(t, requestsInFlightMetrics[1].Label, 14)
 
 			require.Equal(t, []*io_prometheus_client.LabelPair{
 				{
@@ -2379,8 +2344,6 @@ func TestPrometheus(t *testing.T) {
 			requestDurationMetrics := requestDuration.GetMetric()
 
 			require.Len(t, requestDurationMetrics, 2)
-			require.Len(t, requestDurationMetrics[0].Label, 13)
-			require.Len(t, requestDurationMetrics[1].Label, 15)
 
 			require.Equal(t, []*io_prometheus_client.LabelPair{
 				{
@@ -2504,8 +2467,6 @@ func TestPrometheus(t *testing.T) {
 			responseContentLengthMetrics := responseContentLength.GetMetric()
 
 			require.Len(t, responseContentLengthMetrics, 2)
-			require.Len(t, responseContentLengthMetrics[0].Label, 13)
-			require.Len(t, responseContentLengthMetrics[1].Label, 15)
 
 			require.Equal(t, []*io_prometheus_client.LabelPair{
 				{
@@ -2656,8 +2617,6 @@ func TestPrometheus(t *testing.T) {
 			requestTotalMetrics := requestTotal.GetMetric()
 
 			require.Len(t, requestTotalMetrics, 2)
-			require.Len(t, requestTotalMetrics[0].Label, 12)
-			require.Len(t, requestTotalMetrics[1].Label, 14)
 
 			require.Equal(t, []*io_prometheus_client.LabelPair{
 				{
@@ -2773,8 +2732,6 @@ func TestPrometheus(t *testing.T) {
 			requestsInFlightMetrics := requestsInFlight.GetMetric()
 
 			require.Len(t, requestsInFlightMetrics, 2)
-			require.Len(t, requestsInFlightMetrics[0].Label, 9)
-			require.Len(t, requestsInFlightMetrics[1].Label, 13)
 
 			require.Equal(t, []*io_prometheus_client.LabelPair{
 				{
@@ -2869,7 +2826,6 @@ func TestPrometheus(t *testing.T) {
 					Value: PointerOf("employees"),
 				},
 			}, requestsInFlightMetrics[1].Label)
-
 		})
 
 		metricReaderFiltered := metric.NewManualReader()
@@ -2910,8 +2866,6 @@ func TestPrometheus(t *testing.T) {
 			requestsInFlightMetricsFiltered := requestsInFlightFiltered.GetMetric()
 
 			require.Len(t, requestsInFlightMetricsFiltered, 2)
-			require.Len(t, requestsInFlightMetricsFiltered[0].Label, 7)
-			require.Len(t, requestsInFlightMetricsFiltered[1].Label, 11)
 
 			require.Equal(t, []*io_prometheus_client.LabelPair{
 				{
@@ -2995,6 +2949,120 @@ func TestPrometheus(t *testing.T) {
 			require.Greater(t, len(mfFull), len(mfFiltered), "full metrics should have more metrics than filtered")
 			require.Greater(t, len(requestsInFlightMetricsFull[0].Label), len(requestsInFlightMetricsFiltered[0].Label))
 			require.Greater(t, len(requestsInFlightMetricsFull[1].Label), len(requestsInFlightMetricsFiltered[1].Label))
+		})
+	})
+
+	t.Run("Collect and export OTEL metrics to Prometheus with exclude scope info", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			err        error
+			mfFiltered []*io_prometheus_client.MetricFamily
+		)
+
+		metricReaderFiltered := metric.NewManualReader()
+		promRegistryFiltered := prometheus.NewRegistry()
+
+		testenv.Run(t, &testenv.Config{
+			MetricReader:       metricReaderFiltered,
+			PrometheusRegistry: promRegistryFiltered,
+			MetricOptions: testenv.MetricOptions{
+				MetricExclusions: testenv.MetricExclusions{
+					ExcludeScopeInfo: true,
+				},
+			},
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+				Query: `query myQuery { employees { id } }`,
+			})
+
+			require.JSONEq(t, employeesIDData, res.Body)
+
+			mfFiltered, err = promRegistryFiltered.Gather()
+			require.NoError(t, err)
+
+			requestsInFlightFiltered := findMetricFamilyByName(mfFiltered, "router_http_requests_in_flight")
+			requestsInFlightMetricsFiltered := requestsInFlightFiltered.GetMetric()
+
+			require.Len(t, requestsInFlightMetricsFiltered, 2)
+
+			require.Equal(t, []*io_prometheus_client.LabelPair{
+				{
+					Name:  PointerOf("wg_client_name"),
+					Value: PointerOf("unknown"),
+				},
+				{
+					Name:  PointerOf("wg_client_version"),
+					Value: PointerOf("missing"),
+				},
+				{
+					Name:  PointerOf("wg_federated_graph_id"),
+					Value: PointerOf("graph"),
+				},
+				{
+					Name:  PointerOf("wg_operation_protocol"),
+					Value: PointerOf("http"),
+				},
+				{
+					Name:  PointerOf("wg_router_cluster_name"),
+					Value: PointerOf(""),
+				},
+				{
+					Name:  PointerOf("wg_router_config_version"),
+					Value: PointerOf(xEnv.RouterConfigVersionMain()),
+				},
+				{
+					Name:  PointerOf("wg_router_version"),
+					Value: PointerOf("dev"),
+				},
+			}, requestsInFlightMetricsFiltered[0].Label)
+
+			require.Equal(t, []*io_prometheus_client.LabelPair{
+				{
+					Name:  PointerOf("wg_client_name"),
+					Value: PointerOf("unknown"),
+				},
+				{
+					Name:  PointerOf("wg_client_version"),
+					Value: PointerOf("missing"),
+				},
+				{
+					Name:  PointerOf("wg_federated_graph_id"),
+					Value: PointerOf("graph"),
+				},
+				{
+					Name:  PointerOf("wg_operation_name"),
+					Value: PointerOf("myQuery"),
+				},
+				{
+					Name:  PointerOf("wg_operation_protocol"),
+					Value: PointerOf("http"),
+				},
+				{
+					Name:  PointerOf("wg_operation_type"),
+					Value: PointerOf("query"),
+				},
+				{
+					Name:  PointerOf("wg_router_cluster_name"),
+					Value: PointerOf(""),
+				},
+				{
+					Name:  PointerOf("wg_router_config_version"),
+					Value: PointerOf(xEnv.RouterConfigVersionMain()),
+				},
+				{
+					Name:  PointerOf("wg_router_version"),
+					Value: PointerOf("dev"),
+				},
+				{
+					Name:  PointerOf("wg_subgraph_id"),
+					Value: PointerOf("0"),
+				},
+				{
+					Name:  PointerOf("wg_subgraph_name"),
+					Value: PointerOf("employees"),
+				},
+			}, requestsInFlightMetricsFiltered[1].Label)
 		})
 	})
 
@@ -4269,8 +4337,6 @@ func TestPrometheusWithModule(t *testing.T) {
 		requestDurationMetrics := requestDuration.GetMetric()
 
 		require.Len(t, requestDurationMetrics, 2)
-		require.Len(t, requestDurationMetrics[0].Label, 12)
-		require.Len(t, requestDurationMetrics[1].Label, 14)
 
 		require.Equal(t, []*io_prometheus_client.LabelPair{
 			{

--- a/router-tests/prometheus_test.go
+++ b/router-tests/prometheus_test.go
@@ -2986,83 +2986,25 @@ func TestPrometheus(t *testing.T) {
 
 			require.Len(t, requestsInFlightMetricsFiltered, 2)
 
-			require.Equal(t, []*io_prometheus_client.LabelPair{
-				{
-					Name:  PointerOf("wg_client_name"),
-					Value: PointerOf("unknown"),
-				},
-				{
-					Name:  PointerOf("wg_client_version"),
-					Value: PointerOf("missing"),
-				},
-				{
-					Name:  PointerOf("wg_federated_graph_id"),
-					Value: PointerOf("graph"),
-				},
-				{
-					Name:  PointerOf("wg_operation_protocol"),
-					Value: PointerOf("http"),
-				},
-				{
-					Name:  PointerOf("wg_router_cluster_name"),
-					Value: PointerOf(""),
-				},
-				{
-					Name:  PointerOf("wg_router_config_version"),
-					Value: PointerOf(xEnv.RouterConfigVersionMain()),
-				},
-				{
-					Name:  PointerOf("wg_router_version"),
-					Value: PointerOf("dev"),
-				},
-			}, requestsInFlightMetricsFiltered[0].Label)
+			require.NotContains(t, requestsInFlightMetricsFiltered[0].Label, &io_prometheus_client.LabelPair{
+				Name:  PointerOf("otel_scope_name"),
+				Value: PointerOf("cosmo.router.prometheus"),
+			})
 
-			require.Equal(t, []*io_prometheus_client.LabelPair{
-				{
-					Name:  PointerOf("wg_client_name"),
-					Value: PointerOf("unknown"),
-				},
-				{
-					Name:  PointerOf("wg_client_version"),
-					Value: PointerOf("missing"),
-				},
-				{
-					Name:  PointerOf("wg_federated_graph_id"),
-					Value: PointerOf("graph"),
-				},
-				{
-					Name:  PointerOf("wg_operation_name"),
-					Value: PointerOf("myQuery"),
-				},
-				{
-					Name:  PointerOf("wg_operation_protocol"),
-					Value: PointerOf("http"),
-				},
-				{
-					Name:  PointerOf("wg_operation_type"),
-					Value: PointerOf("query"),
-				},
-				{
-					Name:  PointerOf("wg_router_cluster_name"),
-					Value: PointerOf(""),
-				},
-				{
-					Name:  PointerOf("wg_router_config_version"),
-					Value: PointerOf(xEnv.RouterConfigVersionMain()),
-				},
-				{
-					Name:  PointerOf("wg_router_version"),
-					Value: PointerOf("dev"),
-				},
-				{
-					Name:  PointerOf("wg_subgraph_id"),
-					Value: PointerOf("0"),
-				},
-				{
-					Name:  PointerOf("wg_subgraph_name"),
-					Value: PointerOf("employees"),
-				},
-			}, requestsInFlightMetricsFiltered[1].Label)
+			require.NotContains(t, requestsInFlightMetricsFiltered[0].Label, &io_prometheus_client.LabelPair{
+				Name:  PointerOf("otel_scope_version"),
+				Value: PointerOf("0.0.1"),
+			})
+
+			require.NotContains(t, requestsInFlightMetricsFiltered[1].Label, &io_prometheus_client.LabelPair{
+				Name:  PointerOf("otel_scope_name"),
+				Value: PointerOf("cosmo.router.prometheus"),
+			})
+
+			require.NotContains(t, requestsInFlightMetricsFiltered[1].Label, &io_prometheus_client.LabelPair{
+				Name:  PointerOf("otel_scope_version"),
+				Value: PointerOf("0.0.1"),
+			})
 		})
 	})
 

--- a/router-tests/testenv/testenv.go
+++ b/router-tests/testenv/testenv.go
@@ -960,7 +960,8 @@ func configureRouter(listenerAddr string, testConfig *Config, routerConfig *node
 			Metrics: config.Metrics{
 				Attributes: testConfig.CustomMetricAttributes,
 				Prometheus: config.Prometheus{
-					Enabled: true,
+					Enabled:          true,
+					IncludeScopeInfo: true,
 				},
 				OTLP: config.MetricsOTLP{
 					Enabled:       true,

--- a/router-tests/testenv/testenv.go
+++ b/router-tests/testenv/testenv.go
@@ -960,8 +960,7 @@ func configureRouter(listenerAddr string, testConfig *Config, routerConfig *node
 			Metrics: config.Metrics{
 				Attributes: testConfig.CustomMetricAttributes,
 				Prometheus: config.Prometheus{
-					Enabled:          true,
-					IncludeScopeInfo: true,
+					Enabled: true,
 				},
 				OTLP: config.MetricsOTLP{
 					Enabled:       true,

--- a/router-tests/testenv/testenv.go
+++ b/router-tests/testenv/testenv.go
@@ -962,8 +962,7 @@ func configureRouter(listenerAddr string, testConfig *Config, routerConfig *node
 			Metrics: config.Metrics{
 				Attributes: testConfig.CustomMetricAttributes,
 				Prometheus: config.Prometheus{
-					Enabled:          true,
-					ExcludeScopeInfo: true,
+					Enabled: true,
 				},
 				OTLP: config.MetricsOTLP{
 					Enabled:       true,

--- a/router-tests/testenv/testenv.go
+++ b/router-tests/testenv/testenv.go
@@ -240,6 +240,7 @@ type MetricExclusions struct {
 	ExcludedPrometheusMetricLabels []*regexp.Regexp
 	ExcludedOTLPMetrics            []*regexp.Regexp
 	ExcludedOTLPMetricLabels       []*regexp.Regexp
+	ExcludeScopeInfo               bool
 }
 
 type EngineStatOptions struct {
@@ -949,6 +950,7 @@ func configureRouter(listenerAddr string, testConfig *Config, routerConfig *node
 			},
 			ExcludeMetrics:      testConfig.MetricOptions.MetricExclusions.ExcludedPrometheusMetrics,
 			ExcludeMetricLabels: testConfig.MetricOptions.MetricExclusions.ExcludedPrometheusMetricLabels,
+			ExcludeScopeInfo:    testConfig.MetricOptions.MetricExclusions.ExcludeScopeInfo,
 		}
 	}
 
@@ -960,7 +962,8 @@ func configureRouter(listenerAddr string, testConfig *Config, routerConfig *node
 			Metrics: config.Metrics{
 				Attributes: testConfig.CustomMetricAttributes,
 				Prometheus: config.Prometheus{
-					Enabled: true,
+					Enabled:          true,
+					ExcludeScopeInfo: true,
 				},
 				OTLP: config.MetricsOTLP{
 					Enabled:       true,
@@ -980,7 +983,6 @@ func configureRouter(listenerAddr string, testConfig *Config, routerConfig *node
 		c.IsUsingCloudExporter = !testConfig.DisableSimulateCloudExporter
 
 		routerOpts = append(routerOpts, core.WithMetrics(c))
-
 	}
 
 	if testConfig.OverrideGraphQLPath != "" {

--- a/router/core/router.go
+++ b/router/core/router.go
@@ -2027,6 +2027,7 @@ func MetricConfigFromTelemetry(cfg *config.Telemetry) *rmetric.Config {
 			},
 			ExcludeMetrics:      cfg.Metrics.Prometheus.ExcludeMetrics,
 			ExcludeMetricLabels: cfg.Metrics.Prometheus.ExcludeMetricLabels,
+			IncludeScopeInfo:    cfg.Metrics.Prometheus.IncludeScopeInfo,
 		},
 	}
 }

--- a/router/core/router.go
+++ b/router/core/router.go
@@ -2027,7 +2027,7 @@ func MetricConfigFromTelemetry(cfg *config.Telemetry) *rmetric.Config {
 			},
 			ExcludeMetrics:      cfg.Metrics.Prometheus.ExcludeMetrics,
 			ExcludeMetricLabels: cfg.Metrics.Prometheus.ExcludeMetricLabels,
-			IncludeScopeInfo:    cfg.Metrics.Prometheus.IncludeScopeInfo,
+			ExcludeScopeInfo:    cfg.Metrics.Prometheus.ExcludeScopeInfo,
 		},
 	}
 }

--- a/router/pkg/config/config.go
+++ b/router/pkg/config/config.go
@@ -97,6 +97,7 @@ type Prometheus struct {
 	EngineStats         EngineStats `yaml:"engine_stats" envPrefix:"PROMETHEUS_"`
 	ExcludeMetrics      RegExArray  `yaml:"exclude_metrics,omitempty" env:"PROMETHEUS_EXCLUDE_METRICS"`
 	ExcludeMetricLabels RegExArray  `yaml:"exclude_metric_labels,omitempty" env:"PROMETHEUS_EXCLUDE_METRIC_LABELS"`
+	IncludeScopeInfo    bool        `yaml:"include_scope_info" envDefault:"true" env:"PROMETHEUS_INCLUDE_SCOPE_INFO"`
 }
 
 type MetricsOTLPExporter struct {

--- a/router/pkg/config/config.go
+++ b/router/pkg/config/config.go
@@ -97,7 +97,7 @@ type Prometheus struct {
 	EngineStats         EngineStats `yaml:"engine_stats" envPrefix:"PROMETHEUS_"`
 	ExcludeMetrics      RegExArray  `yaml:"exclude_metrics,omitempty" env:"PROMETHEUS_EXCLUDE_METRICS"`
 	ExcludeMetricLabels RegExArray  `yaml:"exclude_metric_labels,omitempty" env:"PROMETHEUS_EXCLUDE_METRIC_LABELS"`
-	IncludeScopeInfo    bool        `yaml:"include_scope_info" envDefault:"true" env:"PROMETHEUS_INCLUDE_SCOPE_INFO"`
+	ExcludeScopeInfo    bool        `yaml:"exclude_scope_info" envDefault:"false" env:"PROMETHEUS_EXCLUDE_SCOPE_INFO"`
 }
 
 type MetricsOTLPExporter struct {

--- a/router/pkg/config/config.schema.json
+++ b/router/pkg/config/config.schema.json
@@ -1081,8 +1081,8 @@
                 },
                 "exclude_scope_info": {
                   "type": "boolean",
-                  "default": true,
-                  "description": "Exclude scope info from Prometheus metrics. The default value is true."
+                  "default": false,
+                  "description": "Exclude scope info from Prometheus metrics. The default value is false."
                 }
               }
             }

--- a/router/pkg/config/config.schema.json
+++ b/router/pkg/config/config.schema.json
@@ -1079,10 +1079,10 @@
                     "type": "string"
                   }
                 },
-                "include_scope_info": {
+                "exclude_scope_info": {
                   "type": "boolean",
                   "default": true,
-                  "description": "Include scope info in Prometheus metrics. The default value is true."
+                  "description": "Exclude scope info from Prometheus metrics. The default value is true."
                 }
               }
             }

--- a/router/pkg/config/config.schema.json
+++ b/router/pkg/config/config.schema.json
@@ -6,7 +6,9 @@
     "version": {
       "type": "string",
       "description": "The version of the configuration file. This is used to ensure that the configuration file is compatible.",
-      "enum": ["1"]
+      "enum": [
+        "1"
+      ]
     },
     "instance_id": {
       "type": "string",
@@ -37,7 +39,10 @@
           "type": "array",
           "items": {
             "type": "object",
-            "required": ["url", "id"],
+            "required": [
+              "url",
+              "id"
+            ],
             "additionalProperties": false,
             "properties": {
               "id": {
@@ -56,7 +61,10 @@
           "type": "array",
           "items": {
             "type": "object",
-            "required": ["urls", "id"],
+            "required": [
+              "urls",
+              "id"
+            ],
             "additionalProperties": false,
             "properties": {
               "id": {
@@ -84,7 +92,10 @@
           "description": "The configuration for the S3 storage provider. If no access key and secret key are provided, the provider will attempt to retreieve IAM credentials from the EC2 service.",
           "items": {
             "type": "object",
-            "required": ["bucket", "id"],
+            "required": [
+              "bucket",
+              "id"
+            ],
             "additionalProperties": false,
             "properties": {
               "id": {
@@ -159,7 +170,10 @@
         },
         "storage": {
           "description": "The storage provider for persisted operation. Only one provider can be active. When no provider is specified, the router will fallback to the Cosmo CDN provider to download the persisted operations.",
-          "required": ["provider_id", "object_prefix"],
+          "required": [
+            "provider_id",
+            "object_prefix"
+          ],
           "properties": {
             "provider_id": {
               "description": "The ID of the storage provider. The ID must match the ID of the storage provider in the storage_providers section.",
@@ -177,7 +191,9 @@
       "type": "object",
       "additionalProperties": false,
       "description": "The configuration for the automatic persisted queries (APQ).",
-      "required": ["enabled"],
+      "required": [
+        "enabled"
+      ],
       "properties": {
         "enabled": {
           "type": "boolean",
@@ -206,7 +222,10 @@
         },
         "storage": {
           "description": "The storage provider for automatic persisted operation. Only one provider can be active. When no provider is specified, the router will use a local in-memory cache for retaining APQ queries",
-          "required": ["provider_id", "object_prefix"],
+          "required": [
+            "provider_id",
+            "object_prefix"
+          ],
           "properties": {
             "provider_id": {
               "description": "The ID of the storage provider. The ID must match the ID of the storage provider in the storage_providers section.",
@@ -232,7 +251,9 @@
               "type": "object",
               "description": "The configuration for the execution config file. The config file is used to load the execution config from the local file system. The file has precedence over the storage provider.",
               "additionalProperties": false,
-              "required": ["path"],
+              "required": [
+                "path"
+              ],
               "properties": {
                 "path": {
                   "type": "string",
@@ -254,7 +275,10 @@
           "properties": {
             "storage": {
               "description": "The storage provider for the execution config. Only one provider can be active. When no provider is specified, the router will fallback to the Cosmo CDN provider to download the execution config. Updating the execution config is happening in the background without downtime.",
-              "required": ["provider_id", "object_path"],
+              "required": [
+                "provider_id",
+                "object_path"
+              ],
               "properties": {
                 "provider_id": {
                   "description": "The ID of the storage provider. The ID must match the ID of the storage provider in the storage_providers section.",
@@ -274,7 +298,9 @@
           "properties": {
             "fallback_storage": {
               "description": "The fallback storage provider for the execution config in case the primary one fails.",
-              "required": ["enabled"],
+              "required": [
+                "enabled"
+              ],
               "properties": {
                 "enabled": {
                   "type": "boolean",
@@ -342,7 +368,9 @@
               "type": "object",
               "description": "The configuration for the client authentication. The client authentication is used to authenticate the clients using the provided certificate.",
               "additionalProperties": false,
-              "required": ["cert_file"],
+              "required": [
+                "cert_file"
+              ],
               "properties": {
                 "required": {
                   "type": "boolean",
@@ -365,7 +393,10 @@
             }
           },
           "then": {
-            "required": ["cert_file", "key_file"]
+            "required": [
+              "cert_file",
+              "key_file"
+            ]
           }
         }
       }
@@ -408,7 +439,9 @@
             "allow_list": {
               "type": "array",
               "description": "The names of the headers to forward. The default value is 'Authorization'.",
-              "default": ["Authorization"],
+              "default": [
+                "Authorization"
+              ],
               "items": {
                 "type": "string"
               }
@@ -427,7 +460,9 @@
             "allow_list": {
               "type": "array",
               "description": "The names of the query parameters to forward. The default value is 'Authorization'.",
-              "default": ["Authorization"],
+              "default": [
+                "Authorization"
+              ],
               "items": {
                 "type": "string"
               }
@@ -500,7 +535,10 @@
               "type": "string",
               "default": "redact",
               "description": "The method used to anonymize the IP addresses. The supported methods are 'redact' and 'hash'. The default value is 'redact'. The 'redact' method replaces the IP addresses with the string '[REDACTED]'. The 'hash' method hashes the IP addresses using the SHA-256 algorithm.",
-              "enum": ["redact", "hash"]
+              "enum": [
+                "redact",
+                "hash"
+              ]
             }
           }
         }
@@ -644,7 +682,10 @@
           "items": {
             "type": "object",
             "additionalProperties": false,
-            "required": ["key", "value"],
+            "required": [
+              "key",
+              "value"
+            ],
             "properties": {
               "key": {
                 "type": "string",
@@ -664,7 +705,9 @@
             "type": "object",
             "description": "The configuration for custom attributes. Custom attributes can be created from request headers or static values. Keep in mind, that every new custom attribute increases the cardinality of the pipeline.",
             "additionalProperties": false,
-            "required": ["key"],
+            "required": [
+              "key"
+            ],
             "properties": {
               "key": {
                 "type": "string",
@@ -689,8 +732,16 @@
                   }
                 },
                 "oneOf": [
-                  {"required": ["request_header"]},
-                  {"required": ["expression"]}
+                  {
+                    "required": [
+                      "request_header"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "expression"
+                    ]
+                  }
                 ]
               }
             }
@@ -731,7 +782,9 @@
               "description": "The exporters to use to export the traces. If no exporters are specified, the default Cosmo Cloud exporter is used. If you override, please make sure to include the default exporter.",
               "items": {
                 "type": "object",
-                "required": ["endpoint"],
+                "required": [
+                  "endpoint"
+                ],
                 "additionalProperties": false,
                 "properties": {
                   "disabled": {
@@ -741,7 +794,10 @@
                     "type": "string",
                     "description": "The exporter to use for the traces. The supported exporters are 'http' and 'grpc'.",
                     "default": "http",
-                    "enum": ["http", "grpc"]
+                    "enum": [
+                      "http",
+                      "grpc"
+                    ]
                   },
                   "endpoint": {
                     "type": "string"
@@ -835,7 +891,9 @@
                 "type": "object",
                 "description": "The configuration for custom attributes. Custom attributes can be created from request headers, static values or context fields. Not every context fields are available at all request life-cycle stages. If a value is a list, the value is JSON encoded for OTLP. For Prometheus, the values are exploded into multiple metrics with unique labels. Keep in mind, that every new custom attribute increases the cardinality.",
                 "additionalProperties": false,
-                "required": ["key"],
+                "required": [
+                  "key"
+                ],
                 "properties": {
                   "key": {
                     "type": "string",
@@ -917,7 +975,10 @@
                         "type": "string",
                         "description": "The exporter protocol to use to export metrics. The supported exporters are 'http' and 'grpc'.",
                         "default": "http",
-                        "enum": ["http", "grpc"]
+                        "enum": [
+                          "http",
+                          "grpc"
+                        ]
                       },
                       "endpoint": {
                         "type": "string",
@@ -939,10 +1000,16 @@
                       "temporality": {
                         "type": "string",
                         "description": "Temporality defines the window that an aggregation is calculated over.",
-                        "enum": ["delta", "cumulative"]
+                        "enum": [
+                          "delta",
+                          "cumulative"
+                        ]
                       }
                     },
-                    "required": ["exporter", "endpoint"]
+                    "required": [
+                      "exporter",
+                      "endpoint"
+                    ]
                   }
                 },
                 "exclude_metrics": {
@@ -1011,6 +1078,11 @@
                   "items": {
                     "type": "string"
                   }
+                },
+                "include_scope_info": {
+                  "type": "boolean",
+                  "default": true,
+                  "description": "Include scope info in Prometheus metrics. The default value is true."
                 }
               }
             }
@@ -1030,18 +1102,32 @@
         "allow_origins": {
           "type": "array",
           "description": "The allowed origins. The default value is to allow all origins. The value can be a list of origins or the wildcard '*'.",
-          "default": ["*"],
+          "default": [
+            "*"
+          ],
           "items": {
             "type": "string"
           }
         },
         "allow_methods": {
           "type": "array",
-          "default": ["GET", "POST", "HEAD"],
+          "default": [
+            "GET",
+            "POST",
+            "HEAD"
+          ],
           "description": "The allowed HTTP methods. The default value is to allow the methods 'GET', 'POST', and 'HEAD'.",
           "items": {
             "type": "string",
-            "enum": ["GET", "POST", "HEAD", "PUT", "DELETE", "PATCH", "OPTIONS"]
+            "enum": [
+              "GET",
+              "POST",
+              "HEAD",
+              "PUT",
+              "DELETE",
+              "PATCH",
+              "OPTIONS"
+            ]
           }
         },
         "allow_headers": {
@@ -1151,7 +1237,14 @@
     },
     "log_level": {
       "type": "string",
-      "enum": ["debug", "info", "warning", "error", "fatal", "panic"],
+      "enum": [
+        "debug",
+        "info",
+        "warning",
+        "error",
+        "fatal",
+        "panic"
+      ],
       "description": "The log level. The log level is used to control the verbosity of the logs. The default value is 'info'.",
       "default": "info"
     },
@@ -1376,17 +1469,23 @@
         "enabled": {
           "type": "boolean",
           "description": "Determines whether cache control policy is enabled.",
-          "examples": [true]
+          "examples": [
+            true
+          ]
         },
         "value": {
           "type": "string",
           "description": "Global cache control value.",
-          "examples": ["max-age=180, public"]
+          "examples": [
+            "max-age=180, public"
+          ]
         },
         "subgraphs": {
           "type": "array",
           "description": "Subgraph-specific cache control settings.",
-          "required": ["name"],
+          "required": [
+            "name"
+          ],
           "additionalProperties": false,
           "items": {
             "type": "object",
@@ -1394,18 +1493,24 @@
               "name": {
                 "type": "string",
                 "description": "Name of the subgraph.",
-                "examples": ["products"]
+                "examples": [
+                  "products"
+                ]
               },
               "value": {
                 "type": "string",
                 "description": "Cache control value for the subgraph.",
-                "examples": ["max-age=60, public"]
+                "examples": [
+                  "max-age=60, public"
+                ]
               }
             }
           }
         }
       },
-      "required": ["enabled"],
+      "required": [
+        "enabled"
+      ],
       "additionalProperties": false
     },
     "modules": {
@@ -1443,7 +1548,21 @@
                     "description": "The allowed algorithms for the keys that are retrieved from the JWKs. An empty list means that all algorithms are allowed.",
                     "items": {
                       "type": "string",
-                      "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512", "EdDSA"]
+                      "enum": [
+                        "HS256",
+                        "HS384",
+                        "HS512",
+                        "RS256",
+                        "RS384",
+                        "RS512",
+                        "ES256",
+                        "ES384",
+                        "ES512",
+                        "PS256",
+                        "PS384",
+                        "PS512",
+                        "EdDSA"
+                      ]
                     }
                   },
                   "refresh_interval": {
@@ -1455,7 +1574,9 @@
                     "default": "1m"
                   }
                 },
-                "required": ["url"]
+                "required": [
+                  "url"
+                ]
               }
             },
             "header_name": {
@@ -1478,13 +1599,17 @@
                   "type": {
                     "type": "string",
                     "description": "The type of the source. The only currently supported type is 'header'.",
-                    "enum": ["header"]
+                    "enum": [
+                      "header"
+                    ]
                   },
                   "name": {
                     "type": "string",
                     "description": "The name of the header. The header is used to extract the token from the request.",
                     "format": "http-header",
-                    "examples": ["X-Authorization"]
+                    "examples": [
+                      "X-Authorization"
+                    ]
                   },
                   "value_prefixes": {
                     "type": "array",
@@ -1494,7 +1619,10 @@
                     }
                   }
                 },
-                "required": ["type", "name"]
+                "required": [
+                  "type",
+                  "name"
+                ]
               }
             }
           }
@@ -1525,7 +1653,9 @@
         },
         "strategy": {
           "type": "string",
-          "enum": ["simple"],
+          "enum": [
+            "simple"
+          ],
           "description": "The strategy used to enforce the rate limit. The supported strategies are 'simple'."
         },
         "simple_strategy": {
@@ -1564,12 +1694,18 @@
               "description": "Hide the rate limit stats from the response extension. If the value is true, the rate limit stats are not included in the response extension."
             }
           },
-          "required": ["rate", "burst", "period"]
+          "required": [
+            "rate",
+            "burst",
+            "period"
+          ]
         },
         "storage": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["urls"],
+          "required": [
+            "urls"
+          ],
           "properties": {
             "cluster_enabled": {
               "type": "boolean",
@@ -1661,7 +1797,10 @@
               "description": "The NATS configuration. The NATS is used to configure the event-driven federated subscriptions.",
               "items": {
                 "type": "object",
-                "required": ["id", "url"],
+                "required": [
+                  "id",
+                  "url"
+                ],
                 "additionalProperties": false,
                 "properties": {
                   "id": {
@@ -1679,7 +1818,9 @@
                     "oneOf": [
                       {
                         "type": "object",
-                        "required": ["token"],
+                        "required": [
+                          "token"
+                        ],
                         "additionalProperties": false,
                         "properties": {
                           "token": {
@@ -1696,7 +1837,10 @@
                             "type": "object",
                             "description": "Userinfo configuration for the NATS provider.",
                             "additionalProperties": false,
-                            "required": ["username", "password"],
+                            "required": [
+                              "username",
+                              "password"
+                            ],
                             "properties": {
                               "username": {
                                 "type": "string",
@@ -1721,7 +1865,10 @@
               "items": {
                 "type": "object",
                 "additionalProperties": false,
-                "required": ["id", "brokers"],
+                "required": [
+                  "id",
+                  "brokers"
+                ],
                 "properties": {
                   "id": {
                     "type": "string",
@@ -1757,7 +1904,10 @@
                             "type": "object",
                             "description": "Plain SASL Authentication configuration for the Kafka provider.",
                             "additionalProperties": false,
-                            "required": ["username", "password"],
+                            "required": [
+                              "username",
+                              "password"
+                            ],
                             "properties": {
                               "username": {
                                 "type": "string",
@@ -1808,7 +1958,13 @@
               }
             }
           },
-          "oneOf": [{ "required": ["filesystem"] }]
+          "oneOf": [
+            {
+              "required": [
+                "filesystem"
+              ]
+            }
+          ]
         },
         "workers": {
           "type": "integer",
@@ -2288,7 +2444,10 @@
         },
         "mode": {
           "type": "string",
-          "enum": ["wrapped", "pass-through"],
+          "enum": [
+            "wrapped",
+            "pass-through"
+          ],
           "default": "wrapped",
           "description": "The mode of error propagation. The supported modes are 'wrapped' (default) and 'pass-through'. The 'wrapped' mode wraps the error in a custom error object to hide internals. The 'pass-through' mode returns the error as is from the Subgraph."
         },
@@ -2312,7 +2471,9 @@
           "items": {
             "type": "string"
           },
-          "default": ["code"],
+          "default": [
+            "code"
+          ],
           "description": "The allowed extension fields. The allowed extension fields are used to specify which fields of the Subgraph errors are allowed to be propagated to the client."
         },
         "omit_locations": {
@@ -2545,7 +2706,9 @@
             "algorithm": {
               "type": "string",
               "description": "The algorithm used to calculate the retry interval. The supported algorithms are 'backoff_jitter'.",
-              "enum": ["backoff_jitter"]
+              "enum": [
+                "backoff_jitter"
+              ]
             },
             "max_attempts": {
               "type": "integer",
@@ -2576,32 +2739,46 @@
       "properties": {
         "op": {
           "type": "string",
-          "enum": ["propagate"],
-          "examples": ["propagate"],
+          "enum": [
+            "propagate"
+          ],
+          "examples": [
+            "propagate"
+          ],
           "description": "The operation to perform on the header. The supported operations are 'propagate'. The 'propagate' operation is used to propagate the header to the subgraphs."
         },
         "matching": {
           "type": "string",
-          "examples": ["(?i)^X-Custom-.*"],
+          "examples": [
+            "(?i)^X-Custom-.*"
+          ],
           "description": "The matching rule for the header. The matching rule is a regular expression that is used to match the header. Can't be used with 'named'."
         },
         "named": {
           "type": "string",
-          "examples": ["X-Test-Header"],
+          "examples": [
+            "X-Test-Header"
+          ],
           "description": "The name of the header to match. Use the canonical version e.g. X-Test-Header. Can't be used with 'matching'."
         },
         "rename": {
           "type": "string",
-          "examples": ["X-Rename-Test-Header"],
+          "examples": [
+            "X-Rename-Test-Header"
+          ],
           "description": "Rename is used to  rename the named or the matching headers. It can be used with either the named or the matching."
         },
         "default": {
           "type": "string",
-          "examples": ["default-value"],
+          "examples": [
+            "default-value"
+          ],
           "description": "The default value of the header in case it is not present in the request."
         }
       },
-      "required": ["op"]
+      "required": [
+        "op"
+      ]
     },
     "traffic_shaping_header_response_rule": {
       "type": "object",
@@ -2610,38 +2787,59 @@
       "properties": {
         "op": {
           "type": "string",
-          "enum": ["propagate"],
-          "examples": ["propagate"],
+          "enum": [
+            "propagate"
+          ],
+          "examples": [
+            "propagate"
+          ],
           "description": "The operation to perform on the header. The supported operations are 'propagate'. The 'propagate' operation is used to propagate the header to the subgraphs."
         },
         "matching": {
           "type": "string",
-          "examples": ["(?i)^X-Custom-.*"],
+          "examples": [
+            "(?i)^X-Custom-.*"
+          ],
           "description": "The matching rule for the header. The matching rule is a regular expression that is used to match the header. Can't be used with 'named'."
         },
         "named": {
           "type": "string",
-          "examples": ["X-Test-Header"],
+          "examples": [
+            "X-Test-Header"
+          ],
           "description": "The name of the header to match. Use the canonical version e.g. X-Test-Header. Can't be used with 'matching'."
         },
         "rename": {
           "type": "string",
-          "examples": ["X-Rename-Test-Header"],
+          "examples": [
+            "X-Rename-Test-Header"
+          ],
           "description": "Rename is used to  rename the named or the matching headers. It can be used with either the named or the matching."
         },
         "default": {
           "type": "string",
-          "examples": ["default-value"],
+          "examples": [
+            "default-value"
+          ],
           "description": "The default value of the header in case it is not present in the request."
         },
         "algorithm": {
           "type": "string",
-          "enum": ["first_write", "last_write", "append"],
-          "examples": ["first_write"],
+          "enum": [
+            "first_write",
+            "last_write",
+            "append"
+          ],
+          "examples": [
+            "first_write"
+          ],
           "description": "The algorith, to use when multiple headers are present. The supported operations are '\"first_write\", \"last_write\", and \"append\". The 'first_write' retains the first value of a given header. The 'last_write' retains the last value of a given header. The 'append' appends all values of a given header."
         }
       },
-      "required": ["op", "algorithm"]
+      "required": [
+        "op",
+        "algorithm"
+      ]
     },
     "set_header_rule": {
       "type": "object",
@@ -2655,29 +2853,40 @@
         },
         "name": {
           "type": "string",
-          "examples": ["X-API-Key"],
+          "examples": [
+            "X-API-Key"
+          ],
           "description": "The name of the header to set."
         },
         "value": {
           "type": "string",
-          "examples": ["My-Secret-Value"],
+          "examples": [
+            "My-Secret-Value"
+          ],
           "description": "The value to set for the header. This can include environment variables."
         },
         "value_from": {
           "type": "object",
           "description": "The configuration for the value from. The value from is used to extract a value from a request context and propagate it to subgraphs. This is currently only valid in requests",
           "additionalProperties": false,
-          "required": ["context_field"],
+          "required": [
+            "context_field"
+          ],
           "properties": {
             "context_field": {
               "type": "string",
               "description": "The field name of the context from which to extract the value. The value is only extracted when a context is available otherwise the default value is used.",
-              "enum": ["operation_name"]
+              "enum": [
+                "operation_name"
+              ]
             }
           }
         }
       },
-      "required": ["op", "name"]
+      "required": [
+        "op",
+        "name"
+      ]
     },
     "context_fields": {
       "type": "array",
@@ -2686,7 +2895,9 @@
         "type": "object",
         "description": "The configuration for custom fields. Custom attributes can be created from request headers or context fields. Not every context fields are available at all request life-cycle stages. If a value is a list, the value is JSON encoded for OTLP. For Prometheus, the values are exploded into multiple metrics with unique labels. Keep in mind, that every new custom attribute increases the cardinality.",
         "additionalProperties": false,
-        "required": ["key"],
+        "required": [
+          "key"
+        ],
         "properties": {
           "key": {
             "type": "string",

--- a/router/pkg/config/config_events_kafka_test.go
+++ b/router/pkg/config/config_events_kafka_test.go
@@ -1,12 +1,15 @@
 package config
 
 import (
-	"github.com/stretchr/testify/require"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestFullValidKafkaProvider(t *testing.T) {
+	t.Parallel()
+
 	f := createTempFileFromFixture(t, `
 version: "1"
 
@@ -32,6 +35,8 @@ events:
 }
 
 func TestValidAuthenticatedKafkaProviderWithSaslPlain(t *testing.T) {
+	t.Parallel()
+
 	f := createTempFileFromFixture(t, `
 version: "1"
 
@@ -56,6 +61,8 @@ events:
 }
 
 func TestInvalidAuthenticatedKafkaProviderWithoutPasswordSaslPlain(t *testing.T) {
+	t.Parallel()
+
 	f := createTempFileFromFixture(t, `
 version: "1"
 
@@ -79,6 +86,8 @@ events:
 }
 
 func TestInvalidAuthenticatedKafkaProviderWithoutUsernameSaslPlain(t *testing.T) {
+	t.Parallel()
+
 	f := createTempFileFromFixture(t, `
 version: "1"
 
@@ -104,7 +113,7 @@ events:
 func createTempFileFromFixture(t *testing.T, fixture string) string {
 	t.Helper()
 
-	f, err := os.CreateTemp("", "config_test")
+	f, err := os.CreateTemp(t.TempDir(), "config_test")
 	require.NoError(t, err)
 
 	t.Cleanup(func() {

--- a/router/pkg/config/config_events_kafka_test.go
+++ b/router/pkg/config/config_events_kafka_test.go
@@ -116,10 +116,6 @@ func createTempFileFromFixture(t *testing.T, fixture string) string {
 	f, err := os.CreateTemp(t.TempDir(), "config_test")
 	require.NoError(t, err)
 
-	t.Cleanup(func() {
-		require.NoError(t, os.Remove(f.Name()))
-	})
-
 	_, err = f.WriteString(fixture)
 	require.NoError(t, err)
 

--- a/router/pkg/config/config_events_nats_test.go
+++ b/router/pkg/config/config_events_nats_test.go
@@ -1,11 +1,14 @@
 package config
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestInvalidAuthenticatedNatsProviderNoUsername(t *testing.T) {
+	t.Parallel()
+
 	f := createTempFileFromFixture(t, `
 version: "1"
 
@@ -28,6 +31,8 @@ events:
 }
 
 func TestInvalidAuthenticatedNatsProviderNoPassword(t *testing.T) {
+	t.Parallel()
+
 	f := createTempFileFromFixture(t, `
 version: "1"
 
@@ -49,6 +54,8 @@ events:
 }
 
 func TestValidAuthenticatedNatsProviderWithToken(t *testing.T) {
+	t.Parallel()
+
 	f := createTempFileFromFixture(t, `
 version: '1'
 
@@ -69,6 +76,8 @@ events:
 }
 
 func TestValidAuthenticatedNatsProviderWithUserInfo(t *testing.T) {
+	t.Parallel()
+
 	f := createTempFileFromFixture(t, `
 version: "1"
 

--- a/router/pkg/config/config_test.go
+++ b/router/pkg/config/config_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"os"
 	"regexp"
 	"testing"
 	"time"
@@ -250,10 +249,8 @@ func TestLoadFullConfig(t *testing.T) {
 }
 
 func TestDefaults(t *testing.T) {
-	t.Parallel()
-
 	// Set in the CI to false. We need to unset it to test the default values
-	_ = os.Unsetenv("ROUTER_REGISTRATION")
+	t.Setenv("ROUTER_REGISTRATION", "")
 
 	f := createTempFileFromFixture(t, `
 version: "1"

--- a/router/pkg/config/fixtures/full.yaml
+++ b/router/pkg/config/fixtures/full.yaml
@@ -132,7 +132,7 @@ telemetry:
         subscriptions: true
       exclude_metrics: []
       exclude_metric_labels: []
-      include_scope_info: true
+      exclude_scope_info: true
 
 cache_control_policy:
   enabled: true

--- a/router/pkg/config/fixtures/full.yaml
+++ b/router/pkg/config/fixtures/full.yaml
@@ -132,6 +132,7 @@ telemetry:
         subscriptions: true
       exclude_metrics: []
       exclude_metric_labels: []
+      include_scope_info: true
 
 cache_control_policy:
   enabled: true
@@ -184,15 +185,15 @@ traffic_shaping:
 headers:
   all: # Header rules for all subgraph requests.
     request:
-      - op: "propagate"            # Forward a client header
-        named: X-Test-Header       # Exact match (Use the canonical version)
+      - op: "propagate" # Forward a client header
+        named: X-Test-Header # Exact match (Use the canonical version)
 
       - op: "propagate"
         matching: (?i)^X-Custom-.* # Regex match (Case insensitive)
 
       - op: "propagate"
         named: "X-User-Id"
-        default: "123"             # Set the value when the header was not set
+        default: "123" # Set the value when the header was not set
       - op: "set"
         name: "X-API-Key"
         value: "some-secret"
@@ -356,9 +357,9 @@ security:
     size: 1024
   complexity_limits:
     depth:
-        enabled: true
-        limit: 5
-        ignore_persisted_operations: true
+      enabled: true
+      limit: 5
+      ignore_persisted_operations: true
     total_fields:
       enabled: true
       limit: 7

--- a/router/pkg/config/testdata/config_defaults.json
+++ b/router/pkg/config/testdata/config_defaults.json
@@ -50,7 +50,8 @@
           "Subscriptions": false
         },
         "ExcludeMetrics": null,
-        "ExcludeMetricLabels": null
+        "ExcludeMetricLabels": null,
+        "IncludeScopeInfo": true
       }
     }
   },

--- a/router/pkg/config/testdata/config_defaults.json
+++ b/router/pkg/config/testdata/config_defaults.json
@@ -51,7 +51,7 @@
         },
         "ExcludeMetrics": null,
         "ExcludeMetricLabels": null,
-        "IncludeScopeInfo": true
+        "ExcludeScopeInfo": false
       }
     }
   },

--- a/router/pkg/config/testdata/config_full.json
+++ b/router/pkg/config/testdata/config_full.json
@@ -69,7 +69,8 @@
           "Subscriptions": true
         },
         "ExcludeMetrics": null,
-        "ExcludeMetricLabels": null
+        "ExcludeMetricLabels": null,
+        "IncludeScopeInfo": true
       }
     }
   },

--- a/router/pkg/config/testdata/config_full.json
+++ b/router/pkg/config/testdata/config_full.json
@@ -70,7 +70,7 @@
         },
         "ExcludeMetrics": null,
         "ExcludeMetricLabels": null,
-        "IncludeScopeInfo": true
+        "ExcludeScopeInfo": true
       }
     }
   },

--- a/router/pkg/metric/config.go
+++ b/router/pkg/metric/config.go
@@ -1,13 +1,14 @@
 package metric
 
 import (
+	"net/url"
+	"regexp"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/wundergraph/cosmo/router/pkg/config"
 	"github.com/wundergraph/cosmo/router/pkg/otel/otelconfig"
 	"go.opentelemetry.io/otel/attribute"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
-	"net/url"
-	"regexp"
 )
 
 // DefaultServerName Default resource name.
@@ -25,6 +26,8 @@ type PrometheusConfig struct {
 	ExcludeMetricLabels []*regexp.Regexp
 	// TestRegistry is used for testing purposes. If set, the registry will be used instead of the default one.
 	TestRegistry *prometheus.Registry
+	// Whether or not to include scope info
+	IncludeScopeInfo bool
 }
 
 type OpenTelemetryExporter struct {
@@ -133,9 +136,10 @@ func DefaultConfig(serviceVersion string) *Config {
 			},
 		},
 		Prometheus: PrometheusConfig{
-			Enabled:    false,
-			ListenAddr: "0.0.0.0:8088",
-			Path:       "/metrics",
+			Enabled:          false,
+			ListenAddr:       "0.0.0.0:8088",
+			Path:             "/metrics",
+			IncludeScopeInfo: true,
 		},
 	}
 }

--- a/router/pkg/metric/config.go
+++ b/router/pkg/metric/config.go
@@ -26,7 +26,7 @@ type PrometheusConfig struct {
 	ExcludeMetricLabels []*regexp.Regexp
 	// TestRegistry is used for testing purposes. If set, the registry will be used instead of the default one.
 	TestRegistry *prometheus.Registry
-	// Whether or not to include scope info
+	// Whether or not to exclude scope info
 	ExcludeScopeInfo bool
 }
 

--- a/router/pkg/metric/config.go
+++ b/router/pkg/metric/config.go
@@ -136,10 +136,9 @@ func DefaultConfig(serviceVersion string) *Config {
 			},
 		},
 		Prometheus: PrometheusConfig{
-			Enabled:          false,
-			ListenAddr:       "0.0.0.0:8088",
-			Path:             "/metrics",
-			ExcludeScopeInfo: true,
+			Enabled:    false,
+			ListenAddr: "0.0.0.0:8088",
+			Path:       "/metrics",
 		},
 	}
 }

--- a/router/pkg/metric/config.go
+++ b/router/pkg/metric/config.go
@@ -27,7 +27,7 @@ type PrometheusConfig struct {
 	// TestRegistry is used for testing purposes. If set, the registry will be used instead of the default one.
 	TestRegistry *prometheus.Registry
 	// Whether or not to include scope info
-	IncludeScopeInfo bool
+	ExcludeScopeInfo bool
 }
 
 type OpenTelemetryExporter struct {
@@ -139,7 +139,7 @@ func DefaultConfig(serviceVersion string) *Config {
 			Enabled:          false,
 			ListenAddr:       "0.0.0.0:8088",
 			Path:             "/metrics",
-			IncludeScopeInfo: true,
+			ExcludeScopeInfo: true,
 		},
 	}
 }

--- a/router/pkg/metric/meter.go
+++ b/router/pkg/metric/meter.go
@@ -133,7 +133,7 @@ func NewPrometheusMeterProvider(ctx context.Context, c *Config, serviceInstanceI
 		otelprom.WithRegisterer(registry),
 	}
 
-	if !c.Prometheus.IncludeScopeInfo {
+	if c.Prometheus.ExcludeScopeInfo {
 		otelPromOpts = append(otelPromOpts, otelprom.WithoutScopeInfo())
 	}
 

--- a/router/pkg/metric/meter.go
+++ b/router/pkg/metric/meter.go
@@ -128,11 +128,16 @@ func NewPrometheusMeterProvider(ctx context.Context, c *Config, serviceInstanceI
 	// Only available on Linux and Windows systems
 	registry.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 
-	promExporter, err := otelprom.New(
+	otelPromOpts := []otelprom.Option{
 		otelprom.WithoutUnits(),
 		otelprom.WithRegisterer(registry),
-	)
+	}
 
+	if !c.Prometheus.IncludeScopeInfo {
+		otelPromOpts = append(otelPromOpts, otelprom.WithoutScopeInfo())
+	}
+
+	promExporter, err := otelprom.New(otelPromOpts...)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
- **test: improve config tests with parallel, fix testify parameter ordering**
- **feat: config to disable otel scope info in prometheus metrics**

# Todo

- [x] Unit tests, if applicable
- [x] Investigate defaults for this portion of the config
- [x] E2E test