### PR TITLE
chore: bump helm chart versions

### DIFF
--- a/helm/cosmo/Chart.yaml
+++ b/helm/cosmo/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: '0.13.0'
+version: '0.14.0'
 
 home: https://github.com/wundergraph/cosmo
 

--- a/helm/cosmo/README.md
+++ b/helm/cosmo/README.md
@@ -2,7 +2,7 @@
 
 For a detailed deployment guide of the chart, including the full documentation, see the [DEV.md](DEV.md) file.
 
-![Version: 0.13.0](https://img.shields.io/badge/Version-0.13.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.14.0](https://img.shields.io/badge/Version-0.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 This is the official Helm Chart for WunderGraph Cosmo - The Full Lifecycle GraphQL API Management Solution.
 

--- a/helm/cosmo/charts/controlplane/Chart.yaml
+++ b/helm/cosmo/charts/controlplane/Chart.yaml
@@ -20,5 +20,5 @@ version: "0.1.0"
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.125.0"
+appVersion: "0.133.1"
 home: https://wundergraph.com

--- a/helm/cosmo/charts/controlplane/README.md
+++ b/helm/cosmo/charts/controlplane/README.md
@@ -1,6 +1,6 @@
 # controlplane
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.125.0](https://img.shields.io/badge/AppVersion-0.125.0-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.133.1](https://img.shields.io/badge/AppVersion-0.133.1-informational?style=flat-square)
 
 WunderGraph Cosmo Controlplane
 

--- a/helm/cosmo/charts/router/Chart.yaml
+++ b/helm/cosmo/charts/router/Chart.yaml
@@ -21,7 +21,7 @@ version: 0.10.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: '0.189.1'
+appVersion: '0.197.1'
 
 keywords:
   - wundergraph

--- a/helm/cosmo/charts/router/README.md
+++ b/helm/cosmo/charts/router/README.md
@@ -1,6 +1,6 @@
 # router
 
-![Version: 0.10.0](https://img.shields.io/badge/Version-0.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.189.1](https://img.shields.io/badge/AppVersion-0.189.1-informational?style=flat-square)
+![Version: 0.10.0](https://img.shields.io/badge/Version-0.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.197.1](https://img.shields.io/badge/AppVersion-0.197.1-informational?style=flat-square)
 
 This is the official Helm Chart for the WunderGraph Cosmo Router.
 

--- a/helm/cosmo/charts/studio/Chart.yaml
+++ b/helm/cosmo/charts/studio/Chart.yaml
@@ -19,5 +19,5 @@ version: "0.0.1"
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.102.0"
+appVersion: "0.111.0"
 home: https://wundergraph.com

--- a/helm/cosmo/charts/studio/README.md
+++ b/helm/cosmo/charts/studio/README.md
@@ -1,6 +1,6 @@
 # studio
 
-![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.102.0](https://img.shields.io/badge/AppVersion-0.102.0-informational?style=flat-square)
+![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.111.0](https://img.shields.io/badge/AppVersion-0.111.0-informational?style=flat-square)
 
 WunderGraph Cosmo Studio.
 


### PR DESCRIPTION
## Motivation and Context

This pull request includes version updates for the `controlplane`, `router`, and `studio` charts in the Helm configuration. The most important changes are the updates to the `appVersion` in both the `Chart.yaml` and `README.md` files for each of these components.

Version updates:

* [`helm/cosmo/charts/controlplane/Chart.yaml`](diffhunk://#diff-76a32f140f02dd1eeba476535b6871995190bc4caa331ae9a29ee28cbfc8c097L23-R23): Updated `appVersion` from "0.125.0" to "0.133.1".
* [`helm/cosmo/charts/controlplane/README.md`](diffhunk://#diff-dea24c7628e27e41ba25f258ed35481700257bf5e48a2ae8bca0401836886659L3-R3): Updated `AppVersion` badge from "0.125.0" to "0.133.1".
* [`helm/cosmo/charts/router/Chart.yaml`](diffhunk://#diff-48692f19ca9f4f61361e95b52c5eb8f50336046ac4c88b821d0637c9ebd09464L24-R24): Updated `appVersion` from '0.189.1' to '0.197.1'.
* [`helm/cosmo/charts/router/README.md`](diffhunk://#diff-ca94d6c332400177e736109d2bacf292b675e212039d92cfa5c42121121b7bceL3-R3): Updated `AppVersion` badge from "0.189.1" to "0.197.1".
* [`helm/cosmo/charts/studio/Chart.yaml`](diffhunk://#diff-0b8f18a999c5ae75dac2484fab0d96c098fc43edbbdfd8f5b76bc47cd14f9f7eL22-R22): Updated `appVersion` from "0.102.0" to "0.111.0".
* [`helm/cosmo/charts/studio/README.md`](diffhunk://#diff-07d99238177d2f2c5c3f62c4d01f888a449325453df9f92542ec977a94b84742L3-R3): Updated `AppVersion` badge from "0.102.0" to "0.111.0".

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->