### PR TITLE
chore: replaced linter action with golangci-lint

### DIFF
--- a/.github/workflows/router-ci.yaml
+++ b/.github/workflows/router-ci.yaml
@@ -56,9 +56,10 @@ jobs:
         working-directory: ./router
         run: go mod download
 
-      - name: Run linters on router-tests
-        uses: ./.github/actions/go-linter
+      - name: Run golangci-lint on router-tests
+        uses: golangci/golangci-lint-action@v7
         with:
+          version: v2.0
           working-directory: ./router-tests
 
       - name: Run linters on router

--- a/.github/workflows/router-ci.yaml
+++ b/.github/workflows/router-ci.yaml
@@ -115,9 +115,10 @@ jobs:
         working-directory: ./router
         run: go mod download
 
-      - name: Run linters on router-tests
-        uses: ./.github/actions/go-linter
+      - name: Run golangci-lint on router-tests
+        uses: golangci/golangci-lint-action@v7
         with:
+          version: v2.0
           working-directory: ./router-tests
 
       - name: Run linters on router

--- a/router-tests/.golangci.yml
+++ b/router-tests/.golangci.yml
@@ -1,12 +1,7 @@
 version: "2"
 linters:
   enable:
-    - errcheck
     - paralleltest
-    - govet
-    - staticcheck
-    - ineffassign
-    - unused
   settings:
     errcheck:
       exclude-functions:

--- a/router-tests/.golangci.yml
+++ b/router-tests/.golangci.yml
@@ -1,0 +1,27 @@
+version: "2"
+linters:
+  enable:
+    - errcheck
+    - paralleltest
+    - govet
+    - staticcheck
+    - ineffassign
+    - unused
+  settings:
+    errcheck:
+      exclude-functions:
+        - (io.ReadCloser).Close
+        - (*net/http.Server).Close
+        - (net/http.ResponseWriter).Write
+        - (*github.com/gorilla/websocket.Conn).Close
+        - (*compress/gzip.Reader).Close
+        - (io.Closer).Close
+        - (*mime/multipart.Writer).Close
+    paralleltest:
+      ignore-missing: false
+      ignore-missing-subtests: false
+  exclusions:
+    rules:
+      - path: "lifecycle/shutdown_test.go"
+        linters:
+          - paralleltest

--- a/router-tests/authentication_test.go
+++ b/router-tests/authentication_test.go
@@ -775,6 +775,8 @@ func TestAuthenticationMultipleProviders(t *testing.T) {
 			for _, prefix := range authenticator1HeaderValuePrefixes {
 				prefix := prefix
 				t.Run("prefix "+prefix, func(t *testing.T) {
+					t.Parallel()
+
 					token, err := authServer1.Token(nil)
 					require.NoError(t, err)
 					header := http.Header{
@@ -804,6 +806,8 @@ func TestAuthenticationMultipleProviders(t *testing.T) {
 			for _, prefix := range authenticator2HeaderValuePrefixes {
 				prefix := prefix
 				t.Run("prefix "+prefix, func(t *testing.T) {
+					t.Parallel()
+
 					token, err := authServer2.Token(nil)
 					require.NoError(t, err)
 					header := http.Header{
@@ -875,6 +879,8 @@ func TestAlgorithmMismatch(t *testing.T) {
 	}
 
 	t.Run("should prevent access with invalid algorithm", func(t *testing.T) {
+		t.Parallel()
+
 		// create a crypto for RSA
 		rsaCrypto, err := jwks.NewRSACrypto("", jwkset.AlgRS256, 2048)
 		require.NoError(t, err)

--- a/router-tests/block_operations_test.go
+++ b/router-tests/block_operations_test.go
@@ -306,17 +306,8 @@ func TestBlockOperations(t *testing.T) {
 
 				// Positive test
 
-				token, err := authServer.Token(map[string]any{
-					"scope": "read:all",
-				})
-				require.NoError(t, err)
-
-				header := http.Header{
-					"Authorization": []string{"Bearer " + token},
-				}
-
 				conn := xEnv.InitGraphQLWebSocketConnection(nil, nil, nil)
-				err = conn.WriteJSON(&testenv.WebSocketMessage{
+				err := conn.WriteJSON(&testenv.WebSocketMessage{
 					ID:      "1",
 					Type:    "subscribe",
 					Payload: []byte(`{"query":"subscription { currentTime { unixTime timeStamp }}"}`),
@@ -339,12 +330,12 @@ func TestBlockOperations(t *testing.T) {
 
 				// Negative test
 
-				token, err = authServer.Token(map[string]any{
+				token, err := authServer.Token(map[string]any{
 					"scope": "read:block",
 				})
 				require.NoError(t, err)
 
-				header = http.Header{
+				header := http.Header{
 					"Authorization": []string{"Bearer " + token},
 				}
 
@@ -402,17 +393,8 @@ func TestBlockOperations(t *testing.T) {
 
 				// Positive test
 
-				token, err := authServer.Token(map[string]any{
-					"scope": "read:all",
-				})
-				require.NoError(t, err)
-
-				header := http.Header{
-					"Authorization": []string{"Bearer " + token},
-				}
-
 				conn := xEnv.InitGraphQLWebSocketConnection(nil, nil, nil)
-				err = conn.WriteJSON(&testenv.WebSocketMessage{
+				err := conn.WriteJSON(&testenv.WebSocketMessage{
 					ID:      "1",
 					Type:    "subscribe",
 					Payload: []byte(`{"query":"subscription { currentTime { unixTime timeStamp }}"}`),
@@ -435,12 +417,12 @@ func TestBlockOperations(t *testing.T) {
 
 				// Negative test
 
-				token, err = authServer.Token(map[string]any{
+				token, err := authServer.Token(map[string]any{
 					"scope": "read:block",
 				})
 				require.NoError(t, err)
 
-				header = http.Header{
+				header := http.Header{
 					"Authorization": []string{"Bearer " + token},
 				}
 
@@ -470,6 +452,7 @@ func TestBlockOperations(t *testing.T) {
 		t.Parallel()
 
 		t.Run("should allow operations", func(t *testing.T) {
+			t.Parallel()
 			testenv.Run(t, &testenv.Config{
 				ModifySecurityConfiguration: func(securityConfiguration *config.SecurityConfiguration) {
 					securityConfiguration.BlockNonPersistedOperations = config.BlockOperationConfiguration{

--- a/router-tests/cache_warmup_test.go
+++ b/router-tests/cache_warmup_test.go
@@ -748,6 +748,7 @@ func TestCacheWarmup(t *testing.T) {
 		})
 
 		t.Run("should correctly also warm the feature flag cache", func(t *testing.T) {
+			t.Parallel()
 			testenv.Run(t, &testenv.Config{
 				RouterOptions: []core.Option{
 					core.WithCacheWarmupConfig(&config.CacheWarmupConfiguration{

--- a/router-tests/events/events_config_test.go
+++ b/router-tests/events/events_config_test.go
@@ -1,10 +1,11 @@
 package events_test
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/wundergraph/cosmo/router-tests/testenv"
 	"github.com/wundergraph/cosmo/router/pkg/config"
-	"testing"
 )
 
 func TestEventsConfig(t *testing.T) {
@@ -13,6 +14,7 @@ func TestEventsConfig(t *testing.T) {
 	}
 
 	t.Run("kafka provider not specified in the router configuration", func(t *testing.T) {
+		t.Parallel()
 		err := testenv.RunWithError(t, &testenv.Config{
 			RouterConfigJSONTemplate: testenv.ConfigWithEdfsJSONTemplate,
 			EnableNats:               true,
@@ -27,6 +29,7 @@ func TestEventsConfig(t *testing.T) {
 	})
 
 	t.Run("nats provider not specified in the router configuration", func(t *testing.T) {
+		t.Parallel()
 		err := testenv.RunWithError(t, &testenv.Config{
 			RouterConfigJSONTemplate: testenv.ConfigWithEdfsJSONTemplate,
 			EnableNats:               false,

--- a/router-tests/events/kafka_events_test.go
+++ b/router-tests/events/kafka_events_test.go
@@ -124,14 +124,15 @@ func TestKafkaEvents(t *testing.T) {
 				oldCount := counter.Load()
 				counter.Add(1)
 
-				if oldCount == 0 {
+				switch oldCount {
+				case 0:
 					var gqlErr graphql.Errors
 					require.ErrorAs(t, errValue, &gqlErr)
 					require.Equal(t, "Invalid message received", gqlErr[0].Message)
-				} else if oldCount == 1 || oldCount == 3 {
+				case 1, 3:
 					require.NoError(t, errValue)
 					require.JSONEq(t, `{"employeeUpdatedMyKafka":{"id":1,"details":{"forename":"Jens","surname":"Neuse"}}}`, string(dataValue))
-				} else if oldCount == 2 {
+				case 2:
 					var gqlErr graphql.Errors
 					require.ErrorAs(t, errValue, &gqlErr)
 					require.Equal(t, "Cannot return null for non-nullable field 'Subscription.employeeUpdatedMyKafka.id'.", gqlErr[0].Message)
@@ -278,11 +279,12 @@ func TestKafkaEvents(t *testing.T) {
 
 				employeeID := gjson.GetBytes(dataValue, "employeeUpdatedMyKafka.id").Int()
 
-				if employeeID == 1 {
+				switch employeeID {
+				case 1:
 					require.JSONEq(t, `{"employeeUpdatedMyKafka":{"id":1,"details":{"forename":"Jens","surname":"Neuse"}}}`, string(dataValue))
-				} else if employeeID == 2 {
+				case 2:
 					require.JSONEq(t, `{"employeeUpdatedMyKafka":{"id":2,"details":{"forename":"Dustin","surname":"Deus"}}}`, string(dataValue))
-				} else {
+				default:
 					t.Errorf("unexpected employeeID %d", employeeID)
 				}
 
@@ -298,11 +300,12 @@ func TestKafkaEvents(t *testing.T) {
 
 				employeeID := gjson.GetBytes(dataValue, "employeeUpdatedMyKafka.id").Int()
 
-				if employeeID == 1 {
+				switch employeeID {
+				case 1:
 					require.JSONEq(t, `{"employeeUpdatedMyKafka":{"id":1,"details":{"forename":"Jens","surname":"Neuse"}}}`, string(dataValue))
-				} else if employeeID == 2 {
+				case 2:
 					require.JSONEq(t, `{"employeeUpdatedMyKafka":{"id":2,"details":{"forename":"Dustin","surname":"Deus"}}}`, string(dataValue))
-				} else {
+				default:
 					t.Errorf("unexpected employeeID %d", employeeID)
 				}
 
@@ -988,14 +991,15 @@ func TestKafkaEvents(t *testing.T) {
 				oldCount := counter.Load()
 				counter.Add(1)
 
-				if oldCount == 0 {
+				switch oldCount {
+				case 0:
 					var gqlErr graphql.Errors
 					require.ErrorAs(t, errValue, &gqlErr)
 					require.Equal(t, "Invalid message received", gqlErr[0].Message)
-				} else if oldCount == 1 || oldCount == 3 {
+				case 1, 3:
 					require.NoError(t, errValue)
 					require.JSONEq(t, `{"employeeUpdatedMyKafka":{"id":1,"details":{"forename":"Jens","surname":"Neuse"}}}`, string(dataValue))
-				} else if oldCount == 2 {
+				case 2:
 					var gqlErr graphql.Errors
 					require.ErrorAs(t, errValue, &gqlErr)
 					require.Equal(t, "Cannot return null for non-nullable field 'Subscription.employeeUpdatedMyKafka.id'.", gqlErr[0].Message)

--- a/router-tests/events/nats_events_test.go
+++ b/router-tests/events/nats_events_test.go
@@ -172,14 +172,15 @@ func TestNatsEvents(t *testing.T) {
 				oldCount := counter.Load()
 				defer counter.Add(1)
 
-				if oldCount == 0 {
+				switch oldCount {
+				case 0:
 					var gqlErr graphql.Errors
 					require.ErrorAs(t, errValue, &gqlErr)
 					require.Equal(t, "Invalid message received", gqlErr[0].Message)
-				} else if oldCount == 1 || oldCount == 3 {
+				case 1, 3:
 					require.NoError(t, errValue)
 					require.JSONEq(t, `{"employeeUpdated":{"id":3,"details":{"forename":"Stefan","surname":"Avram"}}}`, string(dataValue))
-				} else if oldCount == 2 {
+				case 2:
 					var gqlErr graphql.Errors
 					require.ErrorAs(t, errValue, &gqlErr)
 					require.Equal(t, "Cannot return null for non-nullable field 'Subscription.employeeUpdated.id'.", gqlErr[0].Message)
@@ -434,7 +435,7 @@ func TestNatsEvents(t *testing.T) {
 		})
 
 		t.Run("subscribe with closing channel", func(t *testing.T) {
-
+			t.Parallel()
 			testenv.Run(t, &testenv.Config{
 				RouterConfigJSONTemplate: testenv.ConfigWithEdfsNatsJSONTemplate,
 				EnableNats:               true,
@@ -579,13 +580,14 @@ func TestNatsEvents(t *testing.T) {
 						runes := []rune(string(allData))
 
 						for i := 0; i < len(runes); i++ {
-							if runes[i] == '\r' {
+							switch runes[i] {
+							case '\r':
 								// Validate that this is not a stray \r entry
 								if i+1 >= len(runes) || runes[i+1] != '\n' {
 									assert.Fail(t, "Invalid newline detected: '\\r' not followed by '\\n'")
 								}
 								i++
-							} else if runes[i] == '\n' {
+							case '\n':
 								// Validate that this is not a stray \n entry
 								if i == 0 || runes[i-1] != '\r' {
 									assert.Fail(t, "Invalid newline detected: '\\n' not preceded by '\\r'")
@@ -1670,18 +1672,19 @@ func TestNatsEvents(t *testing.T) {
 					return oldCount == produced.Load()-1
 				}, NatsWaitTimeout, time.Millisecond*100)
 
-				if oldCount == 0 {
+				switch oldCount {
+				case 0:
 					var gqlErr graphql.Errors
 					require.ErrorAs(t, errValue, &gqlErr)
 					assert.Equal(t, "Invalid message received", gqlErr[0].Message)
-				} else if oldCount == 1 {
+				case 1:
 					assert.NoError(t, errValue)
 					assert.JSONEq(t, `{"employeeUpdated":{"id":3,"details":{"forename":"Stefan","surname":"Avram"}}}`, string(dataValue))
-				} else if oldCount == 2 {
+				case 2:
 					var gqlErr graphql.Errors
 					require.ErrorAs(t, errValue, &gqlErr)
 					assert.Equal(t, "Cannot return null for non-nullable field 'Subscription.employeeUpdated.id'.", gqlErr[0].Message)
-				} else if oldCount == 3 {
+				case 3:
 					assert.NoError(t, errValue)
 					assert.JSONEq(t, `{"employeeUpdated":{"id":3,"details":{"forename":"Stefan","surname":"Avram"}}}`, string(dataValue))
 				}

--- a/router-tests/file_upload_test.go
+++ b/router-tests/file_upload_test.go
@@ -22,6 +22,7 @@ func TestSingleFileUpload(t *testing.T) {
 	t.Parallel()
 
 	t.Run("variable name file", func(t *testing.T) {
+		t.Parallel()
 		testenv.Run(t, &testenv.Config{}, func(t *testing.T, xEnv *testenv.Environment) {
 			fileContent := bytes.Repeat([]byte("a"), 1024)
 			files := []testenv.FileUpload{{VariablesPath: "variables.file", FileContent: fileContent}}
@@ -35,6 +36,7 @@ func TestSingleFileUpload(t *testing.T) {
 	})
 
 	t.Run("variable name whatever", func(t *testing.T) {
+		t.Parallel()
 		testenv.Run(t, &testenv.Config{}, func(t *testing.T, xEnv *testenv.Environment) {
 			fileContent := bytes.Repeat([]byte("a"), 1024)
 			files := []testenv.FileUpload{{VariablesPath: "variables.whatever", FileContent: fileContent}}
@@ -48,7 +50,9 @@ func TestSingleFileUpload(t *testing.T) {
 	})
 
 	t.Run("nested file uploads", func(t *testing.T) {
+		t.Parallel()
 		t.Run("nested on a first level - no remap", func(t *testing.T) {
+			t.Parallel()
 			testenv.Run(t, &testenv.Config{
 				ModifyEngineExecutionConfiguration: func(engineExecutionConfiguration *config.EngineExecutionConfiguration) {
 					engineExecutionConfiguration.DisableVariablesRemapping = true
@@ -66,6 +70,7 @@ func TestSingleFileUpload(t *testing.T) {
 		})
 
 		t.Run("nested on a first level - with remap", func(t *testing.T) {
+			t.Parallel()
 			testenv.Run(t, &testenv.Config{
 				ModifyEngineExecutionConfiguration: func(engineExecutionConfiguration *config.EngineExecutionConfiguration) {
 					engineExecutionConfiguration.DisableVariablesRemapping = false
@@ -83,6 +88,7 @@ func TestSingleFileUpload(t *testing.T) {
 		})
 
 		t.Run("nested on a second level - with remap", func(t *testing.T) {
+			t.Parallel()
 			testenv.Run(t, &testenv.Config{
 				ModifyEngineExecutionConfiguration: func(engineExecutionConfiguration *config.EngineExecutionConfiguration) {
 					engineExecutionConfiguration.DisableVariablesRemapping = false
@@ -101,6 +107,7 @@ func TestSingleFileUpload(t *testing.T) {
 		})
 
 		t.Run("nested on a third level - with remap", func(t *testing.T) {
+			t.Parallel()
 			testenv.Run(t, &testenv.Config{
 				ModifyEngineExecutionConfiguration: func(engineExecutionConfiguration *config.EngineExecutionConfiguration) {
 					engineExecutionConfiguration.DisableVariablesRemapping = false
@@ -119,6 +126,7 @@ func TestSingleFileUpload(t *testing.T) {
 		})
 
 		t.Run("nested on a third level - with remap", func(t *testing.T) {
+			t.Parallel()
 			t.Skip("not implemented")
 
 			testenv.Run(t, &testenv.Config{
@@ -145,6 +153,7 @@ func TestSingleFileUploadWithCompression(t *testing.T) {
 	t.Parallel()
 
 	t.Run("Uploading file without compressed body should return 422", func(t *testing.T) {
+		t.Parallel()
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
 				core.WithRouterTrafficConfig(&config.RouterTrafficConfiguration{
@@ -173,6 +182,7 @@ func TestSingleFileUploadWithCompression(t *testing.T) {
 	})
 
 	t.Run("Uploading file with compressed body should return 200", func(t *testing.T) {
+		t.Parallel()
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
 				core.WithRouterTrafficConfig(&config.RouterTrafficConfiguration{
@@ -313,7 +323,9 @@ func TestMultipleFilesUpload(t *testing.T) {
 	t.Parallel()
 
 	t.Run("variables remapping enabled", func(t *testing.T) {
+		t.Parallel()
 		t.Run("variable name files", func(t *testing.T) {
+			t.Parallel()
 			testenv.Run(t, &testenv.Config{}, func(t *testing.T, xEnv *testenv.Environment) {
 				files := []testenv.FileUpload{
 					{VariablesPath: "variables.files.0", FileContent: []byte("Contents of first file")},
@@ -330,7 +342,9 @@ func TestMultipleFilesUpload(t *testing.T) {
 		})
 
 		t.Run("list of files", func(t *testing.T) {
+			t.Parallel()
 			t.Run("nested on a second level - with remap", func(t *testing.T) {
+				t.Parallel()
 				testenv.Run(t, &testenv.Config{
 					ModifyEngineExecutionConfiguration: func(engineExecutionConfiguration *config.EngineExecutionConfiguration) {
 						engineExecutionConfiguration.DisableVariablesRemapping = false
@@ -352,6 +366,7 @@ func TestMultipleFilesUpload(t *testing.T) {
 			})
 
 			t.Run("in a variables no remap", func(t *testing.T) {
+				t.Parallel()
 				testenv.Run(t, &testenv.Config{
 					ModifyEngineExecutionConfiguration: func(engineExecutionConfiguration *config.EngineExecutionConfiguration) {
 						engineExecutionConfiguration.DisableVariablesRemapping = false
@@ -375,7 +390,9 @@ func TestMultipleFilesUpload(t *testing.T) {
 	})
 
 	t.Run("variables remapping disabled", func(t *testing.T) {
+		t.Parallel()
 		t.Run("variable name files", func(t *testing.T) {
+			t.Parallel()
 			testenv.Run(t, &testenv.Config{
 				ModifyEngineExecutionConfiguration: func(engineExecutionConfiguration *config.EngineExecutionConfiguration) {
 					engineExecutionConfiguration.DisableVariablesRemapping = true
@@ -396,7 +413,9 @@ func TestMultipleFilesUpload(t *testing.T) {
 		})
 
 		t.Run("list of files", func(t *testing.T) {
+			t.Parallel()
 			t.Run("nested on a second level - with remap", func(t *testing.T) {
+				t.Parallel()
 				testenv.Run(t, &testenv.Config{
 					ModifyEngineExecutionConfiguration: func(engineExecutionConfiguration *config.EngineExecutionConfiguration) {
 						engineExecutionConfiguration.DisableVariablesRemapping = true
@@ -418,6 +437,7 @@ func TestMultipleFilesUpload(t *testing.T) {
 			})
 
 			t.Run("in a variables no remap", func(t *testing.T) {
+				t.Parallel()
 				testenv.Run(t, &testenv.Config{
 					ModifyEngineExecutionConfiguration: func(engineExecutionConfiguration *config.EngineExecutionConfiguration) {
 						engineExecutionConfiguration.DisableVariablesRemapping = true

--- a/router-tests/graphql_over_http_test.go
+++ b/router-tests/graphql_over_http_test.go
@@ -21,6 +21,7 @@ func TestGraphQLOverHTTPCompatibility(t *testing.T) {
 
 	testenv.Run(t, &testenv.Config{}, func(t *testing.T, xEnv *testenv.Environment) {
 		t.Run("valid request should return 200 OK with valid response", func(t *testing.T) {
+			t.Parallel()
 			header := http.Header{
 				"Content-Type": []string{"application/json"},
 				"Accept":       []string{"application/json"},
@@ -35,6 +36,7 @@ func TestGraphQLOverHTTPCompatibility(t *testing.T) {
 			require.Equal(t, `{"data":{"findEmployees":[{"id":1,"details":{"forename":"Jens","surname":"Neuse"}},{"id":2,"details":{"forename":"Dustin","surname":"Deus"}},{"id":4,"details":{"forename":"Björn","surname":"Schwenzer"}},{"id":11,"details":{"forename":"Alexandra","surname":"Neuse"}}]}}`, string(data))
 		})
 		t.Run("valid request with Operation Name null should return 200 OK with valid response", func(t *testing.T) {
+			t.Parallel()
 			header := http.Header{
 				"Content-Type": []string{"application/json"},
 				"Accept":       []string{"application/json"},
@@ -49,6 +51,7 @@ func TestGraphQLOverHTTPCompatibility(t *testing.T) {
 			require.Equal(t, `{"data":{"findEmployees":[{"id":1,"details":{"forename":"Jens","surname":"Neuse"}},{"id":2,"details":{"forename":"Dustin","surname":"Deus"}},{"id":4,"details":{"forename":"Björn","surname":"Schwenzer"}},{"id":11,"details":{"forename":"Alexandra","surname":"Neuse"}}]}}`, string(data))
 		})
 		t.Run("return 400 bad request when variables is not a map", func(t *testing.T) {
+			t.Parallel()
 			header := http.Header{
 				"Content-Type": []string{"application/json"},
 				"Accept":       []string{"application/json"},
@@ -63,6 +66,7 @@ func TestGraphQLOverHTTPCompatibility(t *testing.T) {
 			require.Equal(t, `{"errors":[{"message":"error parsing request body"}]}`, string(data))
 		})
 		t.Run("return 400 bad request when extensions is not a map", func(t *testing.T) {
+			t.Parallel()
 			header := http.Header{
 				"Content-Type": []string{"application/json"},
 				"Accept":       []string{"application/json"},
@@ -77,6 +81,7 @@ func TestGraphQLOverHTTPCompatibility(t *testing.T) {
 			require.Equal(t, `{"errors":[{"message":"error parsing request body"}]}`, string(data))
 		})
 		t.Run("valid request with Operation Name should return 200 OK with valid response", func(t *testing.T) {
+			t.Parallel()
 			header := http.Header{
 				"Content-Type": []string{"application/json"},
 				"Accept":       []string{"application/json"},
@@ -90,6 +95,7 @@ func TestGraphQLOverHTTPCompatibility(t *testing.T) {
 			require.Equal(t, `{"data":{"findEmployees":[{"id":1,"details":{"forename":"Jens","surname":"Neuse"}},{"id":2,"details":{"forename":"Dustin","surname":"Deus"}},{"id":4,"details":{"forename":"Björn","surname":"Schwenzer"}},{"id":11,"details":{"forename":"Alexandra","surname":"Neuse"}}]}}`, string(data))
 		})
 		t.Run("malformed JSON should return 400", func(t *testing.T) {
+			t.Parallel()
 			header := http.Header{
 				"Content-Type": []string{"application/json"},
 				"Accept":       []string{"application/json"},
@@ -104,6 +110,7 @@ func TestGraphQLOverHTTPCompatibility(t *testing.T) {
 			require.Equal(t, `{"errors":[{"message":"error parsing request body"}]}`, string(data))
 		})
 		t.Run("malformed JSON variant should return 400", func(t *testing.T) {
+			t.Parallel()
 			header := http.Header{
 				"Content-Type": []string{"application/json"},
 				"Accept":       []string{"application/json"},
@@ -118,6 +125,7 @@ func TestGraphQLOverHTTPCompatibility(t *testing.T) {
 			require.Equal(t, `{"errors":[{"message":"error parsing request body"}]}`, string(data))
 		})
 		t.Run("malformed JSON variant #2 should return 400", func(t *testing.T) {
+			t.Parallel()
 			header := http.Header{
 				"Content-Type": []string{"application/json"},
 				"Accept":       []string{"application/json"},
@@ -132,6 +140,7 @@ func TestGraphQLOverHTTPCompatibility(t *testing.T) {
 			require.Equal(t, `{"errors":[{"message":"error parsing request body"}]}`, string(data))
 		})
 		t.Run("malformed JSON variables variant should return 400", func(t *testing.T) {
+			t.Parallel()
 			header := http.Header{
 				"Content-Type": []string{"application/json"},
 				"Accept":       []string{"application/json"},
@@ -146,6 +155,7 @@ func TestGraphQLOverHTTPCompatibility(t *testing.T) {
 			require.Equal(t, `{"errors":[{"message":"error parsing request body"}]}`, string(data))
 		})
 		t.Run("missing variables should return 200 OK with validation errors response", func(t *testing.T) {
+			t.Parallel()
 			header := http.Header{
 				"Content-Type": []string{"application/json"},
 				"Accept":       []string{"application/json"},
@@ -160,6 +170,7 @@ func TestGraphQLOverHTTPCompatibility(t *testing.T) {
 			require.Equal(t, `{"errors":[{"message":"Variable \"$criteria\" of required type \"SearchInput!\" was not provided."}]}`, string(data))
 		})
 		t.Run("mismatching variables although valid JSON should not be 400", func(t *testing.T) {
+			t.Parallel()
 			header := http.Header{
 				"Content-Type": []string{"application/json"},
 				"Accept":       []string{"application/json"},
@@ -174,6 +185,7 @@ func TestGraphQLOverHTTPCompatibility(t *testing.T) {
 			require.Equal(t, `{"errors":[{"message":"Variable \"$criteria\" of required type \"SearchInput!\" was not provided."}]}`, string(data))
 		})
 		t.Run("variables null should be 200 ok with validation error", func(t *testing.T) {
+			t.Parallel()
 			header := http.Header{
 				"Content-Type": []string{"application/json"},
 				"Accept":       []string{"application/json"},
@@ -188,6 +200,7 @@ func TestGraphQLOverHTTPCompatibility(t *testing.T) {
 			require.Equal(t, `{"errors":[{"message":"Variable \"$criteria\" of required type \"SearchInput!\" was not provided."}]}`, string(data))
 		})
 		t.Run("variables null with space should be 200 ok with validation error", func(t *testing.T) {
+			t.Parallel()
 			header := http.Header{
 				"Content-Type": []string{"application/json"},
 				"Accept":       []string{"application/json"},
@@ -202,6 +215,7 @@ func TestGraphQLOverHTTPCompatibility(t *testing.T) {
 			require.Equal(t, `{"errors":[{"message":"Variable \"$criteria\" of required type \"SearchInput!\" was not provided."}]}`, string(data))
 		})
 		t.Run("request with spaces and tabs should be 200 ok", func(t *testing.T) {
+			t.Parallel()
 			header := http.Header{
 				"Content-Type": []string{"application/json"},
 				"Accept":       []string{"application/json"},
@@ -216,6 +230,7 @@ func TestGraphQLOverHTTPCompatibility(t *testing.T) {
 			require.Equal(t, `{"data":{"findEmployees":[{"id":1,"details":{"forename":"Jens","surname":"Neuse"}},{"id":2,"details":{"forename":"Dustin","surname":"Deus"}},{"id":4,"details":{"forename":"Björn","surname":"Schwenzer"}},{"id":11,"details":{"forename":"Alexandra","surname":"Neuse"}}]}}`, string(data))
 		})
 		t.Run("request with long header should return 431 response", func(t *testing.T) {
+			t.Parallel()
 			header := http.Header{}
 
 			// the limit actually behaves a bit weird in the http library. It's not exactly 1<<20 (1MiB)

--- a/router-tests/headers_test.go
+++ b/router-tests/headers_test.go
@@ -191,6 +191,7 @@ func TestForwardHeaders(t *testing.T) {
 			for _, c := range cases {
 				headerName := c.headerName
 				t.Run(c.testName, func(t *testing.T) {
+					t.Parallel()
 					res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
 						Header: http.Header{
 							headerName: []string{headerValue},
@@ -296,7 +297,7 @@ func TestForwardHeaders(t *testing.T) {
 			for _, c := range cases {
 				c := c
 				t.Run(c.testName, func(t *testing.T) {
-
+					t.Parallel()
 					header := http.Header{
 						c.headerName: []string{headerValue},
 					}
@@ -364,6 +365,7 @@ func TestForwardHeaders(t *testing.T) {
 			for _, c := range cases {
 				c := c
 				t.Run(c.testName, func(t *testing.T) {
+					t.Parallel()
 					header1 := http.Header{
 						c.headerName: []string{headerValue},
 					}
@@ -468,6 +470,7 @@ func TestForwardRenamedHeaders(t *testing.T) {
 				log.Println(c.testName, c.headerName, c.headerRename)
 				log.Println(headerName, headerValue)
 				t.Run(c.testName, func(t *testing.T) {
+					t.Parallel()
 					res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
 						Header: http.Header{
 							headerName: []string{headerValue},
@@ -523,7 +526,7 @@ func TestForwardRenamedHeaders(t *testing.T) {
 			for _, c := range cases {
 				c := c
 				t.Run(c.testName, func(t *testing.T) {
-
+					t.Parallel()
 					header := http.Header{
 						c.headerName: []string{headerValue},
 					}
@@ -591,6 +594,7 @@ func TestForwardRenamedHeaders(t *testing.T) {
 			for _, c := range cases {
 				c := c
 				t.Run(c.testName, func(t *testing.T) {
+					t.Parallel()
 					header1 := http.Header{
 						c.headerName: []string{headerValue},
 					}

--- a/router-tests/integration_test.go
+++ b/router-tests/integration_test.go
@@ -329,6 +329,7 @@ func TestVariables(t *testing.T) {
 
 	testenv.Run(t, &testenv.Config{}, func(t *testing.T, xEnv *testenv.Environment) {
 		t.Run("correct validation", func(t *testing.T) {
+			t.Parallel()
 			res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
 				Query:     `query Find($criteria: SearchInput!) {findEmployees(criteria: $criteria){id details {forename surname}}}`,
 				Variables: json.RawMessage(`{"criteria":{"nationality":"GERMAN"}}`),
@@ -337,6 +338,7 @@ func TestVariables(t *testing.T) {
 		})
 
 		t.Run("query with variables", func(t *testing.T) {
+			t.Parallel()
 			res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
 				Query:     `query ($n:Int!) { employee(id:$n) { id details { forename surname } } }`,
 				Variables: json.RawMessage(`{"n":1}`),
@@ -345,6 +347,7 @@ func TestVariables(t *testing.T) {
 		})
 
 		t.Run("inline variables", func(t *testing.T) {
+			t.Parallel()
 			res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
 				Query: `{ employee(id:1) { id details { forename surname } } }`,
 			})
@@ -352,6 +355,7 @@ func TestVariables(t *testing.T) {
 		})
 
 		t.Run("invalid number", func(t *testing.T) {
+			t.Parallel()
 			res, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
 				Query:     `query Find($criteria: SearchInput!) {findEmployees(criteria: $criteria){id details {forename surname}}}`,
 				Variables: json.RawMessage(`1`),
@@ -362,6 +366,7 @@ func TestVariables(t *testing.T) {
 		})
 
 		t.Run("invalid string", func(t *testing.T) {
+			t.Parallel()
 			res, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
 				Query:     `query Find($criteria: SearchInput!) {findEmployees(criteria: $criteria){id details {forename surname}}}`,
 				Variables: json.RawMessage(`"1"`),
@@ -372,6 +377,7 @@ func TestVariables(t *testing.T) {
 		})
 
 		t.Run("invalid boolean", func(t *testing.T) {
+			t.Parallel()
 			res, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
 				Query:     `query Find($criteria: SearchInput!) {findEmployees(criteria: $criteria){id details {forename surname}}}`,
 				Variables: json.RawMessage(`true`),
@@ -382,6 +388,7 @@ func TestVariables(t *testing.T) {
 		})
 
 		t.Run("invalid array", func(t *testing.T) {
+			t.Parallel()
 			res, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
 				Query:     `query Find($criteria: SearchInput!) {findEmployees(criteria: $criteria){id details {forename surname}}}`,
 				Variables: json.RawMessage(`[]`),
@@ -392,6 +399,7 @@ func TestVariables(t *testing.T) {
 		})
 
 		t.Run("missing", func(t *testing.T) {
+			t.Parallel()
 			res, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
 				Query:     `query Find($criteria: SearchInput!) {findEmployees(criteria: $criteria){id details {forename surname}}}`,
 				Variables: json.RawMessage(`{}`),
@@ -402,6 +410,7 @@ func TestVariables(t *testing.T) {
 		})
 
 		t.Run("wrong value variable", func(t *testing.T) {
+			t.Parallel()
 			res, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
 				Query:     `query Find($criteria: SearchInput!) {findEmployees(criteria: $criteria){id details {forename surname}}}`,
 				Variables: json.RawMessage(`{"criteria":1}`),
@@ -417,6 +426,7 @@ func TestVariablesRemapping(t *testing.T) {
 	t.Parallel()
 
 	t.Run("enabled", func(t *testing.T) {
+		t.Parallel()
 		testenv.Run(t, &testenv.Config{
 			Subgraphs: testenv.SubgraphsConfig{
 				Employees: testenv.SubgraphConfig{
@@ -452,6 +462,7 @@ func TestVariablesRemapping(t *testing.T) {
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			t.Run("scalar argument type", func(t *testing.T) {
+				t.Parallel()
 				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
 					Query:     `query ($count:Int!) { employee(id:$count) { id } }`,
 					Variables: json.RawMessage(`{"count":1}`),
@@ -460,6 +471,7 @@ func TestVariablesRemapping(t *testing.T) {
 			})
 
 			t.Run("input object argument type - variable argument", func(t *testing.T) {
+				t.Parallel()
 				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
 					Query:     `query ($arg:InputArg!) { rootFieldWithInput(arg: $arg) }`,
 					Variables: json.RawMessage(`{"arg":{"string": "foo"}}`),
@@ -468,6 +480,7 @@ func TestVariablesRemapping(t *testing.T) {
 			})
 
 			t.Run("input object argument type - inline value", func(t *testing.T) {
+				t.Parallel()
 				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
 					Query: `query { rootFieldWithInput(arg: {string: "foo"}) }`,
 				})
@@ -477,6 +490,7 @@ func TestVariablesRemapping(t *testing.T) {
 	})
 
 	t.Run("disabled", func(t *testing.T) {
+		t.Parallel()
 		testenv.Run(t, &testenv.Config{
 			ModifyEngineExecutionConfiguration: func(cfg *config.EngineExecutionConfiguration) {
 				cfg.DisableVariablesRemapping = true
@@ -515,6 +529,7 @@ func TestVariablesRemapping(t *testing.T) {
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			t.Run("scalar argument type", func(t *testing.T) {
+				t.Parallel()
 				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
 					Query:     `query ($count:Int!) { employee(id:$count) { id } }`,
 					Variables: json.RawMessage(`{"count":1}`),
@@ -523,6 +538,7 @@ func TestVariablesRemapping(t *testing.T) {
 			})
 
 			t.Run("input object argument type", func(t *testing.T) {
+				t.Parallel()
 				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
 					Query:     `query ($arg:InputArg!) { rootFieldWithInput(arg: $arg) }`,
 					Variables: json.RawMessage(`{"arg":{"string": "foo"}}`),

--- a/router-tests/mcp_test.go
+++ b/router-tests/mcp_test.go
@@ -12,9 +12,10 @@ import (
 )
 
 func TestMCP(t *testing.T) {
-
 	t.Run("Discovery", func(t *testing.T) {
+		t.Parallel()
 		t.Run("List default discovery Tools", func(t *testing.T) {
+			t.Parallel()
 			testenv.Run(t, &testenv.Config{
 				MCP: config.MCPConfiguration{
 					Enabled: true,
@@ -40,6 +41,7 @@ func TestMCP(t *testing.T) {
 		})
 
 		t.Run("List optional discovery tools", func(t *testing.T) {
+			t.Parallel()
 			testenv.Run(t, &testenv.Config{
 				MCP: config.MCPConfiguration{
 					Enabled: true,
@@ -100,6 +102,7 @@ func TestMCP(t *testing.T) {
 		})
 
 		t.Run("List User Operations", func(t *testing.T) {
+			t.Parallel()
 			testenv.Run(t, &testenv.Config{
 				MCP: config.MCPConfiguration{
 					Enabled: true,
@@ -120,6 +123,7 @@ func TestMCP(t *testing.T) {
 			})
 
 			t.Run("List user Operations / Static operations of type mutation aren't exposed when excludeMutations is set", func(t *testing.T) {
+				t.Parallel()
 				testenv.Run(t, &testenv.Config{
 					MCP: config.MCPConfiguration{
 						Enabled:          true,
@@ -146,6 +150,7 @@ func TestMCP(t *testing.T) {
 			})
 
 			t.Run("Execute Operation Info", func(t *testing.T) {
+				t.Parallel()
 				testenv.Run(t, &testenv.Config{
 					MCP: config.MCPConfiguration{
 						Enabled:   true,
@@ -177,7 +182,9 @@ func TestMCP(t *testing.T) {
 			})
 
 			t.Run("Execute Query", func(t *testing.T) {
+				t.Parallel()
 				t.Run("Execute operation of type query with valid input", func(t *testing.T) {
+					t.Parallel()
 					testenv.Run(t, &testenv.Config{
 						MCP: config.MCPConfiguration{
 							Enabled: true,
@@ -207,6 +214,7 @@ func TestMCP(t *testing.T) {
 				})
 
 				t.Run("Execute operation of type query with invalid input", func(t *testing.T) {
+					t.Parallel()
 					testenv.Run(t, &testenv.Config{
 						MCP: config.MCPConfiguration{
 							Enabled: true,
@@ -233,7 +241,9 @@ func TestMCP(t *testing.T) {
 			})
 
 			t.Run("Execute Mutation", func(t *testing.T) {
+				t.Parallel()
 				t.Run("Execute operation of type mutation with valid input", func(t *testing.T) {
+					t.Parallel()
 					testenv.Run(t, &testenv.Config{
 						MCP: config.MCPConfiguration{
 							Enabled: true,
@@ -264,7 +274,9 @@ func TestMCP(t *testing.T) {
 			})
 
 			t.Run("Developer Tools", func(t *testing.T) {
+				t.Parallel()
 				t.Run("Execute an arbitrary query", func(t *testing.T) {
+					t.Parallel()
 					testenv.Run(t, &testenv.Config{
 						MCP: config.MCPConfiguration{
 							Enabled:                   true,
@@ -301,6 +313,7 @@ func TestMCP(t *testing.T) {
 				})
 
 				t.Run("Get the full graph schema of the base graph", func(t *testing.T) {
+					t.Parallel()
 					testenv.Run(t, &testenv.Config{
 						MCP: config.MCPConfiguration{
 							Enabled:      true,

--- a/router-tests/modules/module_test.go
+++ b/router-tests/modules/module_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestModuleSetCustomHeader(t *testing.T) {
+	t.Parallel()
 	cfg := config.Config{
 		Graph: config.Graph{},
 		Modules: map[string]interface{}{
@@ -44,6 +45,7 @@ func TestModuleSetCustomHeader(t *testing.T) {
 }
 
 func TestCustomModuleLogs(t *testing.T) {
+	t.Parallel()
 	cfg := config.Config{
 		Graph: config.Graph{},
 		Modules: map[string]interface{}{

--- a/router-tests/safelist_test.go
+++ b/router-tests/safelist_test.go
@@ -22,6 +22,7 @@ func TestSafelist(t *testing.T) {
 	)
 
 	t.Run("router fails if APQ and Safelist are both enabled", func(t *testing.T) {
+		t.Parallel()
 		testenv.FailsOnStartup(t, &testenv.Config{
 			ApqConfig: config.AutomaticPersistedQueriesConfig{Enabled: true},
 			RouterOptions: []core.Option{
@@ -35,6 +36,7 @@ func TestSafelist(t *testing.T) {
 	})
 
 	t.Run("safelist should allow a persisted query to run", func(t *testing.T) {
+		t.Parallel()
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
 				core.WithPersistedOperationsConfig(config.PersistedOperationsConfig{
@@ -55,6 +57,7 @@ func TestSafelist(t *testing.T) {
 	})
 
 	t.Run("safelist should allow a persisted query (run with ID) to run", func(t *testing.T) {
+		t.Parallel()
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
 				core.WithPersistedOperationsConfig(config.PersistedOperationsConfig{
@@ -75,6 +78,7 @@ func TestSafelist(t *testing.T) {
 	})
 
 	t.Run("safelist should reject a query with different spacing from the persisted operation", func(t *testing.T) {
+		t.Parallel()
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
 				core.WithPersistedOperationsConfig(config.PersistedOperationsConfig{
@@ -95,6 +99,7 @@ func TestSafelist(t *testing.T) {
 	})
 
 	t.Run("safelist should block a non persisted query", func(t *testing.T) {
+		t.Parallel()
 		testenv.Run(t, &testenv.Config{
 			ApqConfig: config.AutomaticPersistedQueriesConfig{
 				Enabled: false,
@@ -118,7 +123,9 @@ func TestSafelist(t *testing.T) {
 	})
 
 	t.Run("log unknown operations", func(t *testing.T) {
+		t.Parallel()
 		t.Run("logs non persisted query but allows them to continue", func(t *testing.T) {
+			t.Parallel()
 			testenv.Run(t, &testenv.Config{
 				ApqConfig: config.AutomaticPersistedQueriesConfig{
 					Enabled: false,
@@ -153,6 +160,7 @@ func TestSafelist(t *testing.T) {
 		})
 
 		t.Run("logs non persisted query and stops them if safelist set", func(t *testing.T) {
+			t.Parallel()
 			testenv.Run(t, &testenv.Config{
 				ApqConfig: config.AutomaticPersistedQueriesConfig{
 					Enabled: false,
@@ -187,6 +195,7 @@ func TestSafelist(t *testing.T) {
 		})
 
 		t.Run("doesn't log persisted queries and allows them to continue", func(t *testing.T) {
+			t.Parallel()
 			testenv.Run(t, &testenv.Config{
 				ApqConfig: config.AutomaticPersistedQueriesConfig{
 					Enabled: false,

--- a/router-tests/structured_logging_test.go
+++ b/router-tests/structured_logging_test.go
@@ -4,16 +4,17 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/otel/sdk/metric"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 	"math"
 	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/sdk/metric"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/wundergraph/cosmo/router-tests/testenv"
 	"github.com/wundergraph/cosmo/router/core"
@@ -2302,6 +2303,7 @@ func TestFlakyAccessLogs(t *testing.T) {
 		})
 
 		t.Run("validate the evaluation of the body.raw expression for a file upload", func(t *testing.T) {
+			t.Parallel()
 			testenv.Run(t, &testenv.Config{
 				AccessLogFields: []config.CustomAttribute{
 					{

--- a/router-tests/subgraph_merge_results_test.go
+++ b/router-tests/subgraph_merge_results_test.go
@@ -11,6 +11,7 @@ import (
 func TestSubgraphMergeResults(t *testing.T) {
 	t.Parallel()
 	t.Run("valid", func(t *testing.T) {
+		t.Parallel()
 		testenv.Run(t, &testenv.Config{}, func(t *testing.T, xEnv *testenv.Environment) {
 			res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
 				Query: `{sharedThings(numOfA: 1,numOfB: 1) {a b}}`,
@@ -19,6 +20,7 @@ func TestSubgraphMergeResults(t *testing.T) {
 		})
 	})
 	t.Run("first 1 second 2", func(t *testing.T) {
+		t.Parallel()
 		testenv.Run(t, &testenv.Config{}, func(t *testing.T, xEnv *testenv.Environment) {
 			res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
 				Query: `{sharedThings(numOfA: 1,numOfB: 2) {a b}}`,
@@ -27,6 +29,7 @@ func TestSubgraphMergeResults(t *testing.T) {
 		})
 	})
 	t.Run("first 2 second 1", func(t *testing.T) {
+		t.Parallel()
 		testenv.Run(t, &testenv.Config{}, func(t *testing.T, xEnv *testenv.Environment) {
 			res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
 				Query: `{sharedThings(numOfA: 1,numOfB: 2) {a b}}`,
@@ -35,6 +38,7 @@ func TestSubgraphMergeResults(t *testing.T) {
 		})
 	})
 	t.Run("incompatible types", func(t *testing.T) {
+		t.Parallel()
 		testenv.Run(t, &testenv.Config{
 			Subgraphs: testenv.SubgraphsConfig{
 				Test1: testenv.SubgraphConfig{

--- a/router-tests/variables_validation_test.go
+++ b/router-tests/variables_validation_test.go
@@ -17,6 +17,7 @@ func TestInputValidation(t *testing.T) {
 
 	testenv.Run(t, &testenv.Config{}, func(t *testing.T, xEnv *testenv.Environment) {
 		t.Run("valid input", func(t *testing.T) {
+			t.Parallel()
 			header := http.Header{
 				"Content-Type": []string{"application/json"},
 				"Accept":       []string{"application/json"},
@@ -30,6 +31,7 @@ func TestInputValidation(t *testing.T) {
 			require.Equal(t, `{"data":{"findEmployees":[{"id":1,"details":{"forename":"Jens","surname":"Neuse"}},{"id":2,"details":{"forename":"Dustin","surname":"Deus"}},{"id":4,"details":{"forename":"Björn","surname":"Schwenzer"}},{"id":11,"details":{"forename":"Alexandra","surname":"Neuse"}}]}}`, string(data))
 		})
 		t.Run("invalid input", func(t *testing.T) {
+			t.Parallel()
 			header := http.Header{
 				"Content-Type": []string{"application/json"},
 				"Accept":       []string{"application/json"},
@@ -49,6 +51,7 @@ func TestInputValidation(t *testing.T) {
 		},
 	}, func(t *testing.T, xEnv *testenv.Environment) {
 		t.Run("invalid input with unexposed error values", func(t *testing.T) {
+			t.Parallel()
 			header := http.Header{
 				"Content-Type": []string{"application/json"},
 				"Accept":       []string{"application/json"},


### PR DESCRIPTION
Replaced custom linter action with golangci-lint action in CI workflow

## Motivation and Context

We want to be sure that tests are as parallel as possible. To add the tests I've converted the ci linter custom action to use golangci-lint and ported old checks.

After executing the checks some errors come up and I've already fixed them:
- added missing t.Parallel and added ignore rules when needed
- removed unused code
- changed multiple if to switch

## Checklist

- [X] I have discussed my proposed changes in an issue and have received approval to proceed.
- [X] I have followed the coding standards of the project.
- [X] Tests or benchmarks have been added or updated.
- [X] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [X] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->