### PR TITLE
test: schema check when one of many subgraphs is empty

### DIFF
--- a/controlplane/test/check-subgraph-schema.test.ts
+++ b/controlplane/test/check-subgraph-schema.test.ts
@@ -467,7 +467,7 @@ type Employee {
     await server.close();
   });
 
-  test('Should handle composition with empty and valid schemas', async () => {
+  test('Should handle composition when one of the subgraphs has an empty schema', async () => {
     const { client, server } = await SetupTest({ dbname, chClient });
 
     const emptySubgraphName = genID('empty-subgraph');

--- a/controlplane/test/check-subgraph-schema.test.ts
+++ b/controlplane/test/check-subgraph-schema.test.ts
@@ -466,4 +466,68 @@ type Employee {
 
     await server.close();
   });
+
+  test('Should handle composition with empty and valid schemas', async () => {
+    const { client, server } = await SetupTest({ dbname, chClient });
+
+    const emptySubgraphName = genID('empty-subgraph');
+    const validSubgraphName = genID('valid-subgraph');
+    const label = genUniqueLabel();
+
+    // Create federated graph
+    const fedGraphName = genID('federated-graph');
+    await client.createFederatedGraph({
+      name: fedGraphName,
+      namespace: DEFAULT_NAMESPACE,
+      labelMatchers: [joinLabel(label)],
+      routingUrl: 'http://localhost:8081',
+    });
+
+    // Create first subgraph with empty schema
+    await client.createFederatedSubgraph({
+      name: emptySubgraphName,
+      namespace: DEFAULT_NAMESPACE,
+      labels: [label],
+      routingUrl: 'http://localhost:8081',
+    });
+
+    // Create second subgraph with valid schema
+    await client.createFederatedSubgraph({
+      name: validSubgraphName,
+      namespace: DEFAULT_NAMESPACE,
+      labels: [label],
+      routingUrl: 'http://localhost:8081',
+    });
+
+    // Publish valid schema
+    let validSchema = `
+    type Query {
+      hello: String
+    }
+  `;
+    const publishValidResp = await client.publishFederatedSubgraph({
+      name: validSubgraphName,
+      namespace: DEFAULT_NAMESPACE,
+      schema: validSchema,
+    });
+    expect(publishValidResp.response?.code).toBe(EnumStatusCode.OK);
+
+    validSchema = `
+    type Query {
+      hello2: String
+    }
+  `;
+
+    // Check valid subgraph with empty schema
+    const checkValidResp = await client.checkSubgraphSchema({
+      subgraphName: validSubgraphName,
+      namespace: DEFAULT_NAMESPACE,
+      schema: Buffer.from(validSchema),
+    });
+    expect(checkValidResp.response?.code).toBe(EnumStatusCode.OK);
+    expect(checkValidResp.compositionErrors.length).toBe(0);
+    expect(checkValidResp.breakingChanges.length).toBe(1);
+
+    await server.close();
+  });
 });


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

## Motivation and Context

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please describe in detail the impact of this change. Attach screenshots if applicable.
-->

A test to ensure a schema check does not error out if one of the subgraphs has an empty sdl

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->