### PR TITLE
feat(router): enable fail open on rate limit redis availability failure

### DIFF
--- a/router/internal/persistedoperation/operationstorage/redis/rdcloser_test.go
+++ b/router/internal/persistedoperation/operationstorage/redis/rdcloser_test.go
@@ -2,10 +2,11 @@ package rd
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/alicebob/miniredis/v2"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
-	"testing"
 )
 
 func TestRedisCloser(t *testing.T) {

--- a/router/pkg/config/config.go
+++ b/router/pkg/config/config.go
@@ -449,6 +449,7 @@ type RateLimitConfiguration struct {
 	Debug               bool                        `yaml:"debug" envDefault:"false" env:"RATE_LIMIT_DEBUG"`
 	KeySuffixExpression string                      `yaml:"key_suffix_expression,omitempty" env:"RATE_LIMIT_KEY_SUFFIX_EXPRESSION"`
 	ErrorExtensionCode  RateLimitErrorExtensionCode `yaml:"error_extension_code"`
+	FailOpen            bool                        `yaml:"fail_open" env:"RATE_LIMIT_FAIL_OPEN"`
 }
 
 type RateLimitErrorExtensionCode struct {

--- a/router/pkg/config/config.schema.json
+++ b/router/pkg/config/config.schema.json
@@ -1751,6 +1751,11 @@
               "default": "RATE_LIMIT_EXCEEDED"
             }
           }
+        },
+        "fail_open": {
+          "type": "boolean",
+          "description": "Enable Rate Limit fail open on redis availability failure. This interacts with Redis timeout configuration parameters, essentially adding to each requests latency in failure.",
+          "default": false
         }
       }
     },

--- a/router/pkg/config/testdata/config_defaults.json
+++ b/router/pkg/config/testdata/config_defaults.json
@@ -218,7 +218,8 @@
     "ErrorExtensionCode": {
       "Enabled": true,
       "Code": "RATE_LIMIT_EXCEEDED"
-    }
+    },
+    "FailOpen": false
   },
   "LocalhostFallbackInsideDocker": true,
   "CDN": {

--- a/router/pkg/config/testdata/config_full.json
+++ b/router/pkg/config/testdata/config_full.json
@@ -436,7 +436,8 @@
     "ErrorExtensionCode": {
       "Enabled": true,
       "Code": "RATE_LIMIT_EXCEEDED"
-    }
+    },
+    "FailOpen": false
   },
   "LocalhostFallbackInsideDocker": true,
   "CDN": {


### PR DESCRIPTION
## Motivation and Context

Per https://github.com/wundergraph/cosmo/issues/1555

On testing a Cosmo Rate Limit implementation I discovered every request would get a 500 response if Redis is scaled to zero, or if authentication is malformed.

This small change introduces a fail open configuration bool on rate_limit that allows requests to succeed, albeit delayed by the timeout on failing to hit Redis per request.

The per request penalty can be ameliorated by setting tighter timeouts on your Redis connection, for example:
`redis://:PASSWORD@redis-master.redis.svc.cluster.local:6379?read_timeout=20ms&write_timeout=20ms&max_retries=-1&dial_timeout=100ms`

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

Testing this additional feature is challenging and would likely need to take place in integration tests, glad to make a stab at that if y'all are interested in moving forward with this!