### PR TITLE
feat: synchronize hovering all graphs in analytics pages

### DIFF
--- a/studio/src/components/analytics/metrics.tsx
+++ b/studio/src/components/analytics/metrics.tsx
@@ -343,10 +343,11 @@ interface SparklineProps {
   timeRange: number;
   className?: string;
   valueFormatter?: (value: any) => any;
+  syncId?: string;
 }
 
 const Sparkline: React.FC<SparklineProps> = (props) => {
-  const { timeRange = 24, valueFormatter } = props;
+  const { timeRange = 24, valueFormatter, syncId } = props;
   const id = useId();
 
   const { data, ticks, domain, timeFormatter } = useChartData(
@@ -362,6 +363,7 @@ const Sparkline: React.FC<SparklineProps> = (props) => {
         <AreaChart
           data={data}
           margin={{ top: 10, right: 6, bottom: 8, left: 6 }}
+          syncId={syncId}
         >
           <defs>
             <linearGradient
@@ -430,9 +432,10 @@ const Sparkline: React.FC<SparklineProps> = (props) => {
 export const RequestMetricsCard = (props: {
   data?: MetricsDashboardMetric;
   isSubgraphAnalytics?: boolean;
+  syncId?: string;
 }) => {
   const timeRange = useTimeRange();
-  const { data } = props;
+  const { data, syncId } = props;
 
   const top = data?.top ?? [];
 
@@ -480,6 +483,7 @@ export const RequestMetricsCard = (props: {
           series={data?.series ?? []}
           valueFormatter={formatter}
           timeRange={timeRange}
+          syncId={syncId}
         />
       </CardContent>
       <TopList
@@ -496,9 +500,10 @@ export const RequestMetricsCard = (props: {
 export const LatencyMetricsCard = (props: {
   data?: MetricsDashboardMetric;
   isSubgraphAnalytics?: boolean;
+  syncId?: string;
 }) => {
   const timeRange = useTimeRange();
-  const { data } = props;
+  const { data, syncId } = props;
 
   const top = data?.top ?? [];
 
@@ -533,6 +538,7 @@ export const LatencyMetricsCard = (props: {
           series={data?.series ?? []}
           valueFormatter={formatter}
           timeRange={timeRange}
+          syncId={syncId}
         />
       </CardContent>
       <TopList
@@ -549,9 +555,10 @@ export const LatencyMetricsCard = (props: {
 export const ErrorMetricsCard = (props: {
   data?: MetricsDashboardMetric;
   isSubgraphAnalytics?: boolean;
+  syncId?: string;
 }) => {
   const timeRange = useTimeRange();
-  const { data } = props;
+  const { data, syncId } = props;
 
   const top = data?.top ?? [];
 
@@ -581,6 +588,7 @@ export const ErrorMetricsCard = (props: {
           series={data?.series ?? []}
           valueFormatter={formatter}
           timeRange={timeRange}
+          syncId={syncId}
         />
       </CardContent>
       <TopList
@@ -599,7 +607,7 @@ export const ErrorMetricsCard = (props: {
 };
 
 const ErrorPercentChart: React.FC<SparklineProps> = (props) => {
-  const { timeRange = 24, valueFormatter } = props;
+  const { timeRange = 24, valueFormatter, syncId } = props;
   const id = useId();
   const { data, ticks, domain, timeFormatter } = useChartData(
     timeRange,
@@ -612,6 +620,7 @@ const ErrorPercentChart: React.FC<SparklineProps> = (props) => {
         <AreaChart
           data={data}
           margin={{ top: 10, right: 6, bottom: 8, left: 6 }}
+          syncId={syncId}
         >
           <defs>
             <linearGradient id={`${id}-gradient`} x1="0" y1="0" x2="0" y2="1">
@@ -664,7 +673,7 @@ const ErrorPercentChart: React.FC<SparklineProps> = (props) => {
   );
 };
 
-export const ErrorRateOverTimeCard = () => {
+export const ErrorRateOverTimeCard = ({ syncId }: { syncId?: string }) => {
   const id = useId();
   const graphContext = useContext(GraphContext);
 
@@ -746,6 +755,7 @@ export const ErrorRateOverTimeCard = () => {
         <AreaChart
           data={data}
           margin={{ top: 8, right: 8, bottom: 8, left: 0 }}
+          syncId={syncId}
         >
           <defs>
             <linearGradient id={`${id}-gradient`} x1="0" y1="0" x2="0" y2="1">
@@ -820,7 +830,7 @@ export const ErrorRateOverTimeCard = () => {
   );
 };
 
-export const LatencyDistributionCard = ({ series } : { series: any[]; }) => {
+export const LatencyDistributionCard = ({ series, syncId } : { series: any[]; syncId?: string; }) => {
   const [activeLatencies, setActiveLatencies] = useState({ p50: false, p90: false, p99: false });
   const timeRange = useTimeRange();
   const formatter = (value: number) => {
@@ -852,6 +862,7 @@ export const LatencyDistributionCard = ({ series } : { series: any[]; }) => {
           <LineChart
             data={data}
             margin={{ top: 8, right: 8, bottom: 8, left: 0 }}
+            syncId={syncId}
           >
             <Line
               name="p99"

--- a/studio/src/pages/[organizationSlug]/[namespace]/graph/[slug]/analytics/index.tsx
+++ b/studio/src/pages/[organizationSlug]/[namespace]/graph/[slug]/analytics/index.tsx
@@ -152,6 +152,7 @@ const OverviewToolbar = ({
 
 const AnalyticsPage: NextPageWithLayout = () => {
   const graphContext = useContext(GraphContext);
+  const syncId = `${graphContext?.graph?.namespace}-${graphContext?.graph?.name}`;
 
   const { filters, range, dateRange, refreshInterval } =
     useAnalyticsQueryState();
@@ -198,13 +199,13 @@ const AnalyticsPage: NextPageWithLayout = () => {
     <div className="w-full space-y-4">
       <OverviewToolbar filters={data?.filters} />
       <div className="flex flex-col gap-4 lg:grid lg:grid-cols-3">
-        <RequestMetricsCard data={data?.requests} />
-        <LatencyMetricsCard data={data?.latency} />
-        <ErrorMetricsCard data={data?.errors} />
+        <RequestMetricsCard data={data?.requests} syncId={syncId} />
+        <LatencyMetricsCard data={data?.latency} syncId={syncId} />
+        <ErrorMetricsCard data={data?.errors} syncId={syncId} />
       </div>
 
-      <ErrorRateOverTimeCard />
-      <LatencyDistributionCard series={data?.latency?.series ?? []} />
+      <ErrorRateOverTimeCard syncId={syncId} />
+      <LatencyDistributionCard series={data?.latency?.series ?? []} syncId={syncId} />
     </div>
   );
 };

--- a/studio/src/pages/[organizationSlug]/[namespace]/subgraph/[subgraphSlug]/analytics/index.tsx
+++ b/studio/src/pages/[organizationSlug]/[namespace]/subgraph/[subgraphSlug]/analytics/index.tsx
@@ -60,7 +60,7 @@ import {
   YAxis,
 } from "recharts";
 
-const SubgraphErrorRateOverTimeCard = () => {
+const SubgraphErrorRateOverTimeCard = ({ syncId }: { syncId?: string }) => {
   const id = useId();
   const subgraph = useSubgraph();
 
@@ -142,6 +142,7 @@ const SubgraphErrorRateOverTimeCard = () => {
         <AreaChart
           data={data}
           margin={{ top: 8, right: 8, bottom: 8, left: 0 }}
+          syncId={syncId}
         >
           <defs>
             <linearGradient id={`${id}-gradient`} x1="0" y1="0" x2="0" y2="1">
@@ -348,6 +349,7 @@ const OverviewToolbar = () => {
 
 const SubgraphAnalyticsPage: NextPageWithLayout = () => {
   const subgraph = useSubgraph();
+  const syncId = `${subgraph?.subgraph?.namespace}-${subgraph?.subgraph?.name}`;
 
   const { filters, range, dateRange, refreshInterval } =
     useAnalyticsQueryState();
@@ -394,13 +396,13 @@ const SubgraphAnalyticsPage: NextPageWithLayout = () => {
     <div className="w-full space-y-4">
       <OverviewToolbar />
       <div className="flex flex-col gap-4 lg:grid lg:grid-cols-3">
-        <RequestMetricsCard data={data?.requests} isSubgraphAnalytics={true} />
-        <LatencyMetricsCard data={data?.latency} isSubgraphAnalytics={true} />
-        <ErrorMetricsCard data={data?.errors} isSubgraphAnalytics={true} />
+        <RequestMetricsCard data={data?.requests} isSubgraphAnalytics={true} syncId={syncId} />
+        <LatencyMetricsCard data={data?.latency} isSubgraphAnalytics={true} syncId={syncId} />
+        <ErrorMetricsCard data={data?.errors} isSubgraphAnalytics={true} syncId={syncId} />
       </div>
 
-      <SubgraphErrorRateOverTimeCard />
-      <LatencyDistributionCard series={data?.latency?.series ?? []} />
+      <SubgraphErrorRateOverTimeCard syncId={syncId} />
+      <LatencyDistributionCard series={data?.latency?.series ?? []} syncId={syncId} />
     </div>
   );
 };


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

## Motivation and Context

As a user, when I hover over any analytics widget, should see the same highlited timestamp for other widgets in the page.

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please describe in detail the impact of this change. Attach screenshots if applicable.
-->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->

https://github.com/user-attachments/assets/b918625d-2e38-41b3-a135-0f8b9ecc3d77


