### PR TITLE
fix(router): graceful shutdown blocked by in-flight requests due to lock

### DIFF
--- a/router-tests/events/kafka_events_test.go
+++ b/router-tests/events/kafka_events_test.go
@@ -323,7 +323,7 @@ func TestKafkaEvents(t *testing.T) {
 
 			require.Eventually(t, func() bool {
 				return counter.Load() == 4
-			}, KafkaWaitTimeout, time.Millisecond*100)
+			}, KafkaWaitTimeout, time.Millisecond*100, "expected 4 events, got %d", counter.Load())
 
 			require.NoError(t, client.Close())
 

--- a/router/core/graph_server.go
+++ b/router/core/graph_server.go
@@ -551,21 +551,20 @@ func (s *graphMux) Shutdown(ctx context.Context) error {
 	if s.planCache != nil {
 		s.planCache.Close()
 	}
-
 	if s.persistedOperationCache != nil {
 		s.persistedOperationCache.Close()
 	}
-
 	if s.normalizationCache != nil {
 		s.normalizationCache.Close()
 	}
-
+	if s.complexityCalculationCache != nil {
+		s.complexityCalculationCache.Close()
+	}
 	if s.validationCache != nil {
 		s.validationCache.Close()
 	}
-
-	if s.complexityCalculationCache != nil {
-		s.complexityCalculationCache.Close()
+	if s.operationHashCache != nil {
+		s.operationHashCache.Close()
 	}
 
 	if s.accessLogsFileLogger != nil {

--- a/router/core/http_server.go
+++ b/router/core/http_server.go
@@ -136,8 +136,6 @@ func (s *server) listenAndServe() error {
 
 func (s *server) Shutdown(ctx context.Context) error {
 	var err error
-	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	if s.graphServer != nil {
 		err = errors.Join(s.graphServer.Shutdown(ctx))
@@ -146,8 +144,10 @@ func (s *server) Shutdown(ctx context.Context) error {
 		err = errors.Join(s.httpServer.Shutdown(ctx))
 	}
 
+	s.mu.Lock()
 	s.graphServer = nil
 	s.handler = nil
+	s.mu.Unlock()
 
 	return err
 }


### PR DESCRIPTION
## Motivation and Context

This PR fixes an issue with the graceful shutdown. 

The write lock actually caused the existing read locks to be blocked. During the server shutdown we attempt to close idle connections but the connections have never been served and were waiting for the handler function. The handler function is blocked by read locks, which were blocked by the write lock.

As we set the write lock before shutting down the server, we prevented any inflight requests from completing. The only reason for the write lock is to set the `graphServer` and `handler` to nil.

By moving the write lock further down, we can ensure that any inflight requests are being processed before shutting down the http server without blocking the handler.

Also unrelated improvement:
`operationHashCache` was not closed yet

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->