### PR TITLE
feat(router): allow json logs in dev mode

### DIFF
--- a/router/pkg/config/config.go
+++ b/router/pkg/config/config.go
@@ -861,6 +861,7 @@ type Config struct {
 	QueryPlansEnabled             bool                        `yaml:"query_plans_enabled" envDefault:"true" env:"QUERY_PLANS_ENABLED"`
 	LogLevel                      string                      `yaml:"log_level" envDefault:"info" env:"LOG_LEVEL"`
 	JSONLog                       bool                        `yaml:"json_log" envDefault:"true" env:"JSON_LOG"`
+	ForceJSONLog                  bool                        `yaml:"force_json_log" envDefault:"false" env:"FORCE_JSON_LOG"`
 	ShutdownDelay                 time.Duration               `yaml:"shutdown_delay" envDefault:"60s" env:"SHUTDOWN_DELAY"`
 	GracePeriod                   time.Duration               `yaml:"grace_period" envDefault:"30s" env:"GRACE_PERIOD"`
 	PollInterval                  time.Duration               `yaml:"poll_interval" envDefault:"10s" env:"POLL_INTERVAL"`
@@ -983,7 +984,7 @@ func LoadConfig(configFilePath string, envOverride string) (*LoadResult, error) 
 	// Post-process the config
 
 	if cfg.Config.DevelopmentMode {
-		cfg.Config.JSONLog = false
+		cfg.Config.JSONLog = cfg.Config.ForceJSONLog
 		cfg.Config.SubgraphErrorPropagation.Enabled = true
 		cfg.Config.SubgraphErrorPropagation.PropagateStatusCodes = true
 		cfg.Config.SubgraphErrorPropagation.OmitLocations = false

--- a/router/pkg/config/config.schema.json
+++ b/router/pkg/config/config.schema.json
@@ -1253,6 +1253,11 @@
       "description": "Enable the JSON log format. The JSON log format is used to log the logs in JSON format. The default value is true. If the value is false, the logs are logged a human friendly text format.",
       "default": true
     },
+    "force_json_log": {
+      "type": "boolean",
+      "description": "Forces JSON log output when router was started in development mode. This flag is only taken into account when 'dev_mode' is set to 'true'. The default value is false.",
+      "default": false
+    },
     "shutdown_delay": {
       "type": "string",
       "duration": {

--- a/router/pkg/config/fixtures/full.yaml
+++ b/router/pkg/config/fixtures/full.yaml
@@ -17,6 +17,7 @@ playground:
   concurrency_limit: 1500
 introspection_enabled: true
 json_log: true
+force_json_log: true
 shutdown_delay: 15s
 grace_period: 20s
 poll_interval: 10s

--- a/router/pkg/config/testdata/config_defaults.json
+++ b/router/pkg/config/testdata/config_defaults.json
@@ -176,6 +176,7 @@
   "QueryPlansEnabled": true,
   "LogLevel": "info",
   "JSONLog": true,
+  "ForceJSONLog": false,
   "ShutdownDelay": 60000000000,
   "GracePeriod": 30000000000,
   "PollInterval": 10000000000,

--- a/router/pkg/config/testdata/config_full.json
+++ b/router/pkg/config/testdata/config_full.json
@@ -356,6 +356,7 @@
   "QueryPlansEnabled": true,
   "LogLevel": "info",
   "JSONLog": true,
+  "ForceJSONLog": true,
   "ShutdownDelay": 15000000000,
   "GracePeriod": 20000000000,
   "PollInterval": 10000000000,


### PR DESCRIPTION
## Motivation and Context

This PR adds a new config field, which allows enabling JSON logs in development mode. 

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->