### PR TITLE
feat: improve error access logs

### DIFF
--- a/router-tests/go.mod
+++ b/router-tests/go.mod
@@ -177,7 +177,7 @@ require (
 replace (
 	github.com/wundergraph/cosmo/demo => ../demo
 	github.com/wundergraph/cosmo/router => ../router
-// github.com/wundergraph/graphql-go-tools/v2 => ../../graphql-go-tools/v2
+	github.com/wundergraph/graphql-go-tools/v2 => ../../graphql-go-tools/v2
 )
 
 replace github.com/hashicorp/consul/sdk => github.com/wundergraph/consul/sdk v0.0.0-20250204115147-ed842a8fd301

--- a/router-tests/go.mod
+++ b/router-tests/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/twmb/franz-go/pkg/kadm v1.11.0
 	github.com/wundergraph/cosmo/demo v0.0.0-20250422163037-46e4333ac50e
 	github.com/wundergraph/cosmo/router v0.0.0-20250422163037-46e4333ac50e
-	github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.172
+	github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.172.0.20250424191051-430af8af6c64
 	go.opentelemetry.io/otel v1.28.0
 	go.opentelemetry.io/otel/sdk v1.28.0
 	go.opentelemetry.io/otel/sdk/metric v1.28.0

--- a/router-tests/go.mod
+++ b/router-tests/go.mod
@@ -177,7 +177,7 @@ require (
 replace (
 	github.com/wundergraph/cosmo/demo => ../demo
 	github.com/wundergraph/cosmo/router => ../router
-	github.com/wundergraph/graphql-go-tools/v2 => ../../graphql-go-tools/v2
+//github.com/wundergraph/graphql-go-tools/v2 => ../../graphql-go-tools/v2
 )
 
 replace github.com/hashicorp/consul/sdk => github.com/wundergraph/consul/sdk v0.0.0-20250204115147-ed842a8fd301

--- a/router-tests/go.sum
+++ b/router-tests/go.sum
@@ -323,6 +323,8 @@ github.com/wundergraph/astjson v0.0.0-20250106123708-be463c97e083 h1:8/D7f8gKxTB
 github.com/wundergraph/astjson v0.0.0-20250106123708-be463c97e083/go.mod h1:eOTL6acwctsN4F3b7YE+eE2t8zcJ/doLm9sZzsxxxrE=
 github.com/wundergraph/consul/sdk v0.0.0-20250204115147-ed842a8fd301 h1:EzfKHQoTjFDDcgaECCCR2aTePqMu9QBmPbyhqIYOhV0=
 github.com/wundergraph/consul/sdk v0.0.0-20250204115147-ed842a8fd301/go.mod h1:wxI0Nak5dI5RvJuzGyiEK4nZj0O9X+Aw6U0tC1wPKq0=
+github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.172.0.20250424191051-430af8af6c64 h1:liXxR8ddgPVY4uyYUTi1KEs0eQr1Ttq3ns4go+4IlG4=
+github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.172.0.20250424191051-430af8af6c64/go.mod h1:B7eV0Qh8Lop9QzIOQcsvKp3S0ejfC6mgyWoJnI917yQ=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb h1:zGWFAtiMcyryUHoUjUJX0/lt1H2+i2Ka2n+D3DImSNo=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=

--- a/router-tests/go.sum
+++ b/router-tests/go.sum
@@ -323,8 +323,6 @@ github.com/wundergraph/astjson v0.0.0-20250106123708-be463c97e083 h1:8/D7f8gKxTB
 github.com/wundergraph/astjson v0.0.0-20250106123708-be463c97e083/go.mod h1:eOTL6acwctsN4F3b7YE+eE2t8zcJ/doLm9sZzsxxxrE=
 github.com/wundergraph/consul/sdk v0.0.0-20250204115147-ed842a8fd301 h1:EzfKHQoTjFDDcgaECCCR2aTePqMu9QBmPbyhqIYOhV0=
 github.com/wundergraph/consul/sdk v0.0.0-20250204115147-ed842a8fd301/go.mod h1:wxI0Nak5dI5RvJuzGyiEK4nZj0O9X+Aw6U0tC1wPKq0=
-github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.172 h1:jrme3DFqhEp+mKYbg4brcc+Y4nw6PIQmPed0uG00pVI=
-github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.172/go.mod h1:B7eV0Qh8Lop9QzIOQcsvKp3S0ejfC6mgyWoJnI917yQ=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb h1:zGWFAtiMcyryUHoUjUJX0/lt1H2+i2Ka2n+D3DImSNo=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=

--- a/router-tests/structured_logging_test.go
+++ b/router-tests/structured_logging_test.go
@@ -4,16 +4,17 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/otel/sdk/metric"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 	"math"
 	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/sdk/metric"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/wundergraph/cosmo/router-tests/testenv"
 	"github.com/wundergraph/cosmo/router/core"
@@ -193,7 +194,7 @@ func TestAccessLogsFileOutput(t *testing.T) {
 			require.NoError(t, os.RemoveAll(fp))
 		})
 
-		logger := logging.NewZapAccessLogger(f, false, false)
+		logger := logging.NewZapAccessLogger(f, zap.InfoLevel, false, false, false)
 		require.NoError(t, err)
 
 		testenv.Run(t, &testenv.Config{
@@ -249,7 +250,7 @@ func TestAccessLogsFileOutput(t *testing.T) {
 				require.NoError(t, os.RemoveAll(fp))
 			})
 
-			logger := logging.NewZapAccessLogger(f, false, false)
+			logger := logging.NewZapAccessLogger(f, zap.InfoLevel, false, false, false)
 			require.NoError(t, err)
 
 			testenv.Run(t, &testenv.Config{

--- a/router-tests/telemetry/telemetry_test.go
+++ b/router-tests/telemetry/telemetry_test.go
@@ -6766,7 +6766,8 @@ func TestFlakyTelemetry(t *testing.T) {
 			require.Equal(t, trace.SpanKindInternal, sn[8].SpanKind())
 			require.Equal(t, codes.Error, sn[8].Status().Code)
 			require.Lenf(t, sn[8].Attributes(), 14, "expected 14 attributes, got %d", len(sn[8].Attributes()))
-			require.Contains(t, sn[8].Status().Description, "connect: connection refused\nFailed to fetch from Subgraph 'products' at Path: 'employees'.")
+			require.Contains(t, sn[8].Status().Description, "Failed to fetch from Subgraph 'products' at Path: 'employees'.")
+			require.Contains(t, sn[8].Status().Description, "connect: connection refused")
 
 			events := sn[8].Events()
 			require.Len(t, events, 1, "expected 1 event because the GraphQL request failed")
@@ -6776,7 +6777,8 @@ func TestFlakyTelemetry(t *testing.T) {
 			require.Equal(t, "query unnamed", sn[10].Name())
 			require.Equal(t, trace.SpanKindServer, sn[10].SpanKind())
 			require.Equal(t, codes.Error, sn[10].Status().Code)
-			require.Contains(t, sn[10].Status().Description, "connect: connection refused\nFailed to fetch from Subgraph 'products' at Path: 'employees'.")
+			require.Contains(t, sn[10].Status().Description, "Failed to fetch from Subgraph 'products' at Path: 'employees'.")
+			require.Contains(t, sn[10].Status().Description, "connect: connection refused")
 		})
 	})
 

--- a/router-tests/testenv/testenv.go
+++ b/router-tests/testenv/testenv.go
@@ -408,14 +408,14 @@ func CreateTestEnv(t testing.TB, cfg *Config) (*Environment, error) {
 	if oc := cfg.LogObservation; oc.Enabled {
 		var zCore zapcore.Core
 		zCore, logObserver = observer.New(oc.LogLevel)
-		cfg.Logger = logging.NewZapLoggerWithCore(zCore, true)
+		cfg.Logger = logging.NewZapLoggerWithCore(zCore, true, true)
 	} else {
 		ec := zap.NewProductionEncoderConfig()
 		ec.EncodeDuration = zapcore.SecondsDurationEncoder
 		ec.TimeKey = "time"
 
 		syncer := zapcore.AddSync(os.Stderr)
-		cfg.Logger = logging.NewZapLogger(syncer, false, true, zapcore.ErrorLevel)
+		cfg.Logger = logging.NewZapLogger(syncer, false, true, true, zapcore.ErrorLevel)
 	}
 
 	if cfg.AccessLogger == nil {

--- a/router/core/engine_loader_hooks.go
+++ b/router/core/engine_loader_hooks.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
+	"time"
+
 	"github.com/wundergraph/cosmo/router/internal/requestlogger"
 	"github.com/wundergraph/cosmo/router/internal/unique"
 	"github.com/wundergraph/cosmo/router/pkg/metric"
@@ -17,8 +20,6 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
-	"slices"
-	"time"
 )
 
 var (
@@ -148,7 +149,12 @@ func (f *engineLoaderHooks) OnFinished(ctx context.Context, ds resolve.DataSourc
 				path = responseInfo.Request.URL.Path
 			}
 		}
-		f.accessLogger.Info(path, fields)
+
+		if responseInfo.Err != nil {
+			f.accessLogger.Error(path, fields)
+		} else {
+			f.accessLogger.Info(path, fields)
+		}
 	}
 
 	if responseInfo.Err != nil {

--- a/router/core/graph_server.go
+++ b/router/core/graph_server.go
@@ -896,6 +896,7 @@ func (s *graphServer) buildGraphMux(ctx context.Context,
 			requestlogger.WithFields(baseLogFields...),
 			requestlogger.WithAttributes(s.accessLogsConfig.Attributes),
 			requestlogger.WithExprAttributes(exprAttributes),
+			requestlogger.WithLogLevelHandler(LogLevelHandler),
 			requestlogger.WithFieldsHandler(RouterAccessLogsFieldHandler),
 		}
 

--- a/router/core/graphql_handler.go
+++ b/router/core/graphql_handler.go
@@ -177,6 +177,7 @@ func (h *GraphQLHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		resp, err := h.executor.Resolver.ResolveGraphQLResponse(ctx, p.Response, nil, HeaderPropagationWriter(w, ctx.Context()))
 
+		// Respects resolver errors and execution errors
 		defer trackResponseError(ctx, err)
 
 		requestContext.dataSourceNames = getSubgraphNames(p.Response.DataSources)
@@ -210,6 +211,7 @@ func (h *GraphQLHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		err := h.executor.Resolver.ResolveGraphQLSubscription(ctx, p.Response, writer)
 		requestContext.dataSourceNames = getSubgraphNames(p.Response.Response.DataSources)
 
+		// Respects resolver errors and execution errors
 		defer trackResponseError(ctx, err)
 
 		if err != nil {

--- a/router/core/router.go
+++ b/router/core/router.go
@@ -152,9 +152,11 @@ type (
 
 	AccessLogsConfig struct {
 		Attributes         []config.CustomAttribute
+		Level              string
 		Logger             *zap.Logger
 		SubgraphEnabled    bool
 		SubgraphAttributes []config.CustomAttribute
+		AddStacktrace      bool
 	}
 
 	// Config defines the configuration options for the Router.

--- a/router/go.mod
+++ b/router/go.mod
@@ -151,4 +151,4 @@ require (
 // Remember you can use Go workspaces to avoid using replace directives in multiple go.mod files
 // Use what is best for your personal workflow. See CONTRIBUTING.md for more information
 
-replace github.com/wundergraph/graphql-go-tools/v2 => ../../graphql-go-tools/v2
+//replace github.com/wundergraph/graphql-go-tools/v2 => ../../graphql-go-tools/v2

--- a/router/go.mod
+++ b/router/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/tidwall/gjson v1.18.0
 	github.com/tidwall/sjson v1.2.5
 	github.com/twmb/franz-go v1.16.1
-	github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.172
+	github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.172.0.20250424191051-430af8af6c64
 	// Do not upgrade, it renames attributes we rely on
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.46.1
 	go.opentelemetry.io/contrib/propagators/b3 v1.23.0

--- a/router/go.mod
+++ b/router/go.mod
@@ -151,4 +151,4 @@ require (
 // Remember you can use Go workspaces to avoid using replace directives in multiple go.mod files
 // Use what is best for your personal workflow. See CONTRIBUTING.md for more information
 
-// replace github.com/wundergraph/graphql-go-tools/v2 => ../../graphql-go-tools/v2
+replace github.com/wundergraph/graphql-go-tools/v2 => ../../graphql-go-tools/v2

--- a/router/go.sum
+++ b/router/go.sum
@@ -270,6 +270,8 @@ github.com/vektah/gqlparser/v2 v2.5.16 h1:1gcmLTvs3JLKXckwCwlUagVn/IlV2bwqle0vJ0
 github.com/vektah/gqlparser/v2 v2.5.16/go.mod h1:1lz1OeCqgQbQepsGxPVywrjdBHW2T08PUS3pJqepRww=
 github.com/wundergraph/astjson v0.0.0-20250106123708-be463c97e083 h1:8/D7f8gKxTBjW+SZK4mhxTTBVpxcqeBgWF1Rfmltbfk=
 github.com/wundergraph/astjson v0.0.0-20250106123708-be463c97e083/go.mod h1:eOTL6acwctsN4F3b7YE+eE2t8zcJ/doLm9sZzsxxxrE=
+github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.172.0.20250424191051-430af8af6c64 h1:liXxR8ddgPVY4uyYUTi1KEs0eQr1Ttq3ns4go+4IlG4=
+github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.172.0.20250424191051-430af8af6c64/go.mod h1:B7eV0Qh8Lop9QzIOQcsvKp3S0ejfC6mgyWoJnI917yQ=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=

--- a/router/go.sum
+++ b/router/go.sum
@@ -270,8 +270,6 @@ github.com/vektah/gqlparser/v2 v2.5.16 h1:1gcmLTvs3JLKXckwCwlUagVn/IlV2bwqle0vJ0
 github.com/vektah/gqlparser/v2 v2.5.16/go.mod h1:1lz1OeCqgQbQepsGxPVywrjdBHW2T08PUS3pJqepRww=
 github.com/wundergraph/astjson v0.0.0-20250106123708-be463c97e083 h1:8/D7f8gKxTBjW+SZK4mhxTTBVpxcqeBgWF1Rfmltbfk=
 github.com/wundergraph/astjson v0.0.0-20250106123708-be463c97e083/go.mod h1:eOTL6acwctsN4F3b7YE+eE2t8zcJ/doLm9sZzsxxxrE=
-github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.172 h1:jrme3DFqhEp+mKYbg4brcc+Y4nw6PIQmPed0uG00pVI=
-github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.172/go.mod h1:B7eV0Qh8Lop9QzIOQcsvKp3S0ejfC6mgyWoJnI917yQ=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=

--- a/router/internal/requestlogger/subgraphlogger.go
+++ b/router/internal/requestlogger/subgraphlogger.go
@@ -56,10 +56,15 @@ func (h *SubgraphAccessLogger) RequestFields(respInfo *resolve.ResponseInfo, sub
 	if h.accessLogger.fieldsHandler != nil {
 		fields = append(fields, h.accessLogger.fieldsHandler(h.logger, h.accessLogger.attributes, h.accessLogger.exprAttributes, respInfo.Err, respInfo.Request, &respInfo.ResponseHeaders)...)
 	}
+	fields = append(fields, subgraphFields...)
 
 	return fields
 }
 
 func (h *SubgraphAccessLogger) Info(message string, fields []zap.Field) {
 	h.logger.Info(message, fields...)
+}
+
+func (h *SubgraphAccessLogger) Error(message string, fields []zap.Field) {
+	h.logger.Error(message, fields...)
 }

--- a/router/internal/requestlogger/subgraphlogger_test.go
+++ b/router/internal/requestlogger/subgraphlogger_test.go
@@ -2,6 +2,9 @@ package requestlogger_test
 
 import (
 	"errors"
+	"net/http"
+	"testing"
+
 	"github.com/stretchr/testify/require"
 	"github.com/wundergraph/cosmo/router/core"
 	"github.com/wundergraph/cosmo/router/internal/requestlogger"
@@ -10,8 +13,6 @@ import (
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
-	"net/http"
-	"testing"
 )
 
 func TestSubgraphAccessLogger(t *testing.T) {
@@ -20,7 +21,7 @@ func TestSubgraphAccessLogger(t *testing.T) {
 	t.Run("writes correct request log", func(t *testing.T) {
 		var zCore zapcore.Core
 		zCore, logObserver := observer.New(zapcore.InfoLevel)
-		l := logging.NewZapLoggerWithCore(zCore, true)
+		l := logging.NewZapLoggerWithCore(zCore, true, true)
 
 		subgraphLogger := requestlogger.NewSubgraphAccessLogger(l, requestlogger.SubgraphOptions{})
 		req, err := http.NewRequest("POST", "http://localhost:3002/graphql", nil)
@@ -48,7 +49,7 @@ func TestSubgraphAccessLogger(t *testing.T) {
 	t.Run("Should include IP as custom attribute if requested", func(t *testing.T) {
 		var zCore zapcore.Core
 		zCore, logObserver := observer.New(zapcore.InfoLevel)
-		l := logging.NewZapLoggerWithCore(zCore, true)
+		l := logging.NewZapLoggerWithCore(zCore, true, true)
 
 		subgraphLogger := requestlogger.NewSubgraphAccessLogger(l, requestlogger.SubgraphOptions{})
 		req, err := http.NewRequest("POST", "http://localhost:3002/graphql", nil)
@@ -77,7 +78,7 @@ func TestSubgraphAccessLogger(t *testing.T) {
 	t.Run("Should redact client IP and add as a custom attribute", func(t *testing.T) {
 		var zCore zapcore.Core
 		zCore, logObserver := observer.New(zapcore.InfoLevel)
-		l := logging.NewZapLoggerWithCore(zCore, true)
+		l := logging.NewZapLoggerWithCore(zCore, true, true)
 
 		subgraphLogger := requestlogger.NewSubgraphAccessLogger(l, requestlogger.SubgraphOptions{
 			IPAnonymizationConfig: &requestlogger.IPAnonymizationConfig{
@@ -111,7 +112,7 @@ func TestSubgraphAccessLogger(t *testing.T) {
 	t.Run("Should hash client IP and add it as a custom attribute", func(t *testing.T) {
 		var zCore zapcore.Core
 		zCore, logObserver := observer.New(zapcore.InfoLevel)
-		l := logging.NewZapLoggerWithCore(zCore, true)
+		l := logging.NewZapLoggerWithCore(zCore, true, true)
 
 		subgraphLogger := requestlogger.NewSubgraphAccessLogger(l, requestlogger.SubgraphOptions{
 			IPAnonymizationConfig: &requestlogger.IPAnonymizationConfig{
@@ -145,7 +146,7 @@ func TestSubgraphAccessLogger(t *testing.T) {
 	t.Run("calls fields handler and adds request/response headers", func(t *testing.T) {
 		var zCore zapcore.Core
 		zCore, logObserver := observer.New(zapcore.InfoLevel)
-		l := logging.NewZapLoggerWithCore(zCore, true)
+		l := logging.NewZapLoggerWithCore(zCore, true, true)
 
 		subgraphLogger := requestlogger.NewSubgraphAccessLogger(l, requestlogger.SubgraphOptions{
 			FieldsHandler: core.SubgraphAccessLogsFieldHandler,
@@ -195,7 +196,7 @@ func TestSubgraphAccessLogger(t *testing.T) {
 	t.Run("can handle a null request", func(t *testing.T) {
 		var zCore zapcore.Core
 		zCore, logObserver := observer.New(zapcore.InfoLevel)
-		l := logging.NewZapLoggerWithCore(zCore, true)
+		l := logging.NewZapLoggerWithCore(zCore, true, true)
 
 		subgraphLogger := requestlogger.NewSubgraphAccessLogger(l, requestlogger.SubgraphOptions{
 			FieldsHandler: core.SubgraphAccessLogsFieldHandler,

--- a/router/pkg/config/config.go
+++ b/router/pkg/config/config.go
@@ -762,11 +762,13 @@ type AutomaticPersistedQueriesConfig struct {
 }
 
 type AccessLogsConfig struct {
-	Enabled   bool                      `yaml:"enabled" env:"ACCESS_LOGS_ENABLED" envDefault:"true"`
-	Buffer    AccessLogsBufferConfig    `yaml:"buffer,omitempty" env:"ACCESS_LOGS_BUFFER"`
-	Output    AccessLogsOutputConfig    `yaml:"output,omitempty" env:"ACCESS_LOGS_OUTPUT"`
-	Router    AccessLogsRouterConfig    `yaml:"router,omitempty" env:"ACCESS_LOGS_ROUTER"`
-	Subgraphs AccessLogsSubgraphsConfig `yaml:"subgraphs,omitempty" env:"ACCESS_LOGS_SUBGRAPH"`
+	Enabled       bool                      `yaml:"enabled" env:"ACCESS_LOGS_ENABLED" envDefault:"true"`
+	Level         string                    `yaml:"level" env:"ACCESS_LOGS_LEVEL" envDefault:"info"`
+	AddStacktrace bool                      `yaml:"addstacktrace" env:"ACCESS_LOGS_ADD_STACK_TRACE" envDefault:"false"`
+	Buffer        AccessLogsBufferConfig    `yaml:"buffer,omitempty" env:"ACCESS_LOGS_BUFFER"`
+	Output        AccessLogsOutputConfig    `yaml:"output,omitempty" env:"ACCESS_LOGS_OUTPUT"`
+	Router        AccessLogsRouterConfig    `yaml:"router,omitempty" env:"ACCESS_LOGS_ROUTER"`
+	Subgraphs     AccessLogsSubgraphsConfig `yaml:"subgraphs,omitempty" env:"ACCESS_LOGS_SUBGRAPH"`
 }
 
 type BatchingConfig struct {

--- a/router/pkg/config/config.schema.json
+++ b/router/pkg/config/config.schema.json
@@ -661,6 +661,20 @@
           "description": "Enable the access logs. The access logs are used to log the incoming requests. By default, the access logs are enabled and logged to the standard output.",
           "default": true
         },
+        "level": {
+          "type": "string",
+          "description": "The level of the access logs. The supported levels are 'info', 'error'. The default value is 'info'. The 'info' level logs all requests. The 'error' level logs only the errors.",
+          "default": "info",
+          "enum": [
+            "info",
+            "error"
+          ]
+        },
+        "add_stacktrace": {
+          "type": "boolean",
+          "description": "Enable the stacktrace in the access logs. The stacktrace is used to log the stacktrace of the error. The default value is false.",
+          "default": false
+        },
         "buffer": {
           "type": "object",
           "additionalProperties": false,
@@ -760,6 +774,7 @@
                               "operation_planning_time",
                               "operation_normalization_time",
                               "request_error",
+                              "response_error",
                               "response_error_message"
                             ]
                           }
@@ -3156,6 +3171,7 @@
                   "persisted_operation_sha256",
                   "operation_sha256",
                   "request_error",
+                  "response_error",
                   "response_error_message",
                   "graphql_error_codes",
                   "graphql_error_service_names",

--- a/router/pkg/config/testdata/config_defaults.json
+++ b/router/pkg/config/testdata/config_defaults.json
@@ -160,6 +160,8 @@
   },
   "AccessLogs": {
     "Enabled": true,
+    "Level": "info",
+    "AddStacktrace": false,
     "Buffer": {
       "Enabled": false,
       "Size": 256000,

--- a/router/pkg/config/testdata/config_full.json
+++ b/router/pkg/config/testdata/config_full.json
@@ -325,6 +325,8 @@
   },
   "AccessLogs": {
     "Enabled": true,
+    "Level": "info",
+    "AddStacktrace": false,
     "Buffer": {
       "Enabled": false,
       "Size": 256000,


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

## Motivation and Context

This PR enhances our GraphQL router’s logging and error pipelines, giving you fine-grained control over access-log verbosity, richer diagnostics in both router and subgraph logs, and tidier error propagation.

### 🎯 What’s Changed

1. **Configurable Access-Log Level**  
   - Now you can set `"level"` to control which requests get logged (`"info"` vs `"error"`).  

2. **Optional Stack Traces**  
   - The new `"add_stacktrace"` flag lets you include full stack traces in your access logs when errors occur.  

2. **New `response_error` context field**  
   -  This field will log the response errors as JSON array and includes verbose information including stacktraces about all errors.

5. **Cleaner Error Composition**  
   - Resolver errors now propagate intact into the final GraphQL error payload, and we’ve removed an accidental “double join” that was duplicating messages.

---

### ⚙️ JSON Config Example

```yaml
access_logs:
  enabled: true
  add_stacktrace: true
  level: error
  router:
    fields:
      - key: "response_error"
        value_from:
          context_field: response_error
  subgraphs:
    enabled: true
    fields:
      - key: "response_error"
        value_from:
          context_field: response_error
```

> In this snippet:
> - **`"level": "error"`** ensures only failed operations are emitted.  
> - **`"add_stacktrace": true"`** appends the stack trace for any error.
> - **Field `response_error`** will log the response errors in JSON format including stacktrace information.
---

Related https://github.com/wundergraph/graphql-go-tools/pull/1132

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please describe in detail the impact of this change. Attach screenshots if applicable.
-->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Access logs now support configurable log levels, allowing you to log all requests or only errors.
  * Option added to include stack traces in access logs for improved error diagnostics.
  * Access logs and metrics can now include response error details.

* **Bug Fixes**
  * Improved error tracking and structured logging for more accurate and informative logs.

* **Documentation**
  * Configuration schema and example files updated to reflect new access log options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->