### PR TITLE
fix: wgc auth login when the user is not part of any organizations

### DIFF
--- a/cli/src/commands/auth/commands/login.ts
+++ b/cli/src/commands/auth/commands/login.ts
@@ -48,6 +48,12 @@ export default (opts: BaseCommandOptions) => {
       program.error('Could not perform authentication. Please try again');
     }
 
+    if (!decoded.groups) {
+      program.error(
+        'You are not part of any organizations on Cosmo. Please login to your account on the browser and try again.',
+      );
+    }
+
     const organizationSlugs = new Set(decoded.groups.map((group) => group.split('/')[1]));
 
     const organizationSlugByDisplayKey = new Map<string, string>();

--- a/cli/src/commands/auth/commands/login.ts
+++ b/cli/src/commands/auth/commands/login.ts
@@ -17,7 +17,7 @@ export default (opts: BaseCommandOptions) => {
   loginCommand.action(async () => {
     const resp = await performDeviceAuth();
     if (!resp.success) {
-      program.error('Could not perform authentication. Please try again');
+      program.error(pc.red('Could not perform authentication. Please try again'));
     }
     console.log('Code: %s\n', resp.response.deviceCode);
     console.log(
@@ -33,11 +33,11 @@ export default (opts: BaseCommandOptions) => {
     });
 
     if (!accessTokenResp.success) {
-      program.error(accessTokenResp.errorMessage + ' Please try again.');
+      program.error(pc.red(accessTokenResp.errorMessage + ' Please try again.'));
     }
 
     if (!accessTokenResp.response) {
-      program.error('Could not perform authentication. Please try again');
+      program.error(pc.red('Could not perform authentication. Please try again'));
     }
 
     let decoded: DecodedAccessToken;
@@ -45,12 +45,14 @@ export default (opts: BaseCommandOptions) => {
     try {
       decoded = jwtDecode<DecodedAccessToken>(accessTokenResp.response.accessToken);
     } catch {
-      program.error('Could not perform authentication. Please try again');
+      program.error(pc.red('Could not perform authentication. Please try again'));
     }
 
     if (!decoded.groups) {
       program.error(
-        'You are not part of any organizations on Cosmo. Please login to your account on the browser and try again.',
+        pc.red(
+          'You are not part of any organizations on Cosmo. Please login to your account in the browser and try again.',
+        ),
       );
     }
 


### PR DESCRIPTION
## Motivation and Context
This pull request adds a new validation step to the `login` command in `cli/src/commands/auth/commands/login.ts` to handle cases where a user is not part of any organizations on Cosmo.

### Validation improvement:
* Added a check to ensure the `decoded.groups` property exists. If it does not, an error message is displayed, instructing the user to log in via the browser and try again. This prevents further processing when the user is not part of any organizations. (`[cli/src/commands/auth/commands/login.tsR51-R56](diffhunk://#diff-ea60d5c07765e97ec7600cb5340d31f44a594f3a783ea51fc69bcc83fd57976eR51-R56)`)

## Checklist

- [x] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

fixes #1804
