### PR TITLE
fix: posthog distinct id for identify

### DIFF
--- a/studio/src/lib/track.ts
+++ b/studio/src/lib/track.ts
@@ -62,6 +62,7 @@ const identify = ({
 
   // Identify with PostHog
   // We use the id posthog sets to identify the user. This way we do not lose cross domain tracking.
+  const posthog = PostHogClient();
   posthog.identify(posthog.get_distinct_id(), {
     id,
     email,

--- a/studio/src/lib/track.ts
+++ b/studio/src/lib/track.ts
@@ -61,10 +61,8 @@ const identify = ({
   });
 
   // Identify with PostHog
-
-  const posthog = PostHogClient();
-  // We set the distinct id to undefined to allow posthog to use its own id. This way we do not lose cross domain tracking.
-  posthog.identify(undefined, {
+  // We use the id posthog sets to identify the user. This way we do not lose cross domain tracking.
+  posthog.identify(posthog.get_distinct_id(), {
     id,
     email,
     organizationId,


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

## Motivation and Context

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please describe in detail the impact of this change. Attach screenshots if applicable.
-->

Posthog has conflicting docs with identify call. For now we can get the posthog id and pass it to identify.

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->