### PR TITLE
feat: add support for deprecated arguments in introspection

### DIFF
--- a/router-tests/go.mod
+++ b/router-tests/go.mod
@@ -24,9 +24,9 @@ require (
 	github.com/tidwall/gjson v1.18.0
 	github.com/twmb/franz-go v1.16.1
 	github.com/twmb/franz-go/pkg/kadm v1.11.0
-	github.com/wundergraph/cosmo/demo v0.0.0-20250505160605-d86364b8f0db
-	github.com/wundergraph/cosmo/router v0.0.0-20250505160605-d86364b8f0db
-	github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.177
+	github.com/wundergraph/cosmo/demo v0.0.0-20250506154008-98e3b3080bb8
+	github.com/wundergraph/cosmo/router v0.0.0-20250506154008-98e3b3080bb8
+	github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.178
 	go.opentelemetry.io/otel v1.28.0
 	go.opentelemetry.io/otel/sdk v1.28.0
 	go.opentelemetry.io/otel/sdk/metric v1.28.0

--- a/router-tests/go.sum
+++ b/router-tests/go.sum
@@ -323,8 +323,8 @@ github.com/wundergraph/astjson v0.0.0-20250106123708-be463c97e083 h1:8/D7f8gKxTB
 github.com/wundergraph/astjson v0.0.0-20250106123708-be463c97e083/go.mod h1:eOTL6acwctsN4F3b7YE+eE2t8zcJ/doLm9sZzsxxxrE=
 github.com/wundergraph/consul/sdk v0.0.0-20250204115147-ed842a8fd301 h1:EzfKHQoTjFDDcgaECCCR2aTePqMu9QBmPbyhqIYOhV0=
 github.com/wundergraph/consul/sdk v0.0.0-20250204115147-ed842a8fd301/go.mod h1:wxI0Nak5dI5RvJuzGyiEK4nZj0O9X+Aw6U0tC1wPKq0=
-github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.177 h1:GyyD8yGgAm7iLN+Wwgre8DnxiBEm4OqHfMMVM/q+pA8=
-github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.177/go.mod h1:B7eV0Qh8Lop9QzIOQcsvKp3S0ejfC6mgyWoJnI917yQ=
+github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.178 h1:NeZwriuQKkowZbqWo2NKuZ19epBc34JgFS5cOfSzQEg=
+github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.178/go.mod h1:B7eV0Qh8Lop9QzIOQcsvKp3S0ejfC6mgyWoJnI917yQ=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb h1:zGWFAtiMcyryUHoUjUJX0/lt1H2+i2Ka2n+D3DImSNo=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=

--- a/router-tests/introspection_test.go
+++ b/router-tests/introspection_test.go
@@ -29,7 +29,7 @@ const introspectionQuery = `query IntrospectionQuery {
       name
       description
       locations
-      args {
+      args(includeDeprecated: true) {
         ...InputValue
       }
     }
@@ -43,7 +43,7 @@ fragment FullType on __Type {
   fields(includeDeprecated: true) {
     name
     description
-    args {
+    args(includeDeprecated: true) {
       ...InputValue
     }
     type {
@@ -52,7 +52,7 @@ fragment FullType on __Type {
     isDeprecated
     deprecationReason
   }
-  inputFields {
+  inputFields(includeDeprecated: true) {
     ...InputValue
   }
   interfaces {
@@ -76,6 +76,8 @@ fragment InputValue on __InputValue {
     ...TypeRef
   }
   defaultValue
+  isDeprecated
+  deprecationReason
 }
 
 fragment TypeRef on __Type {

--- a/router-tests/introspection_test.go
+++ b/router-tests/introspection_test.go
@@ -1,9 +1,12 @@
 package integration
 
 import (
+	"bytes"
+	"encoding/json"
 	"testing"
 
 	"github.com/sebdah/goldie/v2"
+	"github.com/stretchr/testify/require"
 
 	"github.com/wundergraph/cosmo/router-tests/testenv"
 )
@@ -125,7 +128,9 @@ func TestIntrospection(t *testing.T) {
 			res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
 				Query: introspectionQuery,
 			})
-			g.AssertJson(t, "base-graph-schema", res.Body)
+			body := bytes.NewBuffer(nil)
+			require.NoError(t, json.Indent(body, []byte(res.Body), "", "  "))
+			g.Assert(t, "base-graph-schema", body.Bytes())
 		})
 	})
 
@@ -139,7 +144,9 @@ func TestIntrospection(t *testing.T) {
 					"X-Feature-Flag": {"myff"},
 				},
 			})
-			g.AssertJson(t, "feature-graph-schema", res.Body)
+			body := bytes.NewBuffer(nil)
+			require.NoError(t, json.Indent(body, []byte(res.Body), "", "  "))
+			g.Assert(t, "feature-graph-schema", body.Bytes())
 		})
 	})
 

--- a/router-tests/testdata/introspection/base-graph-schema.json
+++ b/router-tests/testdata/introspection/base-graph-schema.json
@@ -1,1 +1,17178 @@
-"{\"data\":{\"__schema\":{\"queryType\":{\"name\":\"Query\"},\"mutationType\":{\"name\":\"Mutation\"},\"subscriptionType\":{\"name\":\"Subscription\"},\"types\":[{\"kind\":\"OBJECT\",\"name\":\"Query\",\"description\":\"\",\"fields\":[{\"name\":\"employee\",\"description\":\"\",\"args\":[{\"name\":\"id\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"defaultValue\":null}],\"type\":{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"employeeAsList\",\"description\":\"\",\"args\":[{\"name\":\"id\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"defaultValue\":null}],\"type\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"employees\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"products\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"UNION\",\"name\":\"Products\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"teammates\",\"description\":\"\",\"args\":[{\"name\":\"team\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"Department\",\"ofType\":null}},\"defaultValue\":null}],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"firstEmployee\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"findEmployees\",\"description\":\"This is a GraphQL query that retrieves a list of employees.\",\"args\":[{\"name\":\"criteria\",\"description\":\"\",\"type\":{\"kind\":\"INPUT_OBJECT\",\"name\":\"SearchInput\",\"ofType\":null},\"defaultValue\":null}],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"productTypes\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"UNION\",\"name\":\"Products\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"topSecretFederationFacts\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"INTERFACE\",\"name\":\"TopSecretFact\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"factTypes\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"TopSecretFactType\",\"ofType\":null}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sharedThings\",\"description\":\"\",\"args\":[{\"name\":\"numOfA\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"defaultValue\":null},{\"name\":\"numOfB\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"defaultValue\":null}],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Thing\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"headerValue\",\"description\":\"Returns the value of the received HTTP header.\",\"args\":[{\"name\":\"name\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"defaultValue\":null}],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"initPayloadValue\",\"description\":\"Returns the value of the given key in the WS initial payload.\",\"args\":[{\"name\":\"key\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"defaultValue\":null}],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"initialPayload\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"SCALAR\",\"name\":\"Map\",\"ofType\":null},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"delay\",\"description\":\"Returns response after the given delay\",\"args\":[{\"name\":\"response\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"defaultValue\":null},{\"name\":\"ms\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"defaultValue\":null}],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bigResponse\",\"description\":\"\",\"args\":[{\"name\":\"artificialDelay\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"defaultValue\":\"0\"},{\"name\":\"bigObjects\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"defaultValue\":\"100\"},{\"name\":\"nestedObjects\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"defaultValue\":\"100\"},{\"name\":\"deeplyNestedObjects\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"defaultValue\":\"100\"}],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"BigObject\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"longResponse\",\"description\":\"\",\"args\":[{\"name\":\"artificialDelay\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"defaultValue\":\"0\"},{\"name\":\"bytes\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"defaultValue\":null}],\"type\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bigAbstractResponse\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"UNION\",\"name\":\"BigAbstractResponse\",\"ofType\":null},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rootFieldWithListArg\",\"description\":\"\",\"args\":[{\"name\":\"arg\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}}}},\"defaultValue\":null}],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rootFieldWithNestedListArg\",\"description\":\"\",\"args\":[{\"name\":\"arg\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}}}}}},\"defaultValue\":null}],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}}}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rootFieldWithListOfInputArg\",\"description\":\"\",\"args\":[{\"name\":\"arg\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"INPUT_OBJECT\",\"name\":\"InputType\",\"ofType\":null}}}},\"defaultValue\":null}],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"InputResponse\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rootFieldWithListOfEnumArg\",\"description\":\"\",\"args\":[{\"name\":\"arg\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"EnumType\",\"ofType\":null}}}},\"defaultValue\":null}],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"EnumType\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rootFieldWithInput\",\"description\":\"\",\"args\":[{\"name\":\"arg\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"INPUT_OBJECT\",\"name\":\"InputArg\",\"ofType\":null}},\"defaultValue\":null}],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"floatField\",\"description\":\"\",\"args\":[{\"name\":\"arg\",\"description\":\"\",\"type\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null},\"defaultValue\":null}],\"type\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"secret\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"OBJECT\",\"name\":\"Secret\",\"ofType\":null},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"SCALAR\",\"name\":\"Upload\",\"description\":\"\",\"fields\":null,\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"Mutation\",\"description\":\"\",\"fields\":[{\"name\":\"updateEmployeeTag\",\"description\":\"\",\"args\":[{\"name\":\"id\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"defaultValue\":null},{\"name\":\"tag\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"defaultValue\":null}],\"type\":{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"singleUpload\",\"description\":\"\",\"args\":[{\"name\":\"file\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Upload\",\"ofType\":null}},\"defaultValue\":null}],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"singleUploadWithInput\",\"description\":\"\",\"args\":[{\"name\":\"arg\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"INPUT_OBJECT\",\"name\":\"FileUpload\",\"ofType\":null}},\"defaultValue\":null}],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"multipleUpload\",\"description\":\"\",\"args\":[{\"name\":\"files\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Upload\",\"ofType\":null}}}},\"defaultValue\":null}],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"addFact\",\"description\":\"\",\"args\":[{\"name\":\"fact\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"INPUT_OBJECT\",\"name\":\"TopSecretFactInput\",\"ofType\":null}},\"defaultValue\":null}],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"INTERFACE\",\"name\":\"TopSecretFact\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"updateAvailability\",\"description\":\"This mutation updates the availability status of an employee in the system.\",\"args\":[{\"name\":\"employeeID\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"defaultValue\":null},{\"name\":\"isAvailable\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"defaultValue\":null}],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"updateMood\",\"description\":\"This mutation update the mood of an employee.\",\"args\":[{\"name\":\"employeeID\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"defaultValue\":null},{\"name\":\"mood\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"Mood\",\"ofType\":null}},\"defaultValue\":null}],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"INPUT_OBJECT\",\"name\":\"FileUpload\",\"description\":\"\",\"fields\":null,\"inputFields\":[{\"name\":\"nested\",\"description\":\"\",\"type\":{\"kind\":\"INPUT_OBJECT\",\"name\":\"DeeplyNestedFileUpload\",\"ofType\":null},\"defaultValue\":null},{\"name\":\"nestedList\",\"description\":\"\",\"type\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Upload\",\"ofType\":null}}},\"defaultValue\":null}],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"INPUT_OBJECT\",\"name\":\"DeeplyNestedFileUpload\",\"description\":\"\",\"fields\":null,\"inputFields\":[{\"name\":\"file\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Upload\",\"ofType\":null}},\"defaultValue\":null}],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"Subscription\",\"description\":\"\",\"fields\":[{\"name\":\"currentTime\",\"description\":\"`currentTime` will return a stream of `Time` objects.\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Time\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"countEmp\",\"description\":\"\",\"args\":[{\"name\":\"max\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"defaultValue\":null},{\"name\":\"intervalMilliseconds\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"defaultValue\":null}],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"countEmp2\",\"description\":\"\",\"args\":[{\"name\":\"max\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"defaultValue\":null},{\"name\":\"intervalMilliseconds\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"defaultValue\":null}],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"countFor\",\"description\":\"\",\"args\":[{\"name\":\"count\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"defaultValue\":null}],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"countHob\",\"description\":\"\",\"args\":[{\"name\":\"max\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"defaultValue\":null},{\"name\":\"intervalMilliseconds\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"defaultValue\":null}],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"headerValue\",\"description\":\"Returns a stream with the value of the received HTTP header.\",\"args\":[{\"name\":\"name\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"defaultValue\":null},{\"name\":\"repeat\",\"description\":\"\",\"type\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null},\"defaultValue\":null}],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"TimestampedString\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"initPayloadValue\",\"description\":\"Returns a stream with the value of value of the given key in the WS initial payload.\",\"args\":[{\"name\":\"key\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"defaultValue\":null},{\"name\":\"repeat\",\"description\":\"\",\"type\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null},\"defaultValue\":null}],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"TimestampedString\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"initialPayload\",\"description\":\"Returns a stream with the value of the WS initial payload.\",\"args\":[{\"name\":\"repeat\",\"description\":\"\",\"type\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null},\"defaultValue\":null}],\"type\":{\"kind\":\"SCALAR\",\"name\":\"Map\",\"ofType\":null},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"returnsError\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"ENUM\",\"name\":\"Department\",\"description\":\"\",\"fields\":null,\"inputFields\":[],\"interfaces\":[],\"enumValues\":[{\"name\":\"ENGINEERING\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"MARKETING\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"OPERATIONS\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null}],\"possibleTypes\":[]},{\"kind\":\"INTERFACE\",\"name\":\"RoleType\",\"description\":\"\",\"fields\":[{\"name\":\"departments\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"Department\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"title\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"employees\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[{\"kind\":\"OBJECT\",\"name\":\"Engineer\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"Marketer\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"Operator\",\"ofType\":null}]},{\"kind\":\"ENUM\",\"name\":\"EngineerType\",\"description\":\"\",\"fields\":null,\"inputFields\":[],\"interfaces\":[],\"enumValues\":[{\"name\":\"BACKEND\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"FRONTEND\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"FULLSTACK\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null}],\"possibleTypes\":[]},{\"kind\":\"INTERFACE\",\"name\":\"Identifiable\",\"description\":\"\",\"fields\":[{\"name\":\"id\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null}]},{\"kind\":\"ENUM\",\"name\":\"OperationType\",\"description\":\"\",\"fields\":null,\"inputFields\":[],\"interfaces\":[],\"enumValues\":[{\"name\":\"FINANCE\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"HUMAN_RESOURCES\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null}],\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"Details\",\"description\":\"\",\"fields\":[{\"name\":\"forename\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"location\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Country\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"surname\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pastLocations\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"City\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"middlename\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null},\"isDeprecated\":true,\"deprecationReason\":\"No longer supported\"},{\"name\":\"hasChildren\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"maritalStatus\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"ENUM\",\"name\":\"MaritalStatus\",\"ofType\":null},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nationality\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"Nationality\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pets\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"INTERFACE\",\"name\":\"Pet\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"City\",\"description\":\"\",\"fields\":[{\"name\":\"type\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"name\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"country\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"OBJECT\",\"name\":\"Country\",\"ofType\":null},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"Country\",\"description\":\"\",\"fields\":[{\"name\":\"key\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"CountryKey\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"language\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"CountryKey\",\"description\":\"\",\"fields\":[{\"name\":\"name\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"ENUM\",\"name\":\"Mood\",\"description\":\"\",\"fields\":null,\"inputFields\":[],\"interfaces\":[],\"enumValues\":[{\"name\":\"HAPPY\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"SAD\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null}],\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"ErrorWrapper\",\"description\":\"\",\"fields\":[{\"name\":\"okField\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"errorField\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"Time\",\"description\":\"\",\"fields\":[{\"name\":\"unixTime\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"timeStamp\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"UNION\",\"name\":\"Products\",\"description\":\"\",\"fields\":null,\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[{\"kind\":\"OBJECT\",\"name\":\"Consultancy\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"Cosmo\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"SDK\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"Documentation\",\"ofType\":null}]},{\"kind\":\"INTERFACE\",\"name\":\"IProduct\",\"description\":\"\",\"fields\":[{\"name\":\"upc\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"ID\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"engineers\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[{\"kind\":\"OBJECT\",\"name\":\"Cosmo\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"SDK\",\"ofType\":null}]},{\"kind\":\"OBJECT\",\"name\":\"Consultancy\",\"description\":\"\",\"fields\":[{\"name\":\"upc\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"ID\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lead\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"isLeadAvailable\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"name\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"ProductName\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"ENUM\",\"name\":\"Class\",\"description\":\"\",\"fields\":null,\"inputFields\":[],\"interfaces\":[],\"enumValues\":[{\"name\":\"FISH\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"MAMMAL\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"REPTILE\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null}],\"possibleTypes\":[]},{\"kind\":\"ENUM\",\"name\":\"Gender\",\"description\":\"\",\"fields\":null,\"inputFields\":[],\"interfaces\":[],\"enumValues\":[{\"name\":\"FEMALE\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"MALE\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"UNKNOWN\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null}],\"possibleTypes\":[]},{\"kind\":\"INTERFACE\",\"name\":\"Animal\",\"description\":\"\",\"fields\":[{\"name\":\"class\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"Class\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gender\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"Gender\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[{\"kind\":\"OBJECT\",\"name\":\"Alligator\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"Cat\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"Dog\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"Mouse\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"Pony\",\"ofType\":null}]},{\"kind\":\"ENUM\",\"name\":\"CatType\",\"description\":\"\",\"fields\":null,\"inputFields\":[],\"interfaces\":[],\"enumValues\":[{\"name\":\"HOME\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"STREET\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null}],\"possibleTypes\":[]},{\"kind\":\"ENUM\",\"name\":\"DogBreed\",\"description\":\"\",\"fields\":null,\"inputFields\":[],\"interfaces\":[],\"enumValues\":[{\"name\":\"GOLDEN_RETRIEVER\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"POODLE\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"ROTTWEILER\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"YORKSHIRE_TERRIER\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null}],\"possibleTypes\":[]},{\"kind\":\"ENUM\",\"name\":\"MaritalStatus\",\"description\":\"\",\"fields\":null,\"inputFields\":[],\"interfaces\":[],\"enumValues\":[{\"name\":\"ENGAGED\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"MARRIED\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null}],\"possibleTypes\":[]},{\"kind\":\"ENUM\",\"name\":\"Nationality\",\"description\":\"\",\"fields\":null,\"inputFields\":[],\"interfaces\":[],\"enumValues\":[{\"name\":\"AMERICAN\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"DUTCH\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"ENGLISH\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"GERMAN\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"INDIAN\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"SPANISH\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"UKRAINIAN\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null}],\"possibleTypes\":[]},{\"kind\":\"INPUT_OBJECT\",\"name\":\"SearchInput\",\"description\":\"Allows to filter employees by their details.\",\"fields\":null,\"inputFields\":[{\"name\":\"hasPets\",\"description\":\"\",\"type\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null},\"defaultValue\":null},{\"name\":\"nationality\",\"description\":\"\",\"type\":{\"kind\":\"ENUM\",\"name\":\"Nationality\",\"ofType\":null},\"defaultValue\":null},{\"name\":\"nested\",\"description\":\"\",\"type\":{\"kind\":\"INPUT_OBJECT\",\"name\":\"NestedSearchInput\",\"ofType\":null},\"defaultValue\":null}],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"INPUT_OBJECT\",\"name\":\"NestedSearchInput\",\"description\":\"\",\"fields\":null,\"inputFields\":[{\"name\":\"maritalStatus\",\"description\":\"\",\"type\":{\"kind\":\"ENUM\",\"name\":\"MaritalStatus\",\"ofType\":null},\"defaultValue\":null},{\"name\":\"hasChildren\",\"description\":\"\",\"type\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null},\"defaultValue\":null}],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"ENUM\",\"name\":\"ExerciseType\",\"description\":\"\",\"fields\":null,\"inputFields\":[],\"interfaces\":[],\"enumValues\":[{\"name\":\"CALISTHENICS\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"HIKING\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"SPORT\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"STRENGTH_TRAINING\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null}],\"possibleTypes\":[]},{\"kind\":\"INTERFACE\",\"name\":\"Experience\",\"description\":\"\",\"fields\":[{\"name\":\"yearsOfExperience\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[{\"kind\":\"OBJECT\",\"name\":\"Flying\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"Gaming\",\"ofType\":null}]},{\"kind\":\"ENUM\",\"name\":\"GameGenre\",\"description\":\"\",\"fields\":null,\"inputFields\":[],\"interfaces\":[],\"enumValues\":[{\"name\":\"ADVENTURE\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"BOARD\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"FPS\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"CARD\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"RPG\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"ROGUELITE\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"SIMULATION\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"STRATEGY\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null}],\"possibleTypes\":[]},{\"kind\":\"ENUM\",\"name\":\"ProgrammingLanguage\",\"description\":\"\",\"fields\":null,\"inputFields\":[],\"interfaces\":[],\"enumValues\":[{\"name\":\"CSHARP\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"GO\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"RUST\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"TYPESCRIPT\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null}],\"possibleTypes\":[]},{\"kind\":\"INTERFACE\",\"name\":\"Hobby\",\"description\":\"\",\"fields\":[{\"name\":\"employees\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[{\"kind\":\"OBJECT\",\"name\":\"Exercise\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"Flying\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"Gaming\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"Other\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"Programming\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"Travelling\",\"ofType\":null}]},{\"kind\":\"OBJECT\",\"name\":\"Thing\",\"description\":\"\",\"fields\":[{\"name\":\"a\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"b\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"INPUT_OBJECT\",\"name\":\"TopSecretFactInput\",\"description\":\"\",\"fields\":null,\"inputFields\":[{\"name\":\"title\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"defaultValue\":null},{\"name\":\"description\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"FactContent\",\"ofType\":null}},\"defaultValue\":null},{\"name\":\"factType\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"TopSecretFactType\",\"ofType\":null}},\"defaultValue\":null}],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"ENUM\",\"name\":\"TopSecretFactType\",\"description\":\"\",\"fields\":null,\"inputFields\":[],\"interfaces\":[],\"enumValues\":[{\"name\":\"DIRECTIVE\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"ENTITY\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"MISCELLANEOUS\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null}],\"possibleTypes\":[]},{\"kind\":\"INTERFACE\",\"name\":\"TopSecretFact\",\"description\":\"\",\"fields\":[{\"name\":\"description\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"FactContent\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"factType\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"ENUM\",\"name\":\"TopSecretFactType\",\"ofType\":null},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[{\"kind\":\"OBJECT\",\"name\":\"DirectiveFact\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"EntityFact\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"MiscellaneousFact\",\"ofType\":null}]},{\"kind\":\"SCALAR\",\"name\":\"FactContent\",\"description\":\"\",\"fields\":null,\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"ENUM\",\"name\":\"ProductName\",\"description\":\"\",\"fields\":null,\"inputFields\":[],\"interfaces\":[],\"enumValues\":[{\"name\":\"CONSULTANCY\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"COSMO\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"ENGINE\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"FINANCE\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"HUMAN_RESOURCES\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"MARKETING\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"SDK\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null}],\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"Documentation\",\"description\":\"\",\"fields\":[{\"name\":\"url\",\"description\":\"\",\"args\":[{\"name\":\"product\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"ProductName\",\"ofType\":null}},\"defaultValue\":null}],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"urls\",\"description\":\"\",\"args\":[{\"name\":\"products\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"ProductName\",\"ofType\":null}}}},\"defaultValue\":null}],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"Secret\",\"description\":\"\",\"fields\":[{\"name\":\"value\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"INPUT_OBJECT\",\"name\":\"InputArg\",\"description\":\"\",\"fields\":null,\"inputFields\":[{\"name\":\"enums\",\"description\":\"\",\"type\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"EnumType\",\"ofType\":null}}},\"defaultValue\":null},{\"name\":\"enum\",\"description\":\"\",\"type\":{\"kind\":\"ENUM\",\"name\":\"EnumType\",\"ofType\":null},\"defaultValue\":null},{\"name\":\"string\",\"description\":\"\",\"type\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null},\"defaultValue\":null},{\"name\":\"strings\",\"description\":\"\",\"type\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}}},\"defaultValue\":null}],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"ENUM\",\"name\":\"EnumType\",\"description\":\"\",\"fields\":null,\"inputFields\":[],\"interfaces\":[],\"enumValues\":[{\"name\":\"A\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"B\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"C\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null}],\"possibleTypes\":[]},{\"kind\":\"INPUT_OBJECT\",\"name\":\"InputType\",\"description\":\"\",\"fields\":null,\"inputFields\":[{\"name\":\"arg\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"defaultValue\":null}],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"InputResponse\",\"description\":\"\",\"fields\":[{\"name\":\"arg\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"SCALAR\",\"name\":\"Map\",\"description\":\"\",\"fields\":null,\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"TimestampedString\",\"description\":\"\",\"fields\":[{\"name\":\"value\",\"description\":\"The value of the string.\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"unixTime\",\"description\":\"The timestamp when the response was generated.\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"seq\",\"description\":\"Sequence number\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"total\",\"description\":\"Total number of responses to be sent\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"initialPayload\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"SCALAR\",\"name\":\"Map\",\"ofType\":null},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"BigObject\",\"description\":\"\",\"fields\":[{\"name\":\"nestedObjects\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"NestedObject\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"NestedObject\",\"description\":\"\",\"fields\":[{\"name\":\"deeplyNestedObjects\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"DeeplyNestedObject\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"DeeplyNestedObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnDeeplyNestedObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnDeeplyNestedObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnDeeplyNestedObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnDeeplyNestedObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnDeeplyNestedObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnDeeplyNestedObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnDeeplyNestedObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnDeeplyNestedObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnDeeplyNestedObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnDeeplyNestedObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnDeeplyNestedObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnDeeplyNestedObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnDeeplyNestedObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnDeeplyNestedObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnDeeplyNestedObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnDeeplyNestedObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnDeeplyNestedObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnDeeplyNestedObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnDeeplyNestedObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnDeeplyNestedObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnDeeplyNestedObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnDeeplyNestedObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnDeeplyNestedObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnDeeplyNestedObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnDeeplyNestedObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnDeeplyNestedObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"UNION\",\"name\":\"BigAbstractResponse\",\"description\":\"\",\"fields\":null,\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[{\"kind\":\"OBJECT\",\"name\":\"ABigObject\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"BBigObject\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"CBigObject\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"DBigObject\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"EBigObject\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"FBigObject\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"GBigObject\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"HBigObject\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"IBigObject\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"JBigObject\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"KBigObject\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"LBigObject\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"MBigObject\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"NBigObject\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"OBigObject\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"PBigObject\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"QBigObject\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"RBigObject\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"SBigObject\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"TBigObject\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"UBigObject\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"VBigObject\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"WBigObject\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"XBigObject\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"YBigObject\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"ZBigObject\",\"ofType\":null}]},{\"kind\":\"OBJECT\",\"name\":\"ABigObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnABigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnABigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnABigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnABigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnABigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnABigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnABigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnABigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnABigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnABigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnABigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnABigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnABigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnABigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnABigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnABigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnABigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnABigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnABigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnABigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnABigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnABigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnABigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnABigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnABigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnABigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"BBigObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnBBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnBBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnBBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnBBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnBBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnBBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnBBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnBBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnBBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnBBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnBBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnBBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnBBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnBBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnBBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnBBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnBBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnBBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnBBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnBBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnBBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnBBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnBBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnBBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnBBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnBBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"CBigObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnCBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnCBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnCBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnCBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnCBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnCBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnCBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnCBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnCBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnCBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnCBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnCBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnCBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnCBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnCBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnCBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnCBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnCBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnCBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnCBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnCBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnCBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnCBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnCBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnCBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnCBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"DBigObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnDBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnDBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnDBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnDBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnDBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnDBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnDBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnDBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnDBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnDBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnDBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnDBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnDBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnDBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnDBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnDBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnDBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnDBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnDBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnDBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnDBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnDBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnDBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnDBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnDBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnDBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"EBigObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnEBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnEBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnEBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnEBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnEBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnEBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnEBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnEBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnEBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnEBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnEBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnEBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnEBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnEBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnEBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnEBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnEBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnEBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnEBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnEBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnEBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnEBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnEBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnEBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnEBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnEBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"FBigObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnFBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnFBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnFBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnFBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnFBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnFBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnFBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnFBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnFBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnFBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnFBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnFBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnFBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnFBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnFBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnFBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnFBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnFBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnFBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnFBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnFBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnFBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnFBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnFBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnFBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnFBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"GBigObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnGBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnGBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnGBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnGBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnGBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnGBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnGBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnGBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnGBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnGBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnGBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnGBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnGBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnGBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnGBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnGBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnGBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnGBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnGBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnGBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnGBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnGBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnGBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnGBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnGBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnGBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"HBigObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnHBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnHBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnHBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnHBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnHBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnHBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnHBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnHBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnHBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnHBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnHBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnHBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnHBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnHBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnHBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnHBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnHBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnHBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnHBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnHBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnHBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnHBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnHBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnHBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnHBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnHBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"IBigObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnIBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnIBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnIBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnIBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnIBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnIBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnIBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnIBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnIBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnIBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnIBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnIBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnIBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnIBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnIBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnIBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnIBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnIBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnIBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnIBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnIBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnIBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnIBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnIBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnIBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnIBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"JBigObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnJBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnJBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnJBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnJBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnJBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnJBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnJBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnJBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnJBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnJBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnJBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnJBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnJBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnJBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnJBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnJBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnJBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnJBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnJBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnJBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnJBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnJBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnJBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnJBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnJBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnJBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"KBigObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnKBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnKBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnKBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnKBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnKBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnKBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnKBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnKBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnKBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnKBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnKBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnKBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnKBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnKBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnKBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnKBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnKBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnKBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnKBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnKBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnKBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnKBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnKBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnKBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnKBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnKBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"LBigObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnLBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnLBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnLBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnLBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnLBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnLBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnLBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnLBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnLBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnLBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnLBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnLBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnLBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnLBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnLBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnLBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnLBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnLBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnLBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnLBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnLBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnLBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnLBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnLBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnLBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnLBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"MBigObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnMBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnMBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnMBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnMBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnMBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnMBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnMBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnMBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnMBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnMBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnMBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnMBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnMBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnMBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnMBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnMBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnMBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnMBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnMBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnMBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnMBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnMBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnMBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnMBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnMBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnMBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"NBigObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnNBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnNBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnNBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnNBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnNBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnNBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnNBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnNBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnNBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnNBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnNBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnNBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnNBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnNBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnNBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnNBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnNBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnNBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnNBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnNBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnNBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnNBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnNBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnNBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnNBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnNBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"OBigObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnOBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnOBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnOBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnOBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnOBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnOBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnOBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnOBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnOBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnOBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnOBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnOBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnOBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnOBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnOBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnOBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnOBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnOBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnOBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnOBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnOBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnOBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnOBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnOBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnOBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnOBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"PBigObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnPBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnPBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnPBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnPBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnPBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnPBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnPBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnPBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnPBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnPBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnPBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnPBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnPBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnPBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnPBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnPBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnPBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnPBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnPBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnPBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnPBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnPBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnPBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnPBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnPBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnPBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"QBigObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnQBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnQBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnQBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnQBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnQBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnQBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnQBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnQBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnQBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnQBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnQBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnQBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnQBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnQBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnQBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnQBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnQBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnQBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnQBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnQBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnQBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnQBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnQBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnQBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnQBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnQBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"RBigObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnRBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnRBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnRBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnRBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnRBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnRBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnRBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnRBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnRBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnRBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnRBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnRBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnRBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnRBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnRBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnRBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnRBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnRBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnRBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnRBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnRBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnRBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnRBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnRBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnRBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnRBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"SBigObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnSBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnSBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnSBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnSBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnSBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnSBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnSBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnSBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnSBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnSBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnSBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnSBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnSBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnSBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnSBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnSBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnSBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnSBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnSBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnSBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnSBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnSBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnSBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnSBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnSBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnSBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"TBigObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnTBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnTBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnTBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnTBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnTBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnTBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnTBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnTBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnTBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnTBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnTBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnTBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnTBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnTBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnTBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnTBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnTBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnTBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnTBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnTBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnTBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnTBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnTBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnTBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnTBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnTBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"UBigObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnUBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnUBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnUBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnUBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnUBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnUBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnUBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnUBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnUBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnUBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnUBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnUBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnUBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnUBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnUBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnUBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnUBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnUBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnUBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnUBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnUBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnUBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnUBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnUBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnUBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnUBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"VBigObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnVBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnVBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnVBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnVBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnVBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnVBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnVBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnVBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnVBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnVBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnVBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnVBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnVBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnVBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnVBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnVBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnVBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnVBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnVBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnVBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnVBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnVBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnVBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnVBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnVBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnVBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"WBigObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnWBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnWBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnWBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnWBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnWBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnWBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnWBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnWBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnWBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnWBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnWBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnWBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnWBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnWBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnWBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnWBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnWBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnWBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnWBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnWBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnWBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnWBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnWBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnWBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnWBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnWBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"XBigObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnXBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnXBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnXBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnXBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnXBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnXBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnXBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnXBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnXBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnXBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnXBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnXBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnXBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnXBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnXBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnXBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnXBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnXBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnXBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnXBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnXBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnXBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnXBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnXBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnXBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnXBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"YBigObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnYBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnYBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnYBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnYBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnYBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnYBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnYBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnYBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnYBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnYBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnYBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnYBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnYBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnYBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnYBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnYBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnYBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnYBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnYBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnYBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnYBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnYBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnYBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnYBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnYBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnYBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"ZBigObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnZBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnZBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnZBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnZBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnZBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnZBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnZBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnZBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnZBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnZBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnZBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnZBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnZBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnZBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnZBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnZBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnZBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnZBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnZBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnZBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnZBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnZBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnZBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnZBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnZBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnZBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"Engineer\",\"description\":\"\",\"fields\":[{\"name\":\"departments\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"Department\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"title\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"employees\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"engineerType\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"EngineerType\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[{\"kind\":\"INTERFACE\",\"name\":\"RoleType\",\"ofType\":null}],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"Marketer\",\"description\":\"\",\"fields\":[{\"name\":\"departments\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"Department\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"title\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"employees\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[{\"kind\":\"INTERFACE\",\"name\":\"RoleType\",\"ofType\":null}],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"Operator\",\"description\":\"\",\"fields\":[{\"name\":\"departments\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"Department\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"title\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"employees\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"operatorType\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"OperationType\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[{\"kind\":\"INTERFACE\",\"name\":\"RoleType\",\"ofType\":null}],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"description\":\"\",\"fields\":[{\"name\":\"details\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"OBJECT\",\"name\":\"Details\",\"ofType\":null},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"id\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tag\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"role\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"INTERFACE\",\"name\":\"RoleType\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"notes\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"updatedAt\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"startDate\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"currentMood\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"Mood\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"derivedMood\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"Mood\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"isAvailable\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rootFieldThrowsError\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rootFieldErrorWrapper\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"OBJECT\",\"name\":\"ErrorWrapper\",\"ofType\":null},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hobbies\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"INTERFACE\",\"name\":\"Hobby\",\"ofType\":null}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"products\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"ProductName\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fieldThrowsError\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[{\"kind\":\"INTERFACE\",\"name\":\"Identifiable\",\"ofType\":null}],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"Cosmo\",\"description\":\"\",\"fields\":[{\"name\":\"upc\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"ID\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"engineers\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lead\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"name\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"ProductName\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"repositoryURL\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[{\"kind\":\"INTERFACE\",\"name\":\"IProduct\",\"ofType\":null}],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"SDK\",\"description\":\"\",\"fields\":[{\"name\":\"upc\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"ID\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"engineers\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"owner\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"unicode\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"clientLanguages\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"ProgrammingLanguage\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[{\"kind\":\"INTERFACE\",\"name\":\"IProduct\",\"ofType\":null}],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"INTERFACE\",\"name\":\"Pet\",\"description\":\"\",\"fields\":[{\"name\":\"class\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"Class\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gender\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"Gender\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"name\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[{\"kind\":\"INTERFACE\",\"name\":\"Animal\",\"ofType\":null}],\"enumValues\":null,\"possibleTypes\":[{\"kind\":\"OBJECT\",\"name\":\"Alligator\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"Cat\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"Dog\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"Mouse\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"Pony\",\"ofType\":null}]},{\"kind\":\"OBJECT\",\"name\":\"Alligator\",\"description\":\"\",\"fields\":[{\"name\":\"class\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"Class\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dangerous\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gender\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"Gender\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"name\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[{\"kind\":\"INTERFACE\",\"name\":\"Pet\",\"ofType\":null},{\"kind\":\"INTERFACE\",\"name\":\"Animal\",\"ofType\":null}],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"Cat\",\"description\":\"\",\"fields\":[{\"name\":\"class\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"Class\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gender\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"Gender\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"name\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"type\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"CatType\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[{\"kind\":\"INTERFACE\",\"name\":\"Pet\",\"ofType\":null},{\"kind\":\"INTERFACE\",\"name\":\"Animal\",\"ofType\":null}],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"Dog\",\"description\":\"\",\"fields\":[{\"name\":\"breed\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"DogBreed\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"class\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"Class\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gender\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"Gender\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"name\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[{\"kind\":\"INTERFACE\",\"name\":\"Pet\",\"ofType\":null},{\"kind\":\"INTERFACE\",\"name\":\"Animal\",\"ofType\":null}],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"Mouse\",\"description\":\"\",\"fields\":[{\"name\":\"class\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"Class\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gender\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"Gender\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"name\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[{\"kind\":\"INTERFACE\",\"name\":\"Pet\",\"ofType\":null},{\"kind\":\"INTERFACE\",\"name\":\"Animal\",\"ofType\":null}],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"Pony\",\"description\":\"\",\"fields\":[{\"name\":\"class\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"Class\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gender\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"Gender\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"name\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[{\"kind\":\"INTERFACE\",\"name\":\"Pet\",\"ofType\":null},{\"kind\":\"INTERFACE\",\"name\":\"Animal\",\"ofType\":null}],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"Exercise\",\"description\":\"\",\"fields\":[{\"name\":\"employees\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"category\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"ExerciseType\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[{\"kind\":\"INTERFACE\",\"name\":\"Hobby\",\"ofType\":null}],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"Flying\",\"description\":\"\",\"fields\":[{\"name\":\"employees\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"planeModels\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yearsOfExperience\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[{\"kind\":\"INTERFACE\",\"name\":\"Experience\",\"ofType\":null},{\"kind\":\"INTERFACE\",\"name\":\"Hobby\",\"ofType\":null}],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"Gaming\",\"description\":\"\",\"fields\":[{\"name\":\"employees\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"genres\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"GameGenre\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"name\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yearsOfExperience\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[{\"kind\":\"INTERFACE\",\"name\":\"Experience\",\"ofType\":null},{\"kind\":\"INTERFACE\",\"name\":\"Hobby\",\"ofType\":null}],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"Other\",\"description\":\"\",\"fields\":[{\"name\":\"employees\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"name\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[{\"kind\":\"INTERFACE\",\"name\":\"Hobby\",\"ofType\":null}],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"Programming\",\"description\":\"\",\"fields\":[{\"name\":\"employees\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"languages\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"ProgrammingLanguage\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[{\"kind\":\"INTERFACE\",\"name\":\"Hobby\",\"ofType\":null}],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"Travelling\",\"description\":\"\",\"fields\":[{\"name\":\"employees\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"countriesLived\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Country\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[{\"kind\":\"INTERFACE\",\"name\":\"Hobby\",\"ofType\":null}],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"DirectiveFact\",\"description\":\"\",\"fields\":[{\"name\":\"title\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"description\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"FactContent\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"factType\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"ENUM\",\"name\":\"TopSecretFactType\",\"ofType\":null},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[{\"kind\":\"INTERFACE\",\"name\":\"TopSecretFact\",\"ofType\":null}],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"EntityFact\",\"description\":\"\",\"fields\":[{\"name\":\"title\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"description\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"FactContent\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"factType\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"ENUM\",\"name\":\"TopSecretFactType\",\"ofType\":null},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[{\"kind\":\"INTERFACE\",\"name\":\"TopSecretFact\",\"ofType\":null}],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"MiscellaneousFact\",\"description\":\"\",\"fields\":[{\"name\":\"title\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"description\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"FactContent\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"factType\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"ENUM\",\"name\":\"TopSecretFactType\",\"ofType\":null},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[{\"kind\":\"INTERFACE\",\"name\":\"TopSecretFact\",\"ofType\":null}],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"SCALAR\",\"name\":\"Int\",\"description\":\"The 'Int' scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.\",\"fields\":null,\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"SCALAR\",\"name\":\"Float\",\"description\":\"The 'Float' scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).\",\"fields\":null,\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"SCALAR\",\"name\":\"String\",\"description\":\"The 'String' scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.\",\"fields\":null,\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"description\":\"The 'Boolean' scalar type represents 'true' or 'false' .\",\"fields\":null,\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"SCALAR\",\"name\":\"ID\",\"description\":\"The 'ID' scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as '4') or integer (such as 4) input value will be accepted as an ID.\",\"fields\":null,\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]}],\"directives\":[{\"name\":\"include\",\"description\":\"Directs the executor to include this field or fragment only when the argument is true.\",\"locations\":[\"FIELD\",\"FRAGMENT_SPREAD\",\"INLINE_FRAGMENT\"],\"args\":[{\"name\":\"if\",\"description\":\"Included when true.\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"defaultValue\":null}]},{\"name\":\"skip\",\"description\":\"Directs the executor to skip this field or fragment when the argument is true.\",\"locations\":[\"FIELD\",\"FRAGMENT_SPREAD\",\"INLINE_FRAGMENT\"],\"args\":[{\"name\":\"if\",\"description\":\"Skipped when true.\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"defaultValue\":null}]},{\"name\":\"deprecated\",\"description\":\"Marks an element of a GraphQL schema as no longer supported.\",\"locations\":[\"FIELD_DEFINITION\",\"ENUM_VALUE\"],\"args\":[{\"name\":\"reason\",\"description\":\"Explains why this element was deprecated, usually also including a suggestion\\n    for how to access supported similar data. Formatted in\\n    [Markdown](https://daringfireball.net/projects/markdown/).\",\"type\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null},\"defaultValue\":\"\\\"No longer supported\\\"\"}]}]}}}"
+{
+  "data": {
+    "__schema": {
+      "queryType": {
+        "name": "Query"
+      },
+      "mutationType": {
+        "name": "Mutation"
+      },
+      "subscriptionType": {
+        "name": "Subscription"
+      },
+      "types": [
+        {
+          "kind": "OBJECT",
+          "name": "Query",
+          "description": "",
+          "fields": [
+            {
+              "name": "employee",
+              "description": "",
+              "args": [
+                {
+                  "name": "id",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Employee",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "employeeAsList",
+              "description": "",
+              "args": [
+                {
+                  "name": "id",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Employee",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "employees",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Employee",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "products",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "UNION",
+                      "name": "Products",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "teammates",
+              "description": "",
+              "args": [
+                {
+                  "name": "team",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "Department",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Employee",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "firstEmployee",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Employee",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "findEmployees",
+              "description": "This is a GraphQL query that retrieves a list of employees.",
+              "args": [
+                {
+                  "name": "criteria",
+                  "description": "",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "SearchInput",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Employee",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "productTypes",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "UNION",
+                      "name": "Products",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "topSecretFederationFacts",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INTERFACE",
+                      "name": "TopSecretFact",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "factTypes",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "TopSecretFactType",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sharedThings",
+              "description": "",
+              "args": [
+                {
+                  "name": "numOfA",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "numOfB",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Thing",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "headerValue",
+              "description": "Returns the value of the received HTTP header.",
+              "args": [
+                {
+                  "name": "name",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "initPayloadValue",
+              "description": "Returns the value of the given key in the WS initial payload.",
+              "args": [
+                {
+                  "name": "key",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "initialPayload",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Map",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "delay",
+              "description": "Returns response after the given delay",
+              "args": [
+                {
+                  "name": "response",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "ms",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bigResponse",
+              "description": "",
+              "args": [
+                {
+                  "name": "artificialDelay",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": "0"
+                },
+                {
+                  "name": "bigObjects",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": "100"
+                },
+                {
+                  "name": "nestedObjects",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": "100"
+                },
+                {
+                  "name": "deeplyNestedObjects",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": "100"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "BigObject",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "longResponse",
+              "description": "",
+              "args": [
+                {
+                  "name": "artificialDelay",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": "0"
+                },
+                {
+                  "name": "bytes",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bigAbstractResponse",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "UNION",
+                "name": "BigAbstractResponse",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rootFieldWithListArg",
+              "description": "",
+              "args": [
+                {
+                  "name": "arg",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "LIST",
+                      "name": null,
+                      "ofType": {
+                        "kind": "NON_NULL",
+                        "name": null,
+                        "ofType": {
+                          "kind": "SCALAR",
+                          "name": "String",
+                          "ofType": null
+                        }
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rootFieldWithNestedListArg",
+              "description": "",
+              "args": [
+                {
+                  "name": "arg",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "LIST",
+                      "name": null,
+                      "ofType": {
+                        "kind": "NON_NULL",
+                        "name": null,
+                        "ofType": {
+                          "kind": "LIST",
+                          "name": null,
+                          "ofType": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                              "kind": "SCALAR",
+                              "name": "String",
+                              "ofType": null
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "LIST",
+                      "name": null,
+                      "ofType": {
+                        "kind": "NON_NULL",
+                        "name": null,
+                        "ofType": {
+                          "kind": "SCALAR",
+                          "name": "String",
+                          "ofType": null
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rootFieldWithListOfInputArg",
+              "description": "",
+              "args": [
+                {
+                  "name": "arg",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "LIST",
+                      "name": null,
+                      "ofType": {
+                        "kind": "NON_NULL",
+                        "name": null,
+                        "ofType": {
+                          "kind": "INPUT_OBJECT",
+                          "name": "InputType",
+                          "ofType": null
+                        }
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "InputResponse",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rootFieldWithListOfEnumArg",
+              "description": "",
+              "args": [
+                {
+                  "name": "arg",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "LIST",
+                      "name": null,
+                      "ofType": {
+                        "kind": "NON_NULL",
+                        "name": null,
+                        "ofType": {
+                          "kind": "ENUM",
+                          "name": "EnumType",
+                          "ofType": null
+                        }
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "EnumType",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rootFieldWithInput",
+              "description": "",
+              "args": [
+                {
+                  "name": "arg",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "InputArg",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "floatField",
+              "description": "",
+              "args": [
+                {
+                  "name": "arg",
+                  "description": "",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Float",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "secret",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Secret",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Upload",
+          "description": "",
+          "fields": null,
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Mutation",
+          "description": "",
+          "fields": [
+            {
+              "name": "updateEmployeeTag",
+              "description": "",
+              "args": [
+                {
+                  "name": "id",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "tag",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Employee",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "singleUpload",
+              "description": "",
+              "args": [
+                {
+                  "name": "file",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Upload",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "singleUploadWithInput",
+              "description": "",
+              "args": [
+                {
+                  "name": "arg",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "FileUpload",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "multipleUpload",
+              "description": "",
+              "args": [
+                {
+                  "name": "files",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "LIST",
+                      "name": null,
+                      "ofType": {
+                        "kind": "NON_NULL",
+                        "name": null,
+                        "ofType": {
+                          "kind": "SCALAR",
+                          "name": "Upload",
+                          "ofType": null
+                        }
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "addFact",
+              "description": "",
+              "args": [
+                {
+                  "name": "fact",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "TopSecretFactInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INTERFACE",
+                  "name": "TopSecretFact",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updateAvailability",
+              "description": "This mutation updates the availability status of an employee in the system.",
+              "args": [
+                {
+                  "name": "employeeID",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "isAvailable",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Boolean",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Employee",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updateMood",
+              "description": "This mutation update the mood of an employee.",
+              "args": [
+                {
+                  "name": "employeeID",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "mood",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "Mood",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Employee",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "FileUpload",
+          "description": "",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "nested",
+              "description": "",
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "DeeplyNestedFileUpload",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "nestedList",
+              "description": "",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Upload",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "DeeplyNestedFileUpload",
+          "description": "",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "file",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Upload",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Subscription",
+          "description": "",
+          "fields": [
+            {
+              "name": "currentTime",
+              "description": "`currentTime` will return a stream of `Time` objects.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Time",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "countEmp",
+              "description": "",
+              "args": [
+                {
+                  "name": "max",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "intervalMilliseconds",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "countEmp2",
+              "description": "",
+              "args": [
+                {
+                  "name": "max",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "intervalMilliseconds",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "countFor",
+              "description": "",
+              "args": [
+                {
+                  "name": "count",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "countHob",
+              "description": "",
+              "args": [
+                {
+                  "name": "max",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "intervalMilliseconds",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "headerValue",
+              "description": "Returns a stream with the value of the received HTTP header.",
+              "args": [
+                {
+                  "name": "name",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "repeat",
+                  "description": "",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "TimestampedString",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "initPayloadValue",
+              "description": "Returns a stream with the value of value of the given key in the WS initial payload.",
+              "args": [
+                {
+                  "name": "key",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "repeat",
+                  "description": "",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "TimestampedString",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "initialPayload",
+              "description": "Returns a stream with the value of the WS initial payload.",
+              "args": [
+                {
+                  "name": "repeat",
+                  "description": "",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Map",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "returnsError",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "ENUM",
+          "name": "Department",
+          "description": "",
+          "fields": null,
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": [
+            {
+              "name": "ENGINEERING",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MARKETING",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "OPERATIONS",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": []
+        },
+        {
+          "kind": "INTERFACE",
+          "name": "RoleType",
+          "description": "",
+          "fields": [
+            {
+              "name": "departments",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "Department",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "title",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "employees",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Employee",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "Engineer",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Marketer",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Operator",
+              "ofType": null
+            }
+          ]
+        },
+        {
+          "kind": "ENUM",
+          "name": "EngineerType",
+          "description": "",
+          "fields": null,
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": [
+            {
+              "name": "BACKEND",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FRONTEND",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FULLSTACK",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": []
+        },
+        {
+          "kind": "INTERFACE",
+          "name": "Identifiable",
+          "description": "",
+          "fields": [
+            {
+              "name": "id",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "Employee",
+              "ofType": null
+            }
+          ]
+        },
+        {
+          "kind": "ENUM",
+          "name": "OperationType",
+          "description": "",
+          "fields": null,
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": [
+            {
+              "name": "FINANCE",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "HUMAN_RESOURCES",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Details",
+          "description": "",
+          "fields": [
+            {
+              "name": "forename",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "location",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Country",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "surname",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pastLocations",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "City",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "middlename",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": true,
+              "deprecationReason": "No longer supported"
+            },
+            {
+              "name": "hasChildren",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "maritalStatus",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "ENUM",
+                "name": "MaritalStatus",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nationality",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "Nationality",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pets",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "INTERFACE",
+                  "name": "Pet",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "City",
+          "description": "",
+          "fields": [
+            {
+              "name": "type",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "country",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Country",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Country",
+          "description": "",
+          "fields": [
+            {
+              "name": "key",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CountryKey",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "language",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "CountryKey",
+          "description": "",
+          "fields": [
+            {
+              "name": "name",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "ENUM",
+          "name": "Mood",
+          "description": "",
+          "fields": null,
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": [
+            {
+              "name": "HAPPY",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SAD",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ErrorWrapper",
+          "description": "",
+          "fields": [
+            {
+              "name": "okField",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "errorField",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Time",
+          "description": "",
+          "fields": [
+            {
+              "name": "unixTime",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "timeStamp",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "UNION",
+          "name": "Products",
+          "description": "",
+          "fields": null,
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "Consultancy",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Cosmo",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "SDK",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Documentation",
+              "ofType": null
+            }
+          ]
+        },
+        {
+          "kind": "INTERFACE",
+          "name": "IProduct",
+          "description": "",
+          "fields": [
+            {
+              "name": "upc",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "engineers",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Employee",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "Cosmo",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "SDK",
+              "ofType": null
+            }
+          ]
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Consultancy",
+          "description": "",
+          "fields": [
+            {
+              "name": "upc",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lead",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Employee",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isLeadAvailable",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "ProductName",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "ENUM",
+          "name": "Class",
+          "description": "",
+          "fields": null,
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": [
+            {
+              "name": "FISH",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MAMMAL",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "REPTILE",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": []
+        },
+        {
+          "kind": "ENUM",
+          "name": "Gender",
+          "description": "",
+          "fields": null,
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": [
+            {
+              "name": "FEMALE",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MALE",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "UNKNOWN",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": []
+        },
+        {
+          "kind": "INTERFACE",
+          "name": "Animal",
+          "description": "",
+          "fields": [
+            {
+              "name": "class",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "Class",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gender",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "Gender",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "Alligator",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Cat",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Dog",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Mouse",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Pony",
+              "ofType": null
+            }
+          ]
+        },
+        {
+          "kind": "ENUM",
+          "name": "CatType",
+          "description": "",
+          "fields": null,
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": [
+            {
+              "name": "HOME",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "STREET",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": []
+        },
+        {
+          "kind": "ENUM",
+          "name": "DogBreed",
+          "description": "",
+          "fields": null,
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": [
+            {
+              "name": "GOLDEN_RETRIEVER",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "POODLE",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ROTTWEILER",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "YORKSHIRE_TERRIER",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": []
+        },
+        {
+          "kind": "ENUM",
+          "name": "MaritalStatus",
+          "description": "",
+          "fields": null,
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": [
+            {
+              "name": "ENGAGED",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MARRIED",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": []
+        },
+        {
+          "kind": "ENUM",
+          "name": "Nationality",
+          "description": "",
+          "fields": null,
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": [
+            {
+              "name": "AMERICAN",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "DUTCH",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ENGLISH",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "GERMAN",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INDIAN",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SPANISH",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "UKRAINIAN",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": []
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "SearchInput",
+          "description": "Allows to filter employees by their details.",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "hasPets",
+              "description": "",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "nationality",
+              "description": "",
+              "type": {
+                "kind": "ENUM",
+                "name": "Nationality",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "nested",
+              "description": "",
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "NestedSearchInput",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "NestedSearchInput",
+          "description": "",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "maritalStatus",
+              "description": "",
+              "type": {
+                "kind": "ENUM",
+                "name": "MaritalStatus",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "hasChildren",
+              "description": "",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "ENUM",
+          "name": "ExerciseType",
+          "description": "",
+          "fields": null,
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": [
+            {
+              "name": "CALISTHENICS",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "HIKING",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SPORT",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "STRENGTH_TRAINING",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": []
+        },
+        {
+          "kind": "INTERFACE",
+          "name": "Experience",
+          "description": "",
+          "fields": [
+            {
+              "name": "yearsOfExperience",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "Flying",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Gaming",
+              "ofType": null
+            }
+          ]
+        },
+        {
+          "kind": "ENUM",
+          "name": "GameGenre",
+          "description": "",
+          "fields": null,
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": [
+            {
+              "name": "ADVENTURE",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "BOARD",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FPS",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CARD",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "RPG",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ROGUELITE",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SIMULATION",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "STRATEGY",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": []
+        },
+        {
+          "kind": "ENUM",
+          "name": "ProgrammingLanguage",
+          "description": "",
+          "fields": null,
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": [
+            {
+              "name": "CSHARP",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "GO",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "RUST",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TYPESCRIPT",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": []
+        },
+        {
+          "kind": "INTERFACE",
+          "name": "Hobby",
+          "description": "",
+          "fields": [
+            {
+              "name": "employees",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Employee",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "Exercise",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Flying",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Gaming",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Other",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Programming",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Travelling",
+              "ofType": null
+            }
+          ]
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Thing",
+          "description": "",
+          "fields": [
+            {
+              "name": "a",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "b",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "TopSecretFactInput",
+          "description": "",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "title",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "description",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "FactContent",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "factType",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "TopSecretFactType",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "ENUM",
+          "name": "TopSecretFactType",
+          "description": "",
+          "fields": null,
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": [
+            {
+              "name": "DIRECTIVE",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ENTITY",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MISCELLANEOUS",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": []
+        },
+        {
+          "kind": "INTERFACE",
+          "name": "TopSecretFact",
+          "description": "",
+          "fields": [
+            {
+              "name": "description",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "FactContent",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "factType",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "ENUM",
+                "name": "TopSecretFactType",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "DirectiveFact",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "EntityFact",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "MiscellaneousFact",
+              "ofType": null
+            }
+          ]
+        },
+        {
+          "kind": "SCALAR",
+          "name": "FactContent",
+          "description": "",
+          "fields": null,
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "ENUM",
+          "name": "ProductName",
+          "description": "",
+          "fields": null,
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": [
+            {
+              "name": "CONSULTANCY",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "COSMO",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ENGINE",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FINANCE",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "HUMAN_RESOURCES",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MARKETING",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SDK",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Documentation",
+          "description": "",
+          "fields": [
+            {
+              "name": "url",
+              "description": "",
+              "args": [
+                {
+                  "name": "product",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "ProductName",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "urls",
+              "description": "",
+              "args": [
+                {
+                  "name": "products",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "LIST",
+                      "name": null,
+                      "ofType": {
+                        "kind": "NON_NULL",
+                        "name": null,
+                        "ofType": {
+                          "kind": "ENUM",
+                          "name": "ProductName",
+                          "ofType": null
+                        }
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Secret",
+          "description": "",
+          "fields": [
+            {
+              "name": "value",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "InputArg",
+          "description": "",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "enums",
+              "description": "",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "EnumType",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "enum",
+              "description": "",
+              "type": {
+                "kind": "ENUM",
+                "name": "EnumType",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "string",
+              "description": "",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "strings",
+              "description": "",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "ENUM",
+          "name": "EnumType",
+          "description": "",
+          "fields": null,
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": [
+            {
+              "name": "A",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "B",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "C",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": []
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "InputType",
+          "description": "",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "arg",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "InputResponse",
+          "description": "",
+          "fields": [
+            {
+              "name": "arg",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Map",
+          "description": "",
+          "fields": null,
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "TimestampedString",
+          "description": "",
+          "fields": [
+            {
+              "name": "value",
+              "description": "The value of the string.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "unixTime",
+              "description": "The timestamp when the response was generated.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "seq",
+              "description": "Sequence number",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "total",
+              "description": "Total number of responses to be sent",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "initialPayload",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Map",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "BigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "nestedObjects",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "NestedObject",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "NestedObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "deeplyNestedObjects",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "DeeplyNestedObject",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "DeeplyNestedObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnDeeplyNestedObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnDeeplyNestedObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnDeeplyNestedObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnDeeplyNestedObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnDeeplyNestedObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnDeeplyNestedObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnDeeplyNestedObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnDeeplyNestedObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnDeeplyNestedObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnDeeplyNestedObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnDeeplyNestedObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnDeeplyNestedObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnDeeplyNestedObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnDeeplyNestedObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnDeeplyNestedObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnDeeplyNestedObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnDeeplyNestedObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnDeeplyNestedObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnDeeplyNestedObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnDeeplyNestedObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnDeeplyNestedObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnDeeplyNestedObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnDeeplyNestedObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnDeeplyNestedObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnDeeplyNestedObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnDeeplyNestedObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "UNION",
+          "name": "BigAbstractResponse",
+          "description": "",
+          "fields": null,
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "ABigObject",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "BBigObject",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "CBigObject",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "DBigObject",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "EBigObject",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "FBigObject",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "GBigObject",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "HBigObject",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "IBigObject",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "JBigObject",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "KBigObject",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "LBigObject",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "MBigObject",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "NBigObject",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "OBigObject",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "PBigObject",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "QBigObject",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "RBigObject",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "SBigObject",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "TBigObject",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "UBigObject",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "VBigObject",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "WBigObject",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "XBigObject",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "YBigObject",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "ZBigObject",
+              "ofType": null
+            }
+          ]
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ABigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnABigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnABigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnABigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnABigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnABigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnABigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnABigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnABigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnABigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnABigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnABigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnABigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnABigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnABigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnABigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnABigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnABigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnABigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnABigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnABigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnABigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnABigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnABigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnABigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnABigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnABigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "BBigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnBBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnBBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnBBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnBBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnBBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnBBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnBBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnBBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnBBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnBBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnBBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnBBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnBBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnBBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnBBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnBBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnBBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnBBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnBBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnBBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnBBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnBBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnBBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnBBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnBBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnBBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "CBigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnCBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnCBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnCBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnCBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnCBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnCBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnCBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnCBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnCBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnCBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnCBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnCBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnCBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnCBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnCBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnCBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnCBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnCBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnCBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnCBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnCBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnCBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnCBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnCBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnCBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnCBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "DBigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnDBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnDBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnDBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnDBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnDBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnDBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnDBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnDBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnDBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnDBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnDBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnDBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnDBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnDBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnDBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnDBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnDBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnDBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnDBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnDBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnDBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnDBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnDBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnDBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnDBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnDBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "EBigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnEBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnEBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnEBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnEBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnEBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnEBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnEBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnEBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnEBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnEBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnEBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnEBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnEBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnEBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnEBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnEBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnEBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnEBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnEBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnEBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnEBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnEBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnEBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnEBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnEBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnEBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "FBigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnFBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnFBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnFBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnFBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnFBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnFBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnFBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnFBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnFBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnFBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnFBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnFBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnFBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnFBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnFBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnFBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnFBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnFBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnFBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnFBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnFBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnFBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnFBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnFBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnFBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnFBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "GBigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnGBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnGBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnGBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnGBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnGBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnGBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnGBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnGBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnGBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnGBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnGBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnGBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnGBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnGBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnGBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnGBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnGBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnGBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnGBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnGBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnGBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnGBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnGBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnGBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnGBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnGBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "HBigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnHBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnHBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnHBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnHBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnHBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnHBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnHBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnHBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnHBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnHBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnHBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnHBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnHBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnHBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnHBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnHBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnHBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnHBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnHBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnHBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnHBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnHBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnHBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnHBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnHBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnHBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "IBigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnIBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnIBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnIBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnIBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnIBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnIBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnIBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnIBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnIBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnIBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnIBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnIBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnIBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnIBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnIBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnIBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnIBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnIBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnIBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnIBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnIBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnIBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnIBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnIBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnIBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnIBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "JBigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnJBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnJBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnJBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnJBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnJBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnJBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnJBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnJBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnJBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnJBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnJBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnJBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnJBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnJBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnJBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnJBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnJBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnJBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnJBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnJBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnJBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnJBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnJBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnJBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnJBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnJBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "KBigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnKBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnKBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnKBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnKBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnKBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnKBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnKBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnKBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnKBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnKBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnKBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnKBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnKBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnKBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnKBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnKBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnKBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnKBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnKBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnKBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnKBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnKBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnKBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnKBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnKBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnKBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "LBigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnLBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnLBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnLBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnLBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnLBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnLBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnLBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnLBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnLBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnLBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnLBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnLBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnLBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnLBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnLBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnLBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnLBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnLBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnLBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnLBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnLBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnLBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnLBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnLBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnLBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnLBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "MBigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnMBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnMBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnMBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnMBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnMBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnMBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnMBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnMBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnMBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnMBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnMBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnMBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnMBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnMBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnMBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnMBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnMBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnMBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnMBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnMBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnMBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnMBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnMBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnMBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnMBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnMBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "NBigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnNBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnNBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnNBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnNBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnNBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnNBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnNBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnNBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnNBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnNBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnNBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnNBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnNBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnNBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnNBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnNBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnNBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnNBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnNBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnNBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnNBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnNBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnNBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnNBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnNBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnNBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "OBigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnOBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnOBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnOBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnOBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnOBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnOBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnOBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnOBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnOBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnOBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnOBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnOBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnOBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnOBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnOBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnOBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnOBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnOBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnOBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnOBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnOBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnOBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnOBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnOBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnOBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnOBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "PBigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnPBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnPBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnPBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnPBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnPBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnPBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnPBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnPBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnPBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnPBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnPBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnPBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnPBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnPBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnPBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnPBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnPBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnPBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnPBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnPBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnPBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnPBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnPBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnPBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnPBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnPBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "QBigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnQBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnQBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnQBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnQBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnQBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnQBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnQBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnQBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnQBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnQBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnQBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnQBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnQBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnQBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnQBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnQBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnQBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnQBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnQBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnQBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnQBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnQBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnQBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnQBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnQBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnQBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "RBigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnRBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnRBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnRBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnRBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnRBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnRBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnRBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnRBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnRBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnRBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnRBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnRBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnRBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnRBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnRBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnRBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnRBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnRBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnRBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnRBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnRBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnRBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnRBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnRBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnRBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnRBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "SBigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnSBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnSBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnSBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnSBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnSBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnSBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnSBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnSBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnSBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnSBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnSBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnSBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnSBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnSBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnSBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnSBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnSBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnSBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnSBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnSBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnSBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnSBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnSBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnSBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnSBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnSBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "TBigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnTBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnTBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnTBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnTBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnTBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnTBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnTBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnTBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnTBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnTBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnTBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnTBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnTBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnTBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnTBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnTBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnTBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnTBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnTBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnTBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnTBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnTBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnTBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnTBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnTBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnTBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "UBigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnUBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnUBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnUBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnUBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnUBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnUBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnUBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnUBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnUBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnUBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnUBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnUBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnUBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnUBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnUBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnUBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnUBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnUBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnUBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnUBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnUBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnUBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnUBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnUBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnUBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnUBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "VBigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnVBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnVBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnVBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnVBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnVBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnVBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnVBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnVBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnVBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnVBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnVBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnVBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnVBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnVBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnVBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnVBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnVBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnVBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnVBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnVBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnVBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnVBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnVBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnVBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnVBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnVBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "WBigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnWBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnWBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnWBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnWBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnWBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnWBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnWBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnWBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnWBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnWBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnWBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnWBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnWBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnWBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnWBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnWBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnWBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnWBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnWBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnWBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnWBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnWBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnWBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnWBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnWBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnWBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "XBigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnXBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnXBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnXBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnXBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnXBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnXBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnXBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnXBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnXBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnXBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnXBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnXBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnXBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnXBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnXBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnXBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnXBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnXBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnXBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnXBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnXBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnXBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnXBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnXBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnXBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnXBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "YBigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnYBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnYBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnYBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnYBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnYBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnYBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnYBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnYBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnYBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnYBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnYBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnYBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnYBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnYBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnYBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnYBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnYBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnYBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnYBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnYBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnYBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnYBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnYBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnYBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnYBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnYBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ZBigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnZBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnZBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnZBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnZBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnZBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnZBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnZBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnZBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnZBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnZBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnZBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnZBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnZBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnZBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnZBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnZBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnZBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnZBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnZBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnZBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnZBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnZBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnZBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnZBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnZBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnZBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Engineer",
+          "description": "",
+          "fields": [
+            {
+              "name": "departments",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "Department",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "title",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "employees",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Employee",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "engineerType",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "EngineerType",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "RoleType",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Marketer",
+          "description": "",
+          "fields": [
+            {
+              "name": "departments",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "Department",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "title",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "employees",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Employee",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "RoleType",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Operator",
+          "description": "",
+          "fields": [
+            {
+              "name": "departments",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "Department",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "title",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "employees",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Employee",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "operatorType",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "OperationType",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "RoleType",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Employee",
+          "description": "",
+          "fields": [
+            {
+              "name": "details",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Details",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tag",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "role",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INTERFACE",
+                  "name": "RoleType",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "notes",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedAt",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "startDate",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "currentMood",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "Mood",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "derivedMood",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "Mood",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isAvailable",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rootFieldThrowsError",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rootFieldErrorWrapper",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ErrorWrapper",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hobbies",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INTERFACE",
+                    "name": "Hobby",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "products",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "ProductName",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fieldThrowsError",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Identifiable",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Cosmo",
+          "description": "",
+          "fields": [
+            {
+              "name": "upc",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "engineers",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Employee",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lead",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Employee",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "ProductName",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "repositoryURL",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "IProduct",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "SDK",
+          "description": "",
+          "fields": [
+            {
+              "name": "upc",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "engineers",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Employee",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "owner",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Employee",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "unicode",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "clientLanguages",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "ProgrammingLanguage",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "IProduct",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "INTERFACE",
+          "name": "Pet",
+          "description": "",
+          "fields": [
+            {
+              "name": "class",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "Class",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gender",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "Gender",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Animal",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "Alligator",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Cat",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Dog",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Mouse",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Pony",
+              "ofType": null
+            }
+          ]
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Alligator",
+          "description": "",
+          "fields": [
+            {
+              "name": "class",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "Class",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dangerous",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gender",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "Gender",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Pet",
+              "ofType": null
+            },
+            {
+              "kind": "INTERFACE",
+              "name": "Animal",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Cat",
+          "description": "",
+          "fields": [
+            {
+              "name": "class",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "Class",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gender",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "Gender",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "type",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CatType",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Pet",
+              "ofType": null
+            },
+            {
+              "kind": "INTERFACE",
+              "name": "Animal",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Dog",
+          "description": "",
+          "fields": [
+            {
+              "name": "breed",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "DogBreed",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "class",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "Class",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gender",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "Gender",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Pet",
+              "ofType": null
+            },
+            {
+              "kind": "INTERFACE",
+              "name": "Animal",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Mouse",
+          "description": "",
+          "fields": [
+            {
+              "name": "class",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "Class",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gender",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "Gender",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Pet",
+              "ofType": null
+            },
+            {
+              "kind": "INTERFACE",
+              "name": "Animal",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Pony",
+          "description": "",
+          "fields": [
+            {
+              "name": "class",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "Class",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gender",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "Gender",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Pet",
+              "ofType": null
+            },
+            {
+              "kind": "INTERFACE",
+              "name": "Animal",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Exercise",
+          "description": "",
+          "fields": [
+            {
+              "name": "employees",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Employee",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "category",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "ExerciseType",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Hobby",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Flying",
+          "description": "",
+          "fields": [
+            {
+              "name": "employees",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Employee",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "planeModels",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yearsOfExperience",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Experience",
+              "ofType": null
+            },
+            {
+              "kind": "INTERFACE",
+              "name": "Hobby",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Gaming",
+          "description": "",
+          "fields": [
+            {
+              "name": "employees",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Employee",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "genres",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "GameGenre",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yearsOfExperience",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Experience",
+              "ofType": null
+            },
+            {
+              "kind": "INTERFACE",
+              "name": "Hobby",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Other",
+          "description": "",
+          "fields": [
+            {
+              "name": "employees",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Employee",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Hobby",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Programming",
+          "description": "",
+          "fields": [
+            {
+              "name": "employees",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Employee",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "languages",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "ProgrammingLanguage",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Hobby",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Travelling",
+          "description": "",
+          "fields": [
+            {
+              "name": "employees",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Employee",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "countriesLived",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Country",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Hobby",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "DirectiveFact",
+          "description": "",
+          "fields": [
+            {
+              "name": "title",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "FactContent",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "factType",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "ENUM",
+                "name": "TopSecretFactType",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "TopSecretFact",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "EntityFact",
+          "description": "",
+          "fields": [
+            {
+              "name": "title",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "FactContent",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "factType",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "ENUM",
+                "name": "TopSecretFactType",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "TopSecretFact",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "MiscellaneousFact",
+          "description": "",
+          "fields": [
+            {
+              "name": "title",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "FactContent",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "factType",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "ENUM",
+                "name": "TopSecretFactType",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "TopSecretFact",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Int",
+          "description": "The 'Int' scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.",
+          "fields": null,
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Float",
+          "description": "The 'Float' scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).",
+          "fields": null,
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "SCALAR",
+          "name": "String",
+          "description": "The 'String' scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
+          "fields": null,
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Boolean",
+          "description": "The 'Boolean' scalar type represents 'true' or 'false' .",
+          "fields": null,
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "SCALAR",
+          "name": "ID",
+          "description": "The 'ID' scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as '4') or integer (such as 4) input value will be accepted as an ID.",
+          "fields": null,
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        }
+      ],
+      "directives": [
+        {
+          "name": "include",
+          "description": "Directs the executor to include this field or fragment only when the argument is true.",
+          "locations": [
+            "FIELD",
+            "FRAGMENT_SPREAD",
+            "INLINE_FRAGMENT"
+          ],
+          "args": [
+            {
+              "name": "if",
+              "description": "Included when true.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ]
+        },
+        {
+          "name": "skip",
+          "description": "Directs the executor to skip this field or fragment when the argument is true.",
+          "locations": [
+            "FIELD",
+            "FRAGMENT_SPREAD",
+            "INLINE_FRAGMENT"
+          ],
+          "args": [
+            {
+              "name": "if",
+              "description": "Skipped when true.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ]
+        },
+        {
+          "name": "deprecated",
+          "description": "Marks an element of a GraphQL schema as no longer supported.",
+          "locations": [
+            "FIELD_DEFINITION",
+            "ENUM_VALUE"
+          ],
+          "args": [
+            {
+              "name": "reason",
+              "description": "Explains why this element was deprecated, usually also including a suggestion\n    for how to access supported similar data. Formatted in\n    [Markdown](https://daringfireball.net/projects/markdown/).",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": "\"No longer supported\""
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/router-tests/testdata/introspection/base-graph-schema.json
+++ b/router-tests/testdata/introspection/base-graph-schema.json
@@ -32,7 +32,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -59,7 +61,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -130,7 +134,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -181,7 +187,9 @@
                     "name": "SearchInput",
                     "ofType": null
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -288,7 +296,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 },
                 {
                   "name": "numOfB",
@@ -302,7 +312,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -341,7 +353,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -372,7 +386,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -415,7 +431,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 },
                 {
                   "name": "ms",
@@ -429,7 +447,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -460,7 +480,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": "0"
+                  "defaultValue": "0",
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 },
                 {
                   "name": "bigObjects",
@@ -474,7 +496,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": "100"
+                  "defaultValue": "100",
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 },
                 {
                   "name": "nestedObjects",
@@ -488,7 +512,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": "100"
+                  "defaultValue": "100",
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 },
                 {
                   "name": "deeplyNestedObjects",
@@ -502,7 +528,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": "100"
+                  "defaultValue": "100",
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -541,7 +569,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": "0"
+                  "defaultValue": "0",
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 },
                 {
                   "name": "bytes",
@@ -555,7 +585,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -602,7 +634,9 @@
                       }
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -657,7 +691,9 @@
                       }
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -712,7 +748,9 @@
                       }
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -759,7 +797,9 @@
                       }
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -798,7 +838,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -825,7 +867,9 @@
                     "name": "Float",
                     "ofType": null
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -885,7 +929,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 },
                 {
                   "name": "tag",
@@ -899,7 +945,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -926,7 +974,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -957,7 +1007,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -996,7 +1048,9 @@
                       }
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -1027,7 +1081,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -1058,7 +1114,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 },
                 {
                   "name": "isAvailable",
@@ -1072,7 +1130,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -1103,7 +1163,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 },
                 {
                   "name": "mood",
@@ -1117,7 +1179,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -1152,7 +1216,9 @@
                 "name": "DeeplyNestedFileUpload",
                 "ofType": null
               },
-              "defaultValue": null
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
               "name": "nestedList",
@@ -1170,7 +1236,9 @@
                   }
                 }
               },
-              "defaultValue": null
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "interfaces": [],
@@ -1195,7 +1263,9 @@
                   "ofType": null
                 }
               },
-              "defaultValue": null
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "interfaces": [],
@@ -1239,7 +1309,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 },
                 {
                   "name": "intervalMilliseconds",
@@ -1253,7 +1325,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -1284,7 +1358,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 },
                 {
                   "name": "intervalMilliseconds",
@@ -1298,7 +1374,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -1329,7 +1407,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -1360,7 +1440,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 },
                 {
                   "name": "intervalMilliseconds",
@@ -1374,7 +1456,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -1405,7 +1489,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 },
                 {
                   "name": "repeat",
@@ -1415,7 +1501,9 @@
                     "name": "Int",
                     "ofType": null
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -1446,7 +1534,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 },
                 {
                   "name": "repeat",
@@ -1456,7 +1546,9 @@
                     "name": "Int",
                     "ofType": null
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -1483,7 +1575,9 @@
                     "name": "Int",
                     "ofType": null
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -2541,7 +2635,9 @@
                 "name": "Boolean",
                 "ofType": null
               },
-              "defaultValue": null
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
               "name": "nationality",
@@ -2551,7 +2647,9 @@
                 "name": "Nationality",
                 "ofType": null
               },
-              "defaultValue": null
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
               "name": "nested",
@@ -2561,7 +2659,9 @@
                 "name": "NestedSearchInput",
                 "ofType": null
               },
-              "defaultValue": null
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "interfaces": [],
@@ -2582,7 +2682,9 @@
                 "name": "MaritalStatus",
                 "ofType": null
               },
-              "defaultValue": null
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
               "name": "hasChildren",
@@ -2592,7 +2694,9 @@
                 "name": "Boolean",
                 "ofType": null
               },
-              "defaultValue": null
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "interfaces": [],
@@ -2893,7 +2997,9 @@
                   "ofType": null
                 }
               },
-              "defaultValue": null
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
               "name": "description",
@@ -2907,7 +3013,9 @@
                   "ofType": null
                 }
               },
-              "defaultValue": null
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
               "name": "factType",
@@ -2921,7 +3029,9 @@
                   "ofType": null
                 }
               },
-              "defaultValue": null
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "interfaces": [],
@@ -3096,7 +3206,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -3135,7 +3247,9 @@
                       }
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -3209,7 +3323,9 @@
                   }
                 }
               },
-              "defaultValue": null
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
               "name": "enum",
@@ -3219,7 +3335,9 @@
                 "name": "EnumType",
                 "ofType": null
               },
-              "defaultValue": null
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
               "name": "string",
@@ -3229,7 +3347,9 @@
                 "name": "String",
                 "ofType": null
               },
-              "defaultValue": null
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
               "name": "strings",
@@ -3247,7 +3367,9 @@
                   }
                 }
               },
-              "defaultValue": null
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "interfaces": [],
@@ -3301,7 +3423,9 @@
                   "ofType": null
                 }
               },
-              "defaultValue": null
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "interfaces": [],
@@ -17123,7 +17247,9 @@
                   "ofType": null
                 }
               },
-              "defaultValue": null
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ]
         },
@@ -17148,7 +17274,9 @@
                   "ofType": null
                 }
               },
-              "defaultValue": null
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ]
         },
@@ -17157,7 +17285,9 @@
           "description": "Marks an element of a GraphQL schema as no longer supported.",
           "locations": [
             "FIELD_DEFINITION",
-            "ENUM_VALUE"
+            "ARGUMENT_DEFINITION",
+            "ENUM_VALUE",
+            "INPUT_FIELD_DEFINITION"
           ],
           "args": [
             {
@@ -17168,7 +17298,34 @@
                 "name": "String",
                 "ofType": null
               },
-              "defaultValue": "\"No longer supported\""
+              "defaultValue": "\"No longer supported\"",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ]
+        },
+        {
+          "name": "specifiedBy",
+          "description": "",
+          "locations": [
+            "SCALAR"
+          ],
+          "args": [
+            {
+              "name": "url",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ]
         }

--- a/router-tests/testdata/introspection/feature-graph-schema.json
+++ b/router-tests/testdata/introspection/feature-graph-schema.json
@@ -32,7 +32,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -59,7 +61,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -130,7 +134,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -181,7 +187,9 @@
                     "name": "SearchInput",
                     "ofType": null
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -288,7 +296,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -319,7 +329,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -362,7 +374,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 },
                 {
                   "name": "ms",
@@ -376,7 +390,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -407,7 +423,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": "0"
+                  "defaultValue": "0",
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 },
                 {
                   "name": "bigObjects",
@@ -421,7 +439,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": "100"
+                  "defaultValue": "100",
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 },
                 {
                   "name": "nestedObjects",
@@ -435,7 +455,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": "100"
+                  "defaultValue": "100",
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 },
                 {
                   "name": "deeplyNestedObjects",
@@ -449,7 +471,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": "100"
+                  "defaultValue": "100",
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -488,7 +512,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": "0"
+                  "defaultValue": "0",
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 },
                 {
                   "name": "bytes",
@@ -502,7 +528,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -549,7 +577,9 @@
                       }
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -604,7 +634,9 @@
                       }
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -659,7 +691,9 @@
                       }
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -706,7 +740,9 @@
                       }
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -745,7 +781,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -772,7 +810,9 @@
                     "name": "Float",
                     "ofType": null
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -799,7 +839,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 },
                 {
                   "name": "numOfB",
@@ -813,7 +855,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -885,7 +929,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 },
                 {
                   "name": "tag",
@@ -899,7 +945,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -926,7 +974,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -957,7 +1007,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -996,7 +1048,9 @@
                       }
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -1027,7 +1081,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -1058,7 +1114,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 },
                 {
                   "name": "isAvailable",
@@ -1072,7 +1130,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -1103,7 +1163,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 },
                 {
                   "name": "mood",
@@ -1117,7 +1179,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -1152,7 +1216,9 @@
                 "name": "DeeplyNestedFileUpload",
                 "ofType": null
               },
-              "defaultValue": null
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
               "name": "nestedList",
@@ -1170,7 +1236,9 @@
                   }
                 }
               },
-              "defaultValue": null
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "interfaces": [],
@@ -1195,7 +1263,9 @@
                   "ofType": null
                 }
               },
-              "defaultValue": null
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "interfaces": [],
@@ -1239,7 +1309,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 },
                 {
                   "name": "intervalMilliseconds",
@@ -1253,7 +1325,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -1284,7 +1358,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 },
                 {
                   "name": "intervalMilliseconds",
@@ -1298,7 +1374,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -1329,7 +1407,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -1360,7 +1440,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 },
                 {
                   "name": "intervalMilliseconds",
@@ -1374,7 +1456,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -1405,7 +1489,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 },
                 {
                   "name": "repeat",
@@ -1415,7 +1501,9 @@
                     "name": "Int",
                     "ofType": null
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -1446,7 +1534,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 },
                 {
                   "name": "repeat",
@@ -1456,7 +1546,9 @@
                     "name": "Int",
                     "ofType": null
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -1483,7 +1575,9 @@
                     "name": "Int",
                     "ofType": null
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -2541,7 +2635,9 @@
                 "name": "Boolean",
                 "ofType": null
               },
-              "defaultValue": null
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
               "name": "nationality",
@@ -2551,7 +2647,9 @@
                 "name": "Nationality",
                 "ofType": null
               },
-              "defaultValue": null
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
               "name": "nested",
@@ -2561,7 +2659,9 @@
                 "name": "NestedSearchInput",
                 "ofType": null
               },
-              "defaultValue": null
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "interfaces": [],
@@ -2582,7 +2682,9 @@
                 "name": "MaritalStatus",
                 "ofType": null
               },
-              "defaultValue": null
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
               "name": "hasChildren",
@@ -2592,7 +2694,9 @@
                 "name": "Boolean",
                 "ofType": null
               },
-              "defaultValue": null
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "interfaces": [],
@@ -2850,7 +2954,9 @@
                   "ofType": null
                 }
               },
-              "defaultValue": null
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
               "name": "description",
@@ -2864,7 +2970,9 @@
                   "ofType": null
                 }
               },
-              "defaultValue": null
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
               "name": "factType",
@@ -2878,7 +2986,9 @@
                   "ofType": null
                 }
               },
-              "defaultValue": null
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "interfaces": [],
@@ -3053,7 +3163,9 @@
                       "ofType": null
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -3092,7 +3204,9 @@
                       }
                     }
                   },
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -3193,7 +3307,9 @@
                   }
                 }
               },
-              "defaultValue": null
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
               "name": "enum",
@@ -3203,7 +3319,9 @@
                 "name": "EnumType",
                 "ofType": null
               },
-              "defaultValue": null
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
               "name": "string",
@@ -3213,7 +3331,9 @@
                 "name": "String",
                 "ofType": null
               },
-              "defaultValue": null
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
               "name": "strings",
@@ -3231,7 +3351,9 @@
                   }
                 }
               },
-              "defaultValue": null
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "interfaces": [],
@@ -3285,7 +3407,9 @@
                   "ofType": null
                 }
               },
-              "defaultValue": null
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "interfaces": [],
@@ -17123,7 +17247,9 @@
                   "ofType": null
                 }
               },
-              "defaultValue": null
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ]
         },
@@ -17148,7 +17274,9 @@
                   "ofType": null
                 }
               },
-              "defaultValue": null
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ]
         },
@@ -17157,7 +17285,9 @@
           "description": "Marks an element of a GraphQL schema as no longer supported.",
           "locations": [
             "FIELD_DEFINITION",
-            "ENUM_VALUE"
+            "ARGUMENT_DEFINITION",
+            "ENUM_VALUE",
+            "INPUT_FIELD_DEFINITION"
           ],
           "args": [
             {
@@ -17168,7 +17298,34 @@
                 "name": "String",
                 "ofType": null
               },
-              "defaultValue": "\"No longer supported\""
+              "defaultValue": "\"No longer supported\"",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ]
+        },
+        {
+          "name": "specifiedBy",
+          "description": "",
+          "locations": [
+            "SCALAR"
+          ],
+          "args": [
+            {
+              "name": "url",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ]
         }

--- a/router-tests/testdata/introspection/feature-graph-schema.json
+++ b/router-tests/testdata/introspection/feature-graph-schema.json
@@ -1,1 +1,17178 @@
-"{\"data\":{\"__schema\":{\"queryType\":{\"name\":\"Query\"},\"mutationType\":{\"name\":\"Mutation\"},\"subscriptionType\":{\"name\":\"Subscription\"},\"types\":[{\"kind\":\"OBJECT\",\"name\":\"Query\",\"description\":\"\",\"fields\":[{\"name\":\"employee\",\"description\":\"\",\"args\":[{\"name\":\"id\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"defaultValue\":null}],\"type\":{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"employeeAsList\",\"description\":\"\",\"args\":[{\"name\":\"id\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"defaultValue\":null}],\"type\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"employees\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"products\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"UNION\",\"name\":\"Products\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"teammates\",\"description\":\"\",\"args\":[{\"name\":\"team\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"Department\",\"ofType\":null}},\"defaultValue\":null}],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"firstEmployee\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"findEmployees\",\"description\":\"This is a GraphQL query that retrieves a list of employees.\",\"args\":[{\"name\":\"criteria\",\"description\":\"\",\"type\":{\"kind\":\"INPUT_OBJECT\",\"name\":\"SearchInput\",\"ofType\":null},\"defaultValue\":null}],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"productTypes\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"UNION\",\"name\":\"Products\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"topSecretFederationFacts\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"INTERFACE\",\"name\":\"TopSecretFact\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"factTypes\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"TopSecretFactType\",\"ofType\":null}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"headerValue\",\"description\":\"Returns the value of the received HTTP header.\",\"args\":[{\"name\":\"name\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"defaultValue\":null}],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"initPayloadValue\",\"description\":\"Returns the value of the given key in the WS initial payload.\",\"args\":[{\"name\":\"key\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"defaultValue\":null}],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"initialPayload\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"SCALAR\",\"name\":\"Map\",\"ofType\":null},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"delay\",\"description\":\"Returns response after the given delay\",\"args\":[{\"name\":\"response\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"defaultValue\":null},{\"name\":\"ms\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"defaultValue\":null}],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bigResponse\",\"description\":\"\",\"args\":[{\"name\":\"artificialDelay\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"defaultValue\":\"0\"},{\"name\":\"bigObjects\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"defaultValue\":\"100\"},{\"name\":\"nestedObjects\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"defaultValue\":\"100\"},{\"name\":\"deeplyNestedObjects\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"defaultValue\":\"100\"}],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"BigObject\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"longResponse\",\"description\":\"\",\"args\":[{\"name\":\"artificialDelay\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"defaultValue\":\"0\"},{\"name\":\"bytes\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"defaultValue\":null}],\"type\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bigAbstractResponse\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"UNION\",\"name\":\"BigAbstractResponse\",\"ofType\":null},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rootFieldWithListArg\",\"description\":\"\",\"args\":[{\"name\":\"arg\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}}}},\"defaultValue\":null}],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rootFieldWithNestedListArg\",\"description\":\"\",\"args\":[{\"name\":\"arg\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}}}}}},\"defaultValue\":null}],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}}}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rootFieldWithListOfInputArg\",\"description\":\"\",\"args\":[{\"name\":\"arg\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"INPUT_OBJECT\",\"name\":\"InputType\",\"ofType\":null}}}},\"defaultValue\":null}],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"InputResponse\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rootFieldWithListOfEnumArg\",\"description\":\"\",\"args\":[{\"name\":\"arg\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"EnumType\",\"ofType\":null}}}},\"defaultValue\":null}],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"EnumType\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rootFieldWithInput\",\"description\":\"\",\"args\":[{\"name\":\"arg\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"INPUT_OBJECT\",\"name\":\"InputArg\",\"ofType\":null}},\"defaultValue\":null}],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"floatField\",\"description\":\"\",\"args\":[{\"name\":\"arg\",\"description\":\"\",\"type\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null},\"defaultValue\":null}],\"type\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sharedThings\",\"description\":\"\",\"args\":[{\"name\":\"numOfA\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"defaultValue\":null},{\"name\":\"numOfB\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"defaultValue\":null}],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Thing\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"secret\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"OBJECT\",\"name\":\"Secret\",\"ofType\":null},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"SCALAR\",\"name\":\"Upload\",\"description\":\"\",\"fields\":null,\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"Mutation\",\"description\":\"\",\"fields\":[{\"name\":\"updateEmployeeTag\",\"description\":\"\",\"args\":[{\"name\":\"id\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"defaultValue\":null},{\"name\":\"tag\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"defaultValue\":null}],\"type\":{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"singleUpload\",\"description\":\"\",\"args\":[{\"name\":\"file\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Upload\",\"ofType\":null}},\"defaultValue\":null}],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"singleUploadWithInput\",\"description\":\"\",\"args\":[{\"name\":\"arg\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"INPUT_OBJECT\",\"name\":\"FileUpload\",\"ofType\":null}},\"defaultValue\":null}],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"multipleUpload\",\"description\":\"\",\"args\":[{\"name\":\"files\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Upload\",\"ofType\":null}}}},\"defaultValue\":null}],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"addFact\",\"description\":\"\",\"args\":[{\"name\":\"fact\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"INPUT_OBJECT\",\"name\":\"TopSecretFactInput\",\"ofType\":null}},\"defaultValue\":null}],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"INTERFACE\",\"name\":\"TopSecretFact\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"updateAvailability\",\"description\":\"This mutation updates the availability status of an employee in the system.\",\"args\":[{\"name\":\"employeeID\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"defaultValue\":null},{\"name\":\"isAvailable\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"defaultValue\":null}],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"updateMood\",\"description\":\"This mutation update the mood of an employee.\",\"args\":[{\"name\":\"employeeID\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"defaultValue\":null},{\"name\":\"mood\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"Mood\",\"ofType\":null}},\"defaultValue\":null}],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"INPUT_OBJECT\",\"name\":\"FileUpload\",\"description\":\"\",\"fields\":null,\"inputFields\":[{\"name\":\"nested\",\"description\":\"\",\"type\":{\"kind\":\"INPUT_OBJECT\",\"name\":\"DeeplyNestedFileUpload\",\"ofType\":null},\"defaultValue\":null},{\"name\":\"nestedList\",\"description\":\"\",\"type\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Upload\",\"ofType\":null}}},\"defaultValue\":null}],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"INPUT_OBJECT\",\"name\":\"DeeplyNestedFileUpload\",\"description\":\"\",\"fields\":null,\"inputFields\":[{\"name\":\"file\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Upload\",\"ofType\":null}},\"defaultValue\":null}],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"Subscription\",\"description\":\"\",\"fields\":[{\"name\":\"currentTime\",\"description\":\"`currentTime` will return a stream of `Time` objects.\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Time\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"countEmp\",\"description\":\"\",\"args\":[{\"name\":\"max\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"defaultValue\":null},{\"name\":\"intervalMilliseconds\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"defaultValue\":null}],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"countEmp2\",\"description\":\"\",\"args\":[{\"name\":\"max\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"defaultValue\":null},{\"name\":\"intervalMilliseconds\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"defaultValue\":null}],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"countFor\",\"description\":\"\",\"args\":[{\"name\":\"count\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"defaultValue\":null}],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"countHob\",\"description\":\"\",\"args\":[{\"name\":\"max\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"defaultValue\":null},{\"name\":\"intervalMilliseconds\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"defaultValue\":null}],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"headerValue\",\"description\":\"Returns a stream with the value of the received HTTP header.\",\"args\":[{\"name\":\"name\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"defaultValue\":null},{\"name\":\"repeat\",\"description\":\"\",\"type\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null},\"defaultValue\":null}],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"TimestampedString\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"initPayloadValue\",\"description\":\"Returns a stream with the value of value of the given key in the WS initial payload.\",\"args\":[{\"name\":\"key\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"defaultValue\":null},{\"name\":\"repeat\",\"description\":\"\",\"type\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null},\"defaultValue\":null}],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"TimestampedString\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"initialPayload\",\"description\":\"Returns a stream with the value of the WS initial payload.\",\"args\":[{\"name\":\"repeat\",\"description\":\"\",\"type\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null},\"defaultValue\":null}],\"type\":{\"kind\":\"SCALAR\",\"name\":\"Map\",\"ofType\":null},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"returnsError\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"ENUM\",\"name\":\"Department\",\"description\":\"\",\"fields\":null,\"inputFields\":[],\"interfaces\":[],\"enumValues\":[{\"name\":\"ENGINEERING\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"MARKETING\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"OPERATIONS\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null}],\"possibleTypes\":[]},{\"kind\":\"INTERFACE\",\"name\":\"RoleType\",\"description\":\"\",\"fields\":[{\"name\":\"departments\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"Department\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"title\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"employees\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[{\"kind\":\"OBJECT\",\"name\":\"Engineer\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"Marketer\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"Operator\",\"ofType\":null}]},{\"kind\":\"ENUM\",\"name\":\"EngineerType\",\"description\":\"\",\"fields\":null,\"inputFields\":[],\"interfaces\":[],\"enumValues\":[{\"name\":\"BACKEND\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"FRONTEND\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"FULLSTACK\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null}],\"possibleTypes\":[]},{\"kind\":\"INTERFACE\",\"name\":\"Identifiable\",\"description\":\"\",\"fields\":[{\"name\":\"id\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null}]},{\"kind\":\"ENUM\",\"name\":\"OperationType\",\"description\":\"\",\"fields\":null,\"inputFields\":[],\"interfaces\":[],\"enumValues\":[{\"name\":\"FINANCE\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"HUMAN_RESOURCES\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null}],\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"Details\",\"description\":\"\",\"fields\":[{\"name\":\"forename\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"location\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Country\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"surname\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pastLocations\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"City\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"middlename\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null},\"isDeprecated\":true,\"deprecationReason\":\"No longer supported\"},{\"name\":\"hasChildren\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"maritalStatus\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"ENUM\",\"name\":\"MaritalStatus\",\"ofType\":null},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nationality\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"Nationality\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pets\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"INTERFACE\",\"name\":\"Pet\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"City\",\"description\":\"\",\"fields\":[{\"name\":\"type\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"name\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"country\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"OBJECT\",\"name\":\"Country\",\"ofType\":null},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"Country\",\"description\":\"\",\"fields\":[{\"name\":\"key\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"CountryKey\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"language\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"CountryKey\",\"description\":\"\",\"fields\":[{\"name\":\"name\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"ENUM\",\"name\":\"Mood\",\"description\":\"\",\"fields\":null,\"inputFields\":[],\"interfaces\":[],\"enumValues\":[{\"name\":\"HAPPY\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"SAD\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null}],\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"ErrorWrapper\",\"description\":\"\",\"fields\":[{\"name\":\"okField\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"errorField\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"Time\",\"description\":\"\",\"fields\":[{\"name\":\"unixTime\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"timeStamp\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"UNION\",\"name\":\"Products\",\"description\":\"\",\"fields\":null,\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[{\"kind\":\"OBJECT\",\"name\":\"Consultancy\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"Cosmo\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"SDK\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"Documentation\",\"ofType\":null}]},{\"kind\":\"INTERFACE\",\"name\":\"IProduct\",\"description\":\"\",\"fields\":[{\"name\":\"upc\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"ID\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"engineers\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[{\"kind\":\"OBJECT\",\"name\":\"Cosmo\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"SDK\",\"ofType\":null}]},{\"kind\":\"OBJECT\",\"name\":\"Consultancy\",\"description\":\"\",\"fields\":[{\"name\":\"upc\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"ID\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lead\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"isLeadAvailable\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"name\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"ProductName\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"ENUM\",\"name\":\"Class\",\"description\":\"\",\"fields\":null,\"inputFields\":[],\"interfaces\":[],\"enumValues\":[{\"name\":\"FISH\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"MAMMAL\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"REPTILE\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null}],\"possibleTypes\":[]},{\"kind\":\"ENUM\",\"name\":\"Gender\",\"description\":\"\",\"fields\":null,\"inputFields\":[],\"interfaces\":[],\"enumValues\":[{\"name\":\"FEMALE\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"MALE\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"UNKNOWN\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null}],\"possibleTypes\":[]},{\"kind\":\"INTERFACE\",\"name\":\"Animal\",\"description\":\"\",\"fields\":[{\"name\":\"class\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"Class\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gender\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"Gender\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[{\"kind\":\"OBJECT\",\"name\":\"Alligator\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"Cat\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"Dog\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"Mouse\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"Pony\",\"ofType\":null}]},{\"kind\":\"ENUM\",\"name\":\"CatType\",\"description\":\"\",\"fields\":null,\"inputFields\":[],\"interfaces\":[],\"enumValues\":[{\"name\":\"HOME\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"STREET\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null}],\"possibleTypes\":[]},{\"kind\":\"ENUM\",\"name\":\"DogBreed\",\"description\":\"\",\"fields\":null,\"inputFields\":[],\"interfaces\":[],\"enumValues\":[{\"name\":\"GOLDEN_RETRIEVER\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"POODLE\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"ROTTWEILER\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"YORKSHIRE_TERRIER\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null}],\"possibleTypes\":[]},{\"kind\":\"ENUM\",\"name\":\"MaritalStatus\",\"description\":\"\",\"fields\":null,\"inputFields\":[],\"interfaces\":[],\"enumValues\":[{\"name\":\"ENGAGED\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"MARRIED\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null}],\"possibleTypes\":[]},{\"kind\":\"ENUM\",\"name\":\"Nationality\",\"description\":\"\",\"fields\":null,\"inputFields\":[],\"interfaces\":[],\"enumValues\":[{\"name\":\"AMERICAN\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"DUTCH\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"ENGLISH\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"GERMAN\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"INDIAN\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"SPANISH\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"UKRAINIAN\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null}],\"possibleTypes\":[]},{\"kind\":\"INPUT_OBJECT\",\"name\":\"SearchInput\",\"description\":\"Allows to filter employees by their details.\",\"fields\":null,\"inputFields\":[{\"name\":\"hasPets\",\"description\":\"\",\"type\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null},\"defaultValue\":null},{\"name\":\"nationality\",\"description\":\"\",\"type\":{\"kind\":\"ENUM\",\"name\":\"Nationality\",\"ofType\":null},\"defaultValue\":null},{\"name\":\"nested\",\"description\":\"\",\"type\":{\"kind\":\"INPUT_OBJECT\",\"name\":\"NestedSearchInput\",\"ofType\":null},\"defaultValue\":null}],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"INPUT_OBJECT\",\"name\":\"NestedSearchInput\",\"description\":\"\",\"fields\":null,\"inputFields\":[{\"name\":\"maritalStatus\",\"description\":\"\",\"type\":{\"kind\":\"ENUM\",\"name\":\"MaritalStatus\",\"ofType\":null},\"defaultValue\":null},{\"name\":\"hasChildren\",\"description\":\"\",\"type\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null},\"defaultValue\":null}],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"ENUM\",\"name\":\"ExerciseType\",\"description\":\"\",\"fields\":null,\"inputFields\":[],\"interfaces\":[],\"enumValues\":[{\"name\":\"CALISTHENICS\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"HIKING\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"SPORT\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"STRENGTH_TRAINING\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null}],\"possibleTypes\":[]},{\"kind\":\"INTERFACE\",\"name\":\"Experience\",\"description\":\"\",\"fields\":[{\"name\":\"yearsOfExperience\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[{\"kind\":\"OBJECT\",\"name\":\"Flying\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"Gaming\",\"ofType\":null}]},{\"kind\":\"ENUM\",\"name\":\"GameGenre\",\"description\":\"\",\"fields\":null,\"inputFields\":[],\"interfaces\":[],\"enumValues\":[{\"name\":\"ADVENTURE\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"BOARD\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"FPS\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"CARD\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"RPG\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"ROGUELITE\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"SIMULATION\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"STRATEGY\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null}],\"possibleTypes\":[]},{\"kind\":\"ENUM\",\"name\":\"ProgrammingLanguage\",\"description\":\"\",\"fields\":null,\"inputFields\":[],\"interfaces\":[],\"enumValues\":[{\"name\":\"CSHARP\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"GO\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"RUST\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"TYPESCRIPT\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null}],\"possibleTypes\":[]},{\"kind\":\"INTERFACE\",\"name\":\"Hobby\",\"description\":\"\",\"fields\":[{\"name\":\"employees\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[{\"kind\":\"OBJECT\",\"name\":\"Exercise\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"Flying\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"Gaming\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"Other\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"Programming\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"Travelling\",\"ofType\":null}]},{\"kind\":\"INPUT_OBJECT\",\"name\":\"TopSecretFactInput\",\"description\":\"\",\"fields\":null,\"inputFields\":[{\"name\":\"title\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"defaultValue\":null},{\"name\":\"description\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"FactContent\",\"ofType\":null}},\"defaultValue\":null},{\"name\":\"factType\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"TopSecretFactType\",\"ofType\":null}},\"defaultValue\":null}],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"ENUM\",\"name\":\"TopSecretFactType\",\"description\":\"\",\"fields\":null,\"inputFields\":[],\"interfaces\":[],\"enumValues\":[{\"name\":\"DIRECTIVE\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"ENTITY\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"MISCELLANEOUS\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null}],\"possibleTypes\":[]},{\"kind\":\"INTERFACE\",\"name\":\"TopSecretFact\",\"description\":\"\",\"fields\":[{\"name\":\"description\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"FactContent\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"factType\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"ENUM\",\"name\":\"TopSecretFactType\",\"ofType\":null},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[{\"kind\":\"OBJECT\",\"name\":\"DirectiveFact\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"EntityFact\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"MiscellaneousFact\",\"ofType\":null}]},{\"kind\":\"SCALAR\",\"name\":\"FactContent\",\"description\":\"\",\"fields\":null,\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"ENUM\",\"name\":\"ProductName\",\"description\":\"\",\"fields\":null,\"inputFields\":[],\"interfaces\":[],\"enumValues\":[{\"name\":\"CONSULTANCY\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"COSMO\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"ENGINE\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"FINANCE\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"HUMAN_RESOURCES\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"MARKETING\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"SDK\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null}],\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"Documentation\",\"description\":\"\",\"fields\":[{\"name\":\"url\",\"description\":\"\",\"args\":[{\"name\":\"product\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"ProductName\",\"ofType\":null}},\"defaultValue\":null}],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"urls\",\"description\":\"\",\"args\":[{\"name\":\"products\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"ProductName\",\"ofType\":null}}}},\"defaultValue\":null}],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"Secret\",\"description\":\"\",\"fields\":[{\"name\":\"value\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"Thing\",\"description\":\"\",\"fields\":[{\"name\":\"b\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"INPUT_OBJECT\",\"name\":\"InputArg\",\"description\":\"\",\"fields\":null,\"inputFields\":[{\"name\":\"enums\",\"description\":\"\",\"type\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"EnumType\",\"ofType\":null}}},\"defaultValue\":null},{\"name\":\"enum\",\"description\":\"\",\"type\":{\"kind\":\"ENUM\",\"name\":\"EnumType\",\"ofType\":null},\"defaultValue\":null},{\"name\":\"string\",\"description\":\"\",\"type\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null},\"defaultValue\":null},{\"name\":\"strings\",\"description\":\"\",\"type\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}}},\"defaultValue\":null}],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"ENUM\",\"name\":\"EnumType\",\"description\":\"\",\"fields\":null,\"inputFields\":[],\"interfaces\":[],\"enumValues\":[{\"name\":\"A\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"B\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"C\",\"description\":\"\",\"isDeprecated\":false,\"deprecationReason\":null}],\"possibleTypes\":[]},{\"kind\":\"INPUT_OBJECT\",\"name\":\"InputType\",\"description\":\"\",\"fields\":null,\"inputFields\":[{\"name\":\"arg\",\"description\":\"\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"defaultValue\":null}],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"InputResponse\",\"description\":\"\",\"fields\":[{\"name\":\"arg\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"SCALAR\",\"name\":\"Map\",\"description\":\"\",\"fields\":null,\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"TimestampedString\",\"description\":\"\",\"fields\":[{\"name\":\"value\",\"description\":\"The value of the string.\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"unixTime\",\"description\":\"The timestamp when the response was generated.\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"seq\",\"description\":\"Sequence number\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"total\",\"description\":\"Total number of responses to be sent\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"initialPayload\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"SCALAR\",\"name\":\"Map\",\"ofType\":null},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"BigObject\",\"description\":\"\",\"fields\":[{\"name\":\"nestedObjects\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"NestedObject\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"NestedObject\",\"description\":\"\",\"fields\":[{\"name\":\"deeplyNestedObjects\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"DeeplyNestedObject\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"DeeplyNestedObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnDeeplyNestedObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnDeeplyNestedObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnDeeplyNestedObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnDeeplyNestedObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnDeeplyNestedObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnDeeplyNestedObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnDeeplyNestedObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnDeeplyNestedObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnDeeplyNestedObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnDeeplyNestedObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnDeeplyNestedObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnDeeplyNestedObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnDeeplyNestedObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnDeeplyNestedObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnDeeplyNestedObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnDeeplyNestedObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnDeeplyNestedObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnDeeplyNestedObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnDeeplyNestedObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnDeeplyNestedObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnDeeplyNestedObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnDeeplyNestedObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnDeeplyNestedObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnDeeplyNestedObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnDeeplyNestedObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnDeeplyNestedObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"UNION\",\"name\":\"BigAbstractResponse\",\"description\":\"\",\"fields\":null,\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[{\"kind\":\"OBJECT\",\"name\":\"ABigObject\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"BBigObject\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"CBigObject\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"DBigObject\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"EBigObject\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"FBigObject\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"GBigObject\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"HBigObject\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"IBigObject\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"JBigObject\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"KBigObject\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"LBigObject\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"MBigObject\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"NBigObject\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"OBigObject\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"PBigObject\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"QBigObject\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"RBigObject\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"SBigObject\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"TBigObject\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"UBigObject\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"VBigObject\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"WBigObject\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"XBigObject\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"YBigObject\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"ZBigObject\",\"ofType\":null}]},{\"kind\":\"OBJECT\",\"name\":\"ABigObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnABigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnABigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnABigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnABigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnABigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnABigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnABigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnABigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnABigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnABigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnABigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnABigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnABigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnABigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnABigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnABigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnABigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnABigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnABigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnABigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnABigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnABigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnABigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnABigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnABigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnABigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"BBigObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnBBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnBBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnBBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnBBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnBBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnBBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnBBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnBBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnBBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnBBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnBBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnBBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnBBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnBBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnBBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnBBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnBBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnBBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnBBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnBBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnBBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnBBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnBBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnBBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnBBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnBBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"CBigObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnCBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnCBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnCBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnCBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnCBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnCBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnCBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnCBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnCBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnCBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnCBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnCBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnCBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnCBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnCBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnCBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnCBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnCBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnCBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnCBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnCBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnCBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnCBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnCBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnCBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnCBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"DBigObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnDBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnDBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnDBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnDBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnDBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnDBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnDBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnDBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnDBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnDBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnDBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnDBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnDBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnDBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnDBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnDBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnDBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnDBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnDBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnDBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnDBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnDBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnDBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnDBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnDBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnDBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"EBigObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnEBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnEBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnEBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnEBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnEBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnEBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnEBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnEBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnEBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnEBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnEBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnEBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnEBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnEBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnEBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnEBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnEBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnEBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnEBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnEBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnEBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnEBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnEBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnEBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnEBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnEBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"FBigObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnFBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnFBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnFBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnFBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnFBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnFBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnFBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnFBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnFBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnFBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnFBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnFBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnFBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnFBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnFBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnFBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnFBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnFBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnFBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnFBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnFBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnFBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnFBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnFBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnFBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnFBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"GBigObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnGBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnGBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnGBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnGBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnGBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnGBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnGBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnGBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnGBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnGBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnGBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnGBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnGBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnGBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnGBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnGBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnGBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnGBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnGBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnGBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnGBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnGBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnGBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnGBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnGBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnGBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"HBigObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnHBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnHBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnHBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnHBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnHBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnHBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnHBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnHBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnHBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnHBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnHBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnHBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnHBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnHBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnHBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnHBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnHBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnHBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnHBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnHBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnHBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnHBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnHBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnHBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnHBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnHBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"IBigObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnIBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnIBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnIBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnIBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnIBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnIBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnIBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnIBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnIBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnIBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnIBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnIBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnIBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnIBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnIBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnIBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnIBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnIBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnIBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnIBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnIBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnIBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnIBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnIBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnIBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnIBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"JBigObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnJBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnJBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnJBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnJBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnJBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnJBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnJBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnJBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnJBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnJBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnJBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnJBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnJBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnJBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnJBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnJBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnJBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnJBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnJBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnJBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnJBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnJBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnJBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnJBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnJBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnJBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"KBigObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnKBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnKBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnKBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnKBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnKBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnKBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnKBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnKBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnKBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnKBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnKBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnKBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnKBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnKBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnKBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnKBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnKBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnKBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnKBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnKBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnKBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnKBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnKBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnKBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnKBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnKBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"LBigObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnLBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnLBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnLBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnLBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnLBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnLBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnLBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnLBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnLBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnLBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnLBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnLBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnLBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnLBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnLBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnLBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnLBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnLBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnLBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnLBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnLBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnLBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnLBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnLBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnLBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnLBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"MBigObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnMBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnMBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnMBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnMBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnMBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnMBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnMBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnMBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnMBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnMBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnMBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnMBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnMBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnMBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnMBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnMBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnMBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnMBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnMBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnMBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnMBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnMBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnMBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnMBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnMBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnMBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"NBigObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnNBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnNBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnNBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnNBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnNBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnNBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnNBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnNBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnNBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnNBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnNBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnNBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnNBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnNBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnNBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnNBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnNBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnNBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnNBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnNBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnNBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnNBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnNBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnNBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnNBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnNBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"OBigObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnOBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnOBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnOBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnOBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnOBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnOBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnOBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnOBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnOBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnOBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnOBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnOBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnOBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnOBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnOBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnOBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnOBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnOBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnOBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnOBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnOBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnOBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnOBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnOBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnOBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnOBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"PBigObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnPBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnPBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnPBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnPBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnPBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnPBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnPBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnPBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnPBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnPBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnPBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnPBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnPBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnPBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnPBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnPBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnPBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnPBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnPBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnPBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnPBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnPBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnPBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnPBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnPBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnPBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"QBigObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnQBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnQBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnQBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnQBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnQBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnQBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnQBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnQBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnQBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnQBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnQBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnQBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnQBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnQBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnQBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnQBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnQBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnQBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnQBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnQBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnQBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnQBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnQBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnQBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnQBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnQBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"RBigObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnRBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnRBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnRBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnRBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnRBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnRBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnRBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnRBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnRBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnRBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnRBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnRBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnRBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnRBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnRBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnRBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnRBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnRBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnRBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnRBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnRBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnRBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnRBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnRBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnRBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnRBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"SBigObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnSBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnSBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnSBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnSBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnSBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnSBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnSBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnSBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnSBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnSBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnSBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnSBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnSBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnSBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnSBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnSBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnSBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnSBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnSBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnSBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnSBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnSBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnSBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnSBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnSBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnSBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"TBigObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnTBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnTBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnTBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnTBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnTBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnTBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnTBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnTBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnTBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnTBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnTBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnTBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnTBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnTBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnTBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnTBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnTBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnTBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnTBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnTBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnTBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnTBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnTBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnTBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnTBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnTBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"UBigObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnUBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnUBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnUBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnUBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnUBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnUBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnUBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnUBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnUBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnUBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnUBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnUBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnUBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnUBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnUBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnUBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnUBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnUBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnUBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnUBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnUBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnUBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnUBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnUBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnUBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnUBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"VBigObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnVBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnVBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnVBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnVBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnVBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnVBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnVBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnVBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnVBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnVBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnVBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnVBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnVBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnVBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnVBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnVBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnVBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnVBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnVBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnVBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnVBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnVBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnVBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnVBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnVBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnVBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"WBigObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnWBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnWBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnWBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnWBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnWBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnWBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnWBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnWBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnWBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnWBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnWBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnWBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnWBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnWBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnWBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnWBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnWBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnWBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnWBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnWBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnWBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnWBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnWBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnWBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnWBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnWBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"XBigObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnXBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnXBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnXBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnXBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnXBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnXBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnXBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnXBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnXBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnXBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnXBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnXBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnXBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnXBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnXBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnXBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnXBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnXBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnXBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnXBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnXBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnXBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnXBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnXBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnXBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnXBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"YBigObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnYBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnYBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnYBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnYBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnYBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnYBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnYBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnYBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnYBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnYBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnYBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnYBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnYBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnYBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnYBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnYBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnYBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnYBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnYBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnYBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnYBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnYBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnYBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnYBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnYBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnYBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"ZBigObject\",\"description\":\"\",\"fields\":[{\"name\":\"aFieldOnZBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"bFieldOnZBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"cFieldOnZBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dFieldOnZBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"eFieldOnZBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fFieldOnZBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gFieldOnZBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hFieldOnZBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"iFieldOnZBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"jFieldOnZBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"kFieldOnZBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lFieldOnZBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"mFieldOnZBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"nFieldOnZBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"oFieldOnZBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"pFieldOnZBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"qFieldOnZBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rFieldOnZBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"sFieldOnZBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tFieldOnZBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"uFieldOnZBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"vFieldOnZBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"wFieldOnZBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"xFieldOnZBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yFieldOnZBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"zFieldOnZBigObject\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"Engineer\",\"description\":\"\",\"fields\":[{\"name\":\"departments\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"Department\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"title\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"employees\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"engineerType\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"EngineerType\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[{\"kind\":\"INTERFACE\",\"name\":\"RoleType\",\"ofType\":null}],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"Marketer\",\"description\":\"\",\"fields\":[{\"name\":\"departments\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"Department\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"title\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"employees\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[{\"kind\":\"INTERFACE\",\"name\":\"RoleType\",\"ofType\":null}],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"Operator\",\"description\":\"\",\"fields\":[{\"name\":\"departments\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"Department\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"title\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"employees\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"operatorType\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"OperationType\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[{\"kind\":\"INTERFACE\",\"name\":\"RoleType\",\"ofType\":null}],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"description\":\"\",\"fields\":[{\"name\":\"details\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"OBJECT\",\"name\":\"Details\",\"ofType\":null},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"id\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"tag\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"role\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"INTERFACE\",\"name\":\"RoleType\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"notes\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"updatedAt\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"startDate\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"currentMood\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"Mood\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"derivedMood\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"Mood\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"isAvailable\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rootFieldThrowsError\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"rootFieldErrorWrapper\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"OBJECT\",\"name\":\"ErrorWrapper\",\"ofType\":null},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"hobbies\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"INTERFACE\",\"name\":\"Hobby\",\"ofType\":null}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"products\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"ProductName\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"productCount\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Int\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"fieldThrowsError\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[{\"kind\":\"INTERFACE\",\"name\":\"Identifiable\",\"ofType\":null}],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"Cosmo\",\"description\":\"\",\"fields\":[{\"name\":\"upc\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"ID\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"engineers\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"lead\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"name\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"ProductName\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"repositoryURL\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[{\"kind\":\"INTERFACE\",\"name\":\"IProduct\",\"ofType\":null}],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"SDK\",\"description\":\"\",\"fields\":[{\"name\":\"upc\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"ID\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"engineers\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"owner\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"unicode\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"clientLanguages\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"ProgrammingLanguage\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[{\"kind\":\"INTERFACE\",\"name\":\"IProduct\",\"ofType\":null}],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"INTERFACE\",\"name\":\"Pet\",\"description\":\"\",\"fields\":[{\"name\":\"class\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"Class\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gender\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"Gender\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"name\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[{\"kind\":\"INTERFACE\",\"name\":\"Animal\",\"ofType\":null}],\"enumValues\":null,\"possibleTypes\":[{\"kind\":\"OBJECT\",\"name\":\"Alligator\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"Cat\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"Dog\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"Mouse\",\"ofType\":null},{\"kind\":\"OBJECT\",\"name\":\"Pony\",\"ofType\":null}]},{\"kind\":\"OBJECT\",\"name\":\"Alligator\",\"description\":\"\",\"fields\":[{\"name\":\"class\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"Class\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"dangerous\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gender\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"Gender\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"name\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[{\"kind\":\"INTERFACE\",\"name\":\"Pet\",\"ofType\":null},{\"kind\":\"INTERFACE\",\"name\":\"Animal\",\"ofType\":null}],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"Cat\",\"description\":\"\",\"fields\":[{\"name\":\"class\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"Class\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gender\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"Gender\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"name\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"type\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"CatType\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[{\"kind\":\"INTERFACE\",\"name\":\"Pet\",\"ofType\":null},{\"kind\":\"INTERFACE\",\"name\":\"Animal\",\"ofType\":null}],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"Dog\",\"description\":\"\",\"fields\":[{\"name\":\"breed\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"DogBreed\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"class\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"Class\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gender\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"Gender\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"name\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[{\"kind\":\"INTERFACE\",\"name\":\"Pet\",\"ofType\":null},{\"kind\":\"INTERFACE\",\"name\":\"Animal\",\"ofType\":null}],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"Mouse\",\"description\":\"\",\"fields\":[{\"name\":\"class\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"Class\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gender\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"Gender\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"name\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[{\"kind\":\"INTERFACE\",\"name\":\"Pet\",\"ofType\":null},{\"kind\":\"INTERFACE\",\"name\":\"Animal\",\"ofType\":null}],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"Pony\",\"description\":\"\",\"fields\":[{\"name\":\"class\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"Class\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"gender\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"Gender\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"name\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[{\"kind\":\"INTERFACE\",\"name\":\"Pet\",\"ofType\":null},{\"kind\":\"INTERFACE\",\"name\":\"Animal\",\"ofType\":null}],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"Exercise\",\"description\":\"\",\"fields\":[{\"name\":\"employees\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"category\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"ExerciseType\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[{\"kind\":\"INTERFACE\",\"name\":\"Hobby\",\"ofType\":null}],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"Flying\",\"description\":\"\",\"fields\":[{\"name\":\"employees\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"planeModels\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yearsOfExperience\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[{\"kind\":\"INTERFACE\",\"name\":\"Experience\",\"ofType\":null},{\"kind\":\"INTERFACE\",\"name\":\"Hobby\",\"ofType\":null}],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"Gaming\",\"description\":\"\",\"fields\":[{\"name\":\"employees\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"genres\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"GameGenre\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"name\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"yearsOfExperience\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Float\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[{\"kind\":\"INTERFACE\",\"name\":\"Experience\",\"ofType\":null},{\"kind\":\"INTERFACE\",\"name\":\"Hobby\",\"ofType\":null}],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"Other\",\"description\":\"\",\"fields\":[{\"name\":\"employees\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"name\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[{\"kind\":\"INTERFACE\",\"name\":\"Hobby\",\"ofType\":null}],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"Programming\",\"description\":\"\",\"fields\":[{\"name\":\"employees\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"languages\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"ENUM\",\"name\":\"ProgrammingLanguage\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[{\"kind\":\"INTERFACE\",\"name\":\"Hobby\",\"ofType\":null}],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"Travelling\",\"description\":\"\",\"fields\":[{\"name\":\"employees\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Employee\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"countriesLived\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"LIST\",\"name\":null,\"ofType\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"OBJECT\",\"name\":\"Country\",\"ofType\":null}}}},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[{\"kind\":\"INTERFACE\",\"name\":\"Hobby\",\"ofType\":null}],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"DirectiveFact\",\"description\":\"\",\"fields\":[{\"name\":\"title\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"description\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"FactContent\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"factType\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"ENUM\",\"name\":\"TopSecretFactType\",\"ofType\":null},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[{\"kind\":\"INTERFACE\",\"name\":\"TopSecretFact\",\"ofType\":null}],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"EntityFact\",\"description\":\"\",\"fields\":[{\"name\":\"title\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"description\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"FactContent\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"factType\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"ENUM\",\"name\":\"TopSecretFactType\",\"ofType\":null},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[{\"kind\":\"INTERFACE\",\"name\":\"TopSecretFact\",\"ofType\":null}],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"OBJECT\",\"name\":\"MiscellaneousFact\",\"description\":\"\",\"fields\":[{\"name\":\"title\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"description\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"FactContent\",\"ofType\":null}},\"isDeprecated\":false,\"deprecationReason\":null},{\"name\":\"factType\",\"description\":\"\",\"args\":[],\"type\":{\"kind\":\"ENUM\",\"name\":\"TopSecretFactType\",\"ofType\":null},\"isDeprecated\":false,\"deprecationReason\":null}],\"inputFields\":[],\"interfaces\":[{\"kind\":\"INTERFACE\",\"name\":\"TopSecretFact\",\"ofType\":null}],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"SCALAR\",\"name\":\"Int\",\"description\":\"The 'Int' scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.\",\"fields\":null,\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"SCALAR\",\"name\":\"Float\",\"description\":\"The 'Float' scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).\",\"fields\":null,\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"SCALAR\",\"name\":\"String\",\"description\":\"The 'String' scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.\",\"fields\":null,\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"description\":\"The 'Boolean' scalar type represents 'true' or 'false' .\",\"fields\":null,\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]},{\"kind\":\"SCALAR\",\"name\":\"ID\",\"description\":\"The 'ID' scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as '4') or integer (such as 4) input value will be accepted as an ID.\",\"fields\":null,\"inputFields\":[],\"interfaces\":[],\"enumValues\":null,\"possibleTypes\":[]}],\"directives\":[{\"name\":\"include\",\"description\":\"Directs the executor to include this field or fragment only when the argument is true.\",\"locations\":[\"FIELD\",\"FRAGMENT_SPREAD\",\"INLINE_FRAGMENT\"],\"args\":[{\"name\":\"if\",\"description\":\"Included when true.\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"defaultValue\":null}]},{\"name\":\"skip\",\"description\":\"Directs the executor to skip this field or fragment when the argument is true.\",\"locations\":[\"FIELD\",\"FRAGMENT_SPREAD\",\"INLINE_FRAGMENT\"],\"args\":[{\"name\":\"if\",\"description\":\"Skipped when true.\",\"type\":{\"kind\":\"NON_NULL\",\"name\":null,\"ofType\":{\"kind\":\"SCALAR\",\"name\":\"Boolean\",\"ofType\":null}},\"defaultValue\":null}]},{\"name\":\"deprecated\",\"description\":\"Marks an element of a GraphQL schema as no longer supported.\",\"locations\":[\"FIELD_DEFINITION\",\"ENUM_VALUE\"],\"args\":[{\"name\":\"reason\",\"description\":\"Explains why this element was deprecated, usually also including a suggestion\\n    for how to access supported similar data. Formatted in\\n    [Markdown](https://daringfireball.net/projects/markdown/).\",\"type\":{\"kind\":\"SCALAR\",\"name\":\"String\",\"ofType\":null},\"defaultValue\":\"\\\"No longer supported\\\"\"}]}]}}}"
+{
+  "data": {
+    "__schema": {
+      "queryType": {
+        "name": "Query"
+      },
+      "mutationType": {
+        "name": "Mutation"
+      },
+      "subscriptionType": {
+        "name": "Subscription"
+      },
+      "types": [
+        {
+          "kind": "OBJECT",
+          "name": "Query",
+          "description": "",
+          "fields": [
+            {
+              "name": "employee",
+              "description": "",
+              "args": [
+                {
+                  "name": "id",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Employee",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "employeeAsList",
+              "description": "",
+              "args": [
+                {
+                  "name": "id",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Employee",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "employees",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Employee",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "products",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "UNION",
+                      "name": "Products",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "teammates",
+              "description": "",
+              "args": [
+                {
+                  "name": "team",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "Department",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Employee",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "firstEmployee",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Employee",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "findEmployees",
+              "description": "This is a GraphQL query that retrieves a list of employees.",
+              "args": [
+                {
+                  "name": "criteria",
+                  "description": "",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "SearchInput",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Employee",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "productTypes",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "UNION",
+                      "name": "Products",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "topSecretFederationFacts",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INTERFACE",
+                      "name": "TopSecretFact",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "factTypes",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "TopSecretFactType",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "headerValue",
+              "description": "Returns the value of the received HTTP header.",
+              "args": [
+                {
+                  "name": "name",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "initPayloadValue",
+              "description": "Returns the value of the given key in the WS initial payload.",
+              "args": [
+                {
+                  "name": "key",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "initialPayload",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Map",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "delay",
+              "description": "Returns response after the given delay",
+              "args": [
+                {
+                  "name": "response",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "ms",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bigResponse",
+              "description": "",
+              "args": [
+                {
+                  "name": "artificialDelay",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": "0"
+                },
+                {
+                  "name": "bigObjects",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": "100"
+                },
+                {
+                  "name": "nestedObjects",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": "100"
+                },
+                {
+                  "name": "deeplyNestedObjects",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": "100"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "BigObject",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "longResponse",
+              "description": "",
+              "args": [
+                {
+                  "name": "artificialDelay",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": "0"
+                },
+                {
+                  "name": "bytes",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bigAbstractResponse",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "UNION",
+                "name": "BigAbstractResponse",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rootFieldWithListArg",
+              "description": "",
+              "args": [
+                {
+                  "name": "arg",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "LIST",
+                      "name": null,
+                      "ofType": {
+                        "kind": "NON_NULL",
+                        "name": null,
+                        "ofType": {
+                          "kind": "SCALAR",
+                          "name": "String",
+                          "ofType": null
+                        }
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rootFieldWithNestedListArg",
+              "description": "",
+              "args": [
+                {
+                  "name": "arg",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "LIST",
+                      "name": null,
+                      "ofType": {
+                        "kind": "NON_NULL",
+                        "name": null,
+                        "ofType": {
+                          "kind": "LIST",
+                          "name": null,
+                          "ofType": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                              "kind": "SCALAR",
+                              "name": "String",
+                              "ofType": null
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "LIST",
+                      "name": null,
+                      "ofType": {
+                        "kind": "NON_NULL",
+                        "name": null,
+                        "ofType": {
+                          "kind": "SCALAR",
+                          "name": "String",
+                          "ofType": null
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rootFieldWithListOfInputArg",
+              "description": "",
+              "args": [
+                {
+                  "name": "arg",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "LIST",
+                      "name": null,
+                      "ofType": {
+                        "kind": "NON_NULL",
+                        "name": null,
+                        "ofType": {
+                          "kind": "INPUT_OBJECT",
+                          "name": "InputType",
+                          "ofType": null
+                        }
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "InputResponse",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rootFieldWithListOfEnumArg",
+              "description": "",
+              "args": [
+                {
+                  "name": "arg",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "LIST",
+                      "name": null,
+                      "ofType": {
+                        "kind": "NON_NULL",
+                        "name": null,
+                        "ofType": {
+                          "kind": "ENUM",
+                          "name": "EnumType",
+                          "ofType": null
+                        }
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "EnumType",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rootFieldWithInput",
+              "description": "",
+              "args": [
+                {
+                  "name": "arg",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "InputArg",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "floatField",
+              "description": "",
+              "args": [
+                {
+                  "name": "arg",
+                  "description": "",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Float",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sharedThings",
+              "description": "",
+              "args": [
+                {
+                  "name": "numOfA",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "numOfB",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Thing",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "secret",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Secret",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Upload",
+          "description": "",
+          "fields": null,
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Mutation",
+          "description": "",
+          "fields": [
+            {
+              "name": "updateEmployeeTag",
+              "description": "",
+              "args": [
+                {
+                  "name": "id",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "tag",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Employee",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "singleUpload",
+              "description": "",
+              "args": [
+                {
+                  "name": "file",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Upload",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "singleUploadWithInput",
+              "description": "",
+              "args": [
+                {
+                  "name": "arg",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "FileUpload",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "multipleUpload",
+              "description": "",
+              "args": [
+                {
+                  "name": "files",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "LIST",
+                      "name": null,
+                      "ofType": {
+                        "kind": "NON_NULL",
+                        "name": null,
+                        "ofType": {
+                          "kind": "SCALAR",
+                          "name": "Upload",
+                          "ofType": null
+                        }
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "addFact",
+              "description": "",
+              "args": [
+                {
+                  "name": "fact",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "TopSecretFactInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INTERFACE",
+                  "name": "TopSecretFact",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updateAvailability",
+              "description": "This mutation updates the availability status of an employee in the system.",
+              "args": [
+                {
+                  "name": "employeeID",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "isAvailable",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Boolean",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Employee",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updateMood",
+              "description": "This mutation update the mood of an employee.",
+              "args": [
+                {
+                  "name": "employeeID",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "mood",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "Mood",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Employee",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "FileUpload",
+          "description": "",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "nested",
+              "description": "",
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "DeeplyNestedFileUpload",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "nestedList",
+              "description": "",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Upload",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "DeeplyNestedFileUpload",
+          "description": "",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "file",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Upload",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Subscription",
+          "description": "",
+          "fields": [
+            {
+              "name": "currentTime",
+              "description": "`currentTime` will return a stream of `Time` objects.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Time",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "countEmp",
+              "description": "",
+              "args": [
+                {
+                  "name": "max",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "intervalMilliseconds",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "countEmp2",
+              "description": "",
+              "args": [
+                {
+                  "name": "max",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "intervalMilliseconds",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "countFor",
+              "description": "",
+              "args": [
+                {
+                  "name": "count",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "countHob",
+              "description": "",
+              "args": [
+                {
+                  "name": "max",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "intervalMilliseconds",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "headerValue",
+              "description": "Returns a stream with the value of the received HTTP header.",
+              "args": [
+                {
+                  "name": "name",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "repeat",
+                  "description": "",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "TimestampedString",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "initPayloadValue",
+              "description": "Returns a stream with the value of value of the given key in the WS initial payload.",
+              "args": [
+                {
+                  "name": "key",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "repeat",
+                  "description": "",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "TimestampedString",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "initialPayload",
+              "description": "Returns a stream with the value of the WS initial payload.",
+              "args": [
+                {
+                  "name": "repeat",
+                  "description": "",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Map",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "returnsError",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "ENUM",
+          "name": "Department",
+          "description": "",
+          "fields": null,
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": [
+            {
+              "name": "ENGINEERING",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MARKETING",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "OPERATIONS",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": []
+        },
+        {
+          "kind": "INTERFACE",
+          "name": "RoleType",
+          "description": "",
+          "fields": [
+            {
+              "name": "departments",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "Department",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "title",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "employees",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Employee",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "Engineer",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Marketer",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Operator",
+              "ofType": null
+            }
+          ]
+        },
+        {
+          "kind": "ENUM",
+          "name": "EngineerType",
+          "description": "",
+          "fields": null,
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": [
+            {
+              "name": "BACKEND",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FRONTEND",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FULLSTACK",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": []
+        },
+        {
+          "kind": "INTERFACE",
+          "name": "Identifiable",
+          "description": "",
+          "fields": [
+            {
+              "name": "id",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "Employee",
+              "ofType": null
+            }
+          ]
+        },
+        {
+          "kind": "ENUM",
+          "name": "OperationType",
+          "description": "",
+          "fields": null,
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": [
+            {
+              "name": "FINANCE",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "HUMAN_RESOURCES",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Details",
+          "description": "",
+          "fields": [
+            {
+              "name": "forename",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "location",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Country",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "surname",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pastLocations",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "City",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "middlename",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": true,
+              "deprecationReason": "No longer supported"
+            },
+            {
+              "name": "hasChildren",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "maritalStatus",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "ENUM",
+                "name": "MaritalStatus",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nationality",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "Nationality",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pets",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "INTERFACE",
+                  "name": "Pet",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "City",
+          "description": "",
+          "fields": [
+            {
+              "name": "type",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "country",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Country",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Country",
+          "description": "",
+          "fields": [
+            {
+              "name": "key",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CountryKey",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "language",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "CountryKey",
+          "description": "",
+          "fields": [
+            {
+              "name": "name",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "ENUM",
+          "name": "Mood",
+          "description": "",
+          "fields": null,
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": [
+            {
+              "name": "HAPPY",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SAD",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ErrorWrapper",
+          "description": "",
+          "fields": [
+            {
+              "name": "okField",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "errorField",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Time",
+          "description": "",
+          "fields": [
+            {
+              "name": "unixTime",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "timeStamp",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "UNION",
+          "name": "Products",
+          "description": "",
+          "fields": null,
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "Consultancy",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Cosmo",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "SDK",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Documentation",
+              "ofType": null
+            }
+          ]
+        },
+        {
+          "kind": "INTERFACE",
+          "name": "IProduct",
+          "description": "",
+          "fields": [
+            {
+              "name": "upc",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "engineers",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Employee",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "Cosmo",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "SDK",
+              "ofType": null
+            }
+          ]
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Consultancy",
+          "description": "",
+          "fields": [
+            {
+              "name": "upc",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lead",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Employee",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isLeadAvailable",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "ProductName",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "ENUM",
+          "name": "Class",
+          "description": "",
+          "fields": null,
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": [
+            {
+              "name": "FISH",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MAMMAL",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "REPTILE",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": []
+        },
+        {
+          "kind": "ENUM",
+          "name": "Gender",
+          "description": "",
+          "fields": null,
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": [
+            {
+              "name": "FEMALE",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MALE",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "UNKNOWN",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": []
+        },
+        {
+          "kind": "INTERFACE",
+          "name": "Animal",
+          "description": "",
+          "fields": [
+            {
+              "name": "class",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "Class",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gender",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "Gender",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "Alligator",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Cat",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Dog",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Mouse",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Pony",
+              "ofType": null
+            }
+          ]
+        },
+        {
+          "kind": "ENUM",
+          "name": "CatType",
+          "description": "",
+          "fields": null,
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": [
+            {
+              "name": "HOME",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "STREET",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": []
+        },
+        {
+          "kind": "ENUM",
+          "name": "DogBreed",
+          "description": "",
+          "fields": null,
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": [
+            {
+              "name": "GOLDEN_RETRIEVER",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "POODLE",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ROTTWEILER",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "YORKSHIRE_TERRIER",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": []
+        },
+        {
+          "kind": "ENUM",
+          "name": "MaritalStatus",
+          "description": "",
+          "fields": null,
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": [
+            {
+              "name": "ENGAGED",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MARRIED",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": []
+        },
+        {
+          "kind": "ENUM",
+          "name": "Nationality",
+          "description": "",
+          "fields": null,
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": [
+            {
+              "name": "AMERICAN",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "DUTCH",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ENGLISH",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "GERMAN",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INDIAN",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SPANISH",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "UKRAINIAN",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": []
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "SearchInput",
+          "description": "Allows to filter employees by their details.",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "hasPets",
+              "description": "",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "nationality",
+              "description": "",
+              "type": {
+                "kind": "ENUM",
+                "name": "Nationality",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "nested",
+              "description": "",
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "NestedSearchInput",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "NestedSearchInput",
+          "description": "",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "maritalStatus",
+              "description": "",
+              "type": {
+                "kind": "ENUM",
+                "name": "MaritalStatus",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "hasChildren",
+              "description": "",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "ENUM",
+          "name": "ExerciseType",
+          "description": "",
+          "fields": null,
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": [
+            {
+              "name": "CALISTHENICS",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "HIKING",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SPORT",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "STRENGTH_TRAINING",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": []
+        },
+        {
+          "kind": "INTERFACE",
+          "name": "Experience",
+          "description": "",
+          "fields": [
+            {
+              "name": "yearsOfExperience",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "Flying",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Gaming",
+              "ofType": null
+            }
+          ]
+        },
+        {
+          "kind": "ENUM",
+          "name": "GameGenre",
+          "description": "",
+          "fields": null,
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": [
+            {
+              "name": "ADVENTURE",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "BOARD",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FPS",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CARD",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "RPG",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ROGUELITE",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SIMULATION",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "STRATEGY",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": []
+        },
+        {
+          "kind": "ENUM",
+          "name": "ProgrammingLanguage",
+          "description": "",
+          "fields": null,
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": [
+            {
+              "name": "CSHARP",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "GO",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "RUST",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TYPESCRIPT",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": []
+        },
+        {
+          "kind": "INTERFACE",
+          "name": "Hobby",
+          "description": "",
+          "fields": [
+            {
+              "name": "employees",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Employee",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "Exercise",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Flying",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Gaming",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Other",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Programming",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Travelling",
+              "ofType": null
+            }
+          ]
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "TopSecretFactInput",
+          "description": "",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "title",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "description",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "FactContent",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "factType",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "TopSecretFactType",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "ENUM",
+          "name": "TopSecretFactType",
+          "description": "",
+          "fields": null,
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": [
+            {
+              "name": "DIRECTIVE",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ENTITY",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MISCELLANEOUS",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": []
+        },
+        {
+          "kind": "INTERFACE",
+          "name": "TopSecretFact",
+          "description": "",
+          "fields": [
+            {
+              "name": "description",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "FactContent",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "factType",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "ENUM",
+                "name": "TopSecretFactType",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "DirectiveFact",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "EntityFact",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "MiscellaneousFact",
+              "ofType": null
+            }
+          ]
+        },
+        {
+          "kind": "SCALAR",
+          "name": "FactContent",
+          "description": "",
+          "fields": null,
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "ENUM",
+          "name": "ProductName",
+          "description": "",
+          "fields": null,
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": [
+            {
+              "name": "CONSULTANCY",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "COSMO",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ENGINE",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FINANCE",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "HUMAN_RESOURCES",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MARKETING",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SDK",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Documentation",
+          "description": "",
+          "fields": [
+            {
+              "name": "url",
+              "description": "",
+              "args": [
+                {
+                  "name": "product",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "ProductName",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "urls",
+              "description": "",
+              "args": [
+                {
+                  "name": "products",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "LIST",
+                      "name": null,
+                      "ofType": {
+                        "kind": "NON_NULL",
+                        "name": null,
+                        "ofType": {
+                          "kind": "ENUM",
+                          "name": "ProductName",
+                          "ofType": null
+                        }
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Secret",
+          "description": "",
+          "fields": [
+            {
+              "name": "value",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Thing",
+          "description": "",
+          "fields": [
+            {
+              "name": "b",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "InputArg",
+          "description": "",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "enums",
+              "description": "",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "EnumType",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "enum",
+              "description": "",
+              "type": {
+                "kind": "ENUM",
+                "name": "EnumType",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "string",
+              "description": "",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "strings",
+              "description": "",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "ENUM",
+          "name": "EnumType",
+          "description": "",
+          "fields": null,
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": [
+            {
+              "name": "A",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "B",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "C",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": []
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "InputType",
+          "description": "",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "arg",
+              "description": "",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "InputResponse",
+          "description": "",
+          "fields": [
+            {
+              "name": "arg",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Map",
+          "description": "",
+          "fields": null,
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "TimestampedString",
+          "description": "",
+          "fields": [
+            {
+              "name": "value",
+              "description": "The value of the string.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "unixTime",
+              "description": "The timestamp when the response was generated.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "seq",
+              "description": "Sequence number",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "total",
+              "description": "Total number of responses to be sent",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "initialPayload",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Map",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "BigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "nestedObjects",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "NestedObject",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "NestedObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "deeplyNestedObjects",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "DeeplyNestedObject",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "DeeplyNestedObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnDeeplyNestedObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnDeeplyNestedObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnDeeplyNestedObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnDeeplyNestedObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnDeeplyNestedObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnDeeplyNestedObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnDeeplyNestedObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnDeeplyNestedObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnDeeplyNestedObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnDeeplyNestedObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnDeeplyNestedObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnDeeplyNestedObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnDeeplyNestedObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnDeeplyNestedObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnDeeplyNestedObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnDeeplyNestedObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnDeeplyNestedObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnDeeplyNestedObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnDeeplyNestedObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnDeeplyNestedObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnDeeplyNestedObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnDeeplyNestedObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnDeeplyNestedObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnDeeplyNestedObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnDeeplyNestedObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnDeeplyNestedObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "UNION",
+          "name": "BigAbstractResponse",
+          "description": "",
+          "fields": null,
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "ABigObject",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "BBigObject",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "CBigObject",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "DBigObject",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "EBigObject",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "FBigObject",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "GBigObject",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "HBigObject",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "IBigObject",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "JBigObject",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "KBigObject",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "LBigObject",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "MBigObject",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "NBigObject",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "OBigObject",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "PBigObject",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "QBigObject",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "RBigObject",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "SBigObject",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "TBigObject",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "UBigObject",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "VBigObject",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "WBigObject",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "XBigObject",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "YBigObject",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "ZBigObject",
+              "ofType": null
+            }
+          ]
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ABigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnABigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnABigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnABigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnABigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnABigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnABigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnABigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnABigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnABigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnABigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnABigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnABigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnABigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnABigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnABigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnABigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnABigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnABigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnABigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnABigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnABigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnABigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnABigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnABigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnABigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnABigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "BBigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnBBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnBBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnBBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnBBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnBBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnBBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnBBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnBBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnBBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnBBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnBBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnBBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnBBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnBBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnBBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnBBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnBBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnBBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnBBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnBBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnBBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnBBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnBBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnBBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnBBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnBBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "CBigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnCBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnCBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnCBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnCBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnCBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnCBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnCBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnCBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnCBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnCBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnCBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnCBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnCBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnCBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnCBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnCBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnCBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnCBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnCBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnCBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnCBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnCBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnCBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnCBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnCBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnCBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "DBigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnDBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnDBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnDBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnDBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnDBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnDBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnDBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnDBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnDBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnDBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnDBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnDBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnDBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnDBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnDBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnDBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnDBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnDBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnDBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnDBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnDBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnDBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnDBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnDBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnDBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnDBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "EBigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnEBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnEBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnEBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnEBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnEBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnEBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnEBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnEBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnEBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnEBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnEBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnEBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnEBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnEBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnEBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnEBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnEBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnEBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnEBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnEBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnEBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnEBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnEBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnEBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnEBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnEBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "FBigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnFBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnFBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnFBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnFBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnFBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnFBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnFBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnFBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnFBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnFBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnFBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnFBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnFBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnFBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnFBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnFBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnFBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnFBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnFBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnFBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnFBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnFBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnFBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnFBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnFBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnFBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "GBigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnGBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnGBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnGBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnGBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnGBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnGBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnGBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnGBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnGBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnGBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnGBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnGBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnGBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnGBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnGBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnGBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnGBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnGBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnGBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnGBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnGBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnGBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnGBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnGBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnGBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnGBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "HBigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnHBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnHBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnHBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnHBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnHBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnHBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnHBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnHBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnHBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnHBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnHBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnHBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnHBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnHBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnHBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnHBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnHBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnHBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnHBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnHBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnHBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnHBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnHBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnHBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnHBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnHBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "IBigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnIBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnIBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnIBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnIBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnIBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnIBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnIBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnIBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnIBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnIBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnIBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnIBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnIBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnIBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnIBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnIBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnIBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnIBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnIBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnIBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnIBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnIBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnIBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnIBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnIBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnIBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "JBigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnJBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnJBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnJBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnJBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnJBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnJBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnJBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnJBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnJBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnJBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnJBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnJBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnJBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnJBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnJBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnJBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnJBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnJBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnJBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnJBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnJBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnJBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnJBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnJBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnJBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnJBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "KBigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnKBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnKBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnKBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnKBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnKBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnKBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnKBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnKBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnKBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnKBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnKBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnKBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnKBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnKBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnKBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnKBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnKBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnKBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnKBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnKBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnKBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnKBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnKBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnKBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnKBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnKBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "LBigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnLBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnLBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnLBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnLBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnLBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnLBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnLBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnLBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnLBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnLBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnLBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnLBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnLBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnLBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnLBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnLBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnLBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnLBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnLBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnLBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnLBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnLBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnLBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnLBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnLBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnLBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "MBigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnMBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnMBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnMBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnMBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnMBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnMBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnMBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnMBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnMBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnMBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnMBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnMBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnMBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnMBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnMBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnMBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnMBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnMBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnMBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnMBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnMBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnMBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnMBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnMBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnMBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnMBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "NBigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnNBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnNBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnNBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnNBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnNBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnNBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnNBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnNBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnNBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnNBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnNBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnNBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnNBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnNBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnNBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnNBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnNBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnNBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnNBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnNBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnNBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnNBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnNBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnNBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnNBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnNBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "OBigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnOBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnOBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnOBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnOBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnOBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnOBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnOBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnOBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnOBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnOBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnOBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnOBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnOBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnOBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnOBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnOBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnOBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnOBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnOBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnOBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnOBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnOBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnOBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnOBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnOBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnOBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "PBigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnPBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnPBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnPBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnPBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnPBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnPBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnPBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnPBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnPBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnPBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnPBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnPBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnPBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnPBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnPBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnPBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnPBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnPBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnPBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnPBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnPBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnPBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnPBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnPBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnPBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnPBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "QBigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnQBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnQBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnQBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnQBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnQBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnQBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnQBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnQBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnQBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnQBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnQBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnQBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnQBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnQBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnQBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnQBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnQBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnQBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnQBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnQBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnQBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnQBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnQBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnQBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnQBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnQBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "RBigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnRBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnRBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnRBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnRBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnRBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnRBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnRBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnRBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnRBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnRBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnRBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnRBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnRBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnRBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnRBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnRBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnRBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnRBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnRBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnRBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnRBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnRBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnRBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnRBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnRBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnRBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "SBigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnSBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnSBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnSBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnSBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnSBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnSBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnSBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnSBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnSBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnSBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnSBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnSBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnSBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnSBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnSBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnSBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnSBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnSBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnSBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnSBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnSBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnSBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnSBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnSBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnSBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnSBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "TBigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnTBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnTBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnTBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnTBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnTBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnTBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnTBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnTBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnTBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnTBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnTBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnTBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnTBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnTBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnTBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnTBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnTBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnTBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnTBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnTBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnTBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnTBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnTBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnTBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnTBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnTBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "UBigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnUBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnUBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnUBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnUBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnUBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnUBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnUBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnUBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnUBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnUBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnUBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnUBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnUBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnUBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnUBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnUBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnUBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnUBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnUBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnUBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnUBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnUBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnUBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnUBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnUBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnUBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "VBigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnVBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnVBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnVBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnVBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnVBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnVBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnVBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnVBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnVBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnVBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnVBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnVBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnVBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnVBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnVBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnVBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnVBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnVBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnVBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnVBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnVBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnVBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnVBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnVBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnVBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnVBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "WBigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnWBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnWBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnWBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnWBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnWBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnWBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnWBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnWBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnWBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnWBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnWBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnWBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnWBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnWBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnWBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnWBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnWBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnWBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnWBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnWBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnWBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnWBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnWBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnWBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnWBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnWBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "XBigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnXBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnXBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnXBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnXBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnXBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnXBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnXBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnXBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnXBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnXBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnXBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnXBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnXBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnXBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnXBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnXBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnXBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnXBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnXBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnXBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnXBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnXBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnXBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnXBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnXBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnXBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "YBigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnYBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnYBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnYBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnYBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnYBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnYBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnYBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnYBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnYBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnYBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnYBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnYBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnYBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnYBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnYBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnYBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnYBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnYBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnYBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnYBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnYBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnYBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnYBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnYBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnYBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnYBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ZBigObject",
+          "description": "",
+          "fields": [
+            {
+              "name": "aFieldOnZBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bFieldOnZBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cFieldOnZBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dFieldOnZBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eFieldOnZBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fFieldOnZBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gFieldOnZBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hFieldOnZBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "iFieldOnZBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "jFieldOnZBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "kFieldOnZBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lFieldOnZBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mFieldOnZBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nFieldOnZBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "oFieldOnZBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pFieldOnZBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "qFieldOnZBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rFieldOnZBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sFieldOnZBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tFieldOnZBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uFieldOnZBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vFieldOnZBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wFieldOnZBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "xFieldOnZBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yFieldOnZBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "zFieldOnZBigObject",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Engineer",
+          "description": "",
+          "fields": [
+            {
+              "name": "departments",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "Department",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "title",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "employees",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Employee",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "engineerType",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "EngineerType",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "RoleType",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Marketer",
+          "description": "",
+          "fields": [
+            {
+              "name": "departments",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "Department",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "title",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "employees",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Employee",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "RoleType",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Operator",
+          "description": "",
+          "fields": [
+            {
+              "name": "departments",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "Department",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "title",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "employees",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Employee",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "operatorType",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "OperationType",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "RoleType",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Employee",
+          "description": "",
+          "fields": [
+            {
+              "name": "details",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Details",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tag",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "role",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INTERFACE",
+                  "name": "RoleType",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "notes",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updatedAt",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "startDate",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "currentMood",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "Mood",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "derivedMood",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "Mood",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isAvailable",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rootFieldThrowsError",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rootFieldErrorWrapper",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ErrorWrapper",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hobbies",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INTERFACE",
+                    "name": "Hobby",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "products",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "ProductName",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "productCount",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fieldThrowsError",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Identifiable",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Cosmo",
+          "description": "",
+          "fields": [
+            {
+              "name": "upc",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "engineers",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Employee",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lead",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Employee",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "ProductName",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "repositoryURL",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "IProduct",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "SDK",
+          "description": "",
+          "fields": [
+            {
+              "name": "upc",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "engineers",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Employee",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "owner",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Employee",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "unicode",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "clientLanguages",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "ProgrammingLanguage",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "IProduct",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "INTERFACE",
+          "name": "Pet",
+          "description": "",
+          "fields": [
+            {
+              "name": "class",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "Class",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gender",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "Gender",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Animal",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "Alligator",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Cat",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Dog",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Mouse",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Pony",
+              "ofType": null
+            }
+          ]
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Alligator",
+          "description": "",
+          "fields": [
+            {
+              "name": "class",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "Class",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dangerous",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gender",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "Gender",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Pet",
+              "ofType": null
+            },
+            {
+              "kind": "INTERFACE",
+              "name": "Animal",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Cat",
+          "description": "",
+          "fields": [
+            {
+              "name": "class",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "Class",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gender",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "Gender",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "type",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CatType",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Pet",
+              "ofType": null
+            },
+            {
+              "kind": "INTERFACE",
+              "name": "Animal",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Dog",
+          "description": "",
+          "fields": [
+            {
+              "name": "breed",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "DogBreed",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "class",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "Class",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gender",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "Gender",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Pet",
+              "ofType": null
+            },
+            {
+              "kind": "INTERFACE",
+              "name": "Animal",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Mouse",
+          "description": "",
+          "fields": [
+            {
+              "name": "class",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "Class",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gender",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "Gender",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Pet",
+              "ofType": null
+            },
+            {
+              "kind": "INTERFACE",
+              "name": "Animal",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Pony",
+          "description": "",
+          "fields": [
+            {
+              "name": "class",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "Class",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gender",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "Gender",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Pet",
+              "ofType": null
+            },
+            {
+              "kind": "INTERFACE",
+              "name": "Animal",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Exercise",
+          "description": "",
+          "fields": [
+            {
+              "name": "employees",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Employee",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "category",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "ExerciseType",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Hobby",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Flying",
+          "description": "",
+          "fields": [
+            {
+              "name": "employees",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Employee",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "planeModels",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yearsOfExperience",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Experience",
+              "ofType": null
+            },
+            {
+              "kind": "INTERFACE",
+              "name": "Hobby",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Gaming",
+          "description": "",
+          "fields": [
+            {
+              "name": "employees",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Employee",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "genres",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "GameGenre",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "yearsOfExperience",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Experience",
+              "ofType": null
+            },
+            {
+              "kind": "INTERFACE",
+              "name": "Hobby",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Other",
+          "description": "",
+          "fields": [
+            {
+              "name": "employees",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Employee",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Hobby",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Programming",
+          "description": "",
+          "fields": [
+            {
+              "name": "employees",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Employee",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "languages",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "ProgrammingLanguage",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Hobby",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Travelling",
+          "description": "",
+          "fields": [
+            {
+              "name": "employees",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Employee",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "countriesLived",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Country",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Hobby",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "DirectiveFact",
+          "description": "",
+          "fields": [
+            {
+              "name": "title",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "FactContent",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "factType",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "ENUM",
+                "name": "TopSecretFactType",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "TopSecretFact",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "EntityFact",
+          "description": "",
+          "fields": [
+            {
+              "name": "title",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "FactContent",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "factType",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "ENUM",
+                "name": "TopSecretFactType",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "TopSecretFact",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "OBJECT",
+          "name": "MiscellaneousFact",
+          "description": "",
+          "fields": [
+            {
+              "name": "title",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "FactContent",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "factType",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "ENUM",
+                "name": "TopSecretFactType",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [],
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "TopSecretFact",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Int",
+          "description": "The 'Int' scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.",
+          "fields": null,
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Float",
+          "description": "The 'Float' scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).",
+          "fields": null,
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "SCALAR",
+          "name": "String",
+          "description": "The 'String' scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
+          "fields": null,
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Boolean",
+          "description": "The 'Boolean' scalar type represents 'true' or 'false' .",
+          "fields": null,
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        },
+        {
+          "kind": "SCALAR",
+          "name": "ID",
+          "description": "The 'ID' scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as '4') or integer (such as 4) input value will be accepted as an ID.",
+          "fields": null,
+          "inputFields": [],
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": []
+        }
+      ],
+      "directives": [
+        {
+          "name": "include",
+          "description": "Directs the executor to include this field or fragment only when the argument is true.",
+          "locations": [
+            "FIELD",
+            "FRAGMENT_SPREAD",
+            "INLINE_FRAGMENT"
+          ],
+          "args": [
+            {
+              "name": "if",
+              "description": "Included when true.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ]
+        },
+        {
+          "name": "skip",
+          "description": "Directs the executor to skip this field or fragment when the argument is true.",
+          "locations": [
+            "FIELD",
+            "FRAGMENT_SPREAD",
+            "INLINE_FRAGMENT"
+          ],
+          "args": [
+            {
+              "name": "if",
+              "description": "Skipped when true.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ]
+        },
+        {
+          "name": "deprecated",
+          "description": "Marks an element of a GraphQL schema as no longer supported.",
+          "locations": [
+            "FIELD_DEFINITION",
+            "ENUM_VALUE"
+          ],
+          "args": [
+            {
+              "name": "reason",
+              "description": "Explains why this element was deprecated, usually also including a suggestion\n    for how to access supported similar data. Formatted in\n    [Markdown](https://daringfireball.net/projects/markdown/).",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": "\"No longer supported\""
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/router/go.mod
+++ b/router/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/tidwall/gjson v1.18.0
 	github.com/tidwall/sjson v1.2.5
 	github.com/twmb/franz-go v1.16.1
-	github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.177
+	github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.178
 	// Do not upgrade, it renames attributes we rely on
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.46.1
 	go.opentelemetry.io/contrib/propagators/b3 v1.23.0

--- a/router/go.sum
+++ b/router/go.sum
@@ -270,8 +270,8 @@ github.com/vektah/gqlparser/v2 v2.5.16 h1:1gcmLTvs3JLKXckwCwlUagVn/IlV2bwqle0vJ0
 github.com/vektah/gqlparser/v2 v2.5.16/go.mod h1:1lz1OeCqgQbQepsGxPVywrjdBHW2T08PUS3pJqepRww=
 github.com/wundergraph/astjson v0.0.0-20250106123708-be463c97e083 h1:8/D7f8gKxTBjW+SZK4mhxTTBVpxcqeBgWF1Rfmltbfk=
 github.com/wundergraph/astjson v0.0.0-20250106123708-be463c97e083/go.mod h1:eOTL6acwctsN4F3b7YE+eE2t8zcJ/doLm9sZzsxxxrE=
-github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.177 h1:GyyD8yGgAm7iLN+Wwgre8DnxiBEm4OqHfMMVM/q+pA8=
-github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.177/go.mod h1:B7eV0Qh8Lop9QzIOQcsvKp3S0ejfC6mgyWoJnI917yQ=
+github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.178 h1:NeZwriuQKkowZbqWo2NKuZ19epBc34JgFS5cOfSzQEg=
+github.com/wundergraph/graphql-go-tools/v2 v2.0.0-rc.178/go.mod h1:B7eV0Qh8Lop9QzIOQcsvKp3S0ejfC6mgyWoJnI917yQ=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

## Motivation and Context

Add support of deprecated directive arguments, field arguments and input object arguments

Updates engine to [v2.0.0-rc.178](https://github.com/wundergraph/graphql-go-tools/releases/tag/v2.0.0-rc.178)

### Features

* add deprecated arguments support to introspection ([#1142](https://github.com/wundergraph/graphql-go-tools/issues/1142)) ([1ac2908](https://github.com/wundergraph/graphql-go-tools/commit/1ac2908ec5ab5cfb5aed17c1fee127aef098c7fc))

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->