### PR TITLE
fix: make multipart subscriptions compatible with client

### DIFF
--- a/router-tests/events/nats_events_test.go
+++ b/router-tests/events/nats_events_test.go
@@ -534,7 +534,7 @@ func TestNatsEvents(t *testing.T) {
 
 					// Read the first part
 
-					expected := "\r\n--graphql\r\nContent-Type: application/json\r\n\r\n{\"payload\":{\"data\":{\"countFor\":0}}}\n"
+					expected := "\r\n--graphql\r\nContent-Type: application/json\r\n\r\n{\"payload\":{\"data\":{\"countFor\":0}}}\r\n"
 					read := make([]byte, len(expected))
 					_, err = reader.Read(read)
 					assert.NoError(t, err)
@@ -583,7 +583,7 @@ func TestNatsEvents(t *testing.T) {
 
 					// Read the first part
 
-					expected := "\r\n--graphql\r\nContent-Type: application/json\r\n\r\n{\"payload\":{\"data\":{\"countFor\":0}}}\n\r\n--graphql"
+					expected := "\r\n--graphql\r\nContent-Type: application/json\r\n\r\n{\"payload\":{\"data\":{\"countFor\":0}}}\r\n\r\n--graphql"
 					read := make([]byte, len(expected))
 					_, err = reader.Read(read)
 					assert.NoError(t, err)

--- a/router-tests/events/nats_events_test.go
+++ b/router-tests/events/nats_events_test.go
@@ -545,6 +545,60 @@ func TestNatsEvents(t *testing.T) {
 				require.Eventually(t, done.Load, NatsWaitTimeout, time.Millisecond*100)
 			})
 		})
+
+		t.Run("multipart format related new line returns should have a preceding carriage return", func(t *testing.T) {
+			t.Parallel()
+
+			testenv.Run(t, &testenv.Config{
+				RouterConfigJSONTemplate: testenv.ConfigWithEdfsNatsJSONTemplate,
+				EnableNats:               true,
+			}, func(t *testing.T, xEnv *testenv.Environment) {
+
+				subscribePayload := []byte(`{"query":"subscription { countFor(count: 3) }"}`)
+
+				var done atomic.Bool
+
+				go func() {
+					defer done.Store(true)
+
+					client := http.Client{}
+					req := xEnv.MakeGraphQLMultipartRequest(http.MethodPost, bytes.NewReader(subscribePayload))
+					resp, err := client.Do(req)
+					require.NoError(t, err)
+					require.Equal(t, http.StatusOK, resp.StatusCode)
+					defer resp.Body.Close()
+
+					reader := bufio.NewReader(resp.Body)
+
+					assert.Eventually(t, func() bool {
+						allData, err := io.ReadAll(reader)
+						if err != nil {
+							assert.Fail(t, fmt.Sprintf("failed to read all data: %v", err))
+						}
+						runes := []rune(string(allData))
+
+						for i := 0; i < len(runes); i++ {
+							if runes[i] == '\r' {
+								// Validate that this is not a stray \r entry
+								if i+1 >= len(runes) || runes[i+1] != '\n' {
+									assert.Fail(t, "Invalid newline detected: '\\r' not followed by '\\n'")
+								}
+								i++
+							} else if runes[i] == '\n' {
+								// Validate that this is not a stray \n entry
+								if i == 0 || runes[i-1] != '\r' {
+									assert.Fail(t, "Invalid newline detected: '\\n' not preceded by '\\r'")
+								}
+							}
+						}
+						return true
+					}, NatsWaitTimeout, time.Millisecond*100)
+				}()
+
+				xEnv.WaitForSubscriptionCount(1, NatsWaitTimeout)
+				require.Eventually(t, done.Load, NatsWaitTimeout, time.Millisecond*100)
+			})
+		})
 	})
 
 	t.Run("multipart with apollo compatibility", func(t *testing.T) {

--- a/router/core/flushwriter.go
+++ b/router/core/flushwriter.go
@@ -50,9 +50,9 @@ func (f *HttpFlushWriter) Complete() {
 	} else if f.multipart {
 		// Write the final boundary in the multipart response
 		if f.apolloSubscriptionMultipartPrintBoundary {
-			_, _ = f.writer.Write([]byte("--\n"))
+			_, _ = f.writer.Write([]byte("--\r\n"))
 		} else {
-			_, _ = f.writer.Write([]byte("--" + multipartBoundary + "--\n"))
+			_, _ = f.writer.Write([]byte("--" + multipartBoundary + "--\r\n"))
 		}
 	}
 	f.Close()
@@ -94,12 +94,12 @@ func (f *HttpFlushWriter) Flush() (err error) {
 		}
 	}
 
-	separation := "\n\n"
+	separation := "\r\n\r\n"
 	if f.multipart {
 		if !f.apolloSubscriptionMultipartPrintBoundary {
-			separation = "\n"
+			separation = "\r\n"
 		} else {
-			separation = "\n" + multipartStart
+			separation = "\r\n" + multipartStart
 		}
 	} else if f.subscribeOnce {
 		separation = ""

--- a/router/core/flushwriter.go
+++ b/router/core/flushwriter.go
@@ -94,7 +94,7 @@ func (f *HttpFlushWriter) Flush() (err error) {
 		}
 	}
 
-	separation := "\r\n\r\n"
+	separation := "\n\n"
 	if f.multipart {
 		if !f.apolloSubscriptionMultipartPrintBoundary {
 			separation = "\r\n"


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

## Motivation and Context

This PR adds the required carriage returns to make multipart subscriptions compatible with apollo kotlin client. This is as apollo kotlin requires a preceeding carraige return on newlines when partitioning parts for multipart responses.

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->