### PR TITLE
fix(cli): typo in schema check

### DIFF
--- a/cli/src/commands/subgraph/commands/check.ts
+++ b/cli/src/commands/subgraph/commands/check.ts
@@ -33,7 +33,7 @@ export default (opts: BaseCommandOptions) => {
       if (!existsSync(schemaFile)) {
         program.error(
           pc.red(
-            pc.bold(`The readme file '${pc.bold(schemaFile)}' does not exist. Please check the path and try again.`),
+            pc.bold(`The schema file '${pc.bold(schemaFile)}' does not exist. Please check the path and try again.`),
           ),
         );
       }


### PR DESCRIPTION
## Motivation and Context

When attempting a schema check for a subgraph, if the schema file is not found, it incorrectly reports that a readme file has not been found.

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).