### PR TITLE
fix: call safelisted operation after persisted one; feat: add file storage for persisted operations

### DIFF
--- a/router-tests/cache_warmup_test.go
+++ b/router-tests/cache_warmup_test.go
@@ -6,13 +6,15 @@ import (
 	"testing"
 	"time"
 
-	nodev1 "github.com/wundergraph/cosmo/router/gen/proto/wg/cosmo/node/v1"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
 
-	"github.com/wundergraph/cosmo/router/pkg/otel"
+	nodev1 "github.com/wundergraph/cosmo/router/gen/proto/wg/cosmo/node/v1"
+
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/wundergraph/cosmo/router/pkg/otel"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -445,8 +447,8 @@ func TestCacheWarmup(t *testing.T) {
 				},
 				AssertCacheMetrics: &testenv.CacheMetricsAssertions{
 					BaseGraphAssertions: testenv.CacheMetricsAssertion{
-						QueryNormalizationMisses:          1, // 1x miss during first safelist call
-						QueryNormalizationHits:            1, // 1x hit during second safelist call
+						QueryNormalizationMisses:          0, // 0x miss during first safelist call - safelisted operation counted as persisted operation
+						QueryNormalizationHits:            0, // 0x hit during second safelist call - safelisted operation counted as persisted operation
 						PersistedQueryNormalizationHits:   2, // 1x hit after warmup, when called with operation name. No hit from second request because of missing operation name, it recomputes it
 						PersistedQueryNormalizationMisses: 5, // 1x miss during warmup, 1 miss for first operation trying without operation name, 1 miss for second operation trying without operation name, 2x miss during safelist because went to normal query normalization cache
 						ValidationHits:                    4,

--- a/router-tests/persisted_operations_test.go
+++ b/router-tests/persisted_operations_test.go
@@ -7,9 +7,11 @@ import (
 	"testing"
 
 	"github.com/buger/jsonparser"
-	"github.com/wundergraph/cosmo/router/core"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/wundergraph/cosmo/router/core"
+
 	"github.com/wundergraph/cosmo/router-tests/testenv"
 	"github.com/wundergraph/cosmo/router/pkg/config"
 )
@@ -134,7 +136,6 @@ func TestPersistedNormalizationCacheWithMultiOperationDocument(t *testing.T) {
 			require.Equal(t, "HIT", res.Response.Header.Get(core.ExecutionPlanCacheHeader))
 		})
 	})
-
 }
 
 func TestPersistedOperationsCache(t *testing.T) {
@@ -226,6 +227,105 @@ func TestPersistedOperationsCache(t *testing.T) {
 			require.Equal(t, 3, numberOfCDNRequests)
 		})
 	})
+}
+
+func TestPersistedOperationsCacheMixedCallsWithSafeList(t *testing.T) {
+	t.Parallel()
+
+	expectedData := `{"data":{"employees":[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5},{"id":7},{"id":8},{"id":10},{"id":11},{"id":12}]}}`
+
+	sendViaBody := func(t *testing.T, xEnv *testenv.Environment, expectedCacheHeaderValue string) {
+		t.Helper()
+		header := make(http.Header)
+		header.Add("graphql-client-name", "my-client")
+		res, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
+			OperationName: []byte(`"Employees"`),
+			Query:         "query Employees {\n  employees {\n    id\n    }\n}",
+			Header:        header,
+		})
+		require.NoError(t, err)
+		require.Equal(t, expectedData, res.Body)
+		require.Equal(t, expectedCacheHeaderValue, res.Response.Header.Get(core.PersistedOperationCacheHeader))
+		require.Equal(t, expectedCacheHeaderValue, res.Response.Header.Get(core.ExecutionPlanCacheHeader))
+	}
+
+	sendViaHash := func(t *testing.T, xEnv *testenv.Environment, expectedCacheHeaderValue string) {
+		t.Helper()
+		header := make(http.Header)
+		header.Add("graphql-client-name", "my-client")
+		res, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
+			Extensions: []byte(`{"persistedQuery": {"version": 1, "sha256Hash": "9015ddfadd802bb378a14e48cea51e9bf9a07c7f8a71d85c56d7b104fea84937"}}`),
+			Header:     header,
+		})
+		require.NoError(t, err)
+		require.Equal(t, expectedData, res.Body)
+		require.Equal(t, expectedCacheHeaderValue, res.Response.Header.Get(core.PersistedOperationCacheHeader))
+		require.Equal(t, expectedCacheHeaderValue, res.Response.Header.Get(core.ExecutionPlanCacheHeader))
+	}
+
+	retrieveNumberOfCDNRequests := func(t *testing.T, cdnURL string) int {
+		requestLogResp, err := http.Get(cdnURL)
+		require.NoError(t, err)
+		defer requestLogResp.Body.Close()
+		var requestLog []string
+		if err := json.NewDecoder(requestLogResp.Body).Decode(&requestLog); err != nil {
+			t.Fatal(err)
+		}
+		return len(requestLog)
+	}
+
+	t.Run("first via body, second via hash", func(t *testing.T) {
+		t.Parallel()
+
+		testenv.Run(t, &testenv.Config{
+			RouterOptions: []core.Option{
+				core.WithPersistedOperationsConfig(config.PersistedOperationsConfig{
+					Safelist: config.SafelistConfiguration{
+						Enabled: true,
+					},
+				}),
+			},
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			sendViaBody(t, xEnv, "MISS")
+			sendViaHash(t, xEnv, "HIT")
+			sendViaBody(t, xEnv, "HIT")
+			numberOfCDNRequests := retrieveNumberOfCDNRequests(t, xEnv.CDN.URL)
+			require.Equal(t, 1, numberOfCDNRequests)
+		})
+	})
+
+	t.Run("first via hash, following via body - with fs provider", func(t *testing.T) {
+		t.Parallel()
+
+		testenv.Run(t, &testenv.Config{
+			RouterOptions: []core.Option{
+				core.WithStorageProviders(config.StorageProviders{
+					FileSystem: []config.FileSystemStorageProvider{
+						{
+							ID:   "fs-cdn",
+							Path: "./testenv/testdata/cdn/organization/graph/operations",
+						},
+					},
+				}),
+				core.WithPersistedOperationsConfig(config.PersistedOperationsConfig{
+					Safelist: config.SafelistConfiguration{
+						Enabled: true,
+					},
+					Storage: config.PersistedOperationsStorageConfig{
+						ProviderID:   "fs-cdn",
+						ObjectPrefix: "my-client",
+					},
+				}),
+			},
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			sendViaHash(t, xEnv, "MISS")
+			sendViaBody(t, xEnv, "HIT")
+			sendViaBody(t, xEnv, "HIT")
+			numberOfCDNRequests := retrieveNumberOfCDNRequests(t, xEnv.CDN.URL)
+			require.Equal(t, 0, numberOfCDNRequests)
+		})
+	})
+
 }
 
 func TestPersistedOperationCacheWithVariables(t *testing.T) {

--- a/router-tests/testenv/testdata/cdn/organization/graph/operations/my-client/9015ddfadd802bb378a14e48cea51e9bf9a07c7f8a71d85c56d7b104fea84937.json
+++ b/router-tests/testenv/testdata/cdn/organization/graph/operations/my-client/9015ddfadd802bb378a14e48cea51e9bf9a07c7f8a71d85c56d7b104fea84937.json
@@ -1,0 +1,4 @@
+{
+  "version": 1,
+  "body": "query Employees {\n  employees {\n    id\n    }\n}"
+}

--- a/router/internal/persistedoperation/operationstorage/fs/client.go
+++ b/router/internal/persistedoperation/operationstorage/fs/client.go
@@ -1,0 +1,72 @@
+package fs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/wundergraph/cosmo/router/internal/persistedoperation"
+)
+
+type Option func(*Client)
+
+type Client struct {
+	path    string
+	options *Options
+}
+
+type Options struct {
+	ObjectPathPrefix string
+}
+
+// NewClient creates a new FileStorage client that can be used to retrieve persisted operations
+func NewClient(path string, options *Options) (persistedoperation.Client, error) {
+	absolutePath, err := filepath.Abs(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get absolute storage path: %w", err)
+	}
+
+	client := &Client{
+		path:    absolutePath,
+		options: options,
+	}
+
+	return client, nil
+}
+
+func (c Client) PersistedOperation(ctx context.Context, clientName, sha256Hash string) ([]byte, bool, error) {
+	content, err := c.persistedOperation(clientName, sha256Hash)
+	if err != nil {
+		return nil, false, err
+	}
+
+	return content, false, nil
+}
+
+func (c Client) persistedOperation(clientName string, sha256Hash string) ([]byte, error) {
+	operationName := fmt.Sprintf("%s.json", sha256Hash)
+	objectPath := filepath.Join(c.path, c.options.ObjectPathPrefix, operationName)
+
+	content, err := os.ReadFile(objectPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, &persistedoperation.PersistentOperationNotFoundError{
+				ClientName: clientName,
+				Sha256Hash: sha256Hash,
+			}
+		}
+		return nil, fmt.Errorf("failed to read persisted operation: %w", err)
+	}
+
+	var po persistedoperation.PersistedOperation
+	err = json.Unmarshal(content, &po)
+	if err != nil {
+		return nil, err
+	}
+
+	return []byte(po.Body), nil
+}
+
+func (c Client) Close() {}


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

## Motivation and Context

closes #1824 

Fixes a problem when safelisted persisted operation was loaded via query body, but was not properly marked as persited, which was having 2 consequences:
- persisted operation cache was not populating
- we were not using persisted operation body, after consequent calls via hash and body

Bonus:
- Adds file storage provider support to persisted operations

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please describe in detail the impact of this change. Attach screenshots if applicable.
-->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->