### PR TITLE
fix: display proposal matches only if the organization has access to proposals

### DIFF
--- a/studio/src/pages/[organizationSlug]/[namespace]/graph/[slug]/checks/[checkId]/index.tsx
+++ b/studio/src/pages/[organizationSlug]/[namespace]/graph/[slug]/checks/[checkId]/index.tsx
@@ -53,6 +53,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { useToast } from "@/components/ui/use-toast";
+import { useFeature } from "@/hooks/use-feature";
 import { useSessionStorage } from "@/hooks/use-session-storage";
 import { formatDate, formatDateTime } from "@/lib/format-date";
 import { NextPageWithLayout } from "@/lib/page";
@@ -391,7 +392,7 @@ const CheckDetails = ({
   const graphContext = useContext(GraphContext);
   const router = useRouter();
   const { toast } = useToast();
-
+  const proposalsFeature = useFeature("proposals");
   const organizationSlug = router.query.organizationSlug as string;
   const namespace = router.query.namespace as string;
   const slug = router.query.slug as string;
@@ -857,8 +858,8 @@ const CheckDetails = ({
                       <Tooltip delayDuration={200}>
                         <TooltipTrigger>No labels passed</TooltipTrigger>
                         <TooltipContent>
-                        Only graphs with empty label matchers will compose this
-                        subgraph
+                          Only graphs with empty label matchers will compose
+                          this subgraph
                         </TooltipContent>
                       </Tooltip>
                     </div>
@@ -1025,20 +1026,22 @@ const CheckDetails = ({
                     ) : null}
                   </Link>
                 </TabsTrigger>
-                <TabsTrigger
-                  value="proposalMatches"
-                  className="flex items-center gap-x-2"
-                  asChild
-                >
-                  <Link
-                    href={{
-                      query: { ...router.query, tab: "proposalMatches" },
-                    }}
+                {proposalsFeature?.enabled && (
+                  <TabsTrigger
+                    value="proposalMatches"
+                    className="flex items-center gap-x-2"
+                    asChild
                   >
-                    <LightningBoltIcon className="flex-shrink-0" />
-                    Proposal Matches
-                  </Link>
-                </TabsTrigger>
+                    <Link
+                      href={{
+                        query: { ...router.query, tab: "proposalMatches" },
+                      }}
+                    >
+                      <LightningBoltIcon className="flex-shrink-0" />
+                      Proposal Matches
+                    </Link>
+                  </TabsTrigger>
+                )}
 
                 {(data.check.checkedSubgraphs.length > 1 ||
                   (data.check.checkedSubgraphs.length === 1 &&
@@ -1251,17 +1254,21 @@ const CheckDetails = ({
                   hasGraphPruningErrors={data.check.hasGraphPruningErrors}
                 />
               </TabsContent>
-              <TabsContent
-                value="proposalMatches"
-                className="w-full space-y-4 px-4 lg:px-6"
-              >
-                <ProposalMatchesTable
-                  proposalMatches={data.proposalMatches}
-                  caption={`${data.proposalMatches.length} matches found`}
-                  isProposalsEnabled={data.isProposalsEnabled}
-                  proposalMatch={data.check.proposalMatch}
-                />
-              </TabsContent>
+
+              {proposalsFeature?.enabled && (
+                <TabsContent
+                  value="proposalMatches"
+                  className="w-full space-y-4 px-4 lg:px-6"
+                >
+                  <ProposalMatchesTable
+                    proposalMatches={data.proposalMatches}
+                    caption={`${data.proposalMatches.length} matches found`}
+                    isProposalsEnabled={data.isProposalsEnabled}
+                    proposalMatch={data.check.proposalMatch}
+                  />
+                </TabsContent>
+              )}
+              
               <TabsContent value="schema" className="relative w-full flex-1">
                 <ProposedSchemas
                   checkId={id}

--- a/studio/src/pages/[organizationSlug]/[namespace]/graph/[slug]/checks/index.tsx
+++ b/studio/src/pages/[organizationSlug]/[namespace]/graph/[slug]/checks/index.tsx
@@ -60,6 +60,7 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 import { useContext } from "react";
 import { cn } from "@/lib/utils";
+import { useFeature } from "@/hooks/use-feature";
 
 const ChecksPage: NextPageWithLayout = () => {
   const router = useRouter();
@@ -78,6 +79,7 @@ const ChecksPage: NextPageWithLayout = () => {
   const endDate = range ? createDateRange(range).end : end;
 
   const graphContext = useContext(GraphContext);
+  const proposalsFeature = useFeature("proposals");
 
   const [, setRouteCache] = useSessionStorage("checks.route", router.asPath);
 
@@ -316,22 +318,24 @@ const ChecksPage: NextPageWithLayout = () => {
                               Pruning Errors
                             </span>
                           </Badge>
-                          <Badge
-                            variant="outline"
-                            className={cn(
-                              "gap-2 py-1.5",
-                              !proposalMatch && "text-muted-foreground",
-                            )}
-                          >
-                            {!proposalMatch ? (
-                              <NoSymbolIcon className="h-4 w-4" />
-                            ) : (
-                              getCheckIcon(proposalMatch !== "error")
-                            )}
-                            <span className="flex-1 truncate">
-                              Proposal Match
-                            </span>
-                          </Badge>
+                          {proposalsFeature?.enabled && (
+                            <Badge
+                              variant="outline"
+                              className={cn(
+                                "gap-2 py-1.5",
+                                !proposalMatch && "text-muted-foreground",
+                              )}
+                            >
+                              {!proposalMatch ? (
+                                <NoSymbolIcon className="h-4 w-4" />
+                              ) : (
+                                getCheckIcon(proposalMatch !== "error")
+                              )}
+                              <span className="flex-1 truncate">
+                                Proposal Match
+                              </span>
+                            </Badge>
+                          )}
                         </div>
                       </TableCell>
 


### PR DESCRIPTION
## Motivation and Context
This PR makes sure that proposalMatches in the check Ui is only shown if the org has access to proposals.

## Checklist

- [x] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).
