### PR TITLE
feat: add request body to expression context

### DIFF
--- a/router-tests/structured_logging_test.go
+++ b/router-tests/structured_logging_test.go
@@ -2313,7 +2313,7 @@ func TestFlakyAccessLogs(t *testing.T) {
 					{
 						Key: "expression_body",
 						ValueFrom: &config.CustomDynamicAttribute{
-							Expression: "request.body.GetRawBody()",
+							Expression: "request.body.raw",
 						},
 					},
 				},

--- a/router/core/access_log_field_handler_test.go
+++ b/router/core/access_log_field_handler_test.go
@@ -48,8 +48,9 @@ func TestAccessLogsFieldHandler(t *testing.T) {
 		rcc := buildRequestContext(requestContextOptions{r: req})
 		req = req.WithContext(withRequestContext(req.Context(), rcc))
 
+		manager := expr.CreateNewExprManager()
 		expressionResponseKey := "testkey"
-		expression, err := expr.CompileAnyExpression("request.error ?? request.url")
+		expression, err := manager.CompileAnyExpression("request.error ?? request.url")
 		require.NoError(t, err)
 
 		exprAttributes := []requestlogger.ExpressionAttribute{
@@ -95,7 +96,8 @@ func TestAccessLogsFieldHandler(t *testing.T) {
 
 		req = req.WithContext(withRequestContext(req.Context(), rcc))
 
-		expression, err := expr.CompileAnyExpression("request.error ?? request.url")
+		manager := expr.CreateNewExprManager()
+		expression, err := manager.CompileAnyExpression("request.error ?? request.url")
 		require.NoError(t, err)
 		expressionResponseKey := "testkey"
 

--- a/router/core/attribute_expressions.go
+++ b/router/core/attribute_expressions.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"fmt"
+	"reflect"
 
 	"github.com/expr-lang/expr/ast"
 	"github.com/expr-lang/expr/vm"
@@ -44,14 +45,14 @@ func (v *VisitorCheckForRequestAuthAccess) Visit(node *ast.Node) {
 	}
 }
 
-func newAttributeExpressions(attr []config.CustomAttribute) (*attributeExpressions, error) {
+func newAttributeExpressions(attr []config.CustomAttribute, exprManager *expr.Manager) (*attributeExpressions, error) {
 	attrExprMap := make(map[string]*vm.Program)
 	attrExprMapWithAuth := make(map[string]*vm.Program)
 
 	for _, a := range attr {
 		if a.ValueFrom != nil && a.ValueFrom.Expression != "" {
 			usesAuth := VisitorCheckForRequestAuthAccess{}
-			prog, err := expr.CompileStringExpressionWithPatch(a.ValueFrom.Expression, &usesAuth)
+			prog, err := exprManager.CompileExpression(a.ValueFrom.Expression, reflect.String, &usesAuth)
 			if err != nil {
 				return nil, fmt.Errorf("custom attribute error, unable to compile '%s' with expression '%s': %s", a.Key, a.ValueFrom.Expression, err)
 			}

--- a/router/core/attribute_expressions_test.go
+++ b/router/core/attribute_expressions_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -73,7 +74,8 @@ func TestVisitorCheckForRequestAuthAccess_Visit(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			v := VisitorCheckForRequestAuthAccess{}
-			out, err := expr.CompileStringExpressionWithPatch(tt.expr, &v)
+			manager := expr.CreateNewExprManager()
+			out, err := manager.CompileExpression(tt.expr, reflect.String, &v)
 			assert.NoError(t, err)
 			assert.NotNil(t, out)
 			assert.Equal(t, tt.expectedHasAuth, v.HasAuth)
@@ -98,7 +100,8 @@ func TestNewAttributeExpressions_SplitsExpressionsUsingAuth(t *testing.T) {
 		},
 	}
 
-	attrExpr, err := newAttributeExpressions(attrs)
+	manager := expr.CreateNewExprManager()
+	attrExpr, err := newAttributeExpressions(attrs, manager)
 	assert.NoError(t, err)
 	require.NotNil(t, attrExpr)
 	assert.Contains(t, attrExpr.expressions, "attr1")

--- a/router/core/ratelimiter.go
+++ b/router/core/ratelimiter.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	rd "github.com/wundergraph/cosmo/router/internal/persistedoperation/operationstorage/redis"
 	"io"
+	"reflect"
 	"sync"
 
 	"github.com/expr-lang/expr/vm"
@@ -27,6 +28,7 @@ type CosmoRateLimiterOptions struct {
 	RejectStatusCode int
 
 	KeySuffixExpression string
+	ExprManager         *expr.Manager
 }
 
 func NewCosmoRateLimiter(opts *CosmoRateLimiterOptions) (rl *CosmoRateLimiter, err error) {
@@ -41,7 +43,7 @@ func NewCosmoRateLimiter(opts *CosmoRateLimiterOptions) (rl *CosmoRateLimiter, e
 		rl.rejectStatusCode = 200
 	}
 	if opts.KeySuffixExpression != "" {
-		rl.keySuffixProgram, err = expr.CompileStringExpression(opts.KeySuffixExpression)
+		rl.keySuffixProgram, err = opts.ExprManager.CompileExpression(opts.KeySuffixExpression, reflect.String)
 		if err != nil {
 			return nil, err
 		}

--- a/router/core/ratelimiter_test.go
+++ b/router/core/ratelimiter_test.go
@@ -48,6 +48,7 @@ func TestRateLimiterGenerateKey(t *testing.T) {
 		t.Parallel()
 		rl, err := NewCosmoRateLimiter(&CosmoRateLimiterOptions{
 			KeySuffixExpression: "request.header.Get('Authorization')",
+			ExprManager:         expr.CreateNewExprManager(),
 		})
 		require.NoError(t, err)
 		key, err := rl.generateKey(
@@ -60,6 +61,7 @@ func TestRateLimiterGenerateKey(t *testing.T) {
 		t.Parallel()
 		rl, err := NewCosmoRateLimiter(&CosmoRateLimiterOptions{
 			KeySuffixExpression: "request.header.Get('Authorization')",
+			ExprManager:         expr.CreateNewExprManager(),
 		})
 		assert.NoError(t, err)
 		key, err := rl.generateKey(
@@ -72,6 +74,7 @@ func TestRateLimiterGenerateKey(t *testing.T) {
 		t.Parallel()
 		rl, err := NewCosmoRateLimiter(&CosmoRateLimiterOptions{
 			KeySuffixExpression: "trim(request.header.Get('Authorization'))",
+			ExprManager:         expr.CreateNewExprManager(),
 		})
 		assert.NoError(t, err)
 		key, err := rl.generateKey(
@@ -84,6 +87,7 @@ func TestRateLimiterGenerateKey(t *testing.T) {
 		t.Parallel()
 		rl, err := NewCosmoRateLimiter(&CosmoRateLimiterOptions{
 			KeySuffixExpression: "request.auth.claims.sub",
+			ExprManager:         expr.CreateNewExprManager(),
 		})
 		assert.NoError(t, err)
 		key, err := rl.generateKey(
@@ -96,6 +100,7 @@ func TestRateLimiterGenerateKey(t *testing.T) {
 		t.Parallel()
 		rl, err := NewCosmoRateLimiter(&CosmoRateLimiterOptions{
 			KeySuffixExpression: "request.auth.claims.sub",
+			ExprManager:         expr.CreateNewExprManager(),
 		})
 		assert.NoError(t, err)
 		key, err := rl.generateKey(
@@ -108,6 +113,7 @@ func TestRateLimiterGenerateKey(t *testing.T) {
 		t.Parallel()
 		rl, err := NewCosmoRateLimiter(&CosmoRateLimiterOptions{
 			KeySuffixExpression: "request.auth.claims.sub ?? request.header.Get('X-Forwarded-For')",
+			ExprManager:         expr.CreateNewExprManager(),
 		})
 		assert.NoError(t, err)
 		key, err := rl.generateKey(
@@ -120,6 +126,7 @@ func TestRateLimiterGenerateKey(t *testing.T) {
 		t.Parallel()
 		rl, err := NewCosmoRateLimiter(&CosmoRateLimiterOptions{
 			KeySuffixExpression: "request.auth.claims.sub ?? request.header.Get('X-Forwarded-For')",
+			ExprManager:         expr.CreateNewExprManager(),
 		})
 		assert.NoError(t, err)
 		key, err := rl.generateKey(

--- a/router/internal/expr/expr_manager.go
+++ b/router/internal/expr/expr_manager.go
@@ -1,0 +1,105 @@
+package expr
+
+import (
+	"errors"
+	"fmt"
+	"github.com/expr-lang/expr"
+	"github.com/expr-lang/expr/ast"
+	"github.com/expr-lang/expr/checker"
+	"github.com/expr-lang/expr/conf"
+	"github.com/expr-lang/expr/parser"
+	"github.com/expr-lang/expr/vm"
+	"reflect"
+)
+
+type Manager struct {
+	VisitorManager *visitorGroup
+}
+
+func CreateNewExprManager() *Manager {
+	return &Manager{
+		VisitorManager: createVisitorMGroup(),
+	}
+}
+
+// CompileExpression compiles an expression and returns the program for the specific type.
+// The exprContext is used to provide the context for the expression evaluation. Not safe for concurrent use.
+func (c *Manager) CompileExpression(exprString string, kind reflect.Kind, visitors ...ast.Visitor) (*vm.Program, error) {
+	options := mergeOptions(expr.AsKind(kind), visitors)
+	return c.compileExpressionWithExprOptions(options, exprString)
+}
+
+// CompileAnyExpression compiles an expression and returns the program for any type.
+// The exprContext is used to provide the context for the expression evaluation. Not safe for concurrent use.
+func (c *Manager) CompileAnyExpression(exprString string, visitors ...ast.Visitor) (*vm.Program, error) {
+	// We need a separate api for any expressions as it does not have an associated reflect.Kind
+	options := mergeOptions(expr.AsAny(), visitors)
+	return c.compileExpressionWithExprOptions(options, exprString)
+}
+
+func (c *Manager) compileExpressionWithExprOptions(options []expr.Option, exprString string) (*vm.Program, error) {
+	v, err := expr.Compile(exprString,
+		c.compileOptions(options...)...,
+	)
+	if err != nil {
+		return nil, handleExpressionError(err)
+	}
+	return v, nil
+}
+
+func (c *Manager) compileOptions(extra ...expr.Option) []expr.Option {
+	options := []expr.Option{
+		expr.Env(Context{}),
+	}
+	options = append(options, extra...)
+
+	for _, visitor := range c.VisitorManager.globalVisitors {
+		options = append(options, expr.Patch(visitor))
+	}
+	return options
+}
+
+func mergeOptions(typeOption expr.Option, visitors []ast.Visitor) []expr.Option {
+	compilationOptions := []expr.Option{
+		typeOption,
+	}
+
+	for _, visitor := range visitors {
+		compilationOptions = append(compilationOptions, expr.Patch(visitor))
+	}
+
+	return compilationOptions
+}
+
+// ValidateAnyExpression compiles the expression to ensure that the expression itself is valid but more
+// importantly it checks if the return type is not nil and is an allowed return type
+// this allows us to ensure that nil and return types such as func or channels are not returned
+func (c *Manager) ValidateAnyExpression(s string) error {
+	tree, err := parser.Parse(s)
+	if err != nil {
+		return handleExpressionError(err)
+	}
+
+	// Check if the expression is just a nil literal
+	if _, ok := tree.Node.(*ast.NilNode); ok {
+		return handleExpressionError(errors.New("disallowed nil"))
+	}
+
+	config := conf.CreateNew()
+	for _, op := range c.compileOptions() {
+		op(config)
+	}
+
+	expectedType, err := checker.Check(tree, config)
+	if err != nil {
+		return handleExpressionError(err)
+	}
+
+	// Disallowed types
+	switch expectedType.Kind() {
+	case reflect.Invalid, reflect.Chan, reflect.Func:
+		return handleExpressionError(fmt.Errorf("disallowed type: %s", expectedType.String()))
+	}
+
+	return nil
+}

--- a/router/internal/expr/expr_manager_test.go
+++ b/router/internal/expr/expr_manager_test.go
@@ -20,8 +20,7 @@ func (v *VisitorExample) Visit(node *ast.Node) {
 		return
 	}
 
-	switch (*node).(type) {
-	case *ast.MemberNode:
+	if _, ok := (*node).(*ast.MemberNode); ok {
 		v.Uses = true
 	}
 }

--- a/router/internal/expr/expr_manager_test.go
+++ b/router/internal/expr/expr_manager_test.go
@@ -1,0 +1,177 @@
+package expr
+
+import (
+	"github.com/expr-lang/expr/ast"
+	"github.com/stretchr/testify/require"
+	"reflect"
+	"testing"
+)
+
+type VisitorExample struct {
+	Uses bool
+}
+
+func (v *VisitorExample) Visit(node *ast.Node) {
+	if node == nil {
+		return
+	}
+
+	if v.Uses {
+		return
+	}
+
+	switch (*node).(type) {
+	case *ast.MemberNode:
+		v.Uses = true
+	}
+}
+
+func TestExprManager(t *testing.T) {
+	t.Parallel()
+
+	t.Run("verify compiling any expression", func(t *testing.T) {
+		t.Parallel()
+
+		exprManager := CreateNewExprManager()
+
+		expr, err := exprManager.CompileAnyExpression("request.error ?? 'somevalue'")
+		require.NoError(t, err)
+
+		context := Context{
+			Request: Request{
+				Error: nil,
+			},
+		}
+
+		result, err := ResolveAnyExpression(expr, context)
+		if err != nil {
+			return
+		}
+		require.NoError(t, err)
+		require.Equal(t, "somevalue", result)
+	})
+
+	t.Run("verify compiling expression with type", func(t *testing.T) {
+		t.Parallel()
+
+		exprManager := CreateNewExprManager()
+
+		expr, err := exprManager.CompileExpression("request.error == nil", reflect.Bool)
+		require.NoError(t, err)
+
+		context := Context{
+			Request: Request{
+				Error: nil,
+			},
+		}
+
+		result, err := ResolveBoolExpression(expr, context)
+		if err != nil {
+			return
+		}
+		require.NoError(t, err)
+		require.True(t, result)
+	})
+
+	t.Run("verify compiling expression with type", func(t *testing.T) {
+		t.Parallel()
+
+		exprManager := CreateNewExprManager()
+
+		expr, err := exprManager.CompileExpression("request.error == nil", reflect.Bool)
+		require.NoError(t, err)
+
+		context := Context{
+			Request: Request{
+				Error: nil,
+			},
+		}
+
+		result, err := ResolveBoolExpression(expr, context)
+		if err != nil {
+			return
+		}
+		require.NoError(t, err)
+		require.True(t, result)
+	})
+
+	t.Run("verify compiling an expression", func(t *testing.T) {
+		t.Parallel()
+
+		exprManager := CreateNewExprManager()
+
+		_, err := exprManager.CompileAnyExpression("request.error ?? 'somevalue'")
+		require.NoError(t, err)
+	})
+
+	t.Run("verify compiling expression with custom visitor", func(t *testing.T) {
+		t.Parallel()
+
+		exprManager := CreateNewExprManager()
+
+		visitorExample := VisitorExample{}
+		require.False(t, visitorExample.Uses)
+
+		expr, err := exprManager.CompileExpression("request.error == nil", reflect.Bool, &visitorExample)
+		require.NoError(t, err)
+
+		context := Context{}
+
+		_, err = ResolveBoolExpression(expr, context)
+		if err != nil {
+			return
+		}
+		require.NoError(t, err)
+		require.True(t, visitorExample.Uses)
+	})
+
+	t.Run("verify when body.raw is not accessed", func(t *testing.T) {
+		t.Parallel()
+
+		exprManager := CreateNewExprManager()
+
+		_, err := exprManager.CompileAnyExpression("request.error")
+		if err != nil {
+			require.Fail(t, "unexpected error", err)
+		}
+
+		_, err = exprManager.CompileAnyExpression("request.body")
+		if err != nil {
+			require.Fail(t, "unexpected error", err)
+		}
+
+		require.False(t, exprManager.VisitorManager.IsBodyUsedInExpressions())
+	})
+
+	t.Run("verify when body.raw is accessed", func(t *testing.T) {
+		t.Parallel()
+
+		exprManager := CreateNewExprManager()
+
+		_, err := exprManager.CompileAnyExpression("request.error")
+		if err != nil {
+			require.Fail(t, "unexpected error", err)
+		}
+
+		_, err = exprManager.CompileAnyExpression("request.body.raw")
+		if err != nil {
+			require.Fail(t, "unexpected error", err)
+		}
+
+		require.True(t, exprManager.VisitorManager.IsBodyUsedInExpressions())
+	})
+
+	t.Run("verify when body.raw is called conditionally", func(t *testing.T) {
+		t.Parallel()
+
+		exprManager := CreateNewExprManager()
+
+		_, err := exprManager.CompileAnyExpression("request.error ?? request.body.raw")
+		if err != nil {
+			require.Fail(t, "unexpected error", err)
+		}
+
+		require.True(t, exprManager.VisitorManager.IsBodyUsedInExpressions())
+	})
+
+}

--- a/router/internal/expr/resolvers.go
+++ b/router/internal/expr/resolvers.go
@@ -1,0 +1,54 @@
+package expr
+
+import (
+	"fmt"
+	"github.com/expr-lang/expr"
+	"github.com/expr-lang/expr/vm"
+)
+
+// ResolveAnyExpression evaluates the expression and returns the result as a any. The exprContext is used to
+// provide the context for the expression evaluation. Not safe for concurrent use.
+func ResolveAnyExpression(vm *vm.Program, ctx Context) (any, error) {
+	r, err := expr.Run(vm, ctx)
+	if err != nil {
+		return "", handleExpressionError(err)
+	}
+
+	return r, nil
+}
+
+// ResolveStringExpression evaluates the expression and returns the result as a string. The exprContext is used to
+// provide the context for the expression evaluation. Not safe for concurrent use.
+func ResolveStringExpression(vm *vm.Program, ctx Context) (string, error) {
+	r, err := expr.Run(vm, ctx)
+	if err != nil {
+		return "", handleExpressionError(err)
+	}
+
+	switch v := r.(type) {
+	case string:
+		return v, nil
+	default:
+		return "", fmt.Errorf("expected string, got %T", r)
+	}
+}
+
+// ResolveBoolExpression evaluates the expression and returns the result as a bool. The exprContext is used to
+// provide the context for the expression evaluation. Not safe for concurrent use.
+func ResolveBoolExpression(vm *vm.Program, ctx Context) (bool, error) {
+	if vm == nil {
+		return false, nil
+	}
+
+	r, err := expr.Run(vm, ctx)
+	if err != nil {
+		return false, handleExpressionError(err)
+	}
+
+	switch v := r.(type) {
+	case bool:
+		return v, nil
+	default:
+		return false, fmt.Errorf("failed to run expression: expected bool, got %T", r)
+	}
+}

--- a/router/internal/expr/use_body.go
+++ b/router/internal/expr/use_body.go
@@ -1,0 +1,47 @@
+package expr
+
+import (
+	"github.com/expr-lang/expr/ast"
+)
+
+type UsesBody struct {
+	UsesBody bool
+}
+
+func (v *UsesBody) Visit(baseNode *ast.Node) {
+	if baseNode == nil || v.UsesBody {
+		return
+	}
+
+	// Check if it's a member access
+	rawAccess, ok := (*baseNode).(*ast.MemberNode)
+	if !ok {
+		return
+	}
+
+	// Check if the property is "raw"
+	rawProperty, ok := rawAccess.Property.(*ast.StringNode)
+	if !ok || rawProperty.Value != "raw" {
+		return
+	}
+
+	// Check if the node is request.body
+	bodyAccess, ok := rawAccess.Node.(*ast.MemberNode)
+	if !ok {
+		return
+	}
+
+	// Check if the property is "body"
+	bodyProperty, ok := bodyAccess.Property.(*ast.StringNode)
+	if !ok || bodyProperty.Value != "body" {
+		return
+	}
+
+	// Check if the node is "request"
+	requestNode, ok := bodyAccess.Node.(*ast.IdentifierNode)
+	if !ok || requestNode.Value != "request" {
+		return
+	}
+
+	v.UsesBody = true
+}

--- a/router/internal/expr/use_body_test.go
+++ b/router/internal/expr/use_body_test.go
@@ -1,0 +1,163 @@
+package expr
+
+import (
+	"testing"
+
+	"github.com/expr-lang/expr/ast"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUsesBody(t *testing.T) {
+	t.Parallel()
+
+	t.Run("verify valid body.raw access", func(t *testing.T) {
+		t.Parallel()
+
+		requestNode := &ast.IdentifierNode{Value: "request"}
+		bodyNode := &ast.StringNode{Value: "body"}
+		requestBody := &ast.MemberNode{
+			Node:     requestNode,
+			Property: bodyNode,
+		}
+		rawNode := &ast.StringNode{Value: "raw"}
+		member := &ast.MemberNode{
+			Node:     requestBody,
+			Property: rawNode,
+		}
+		var n ast.Node = member
+
+		visitor := &UsesBody{}
+		visitor.Visit(&n)
+		require.True(t, visitor.UsesBody)
+	})
+
+	t.Run("verify nil node", func(t *testing.T) {
+		t.Parallel()
+
+		visitor := &UsesBody{}
+		visitor.Visit(nil)
+		require.False(t, visitor.UsesBody)
+	})
+
+	t.Run("verify non-member node", func(t *testing.T) {
+		t.Parallel()
+
+		requestNode := &ast.IdentifierNode{Value: "request"}
+		var n ast.Node = requestNode
+
+		visitor := &UsesBody{}
+		visitor.Visit(&n)
+		require.False(t, visitor.UsesBody)
+	})
+
+	t.Run("verify inner node not member node", func(t *testing.T) {
+		t.Parallel()
+
+		requestNode := &ast.IdentifierNode{Value: "request"}
+		rawNode := &ast.StringNode{Value: "raw"}
+		member := &ast.MemberNode{
+			Node:     requestNode,
+			Property: rawNode,
+		}
+		var n ast.Node = member
+
+		visitor := &UsesBody{}
+		visitor.Visit(&n)
+		require.False(t, visitor.UsesBody)
+	})
+
+	t.Run("verify property not string node", func(t *testing.T) {
+		t.Parallel()
+
+		requestNode := &ast.IdentifierNode{Value: "request"}
+		bodyNode := &ast.StringNode{Value: "body"}
+		requestBody := &ast.MemberNode{
+			Node:     requestNode,
+			Property: bodyNode,
+		}
+		rawNode := &ast.IdentifierNode{Value: "raw"}
+		member := &ast.MemberNode{
+			Node:     requestBody,
+			Property: rawNode,
+		}
+		var n ast.Node = member
+
+		visitor := &UsesBody{}
+		visitor.Visit(&n)
+		require.False(t, visitor.UsesBody)
+	})
+
+	t.Run("verify early return when UsesBody is already true", func(t *testing.T) {
+		t.Parallel()
+
+		requestNode := &ast.IdentifierNode{Value: "request"}
+		var n ast.Node = requestNode
+
+		visitor := &UsesBody{UsesBody: true}
+		visitor.Visit(&n)
+		require.True(t, visitor.UsesBody)
+	})
+
+	t.Run("verify wrong request identifier", func(t *testing.T) {
+		t.Parallel()
+
+		requestNode := &ast.IdentifierNode{Value: "wrong"}
+		bodyNode := &ast.StringNode{Value: "body"}
+		requestBody := &ast.MemberNode{
+			Node:     requestNode,
+			Property: bodyNode,
+		}
+		rawNode := &ast.StringNode{Value: "raw"}
+		member := &ast.MemberNode{
+			Node:     requestBody,
+			Property: rawNode,
+		}
+		var n ast.Node = member
+
+		visitor := &UsesBody{}
+		visitor.Visit(&n)
+		require.False(t, visitor.UsesBody)
+	})
+
+	t.Run("verify wrong body property", func(t *testing.T) {
+		t.Parallel()
+
+		requestNode := &ast.IdentifierNode{Value: "request"}
+		bodyNode := &ast.StringNode{Value: "wrong"}
+		requestBody := &ast.MemberNode{
+			Node:     requestNode,
+			Property: bodyNode,
+		}
+		rawNode := &ast.StringNode{Value: "raw"}
+		member := &ast.MemberNode{
+			Node:     requestBody,
+			Property: rawNode,
+		}
+		var n ast.Node = member
+
+		visitor := &UsesBody{}
+		visitor.Visit(&n)
+		require.False(t, visitor.UsesBody)
+	})
+
+	t.Run("verify wrong raw property", func(t *testing.T) {
+		t.Parallel()
+
+		requestNode := &ast.IdentifierNode{Value: "request"}
+		bodyNode := &ast.StringNode{Value: "body"}
+		requestBody := &ast.MemberNode{
+			Node:     requestNode,
+			Property: bodyNode,
+		}
+		rawNode := &ast.StringNode{Value: "wrong"}
+		member := &ast.MemberNode{
+			Node:     requestBody,
+			Property: rawNode,
+		}
+		var n ast.Node = member
+
+		visitor := &UsesBody{}
+		visitor.Visit(&n)
+		require.False(t, visitor.UsesBody)
+	})
+}

--- a/router/internal/expr/visitor_group.go
+++ b/router/internal/expr/visitor_group.go
@@ -1,0 +1,30 @@
+package expr
+
+import "github.com/expr-lang/expr/ast"
+
+type visitorKind uint
+
+const (
+	usesBodyKey visitorKind = iota
+)
+
+// VisitorGroup is a struct that holds all the VisitorManager that are used to compile the expressions
+// We use a separate struct so that the visitor is passed in to places  will use it that are in the request chain
+// this means that they don't have access to compiling expressions in a request by default via the expr manager
+type visitorGroup struct {
+	// contains a list of global visitors that are applicable for all compilations
+	globalVisitors map[visitorKind]ast.Visitor
+}
+
+func createVisitorMGroup() *visitorGroup {
+	return &visitorGroup{
+		globalVisitors: map[visitorKind]ast.Visitor{
+			usesBodyKey: &UsesBody{},
+		},
+	}
+}
+
+func (c *visitorGroup) IsBodyUsedInExpressions() bool {
+	body := c.globalVisitors[usesBodyKey].(*UsesBody)
+	return body.UsesBody
+}

--- a/router/internal/requestlogger/access_log_expression.go
+++ b/router/internal/requestlogger/access_log_expression.go
@@ -13,19 +13,19 @@ type ExpressionAttribute struct {
 	Expr    *vm.Program
 }
 
-func GetAccessLogConfigExpressions(attributes []config.CustomAttribute) ([]ExpressionAttribute, error) {
+func GetAccessLogConfigExpressions(attributes []config.CustomAttribute, exprManager *exprlocal.Manager) ([]ExpressionAttribute, error) {
 	exprSlice := make([]ExpressionAttribute, 0, len(attributes))
 	for _, sAttribute := range attributes {
 		if sAttribute.ValueFrom == nil || sAttribute.ValueFrom.Expression == "" {
 			continue
 		}
 
-		err := exprlocal.ValidateAnyExpression(sAttribute.ValueFrom.Expression)
+		err := exprManager.ValidateAnyExpression(sAttribute.ValueFrom.Expression)
 		if err != nil {
 			return nil, fmt.Errorf("failed when validating log expressions: %w", err)
 		}
 
-		expression, err := exprlocal.CompileAnyExpression(sAttribute.ValueFrom.Expression)
+		expression, err := exprManager.CompileAnyExpression(sAttribute.ValueFrom.Expression)
 		if err != nil {
 			return nil, fmt.Errorf("failed when compiling log expressions: %w", err)
 		}

--- a/router/internal/requestlogger/access_log_expression_test.go
+++ b/router/internal/requestlogger/access_log_expression_test.go
@@ -2,6 +2,7 @@ package requestlogger
 
 import (
 	"github.com/stretchr/testify/require"
+	"github.com/wundergraph/cosmo/router/internal/expr"
 	"github.com/wundergraph/cosmo/router/pkg/config"
 	"testing"
 )
@@ -29,7 +30,8 @@ func TestAccessLogExpressionParsing(t *testing.T) {
 			},
 		}
 
-		expressions, err := GetAccessLogConfigExpressions(customAttributes)
+		exprManager := expr.CreateNewExprManager()
+		expressions, err := GetAccessLogConfigExpressions(customAttributes, exprManager)
 		if err != nil {
 			require.Fail(t, "unexpected error", err)
 		}
@@ -64,7 +66,8 @@ func TestAccessLogExpressionParsing(t *testing.T) {
 			},
 		}
 
-		expressions, err := GetAccessLogConfigExpressions(customAttributes)
+		exprManager := expr.CreateNewExprManager()
+		expressions, err := GetAccessLogConfigExpressions(customAttributes, exprManager)
 		require.NoError(t, err)
 
 		require.Len(t, expressions, 2)
@@ -96,7 +99,8 @@ func TestAccessLogExpressionParsing(t *testing.T) {
 			},
 		}
 
-		_, err := GetAccessLogConfigExpressions(customAttributes)
+		exprManager := expr.CreateNewExprManager()
+		_, err := GetAccessLogConfigExpressions(customAttributes, exprManager)
 		if err != nil {
 			require.Error(t, err)
 			return


### PR DESCRIPTION
## Motivation and Context

We want to add the request raw body to the expression context. This will allow users to use the body as the basis for expressions throughout the router.


## Checklist

- [x] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [x] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->