### PR TITLE
fix: refactor telemetry tests

### DIFF
--- a/router-tests/telemetry/telemetry_test.go
+++ b/router-tests/telemetry/telemetry_test.go
@@ -36,7 +36,7 @@ import (
 )
 
 const (
-	defaultExposedScopedMetricsCount = 2
+	defaultExposedScopedMetricsCount = 1
 )
 
 func TestFlakyEngineStatisticsTelemetry(t *testing.T) {

--- a/router-tests/telemetry/telemetry_test.go
+++ b/router-tests/telemetry/telemetry_test.go
@@ -3566,7 +3566,7 @@ func TestFlakyTelemetry(t *testing.T) {
 
 			require.Len(t, rm.ScopeMetrics, defaultExposedScopedMetricsCount)
 
-			scopeMetric := getScopeMetricsByName(t, rm, "")
+			scopeMetric := *integration.GetMetricScopeByName(rm.ScopeMetrics, "cosmo.router")
 			require.Len(t, scopeMetric.Metrics, 6)
 
 			metricdatatest.AssertEqual(t, want, scopeMetric, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue())
@@ -3993,7 +3993,8 @@ func TestFlakyTelemetry(t *testing.T) {
 			require.Contains(t, rm.Resource.Attributes(), attribute.String("service.name", "cosmo-router"))
 
 			require.Len(t, rm.ScopeMetrics, defaultExposedScopedMetricsCount)
-			scopeMetric := getScopeMetricsByName(t, rm, "")
+
+			scopeMetric := *integration.GetMetricScopeByName(rm.ScopeMetrics, "cosmo.router")
 			require.Len(t, scopeMetric.Metrics, 6)
 		})
 	})
@@ -4678,7 +4679,7 @@ func TestFlakyTelemetry(t *testing.T) {
 
 			require.Len(t, rm.ScopeMetrics, defaultExposedScopedMetricsCount)
 
-			scopeMetric := getScopeMetricsByName(t, rm, "")
+			scopeMetric := *integration.GetMetricScopeByName(rm.ScopeMetrics, "cosmo.router")
 			require.Len(t, scopeMetric.Metrics, 6)
 
 			metricdatatest.AssertEqual(t, want, scopeMetric, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue())
@@ -5006,7 +5007,7 @@ func TestFlakyTelemetry(t *testing.T) {
 
 			require.Len(t, rm.ScopeMetrics, defaultExposedScopedMetricsCount)
 
-			scopeMetric := getScopeMetricsByName(t, rm, "")
+			scopeMetric := *integration.GetMetricScopeByName(rm.ScopeMetrics, "cosmo.router")
 			require.Len(t, scopeMetric.Metrics, 6)
 
 			metricdatatest.AssertEqual(t, want, scopeMetric, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue())
@@ -5320,7 +5321,7 @@ func TestFlakyTelemetry(t *testing.T) {
 
 			require.Len(t, rm.ScopeMetrics, defaultExposedScopedMetricsCount)
 
-			scopeMetric := getScopeMetricsByName(t, rm, "")
+			scopeMetric := *integration.GetMetricScopeByName(rm.ScopeMetrics, "cosmo.router")
 			require.Len(t, scopeMetric.Metrics, 6)
 
 			metricdatatest.AssertEqual(t, want, scopeMetric, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue())
@@ -5726,7 +5727,7 @@ func TestFlakyTelemetry(t *testing.T) {
 
 			require.Len(t, rm.ScopeMetrics, defaultExposedScopedMetricsCount)
 
-			scopeMetric := getScopeMetricsByName(t, rm, "")
+			scopeMetric := *integration.GetMetricScopeByName(rm.ScopeMetrics, "cosmo.router")
 			require.Len(t, scopeMetric.Metrics, 6)
 
 			metricdatatest.AssertEqual(t, want, scopeMetric, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue())
@@ -6128,7 +6129,7 @@ func TestFlakyTelemetry(t *testing.T) {
 
 			require.Len(t, rm.ScopeMetrics, defaultExposedScopedMetricsCount)
 
-			scopeMetric := getScopeMetricsByName(t, rm, "")
+			scopeMetric := *integration.GetMetricScopeByName(rm.ScopeMetrics, "cosmo.router")
 			require.Len(t, scopeMetric.Metrics, 6)
 
 			metricdatatest.AssertEqual(t, want, scopeMetric, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue())
@@ -6494,7 +6495,7 @@ func TestFlakyTelemetry(t *testing.T) {
 
 			require.Len(t, rm.ScopeMetrics, defaultExposedScopedMetricsCount)
 
-			scopeMetric := getScopeMetricsByName(t, rm, "")
+			scopeMetric := *integration.GetMetricScopeByName(rm.ScopeMetrics, "cosmo.router")
 			require.Len(t, scopeMetric.Metrics, 6)
 
 			metricdatatest.AssertEqual(t, want, scopeMetric, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue())
@@ -7253,7 +7254,7 @@ func TestFlakyTelemetry(t *testing.T) {
 			err := metricReaderFull.Collect(context.Background(), &rmFull)
 			require.NoError(t, err)
 
-			scopeMetrics := getScopeMetricsByName(t, rmFull, "")
+			scopeMetrics := *integration.GetMetricScopeByName(rmFull.ScopeMetrics, "cosmo.router")
 			require.Len(t, rmFull.ScopeMetrics, defaultExposedScopedMetricsCount)
 			require.Len(t, scopeMetrics.Metrics, 6)
 
@@ -7297,8 +7298,9 @@ func TestFlakyTelemetry(t *testing.T) {
 			err := metricReaderFiltered.Collect(context.Background(), &rmFiltered)
 			require.NoError(t, err)
 
-			rmFilteredScopeMetrics := getScopeMetricsByName(t, rmFiltered, "")
-			rmFullScopeMetrics := getScopeMetricsByName(t, rmFull, "")
+			rmFilteredScopeMetrics := *integration.GetMetricScopeByName(rmFiltered.ScopeMetrics, "cosmo.router")
+
+			rmFullScopeMetrics := *integration.GetMetricScopeByName(rmFull.ScopeMetrics, "cosmo.router")
 
 			require.Len(t, rmFiltered.ScopeMetrics, defaultExposedScopedMetricsCount)
 			require.Len(t, rmFilteredScopeMetrics.Metrics, 5)
@@ -7418,7 +7420,7 @@ func TestFlakyTelemetry(t *testing.T) {
 
 				require.Len(t, rm.ScopeMetrics, defaultExposedScopedMetricsCount)
 
-				scopeMetric := getScopeMetricsByName(t, rm, "")
+				scopeMetric := *integration.GetMetricScopeByName(rm.ScopeMetrics, "cosmo.router")
 				require.Len(t, scopeMetric.Metrics, 7)
 
 				httpRequestsMetric := metricdata.Metrics{
@@ -7969,7 +7971,7 @@ func TestFlakyTelemetry(t *testing.T) {
 
 				require.Len(t, rm.ScopeMetrics, defaultExposedScopedMetricsCount)
 
-				scopeMetric := getScopeMetricsByName(t, rm, "")
+				scopeMetric := *integration.GetMetricScopeByName(rm.ScopeMetrics, "cosmo.router")
 				require.Len(t, scopeMetric.Metrics, 7)
 
 				httpRequestsMetric := metricdata.Metrics{
@@ -8479,7 +8481,7 @@ func TestFlakyTelemetry(t *testing.T) {
 
 				found := false
 
-				scopeMetric := getScopeMetricsByName(t, rm, "")
+				scopeMetric := *integration.GetMetricScopeByName(rm.ScopeMetrics, "cosmo.router")
 				for _, point := range scopeMetric.Metrics[1].Data.(metricdata.Sum[int64]).DataPoints {
 
 					require.Equal(t, int64(1), point.Value)
@@ -8810,7 +8812,7 @@ func TestFlakyTelemetry(t *testing.T) {
 				require.NoError(t, err)
 				rm := metricdata.ResourceMetrics{}
 				err = metricReader.Collect(context.Background(), &rm)
-				scopeMetric := getScopeMetricsByName(t, rm, "")
+				scopeMetric := *integration.GetMetricScopeByName(rm.ScopeMetrics, "cosmo.router")
 
 				require.NoError(t, err)
 				require.Greater(t, len(rm.ScopeMetrics), 0)
@@ -8857,7 +8859,7 @@ func TestFlakyTelemetry(t *testing.T) {
 				require.NoError(t, err)
 				rm := metricdata.ResourceMetrics{}
 				err = metricReader.Collect(context.Background(), &rm)
-				scopeMetric := getScopeMetricsByName(t, rm, "")
+				scopeMetric := *integration.GetMetricScopeByName(rm.ScopeMetrics, "cosmo.router")
 
 				require.NoError(t, err)
 				require.Greater(t, len(rm.ScopeMetrics), 0)
@@ -8903,7 +8905,7 @@ func TestFlakyTelemetry(t *testing.T) {
 				require.NoError(t, err)
 				rm := metricdata.ResourceMetrics{}
 				err = metricReader.Collect(context.Background(), &rm)
-				scopeMetric := getScopeMetricsByName(t, rm, "")
+				scopeMetric := *integration.GetMetricScopeByName(rm.ScopeMetrics, "cosmo.router")
 
 				require.NoError(t, err)
 				require.Greater(t, len(rm.ScopeMetrics), 0)
@@ -9005,7 +9007,7 @@ func TestFlakyTelemetry(t *testing.T) {
 
 				rm := metricdata.ResourceMetrics{}
 				err = metricReader.Collect(context.Background(), &rm)
-				scopeMetric := getScopeMetricsByName(t, rm, "")
+				scopeMetric := *integration.GetMetricScopeByName(rm.ScopeMetrics, "cosmo.router")
 
 				require.NoError(t, err)
 				require.Greater(t, len(rm.ScopeMetrics), 0)
@@ -9062,7 +9064,7 @@ func TestFlakyTelemetry(t *testing.T) {
 
 				rm := metricdata.ResourceMetrics{}
 				err = metricReader.Collect(context.Background(), &rm)
-				scopeMetric := getScopeMetricsByName(t, rm, "")
+				scopeMetric := *integration.GetMetricScopeByName(rm.ScopeMetrics, "cosmo.router")
 
 				require.NoError(t, err)
 				require.Greater(t, len(rm.ScopeMetrics), 0)
@@ -9117,7 +9119,7 @@ func TestFlakyTelemetry(t *testing.T) {
 
 				rm := metricdata.ResourceMetrics{}
 				err = metricReader.Collect(context.Background(), &rm)
-				scopeMetric := getScopeMetricsByName(t, rm, "")
+				scopeMetric := *integration.GetMetricScopeByName(rm.ScopeMetrics, "cosmo.router")
 
 				require.NoError(t, err)
 				require.Greater(t, len(rm.ScopeMetrics), 0)
@@ -9153,17 +9155,4 @@ func TestFlakyTelemetry(t *testing.T) {
 		})
 	})
 
-}
-
-func getScopeMetricsByName(t *testing.T, rm metricdata.ResourceMetrics, name string) metricdata.ScopeMetrics {
-	if name == "" {
-		name = "cosmo.router"
-	}
-	for _, scopeMetric := range rm.ScopeMetrics {
-		if scopeMetric.Scope.Name == name {
-			return scopeMetric
-		}
-	}
-	require.Fail(t, "did not find")
-	return metricdata.ScopeMetrics{}
 }


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

## Motivation and Context

Right now the telemetry tests use array index for tests. Thus if the array element order changes due to a change in the code the tests will fail. This tests fixes this by making the telemetry tests get the required array (scope metric) element by name, instead of relying on the array index then.

This is opened as a separate PR, before the router gauge PR.

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->