### PR TITLE
fix: set cache-control to `no-store` when errors are present, engine v2.0.0-rc.175

### DIFF
--- a/router-tests/go.mod
+++ b/router-tests/go.mod
@@ -24,9 +24,9 @@ require (
 	github.com/tidwall/gjson v1.18.0
 	github.com/twmb/franz-go v1.16.1
 	github.com/twmb/franz-go/pkg/kadm v1.11.0
-	github.com/wundergraph/cosmo/demo v0.0.0-20250422163037-46e4333ac50e
-	github.com/wundergraph/cosmo/router v0.0.0-20250422163037-46e4333ac50e
-	github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.174
+	github.com/wundergraph/cosmo/demo v0.0.0-20250429145023-6d79ea9e0230
+	github.com/wundergraph/cosmo/router v0.0.0-20250429145023-6d79ea9e0230
+	github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.175
 	go.opentelemetry.io/otel v1.28.0
 	go.opentelemetry.io/otel/sdk v1.28.0
 	go.opentelemetry.io/otel/sdk/metric v1.28.0

--- a/router-tests/go.sum
+++ b/router-tests/go.sum
@@ -323,8 +323,8 @@ github.com/wundergraph/astjson v0.0.0-20250106123708-be463c97e083 h1:8/D7f8gKxTB
 github.com/wundergraph/astjson v0.0.0-20250106123708-be463c97e083/go.mod h1:eOTL6acwctsN4F3b7YE+eE2t8zcJ/doLm9sZzsxxxrE=
 github.com/wundergraph/consul/sdk v0.0.0-20250204115147-ed842a8fd301 h1:EzfKHQoTjFDDcgaECCCR2aTePqMu9QBmPbyhqIYOhV0=
 github.com/wundergraph/consul/sdk v0.0.0-20250204115147-ed842a8fd301/go.mod h1:wxI0Nak5dI5RvJuzGyiEK4nZj0O9X+Aw6U0tC1wPKq0=
-github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.174 h1:9R1fUgnVuRVtoTZYZxcKz08RFFJoCE/T4b8YTJxM+QI=
-github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.174/go.mod h1:B7eV0Qh8Lop9QzIOQcsvKp3S0ejfC6mgyWoJnI917yQ=
+github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.175 h1:yyUIHwvAhu/L3wwIBRUy7gydEtHTojXVmZW9s01H7x8=
+github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.175/go.mod h1:B7eV0Qh8Lop9QzIOQcsvKp3S0ejfC6mgyWoJnI917yQ=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb h1:zGWFAtiMcyryUHoUjUJX0/lt1H2+i2Ka2n+D3DImSNo=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=

--- a/router-tests/header_propagation_test.go
+++ b/router-tests/header_propagation_test.go
@@ -31,7 +31,7 @@ func TestCacheControl(t *testing.T) {
 				Query: `{ employees { id details { forename surname } notes } }`,
 			})
 
-			assert.Equal(t, "no-cache", res.Response.Header.Get("Cache-Control"))
+			assert.Equal(t, "no-store, no-cache, must-revalidate", res.Response.Header.Get("Cache-Control"))
 			assert.Equal(t, `{"errors":[{"message":"Failed to fetch from Subgraph 'products' at Path 'employees'."}],"data":{"employees":[{"id":1,"details":{"forename":"Jens","surname":"Neuse"},"notes":null},{"id":2,"details":{"forename":"Dustin","surname":"Deus"},"notes":null},{"id":3,"details":{"forename":"Stefan","surname":"Avram"},"notes":null},{"id":4,"details":{"forename":"Björn","surname":"Schwenzer"},"notes":null},{"id":5,"details":{"forename":"Sergiy","surname":"Petrunin"},"notes":null},{"id":7,"details":{"forename":"Suvij","surname":"Surya"},"notes":null},{"id":8,"details":{"forename":"Nithin","surname":"Kumar"},"notes":null},{"id":10,"details":{"forename":"Eelco","surname":"Wiersma"},"notes":null},{"id":11,"details":{"forename":"Alexandra","surname":"Neuse"},"notes":null},{"id":12,"details":{"forename":"David","surname":"Stutt"},"notes":null}]}}`, res.Body)
 		})
 	})
@@ -52,7 +52,7 @@ func TestCacheControl(t *testing.T) {
 			})
 
 			require.Contains(t, res.Body, "PERSISTED_QUERY_NOT_FOUND")
-			require.Equal(t, "no-cache", res.Response.Header.Get("Cache-Control"))
+			require.Equal(t, "no-store, no-cache, must-revalidate", res.Response.Header.Get("Cache-Control"))
 		})
 	})
 
@@ -68,7 +68,7 @@ func TestCacheControl(t *testing.T) {
 				Query: `{ employee(id: 1) { id rootFieldThrowsError } }`,
 			})
 
-			assert.Equal(t, "no-cache", res.Response.Header.Get("Cache-Control"))
+			assert.Equal(t, "no-store, no-cache, must-revalidate", res.Response.Header.Get("Cache-Control"))
 			assert.Equal(t, `{"errors":[{"message":"Failed to fetch from Subgraph 'employees'.","extensions":{"errors":[{"message":"error resolving RootFieldThrowsError for Employee 1","path":["employee","rootFieldThrowsError"],"extensions":{"code":"ERROR_CODE"}}],"statusCode":200}}],"data":{"employee":{"id":1,"rootFieldThrowsError":null}}}`, res.Body)
 		})
 	})

--- a/router/core/errors.go
+++ b/router/core/errors.go
@@ -276,7 +276,7 @@ func writeMultipartError(
 	// before, some clients that rely on both CR and LF strictly to parse blocks were broken and not parsing our
 	// multipart chunks correctly. With this fix here (and in a few other places) the clients are now working.
 	resp = append(resp, []byte("\r\n--graphql--")...)
- 
+
 	if _, err := w.Write([]byte(resp)); err != nil {
 		return err
 	}
@@ -312,6 +312,7 @@ func writeOperationError(r *http.Request, w http.ResponseWriter, requestLogger *
 	case errors.As(err, &httpErr):
 		writeRequestErrors(r, w, httpErr.StatusCode(), requestErrorsFromHttpError(httpErr), requestLogger)
 	case errors.As(err, &poNotFoundErr):
+		w.Header().Set("Cache-Control", "no-cache")
 		newErr := NewHttpGraphqlError("PersistedQueryNotFound", "PERSISTED_QUERY_NOT_FOUND", http.StatusOK)
 		writeRequestErrors(r, w, http.StatusOK, requestErrorsFromHttpError(newErr), requestLogger)
 	case errors.As(err, &reportErr):

--- a/router/core/errors.go
+++ b/router/core/errors.go
@@ -190,6 +190,8 @@ func writeRequestErrors(r *http.Request, w http.ResponseWriter, statusCode int, 
 		return
 	}
 
+	w.Header().Set("Cache-Control", "no-cache")
+
 	// According to the tests requestContext can be nil (when called from module WriteResponseError)
 	// As such we have coded this condition defensively to be safe
 	requestContext := getRequestContext(r.Context())
@@ -312,7 +314,6 @@ func writeOperationError(r *http.Request, w http.ResponseWriter, requestLogger *
 	case errors.As(err, &httpErr):
 		writeRequestErrors(r, w, httpErr.StatusCode(), requestErrorsFromHttpError(httpErr), requestLogger)
 	case errors.As(err, &poNotFoundErr):
-		w.Header().Set("Cache-Control", "no-cache")
 		newErr := NewHttpGraphqlError("PersistedQueryNotFound", "PERSISTED_QUERY_NOT_FOUND", http.StatusOK)
 		writeRequestErrors(r, w, http.StatusOK, requestErrorsFromHttpError(newErr), requestLogger)
 	case errors.As(err, &reportErr):

--- a/router/core/errors.go
+++ b/router/core/errors.go
@@ -190,7 +190,7 @@ func writeRequestErrors(r *http.Request, w http.ResponseWriter, statusCode int, 
 		return
 	}
 
-	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Cache-Control", "no-store, no-cache, must-revalidate")
 
 	// According to the tests requestContext can be nil (when called from module WriteResponseError)
 	// As such we have coded this condition defensively to be safe

--- a/router/core/graphql_handler.go
+++ b/router/core/graphql_handler.go
@@ -177,8 +177,24 @@ func (h *GraphQLHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		defer propagateSubgraphErrors(ctx)
 
-		resp, err := h.executor.Resolver.ResolveGraphQLResponse(ctx, p.Response, nil, HeaderPropagationWriter(w, ctx.Context()))
+		respBuf := bytes.Buffer{}
+
+		resp, err := h.executor.Resolver.ResolveGraphQLResponse(ctx, p.Response, nil, &respBuf)
 		requestContext.dataSourceNames = getSubgraphNames(p.Response.DataSources)
+
+		if err != nil {
+			trackFinalResponseError(ctx.Context(), err)
+			h.WriteError(ctx, err, p.Response, w)
+			return
+		}
+
+		if errs := ctx.SubgraphErrors(); errs != nil {
+			w.Header().Set("Cache-Control", "no-cache")
+		}
+
+		// Write contents of buf to the header propagation writer
+		hpw := HeaderPropagationWriter(w, ctx.Context())
+		_, err = respBuf.WriteTo(hpw)
 
 		if err != nil {
 			trackFinalResponseError(ctx.Context(), err)

--- a/router/core/graphql_handler.go
+++ b/router/core/graphql_handler.go
@@ -189,7 +189,7 @@ func (h *GraphQLHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if errs := ctx.SubgraphErrors(); errs != nil {
-			w.Header().Set("Cache-Control", "no-cache")
+			w.Header().Set("Cache-Control", "no-store, no-cache, must-revalidate")
 		}
 
 		// Write contents of buf to the header propagation writer

--- a/router/go.mod
+++ b/router/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/tidwall/gjson v1.18.0
 	github.com/tidwall/sjson v1.2.5
 	github.com/twmb/franz-go v1.16.1
-	github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.174
+	github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.175
 	// Do not upgrade, it renames attributes we rely on
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.46.1
 	go.opentelemetry.io/contrib/propagators/b3 v1.23.0

--- a/router/go.sum
+++ b/router/go.sum
@@ -270,8 +270,8 @@ github.com/vektah/gqlparser/v2 v2.5.16 h1:1gcmLTvs3JLKXckwCwlUagVn/IlV2bwqle0vJ0
 github.com/vektah/gqlparser/v2 v2.5.16/go.mod h1:1lz1OeCqgQbQepsGxPVywrjdBHW2T08PUS3pJqepRww=
 github.com/wundergraph/astjson v0.0.0-20250106123708-be463c97e083 h1:8/D7f8gKxTBjW+SZK4mhxTTBVpxcqeBgWF1Rfmltbfk=
 github.com/wundergraph/astjson v0.0.0-20250106123708-be463c97e083/go.mod h1:eOTL6acwctsN4F3b7YE+eE2t8zcJ/doLm9sZzsxxxrE=
-github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.174 h1:9R1fUgnVuRVtoTZYZxcKz08RFFJoCE/T4b8YTJxM+QI=
-github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.174/go.mod h1:B7eV0Qh8Lop9QzIOQcsvKp3S0ejfC6mgyWoJnI917yQ=
+github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.175 h1:yyUIHwvAhu/L3wwIBRUy7gydEtHTojXVmZW9s01H7x8=
+github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.175/go.mod h1:B7eV0Qh8Lop9QzIOQcsvKp3S0ejfC6mgyWoJnI917yQ=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=


### PR DESCRIPTION
## Motivation and Context

Current behaviour does not treat unreachable subgraph, or other router-sourced errors as `no-cache`, we now explicitly set `Cache-Control` to `no-cache` 

## Todo

- [x] Unreachable subgraph should cause no-cache
- [x] PERSISTED_QUERY_NOT_FOUND should cause no-cache
- [x] Erroring subgraph response should cause no-cache

## Checklist

- [x] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [x] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Engine changelog

## [2.0.0-rc.175](https://github.com/wundergraph/graphql-go-tools/compare/v2.0.0-rc.174...v2.0.0-rc.175) (2025-04-29)


### Features

* remove intermediate buffer from ResolveGraphQLResponse ([#1137](https://github.com/wundergraph/graphql-go-tools/issues/1137)) ([9f25e6f](https://github.com/wundergraph/graphql-go-tools/commit/9f25e6fccd15fa0a847d453ebd05276c2b250721))

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
