### PR TITLE
fix: only redirect to cosmo urls

### DIFF
--- a/controlplane/src/core/controllers/auth.ts
+++ b/controlplane/src/core/controllers/auth.ts
@@ -302,7 +302,11 @@ const plugin: FastifyPluginCallback<AuthControllerOptions> = function Auth(fasti
           opts.authUtils.createSsoCookie(res, ssoSlug);
         }
         if (redirectURL) {
-          res.redirect(redirectURL);
+          if (redirectURL.startsWith(opts.webBaseUrl)) {
+            res.redirect(redirectURL);
+          } else {
+            res.redirect(opts.webBaseUrl);
+          }
         } else if (orgs.length === 0) {
           res.redirect(opts.webBaseUrl + '?migrate=true');
         } else {


### PR DESCRIPTION
## Motivation and Context
This pull request includes a small but important change to the `controlplane/src/core/controllers/auth.ts` file. The change ensures that the `redirectURL` is validated to start with the `webBaseUrl` before redirecting. If it does not, the code now redirects to the `webBaseUrl` to prevent potential security issues.

* Added validation to check if `redirectURL` starts with `opts.webBaseUrl` before redirecting. If not, it redirects to `opts.webBaseUrl`. (`controlplane/src/core/controllers/auth.ts`)


## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).
