### PR TITLE
feat: implement `--client-schema` flag

### DIFF
--- a/cli/src/commands/graph/common/fetch-schema.ts
+++ b/cli/src/commands/graph/common/fetch-schema.ts
@@ -14,6 +14,7 @@ export default (opts: CommonGraphCommandOptions) => {
   command.argument('<name>', `The name of the ${graphType} to fetch.`);
   command.option('-n, --namespace [string]', `The namespace of the ${graphType}.`);
   command.option('-o, --out [string]', 'Destination file for the SDL.');
+  command.option('-c, --client-schema', 'Output the client schema SDL.');
   command.action(async (name, options) => {
     const resp = await opts.client.platform.getFederatedGraphSDLByName(
       {
@@ -35,10 +36,11 @@ export default (opts: CommonGraphCommandOptions) => {
       return;
     }
 
+    const schema = (options.clientSchema ? resp.clientSchema : resp.sdl) ?? '';
     if (options.out) {
-      await writeFile(resolve(options.out), resp.sdl ?? '');
+      await writeFile(resolve(options.out), schema);
     } else {
-      console.log(resp.sdl);
+      console.log(schema);
     }
   });
 

--- a/cli/test/fetch-schema.test.ts
+++ b/cli/test/fetch-schema.test.ts
@@ -1,0 +1,91 @@
+import { rmSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, test, expect } from 'vitest';
+import { Command } from 'commander';
+import { createPromiseClient, createRouterTransport } from '@connectrpc/connect';
+import { PlatformService } from '@wundergraph/cosmo-connect/dist/platform/v1/platform_connect';
+import { EnumStatusCode } from '@wundergraph/cosmo-connect/dist/common/common_pb';
+import { Client } from '../src/core/client/client.js';
+import FetchSchemaCommand from '../src/commands/graph/common/fetch-schema.js';
+
+const routerSdl = 'type User {\n  id: String @authenticated\n}';
+const clientSdl = 'type User {\n  id: String\n}';
+
+export const mockPlatformTransport = () =>
+  createRouterTransport(({ service }) => {
+    service(PlatformService, {
+      getFederatedGraphSDLByName: (ctx) => {
+        return {
+          response: {
+            code: EnumStatusCode.OK,
+          },
+          sdl: routerSdl,
+          versionId: '1234',
+          clientSchema: clientSdl,
+        };
+      },
+    });
+  });
+
+describe('Fetch schema', () => {
+  test('should return router schema', async () => {
+    const client: Client = {
+      platform: createPromiseClient(PlatformService, mockPlatformTransport()),
+      // @ts-ignore
+      node: null,
+    };
+
+    const program = new Command();
+    program.addCommand(
+      FetchSchemaCommand({
+        client,
+      }),
+    );
+
+    const tmp = join(tmpdir(), `router-schema-${Date.now()}.graphql`);
+    try {
+      const command = await program.parseAsync(
+        ['fetch-schema', 'mygraph', '-o', tmp],
+        {
+          from: 'user',
+        }
+      );
+
+      const content = readFileSync(tmp, 'utf8');
+      expect(content).toBe(routerSdl);
+    } finally {
+      rmSync(tmp);
+    }
+  });
+
+  test('should return client schema', async () => {
+    const client: Client = {
+      platform: createPromiseClient(PlatformService, mockPlatformTransport()),
+      // @ts-ignore
+      node: null,
+    };
+
+    const program = new Command();
+    program.addCommand(
+      FetchSchemaCommand({
+        client,
+      }),
+    );
+
+    const tmp = join(tmpdir(), `client-schema-${Date.now()}.graphql`);
+    try {
+      const command = await program.parseAsync(
+        ['fetch-schema', 'mygraph', '-o', tmp, '--client-schema'],
+        {
+          from: 'user',
+        }
+      );
+
+      const content = readFileSync(tmp, 'utf8');
+      expect(content).toBe(clientSdl);
+    } finally {
+      rmSync(tmp);
+    }
+  });
+});


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

## Motivation and Context

By default, the `monograph fetch-schema` and `federated-graph fetch-schema` output the router schema SDL. This PR introduces a way to output the client schema SDL instead.

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please describe in detail the impact of this change. Attach screenshots if applicable.
-->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [x] Tests or benchmarks have been added or updated.
- [x] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->