### PR TITLE
fix: checkFederatedGraph by filtering out subgraphs without schemas for composition

### DIFF
--- a/controlplane/src/core/bufservices/federated-graph/checkFederatedGraph.ts
+++ b/controlplane/src/core/bufservices/federated-graph/checkFederatedGraph.ts
@@ -76,7 +76,9 @@ export function checkFederatedGraph(
       namespaceId: federatedGraph.namespaceId,
     });
 
-    const subgraphsDetails: PlainMessage<Subgraph>[] = subgraphs.map((s) => ({
+    const subgraphsUsedForComposition = subgraphs.filter((s) => !!s.schemaSDL);
+
+    const subgraphsDetails: PlainMessage<Subgraph>[] = subgraphsUsedForComposition.map((s) => ({
       id: s.id,
       name: s.name,
       routingURL: s.routingUrl,
@@ -92,7 +94,7 @@ export function checkFederatedGraph(
     }));
 
     const result = composeSubgraphs(
-      subgraphs.map((s) => ({
+      subgraphsUsedForComposition.map((s) => ({
         id: s.id,
         name: s.name,
         url: s.routingUrl,


### PR DESCRIPTION
## Motivation and Context
This PR fixes checkFederatedGraph to handle subgraphs without schemas during composition.

## Checklist

- [x] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [x] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).