### PR TITLE
feat(router): support NATS JWT credentials files.

### DIFF
--- a/router/core/executor.go
+++ b/router/core/executor.go
@@ -234,6 +234,8 @@ func buildNatsOptions(eventSource config.NatsEventSource, logger *zap.Logger) ([
 			opts = append(opts, nats.Token(*eventSource.Authentication.Token))
 		} else if eventSource.Authentication.UserInfo.Username != nil && eventSource.Authentication.UserInfo.Password != nil {
 			opts = append(opts, nats.UserInfo(*eventSource.Authentication.UserInfo.Username, *eventSource.Authentication.UserInfo.Password))
+		} else if eventSource.Authentication.NatsCredentialsFileAuthentication.CredentialsFile != nil {
+			opts = append(opts, nats.UserCredentials(*eventSource.Authentication.NatsCredentialsFileAuthentication.CredentialsFile))
 		}
 	}
 

--- a/router/pkg/config/config.go
+++ b/router/pkg/config/config.go
@@ -487,9 +487,14 @@ type NatsCredentialsAuthentication struct {
 	Username *string `yaml:"username,omitempty"`
 }
 
+type NatsCredentialsFileAuthentication struct {
+	CredentialsFile *string `yaml:"credentials_file,omitempty"`
+}
+
 type NatsAuthentication struct {
-	UserInfo                     NatsCredentialsAuthentication `yaml:"user_info"`
-	NatsTokenBasedAuthentication `yaml:"token,inline"`
+	UserInfo                          NatsCredentialsAuthentication `yaml:"user_info"`
+	NatsTokenBasedAuthentication      `yaml:"token,inline"`
+	NatsCredentialsFileAuthentication `yaml:"credentials_file,inline"`
 }
 
 type NatsEventSource struct {

--- a/router/pkg/config/config.schema.json
+++ b/router/pkg/config/config.schema.json
@@ -1912,6 +1912,17 @@
                             }
                           }
                         }
+                      },
+                      {
+                        "type": "object",
+                        "required": ["credentials_file"],
+                        "additionalProperties": false,
+                        "properties": {
+                          "credentials_file": {
+                            "type": "string",
+                            "description": "The path to a NATS credentials file for authentication."
+                          }
+                        }
                       }
                     ]
                   }

--- a/router/pkg/config/config_events_nats_test.go
+++ b/router/pkg/config/config_events_nats_test.go
@@ -99,3 +99,25 @@ events:
 	_, err := LoadConfig(f, "")
 	require.NoError(t, err)
 }
+
+func TestValidAuthenticatedNatsProviderWithCredsFile(t *testing.T) {
+	t.Parallel()
+
+	f := createTempFileFromFixture(t, `
+version: "1"
+
+graph:
+  token: "token"
+
+events:
+  providers:
+    nats:
+      - id: default
+        url: "nats://localhost:4222"
+        authentication:
+          credentials_file: "/nkeys/creds/user.creds"
+`)
+
+	_, err := LoadConfig(f, "")
+	require.NoError(t, err)
+}

--- a/router/pkg/config/testdata/config_full.json
+++ b/router/pkg/config/testdata/config_full.json
@@ -460,7 +460,8 @@
               "Password": "admin",
               "Username": "admin"
             },
-            "Token": null
+            "Token": null,
+            "CredentialsFile": null
           }
         }
       ],


### PR DESCRIPTION
Closes #1756

## Motivation and Context

Context is given in #1756, but the tl;dr is: we use decentralized JWT authentication in our NATS deployment and would like to use the same authentication method for EDFS in Cosmo Router.

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [X] I have followed the coding standards of the project.
- [X] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [X] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).
