### PR TITLE
feat: align the selected checks filter with the filter

### DIFF
--- a/studio/src/components/checks/checks-filter-menu.tsx
+++ b/studio/src/components/checks/checks-filter-menu.tsx
@@ -3,6 +3,7 @@ import { useApplyParams } from "@/components/analytics/use-apply-params";
 import { DataTablePrimaryFilterMenu } from "@/components/analytics/data-table-primary-filter-menu";
 import { GraphContext } from "@/components/layout/graph-layout";
 import { useRouter } from "next/router";
+import { SelectedChecksFilters } from "./selected-checks-filters";
 
 export const parseSelectedSubgraphs = (value: unknown) => {
   if (typeof value === "string") {
@@ -16,23 +17,34 @@ export function ChecksFilterMenu() {
   const router = useRouter();
   const applyParams = useApplyParams();
   const { subgraphs = [] } = useContext(GraphContext) ?? {};
+  const selectedSubgraphs = parseSelectedSubgraphs(router.query.subgraphs);
 
   return (
-    <DataTablePrimaryFilterMenu
-      filters={[
-        {
-          id: "subgraphs",
-          title: "Subgraphs",
-          selectedOptions: parseSelectedSubgraphs(router.query.subgraphs),
-          onSelect: (selected) => {
-            applyParams({ subgraphs: selected?.join(',') ?? null });
-          },
-          options: subgraphs.map((sg) => ({
-            label: sg.name,
-            value: sg.id
-          })),
-        }
-      ]}
-    />
+    <div className="flex flex-col gap-2 space-y-2">
+      <div className="flex gap-2">
+        <div className="flex flex-wrap gap-2">
+          <DataTablePrimaryFilterMenu
+            filters={[
+              {
+                id: "subgraphs",
+                title: "Subgraphs",
+                selectedOptions: selectedSubgraphs,
+                onSelect: (selected) => {
+                  applyParams({ subgraphs: selected?.join(',') ?? null });
+                },
+                options: subgraphs.map((sg) => ({
+                  label: sg.name,
+                  value: sg.id
+                })),
+              }
+            ]}
+          />
+
+          <div className="flex flex-wrap gap-1">
+            <SelectedChecksFilters selectedSubgraphs={selectedSubgraphs} />
+          </div>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/studio/src/components/checks/selected-checks-filters.tsx
+++ b/studio/src/components/checks/selected-checks-filters.tsx
@@ -25,7 +25,7 @@ export function SelectedChecksFilters({
   }));
 
   return (
-    <div className="flex flex-wrap gap-1">
+    <>
       <div>
         <DataTableFacetedFilter
           id="subgraphs"
@@ -52,6 +52,6 @@ export function SelectedChecksFilters({
         <Cross2Icon className="mr-2 h-4 w-4" />
         Reset
       </Button>
-    </div>
+    </>
   );
 }

--- a/studio/src/pages/[organizationSlug]/[namespace]/graph/[slug]/checks/index.tsx
+++ b/studio/src/pages/[organizationSlug]/[namespace]/graph/[slug]/checks/index.tsx
@@ -148,7 +148,6 @@ const ChecksPage: NextPageWithLayout = () => {
 
   return (
     <div className="flex h-full flex-col gap-y-3">
-      <SelectedChecksFilters selectedSubgraphs={selectedSubgraphs} />
       <TableWrapper>
         <Table>
           <TableHeader>


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

## Motivation and Context

The selected checks filter should be aligned next to the filter box to prevent content shift.

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please describe in detail the impact of this change. Attach screenshots if applicable.
-->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->

<img width="1592" alt="preview" src="https://github.com/user-attachments/assets/fd93f1da-2b3e-4b05-8dc6-ba5608dfab06" />