### PR TITLE
fix: prefer json as a content type for non subscriptions

### DIFF
--- a/router/core/errors.go
+++ b/router/core/errors.go
@@ -190,9 +190,10 @@ func writeRequestErrors(r *http.Request, w http.ResponseWriter, statusCode int, 
 		return
 	}
 
+	// According to the tests requestContext can be nil (when called from module WriteResponseError)
+	// As such we have coded this condition defensively to be safe
 	requestContext := getRequestContext(r.Context())
-	// We want to prioritize json if it is not a subscription
-	isSubscription := requestContext.operation.opType == "subscription"
+	isSubscription := requestContext != nil && requestContext.operation != nil && requestContext.operation.opType == "subscription"
 
 	wgRequestParams := NegotiateSubscriptionParams(r, !isSubscription)
 

--- a/router/core/flushwriter.go
+++ b/router/core/flushwriter.go
@@ -232,7 +232,6 @@ func NegotiateSubscriptionParams(r *http.Request, preferJson bool) SubscriptionP
 
 		// We also have an exception where we prioritize json over higher priority media types
 		if preferJson && strings.EqualFold(mediaType, jsonContent) {
-			bestQ = qValue
 			bestType = mediaType
 			break
 		}

--- a/router/core/flushwriter_test.go
+++ b/router/core/flushwriter_test.go
@@ -117,7 +117,7 @@ func TestNegotiateSubscriptionParams(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equalf(t, tt.want, NegotiateSubscriptionParams(tt.args.r), "NegotiateSubscriptionParams(%v)", tt.args.r)
+			assert.Equalf(t, tt.want, NegotiateSubscriptionParams(tt.args.r, false), "NegotiateSubscriptionParams(%v)", tt.args.r)
 		})
 	}
 }


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

## Motivation and Context

Some clients have various requirements for parsing multipart (for example one client needs the specification in the content-type returned, if not it wont parse multipart). To avoid all of these complexities we will default to returning json for non-subscription operations WHEN the `accept` header has `application/json` in the value, so if `application/json` is even the 10th entry we will prefer it.

This also mimics the behaviour of a different product.

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->