### PR TITLE
fix: update go tools

### DIFF
--- a/router/go.mod
+++ b/router/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/tidwall/gjson v1.18.0
 	github.com/tidwall/sjson v1.2.5
 	github.com/twmb/franz-go v1.16.1
-	github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.176
+	github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.177
 	// Do not upgrade, it renames attributes we rely on
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.46.1
 	go.opentelemetry.io/contrib/propagators/b3 v1.23.0

--- a/router/go.sum
+++ b/router/go.sum
@@ -270,8 +270,8 @@ github.com/vektah/gqlparser/v2 v2.5.16 h1:1gcmLTvs3JLKXckwCwlUagVn/IlV2bwqle0vJ0
 github.com/vektah/gqlparser/v2 v2.5.16/go.mod h1:1lz1OeCqgQbQepsGxPVywrjdBHW2T08PUS3pJqepRww=
 github.com/wundergraph/astjson v0.0.0-20250106123708-be463c97e083 h1:8/D7f8gKxTBjW+SZK4mhxTTBVpxcqeBgWF1Rfmltbfk=
 github.com/wundergraph/astjson v0.0.0-20250106123708-be463c97e083/go.mod h1:eOTL6acwctsN4F3b7YE+eE2t8zcJ/doLm9sZzsxxxrE=
-github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.176 h1:G3Khr9VLXQ77vGeCU6V7e6uK1EE8P/fUQCydqj3cH5w=
-github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.176/go.mod h1:B7eV0Qh8Lop9QzIOQcsvKp3S0ejfC6mgyWoJnI917yQ=
+github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.177 h1:GyyD8yGgAm7iLN+Wwgre8DnxiBEm4OqHfMMVM/q+pA8=
+github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.177/go.mod h1:B7eV0Qh8Lop9QzIOQcsvKp3S0ejfC6mgyWoJnI917yQ=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=


### PR DESCRIPTION
## Motivation and Context

This pull request updates the version of a dependency in the `router/go.mod` file. The change upgrades `github.com/wundergraph/graphql-go-tools/v2` from version `v2.0.0-rc.176` to `v2.0.0-rc.177`.