### PR TITLE
feat: pass read timeout to subscription client

### DIFF
--- a/router-tests/testenv/testenv.go
+++ b/router-tests/testenv/testenv.go
@@ -829,8 +829,8 @@ func configureRouter(listenerAddr string, testConfig *Config, routerConfig *node
 		},
 		WebSocketClientPollTimeout:    300 * time.Millisecond,
 		WebSocketClientConnBufferSize: 1,
-		WebSocketClientReadTimeout:    100 * time.Millisecond,
-		WebSocketClientWriteTimeout:   1 * time.Second,
+		WebSocketClientReadTimeout:    1 * time.Second,
+		WebSocketClientWriteTimeout:   2 * time.Second,
 		// Avoid get in conflict with any test that doesn't expect to handle pings
 		WebSocketClientPingInterval:    30 * time.Second,
 		MaxConcurrentResolvers:         32,

--- a/router/core/factoryresolver.go
+++ b/router/core/factoryresolver.go
@@ -120,6 +120,9 @@ func NewDefaultFactoryResolver(
 		if subscriptionClientOptions.PingInterval > 0 {
 			options = append(options, graphql_datasource.WithPingInterval(subscriptionClientOptions.PingInterval))
 		}
+		if subscriptionClientOptions.ReadTimeout > 0 {
+			options = append(options, graphql_datasource.WithReadTimeout(subscriptionClientOptions.ReadTimeout))
+		}
 	}
 
 	subscriptionClient := graphql_datasource.NewGraphQLSubscriptionClient(

--- a/router/core/graph_server.go
+++ b/router/core/graph_server.go
@@ -955,6 +955,7 @@ func (s *graphServer) buildGraphMux(ctx context.Context,
 		trackUsageInfo:   s.graphqlMetricsConfig.Enabled || s.metricConfig.Prometheus.PromSchemaFieldUsage.Enabled,
 		subscriptionClientOptions: &SubscriptionClientOptions{
 			PingInterval: s.engineExecutionConfiguration.WebSocketClientPingInterval,
+			ReadTimeout:  s.engineExecutionConfiguration.WebSocketClientReadTimeout,
 		},
 		transportOptions: &TransportOptions{
 			SubgraphTransportOptions: s.subgraphTransportOptions,

--- a/router/core/transport.go
+++ b/router/core/transport.go
@@ -339,6 +339,7 @@ type TransportOptions struct {
 
 type SubscriptionClientOptions struct {
 	PingInterval time.Duration
+	ReadTimeout  time.Duration
 }
 
 func NewTransport(opts *TransportOptions) *TransportFactory {


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

## Motivation and Context

This PR ensures that we pass the readTimeout to the subscription client. Currently, we relied on the engine default, but this was too small. In the related engine PR we modified the code to use the timeout for all reads.

Engine: https://github.com/wundergraph/graphql-go-tools/pull/1133

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please describe in detail the impact of this change. Attach screenshots if applicable.
-->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->