### PR TITLE
fix: solve issue caused by improper use of `useDayPicker`

### DIFF
--- a/studio/src/pages/[organizationSlug]/[namespace]/graph/[slug]/compositions/[compositionId]/feature-flag/[featureFlagCompositionId]/index.tsx
+++ b/studio/src/pages/[organizationSlug]/[namespace]/graph/[slug]/compositions/[compositionId]/feature-flag/[featureFlagCompositionId]/index.tsx
@@ -9,7 +9,7 @@ import { ExclamationTriangleIcon } from "@radix-ui/react-icons";
 import { EnumStatusCode } from "@wundergraph/cosmo-connect/dist/common/common_pb";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { Button } from "react-day-picker";
+import { Button } from "@/components/ui/button";
 import { CompositionDetails } from "../..";
 import { getCompositionDetails } from "@wundergraph/cosmo-connect/dist/platform/v1/platform-PlatformService_connectquery";
 import { useQuery } from "@connectrpc/connect-query";

--- a/studio/src/pages/[organizationSlug]/[namespace]/graph/[slug]/feature-flags/[featureFlagSlug]/index.tsx
+++ b/studio/src/pages/[organizationSlug]/[namespace]/graph/[slug]/feature-flags/[featureFlagSlug]/index.tsx
@@ -12,7 +12,7 @@ import { EnumStatusCode } from "@wundergraph/cosmo-connect/dist/common/common_pb
 import { getFeatureFlagByName } from "@wundergraph/cosmo-connect/dist/platform/v1/platform-PlatformService_connectquery";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { Button } from "react-day-picker";
+import { Button } from "@/components/ui/button";
 
 const FeatureFlagDetailsPage: NextPageWithLayout = () => {
   const router = useRouter();

--- a/studio/src/pages/[organizationSlug]/feature-flags/[featureFlagSlug]/index.tsx
+++ b/studio/src/pages/[organizationSlug]/feature-flags/[featureFlagSlug]/index.tsx
@@ -8,7 +8,7 @@ import { ExclamationTriangleIcon } from "@radix-ui/react-icons";
 import { EnumStatusCode } from "@wundergraph/cosmo-connect/dist/common/common_pb";
 import { getFeatureFlagByName } from "@wundergraph/cosmo-connect/dist/platform/v1/platform-PlatformService_connectquery";
 import { useRouter } from "next/router";
-import { Button } from "react-day-picker";
+import { Button } from "@/components/ui/button";
 import Link from "next/link";
 import { FeatureFlagDetails } from "@/components/feature-flag-details";
 


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

## Motivation and Context

An issue was found caused by importing the `Button` component from the `react-day-picker` package instead of the components library which caused the error `useDayPicker must be used within a DayPickerProvider` to be raised.

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please describe in detail the impact of this change. Attach screenshots if applicable.
-->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->