### PR TITLE
fix: bump umbrella version

### DIFF
--- a/helm/cosmo/Chart.yaml
+++ b/helm/cosmo/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: '0.14.0'
+version: '0.14.1'
 
 home: https://github.com/wundergraph/cosmo
 

--- a/helm/cosmo/README.md
+++ b/helm/cosmo/README.md
@@ -2,7 +2,7 @@
 
 For a detailed deployment guide of the chart, including the full documentation, see the [DEV.md](DEV.md) file.
 
-![Version: 0.14.0](https://img.shields.io/badge/Version-0.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.14.1](https://img.shields.io/badge/Version-0.14.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 This is the official Helm Chart for WunderGraph Cosmo - The Full Lifecycle GraphQL API Management Solution.
 


### PR DESCRIPTION
## Motivation and Context

This pull request includes a version update for the Helm chart of the WunderGraph Cosmo application.

Version update:

* [`helm/cosmo/Chart.yaml`](diffhunk://#diff-92340eb5c6356f50976b456e0fb8c1d04593d5ca11d5f41006f87e878a0be96fL19-R19): Updated the chart version from '0.14.0' to '0.14.1'.
* [`helm/cosmo/README.md`](diffhunk://#diff-34aedcd17a51f815addb1acf5b680da11758d35bd8cf11f17c3040b1322a34c5L5-R5): Updated the version badge to reflect the new version '0.14.1'.

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->