### PR TITLE
feat(plan-generator): improve memory and cpu usage

### DIFF
--- a/router/cmd/plan_generator.go
+++ b/router/cmd/plan_generator.go
@@ -95,8 +95,8 @@ func PlanGenerator(args []string) {
 			logger.Info("GOMEMLIMIT set automatically", zap.String("size", humanize.Bytes(uint64(mLimit))))
 		} else {
 			logger.Info(
-				"GOMEMLIMIT was not set. Please set it manually to around 90%% of the available memory to prevent"+
-					" OOM kills",
+				"GOMEMLIMIT was not set. Please set it manually to around 90%% of the available memory to "+
+					"prevent OOM kills",
 				zap.Error(err),
 			)
 		}

--- a/router/core/plan_generator.go
+++ b/router/core/plan_generator.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/wundergraph/cosmo/router/pkg/config"
 
-	"github.com/jensneuse/abstractlogger"
 	"github.com/wundergraph/cosmo/router/pkg/execution_config"
 )
 
@@ -34,32 +33,29 @@ type PlanGenerator struct {
 	definition        *ast.Document
 }
 
-func NewPlanGenerator(configFilePath string, logger *zap.Logger) (*PlanGenerator, error) {
-	pg := &PlanGenerator{}
-	if err := pg.loadConfiguration(configFilePath); err != nil {
-		return nil, err
-	}
+type Planner struct {
+	planner    *plan.Planner
+	definition *ast.Document
+}
 
-	if logger != nil {
-		pg.planConfiguration.Logger = abstractlogger.NewZapLogger(logger, abstractlogger.DebugLevel)
-	}
-
-	planner, err := plan.NewPlanner(*pg.planConfiguration)
+func NewPlanner(planConfiguration *plan.Configuration, definition *ast.Document) (*Planner, error) {
+	planner, err := plan.NewPlanner(*planConfiguration)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create planner: %w", err)
 	}
-	pg.planner = planner
-
-	return pg, nil
+	return &Planner{
+		planner:    planner,
+		definition: definition,
+	}, nil
 }
 
-func (pg *PlanGenerator) PlanOperation(operationFilePath string) (string, error) {
-	operation, err := pg.parseOperation(operationFilePath)
+func (pl *Planner) PlanOperation(operationFilePath string) (string, error) {
+	operation, err := pl.parseOperation(operationFilePath)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse operation: %w", err)
 	}
 
-	rawPlan, err := pg.planOperation(operation)
+	rawPlan, err := pl.planOperation(operation)
 	if err != nil {
 		return "", fmt.Errorf("failed to plan operation: %w", err)
 	}
@@ -67,7 +63,7 @@ func (pg *PlanGenerator) PlanOperation(operationFilePath string) (string, error)
 	return rawPlan.PrettyPrint(), nil
 }
 
-func (pg *PlanGenerator) planOperation(operation *ast.Document) (*resolve.FetchTreeQueryPlanNode, error) {
+func (pl *Planner) planOperation(operation *ast.Document) (*resolve.FetchTreeQueryPlanNode, error) {
 	report := operationreport.Report{}
 
 	var operationName []byte
@@ -83,10 +79,10 @@ func (pg *PlanGenerator) planOperation(operation *ast.Document) (*resolve.FetchT
 		return nil, errors.New("operation name not found")
 	}
 
-	astnormalization.NormalizeNamedOperation(operation, pg.definition, operationName, &report)
+	astnormalization.NormalizeNamedOperation(operation, pl.definition, operationName, &report)
 
 	// create and postprocess the plan
-	preparedPlan := pg.planner.Plan(operation, pg.definition, string(operationName), &report, plan.IncludeQueryPlanInResponse())
+	preparedPlan := pl.planner.Plan(operation, pl.definition, string(operationName), &report, plan.IncludeQueryPlanInResponse())
 	if report.HasErrors() {
 		return nil, errors.New(report.Error())
 	}
@@ -100,7 +96,7 @@ func (pg *PlanGenerator) planOperation(operation *ast.Document) (*resolve.FetchT
 	return &resolve.FetchTreeQueryPlanNode{}, nil
 }
 
-func (pg *PlanGenerator) parseOperation(operationFilePath string) (*ast.Document, error) {
+func (pl *Planner) parseOperation(operationFilePath string) (*ast.Document, error) {
 	content, err := os.ReadFile(operationFilePath)
 	if err != nil {
 		return nil, err
@@ -112,6 +108,23 @@ func (pg *PlanGenerator) parseOperation(operationFilePath string) (*ast.Document
 	}
 
 	return &doc, nil
+}
+
+func NewPlanGenerator(configFilePath string, logger *zap.Logger) (*PlanGenerator, error) {
+	pg := &PlanGenerator{}
+	if err := pg.loadConfiguration(configFilePath); err != nil {
+		return nil, err
+	}
+
+	if logger != nil {
+		pg.planConfiguration.Logger = log.NewZapLogger(logger, log.DebugLevel)
+	}
+
+	return pg, nil
+}
+
+func (pg *PlanGenerator) GetPlanner() (*Planner, error) {
+	return NewPlanner(pg.planConfiguration, pg.definition)
 }
 
 func (pg *PlanGenerator) loadConfiguration(configFilePath string) error {

--- a/router/core/plan_generator.go
+++ b/router/core/plan_generator.go
@@ -20,9 +20,11 @@ import (
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/postprocess"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/operationreport"
+	"go.uber.org/zap"
 
 	"github.com/wundergraph/cosmo/router/pkg/config"
 
+	"github.com/jensneuse/abstractlogger"
 	"github.com/wundergraph/cosmo/router/pkg/execution_config"
 )
 
@@ -32,10 +34,14 @@ type PlanGenerator struct {
 	definition        *ast.Document
 }
 
-func NewPlanGenerator(configFilePath string) (*PlanGenerator, error) {
+func NewPlanGenerator(configFilePath string, logger *zap.Logger) (*PlanGenerator, error) {
 	pg := &PlanGenerator{}
 	if err := pg.loadConfiguration(configFilePath); err != nil {
 		return nil, err
+	}
+
+	if logger != nil {
+		pg.planConfiguration.Logger = abstractlogger.NewZapLogger(logger, abstractlogger.DebugLevel)
 	}
 
 	planner, err := plan.NewPlanner(*pg.planConfiguration)

--- a/router/core/plan_generator.go
+++ b/router/core/plan_generator.go
@@ -29,7 +29,6 @@ import (
 
 type PlanGenerator struct {
 	planConfiguration *plan.Configuration
-	planner           *plan.Planner
 	definition        *ast.Document
 }
 

--- a/router/pkg/plan_generator/plan_generator.go
+++ b/router/pkg/plan_generator/plan_generator.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/wundergraph/cosmo/router/core"
+	"go.uber.org/zap"
 )
 
 const ReportFileName = "report.json"
@@ -29,6 +30,8 @@ type QueryPlanConfig struct {
 	OutputReport    bool
 	FailOnPlanError bool
 	FailFast        bool
+	LogLevel        string
+	Logger          *zap.Logger
 }
 
 type QueryPlanResults struct {
@@ -104,7 +107,7 @@ func PlanGenerator(ctx context.Context, cfg QueryPlanConfig) error {
 	for i := 0; i < cfg.Concurrency; i++ {
 		go func(i int) {
 			defer wg.Done()
-			pg, err := core.NewPlanGenerator(executionConfigPath)
+			pg, err := core.NewPlanGenerator(executionConfigPath, cfg.Logger)
 			if err != nil {
 				cancelError(fmt.Errorf("failed to create plan generator: %v", err))
 				return


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

## Motivation and Context

A customer is having issues with how much memory the query planner is using. After some debugging we found two things:
- the customer was deploying the query planner in a container, and the query planner was instead using the memory and cpu limits from the host
- the PlanGenerator was creating a new plan.Configuration and ast.Document for each go routine

This PR is acting on this two issues:
- using `go.uber.org/automaxprocs/maxprocs` and `github.com/KimMachineGun/automemlimit/memlimit` to recognize when running inside a container and set the right limits
- refactoring the PlanGenerator so that it can be instantiate only one time, and then each operation can get its own planner.

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please describe in detail the impact of this change. Attach screenshots if applicable.
-->

## Checklist

- [x] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [x] Tests or benchmarks have been added or updated.
- [x] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->

## Results

Testing with a big configuration (9MB), a concurrency of 20 and 643 queries, with the query-plan deployed with the router 0.189.2, we got the following result:
```
ale@Alessandros-MacBook-Pro router % /usr/bin/time -l ./router query-plan -execution-config ../routerConfig.json -operations ../operations  -plans ../plans --concurrency 20
        0.96 real         9.70 user         0.74 sys
          2041774080  maximum resident set size
                   0  average shared memory size
                   0  average unshared data size
                   0  average unshared stack size
              125644  page reclaims
                   0  page faults
                   0  swaps
                   0  block input operations
                   0  block output operations
                   0  messages sent
                   0  messages received
                1377  signals received
                1787  voluntary context switches
               42662  involuntary context switches
        115559925736  instructions retired
         37222549148  cycles elapsed
          2026227680  peak memory footprint
```
The results vary a bit on each execution, by they are always arount this values.

With the router build from this PR we got the following result:
```
ale@Alessandros-MacBook-Pro router % /usr/bin/time -l ./router query-plan -execution-config ../routerConfig.json -operations ../perations  -plans ../plans --concurrency 20
        0.77 real         7.28 user         0.35 sys
           509607936  maximum resident set size
                   0  average shared memory size
                   0  average unshared data size
                   0  average unshared stack size
               31690  page reclaims
                   0  page faults
                   0  swaps
                   0  block input operations
                   0  block output operations
                   0  messages sent
                   0  messages received
                1598  signals received
                1763  voluntary context switches
               27882  involuntary context switches
         87230173821  instructions retired
         27234204057  cycles elapsed
           493224824  peak memory footprint
```
So we went from a peak RSS of 2GB to 0.5GB!