### PR TITLE
fix: fix incorrect calculation of the `p90` and `p99` subgraph metrics

### DIFF
--- a/controlplane/src/core/repositories/analytics/SubgraphMetricsRepository.ts
+++ b/controlplane/src/core/repositories/analytics/SubgraphMetricsRepository.ts
@@ -291,7 +291,7 @@ export class SubgraphMetricsRepository {
             ) as p50,
             -- P90
             func_rank(0.90, BucketCounts) as rank90,
-            func_rank_bucket_lower_index(rank50, BucketCounts) as b90,
+            func_rank_bucket_lower_index(rank90, BucketCounts) as b90,
             func_histogram_v2(
                 rank90,
                 b90,
@@ -300,7 +300,7 @@ export class SubgraphMetricsRepository {
             ) as p90,
             -- P99
             func_rank(0.99, BucketCounts) as rank99,
-            func_rank_bucket_lower_index(rank50, BucketCounts) as b99,
+            func_rank_bucket_lower_index(rank99, BucketCounts) as b99,
             func_histogram_v2(
                 rank99,
                 b99,


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

## Motivation and Context

A bug was introduced where the `p90` and `p99` latencies were calculated incorrectly when looking at an specific subgraph analytics. The main graph analytics was unaffected by this.

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please describe in detail the impact of this change. Attach screenshots if applicable.
-->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->