### PR TITLE
fix: improve performance when updating member role

### DIFF
--- a/.github/scripts/setup-keycloak.sh
+++ b/.github/scripts/setup-keycloak.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export KC_VERSION=22.0.4
+export KC_VERSION=25.0.1
 curl -LO  https://github.com/keycloak/keycloak/releases/download/"${KC_VERSION}"/keycloak-"${KC_VERSION}".zip
 
 unzip -q keycloak-${KC_VERSION}.zip

--- a/.github/workflows/controlplane-ci.yaml
+++ b/.github/workflows/controlplane-ci.yaml
@@ -6,6 +6,7 @@ on:
       - "connect/**/*"
       - "composition/**/*"
       - ".github/workflows/cp-ci.yaml"
+      - ".github/scripts/setup-keycloak.sh"
 
 concurrency:
   group: ${{github.workflow}}-${{github.head_ref}}

--- a/controlplane/src/core/bufservices/user/updateOrgMemberRole.ts
+++ b/controlplane/src/core/bufservices/user/updateOrgMemberRole.ts
@@ -138,12 +138,12 @@ export function updateOrgMemberRole(
         },
       };
     }
-    
+
     const organizationSubGroups = await opts.keycloakClient.fetchAllSubGroups({
       realm: opts.keycloakRealm,
       kcGroupId: organizationGroups[0].id!,
     });
-    
+
     const targetGroup = organizationSubGroups.find((group) => group.name === req.role);
     if (!targetGroup) {
       throw new Error(`Invalid role ${req.role}`);
@@ -155,14 +155,14 @@ export function updateOrgMemberRole(
       if (!childGroup) {
         continue;
       }
-      
+
       await opts.keycloakClient.client.users.delFromGroup({
         id: users[0].id!,
         realm: opts.keycloakRealm,
         groupId: childGroup.id!,
       });
     }
-    
+
     await opts.keycloakClient.client.users.addToGroup({
       id: users[0].id!,
       realm: opts.keycloakRealm,

--- a/controlplane/src/core/services/Keycloak.ts
+++ b/controlplane/src/core/services/Keycloak.ts
@@ -347,8 +347,8 @@ export default class Keycloak {
     });
   }
 
-  public async fetchAllSubGroups({ realm, kcGroupId }: { realm?: string; kcGroupId: string }) {
-    return await this.client.groups.listSubGroups({
+  public fetchAllSubGroups({ realm, kcGroupId }: { realm?: string; kcGroupId: string }) {
+    return this.client.groups.listSubGroups({
       parentId: kcGroupId,
       realm: realm || this.realm,
     });

--- a/controlplane/src/core/services/Keycloak.ts
+++ b/controlplane/src/core/services/Keycloak.ts
@@ -358,18 +358,13 @@ export default class Keycloak {
     kcGroupId: string;
     childGroupType: MemberRole;
   }) {
-    const orgGroups = await this.client.groups.find({
+    const orgGroups = await this.client.groups.listSubGroups({
       search: childGroupType,
+      parentId: kcGroupId,
       realm: realm || this.realm,
     });
 
-    if (orgGroups.length === 0) {
-      throw new Error(`Organization group '${orgSlug}' does not have any child groups`);
-    }
-
-    const orgGroup = orgGroups.find((group) => group.id === kcGroupId);
-    const childGroup = orgGroup?.subGroups?.find((group) => group.path === `/${orgSlug}/${childGroupType}`);
-
+    const childGroup = orgGroups?.find((group) => group.path === `/${orgSlug}/${childGroupType}`);
     if (!childGroup) {
       throw new Error(`Organization child group '/${orgSlug}/${childGroupType}' not found`);
     }

--- a/controlplane/src/core/services/Keycloak.ts
+++ b/controlplane/src/core/services/Keycloak.ts
@@ -346,8 +346,8 @@ export default class Keycloak {
       groupId: adminGroup.id,
     });
   }
-  
-  public async fetchAllSubGroups({ realm, kcGroupId }: { realm?: string, kcGroupId: string }) {
+
+  public async fetchAllSubGroups({ realm, kcGroupId }: { realm?: string; kcGroupId: string }) {
     return await this.client.groups.listSubGroups({
       parentId: kcGroupId,
       realm: realm || this.realm,

--- a/controlplane/src/core/services/Keycloak.ts
+++ b/controlplane/src/core/services/Keycloak.ts
@@ -346,6 +346,13 @@ export default class Keycloak {
       groupId: adminGroup.id,
     });
   }
+  
+  public async fetchAllSubGroups({ realm, kcGroupId }: { realm?: string, kcGroupId: string }) {
+    return await this.client.groups.listSubGroups({
+      parentId: kcGroupId,
+      realm: realm || this.realm,
+    });
+  }
 
   public async fetchChildGroup({
     realm,

--- a/controlplane/test/test-util.ts
+++ b/controlplane/test/test-util.ts
@@ -97,7 +97,7 @@ export const SetupTest = async function ({
 
   const authenticator = createTestAuthenticator(users);
 
-  const realm = `test-${randomUUID()}`;
+  const realm = 'test';
   const loginRealm = 'master';
   const apiUrl = 'http://localhost:8080';
   const clientId = 'studio';

--- a/controlplane/test/test-util.ts
+++ b/controlplane/test/test-util.ts
@@ -97,7 +97,7 @@ export const SetupTest = async function ({
 
   const authenticator = createTestAuthenticator(users);
 
-  const realm = 'test';
+  const realm = `test-${randomUUID()}`;
   const loginRealm = 'master';
   const apiUrl = 'http://localhost:8080';
   const clientId = 'studio';


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

## Motivation and Context

When updating member roles the operation could take anywhere from a few seconds to over a minute (eventually failing).

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please describe in detail the impact of this change. Attach screenshots if applicable.
-->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->

Both operations were executed with 7400 organizations.

Before:
<img width="1592" alt="before" src="https://github.com/user-attachments/assets/33a4cb7b-748b-4ec0-ab95-2f943ded525d" />

After:
<img width="1595" alt="after" src="https://github.com/user-attachments/assets/32f0abab-f869-498a-b83a-f1d1430eb956" />

## Analysis

The `organizations` are created as groups inside `Keycloak` and the roles are subgroups of the organizations.

To find the identifier of the role in `Keycloak` we were searching by the role name, for example `admin`, this causes `Keycloak` to return all the organizations as the `admin` role should exist in all of them. This issue scales with the amount of organizations created in `Keycloak`.

Something that added to the issue is that we were performing this operation 3 times in a row to load the relevant organization roles.

## Solution

The solution is to use the organization identifier (`kcGroupId`) to list the subgroups (roles) of the organization and filter them by name.

Additionally, to avoid performing this operation multiple times in a row just with different role, a new method was introduced to load all organization roles at once and filter in memory.