### PR TITLE
fix: rename test to flaky so it can be retried

### DIFF
--- a/router-tests/config_hot_reload_test.go
+++ b/router-tests/config_hot_reload_test.go
@@ -96,89 +96,6 @@ func TestConfigHotReloadPoller(t *testing.T) {
 		})
 	})
 
-	t.Run("verify the config version is updated after config reload", func(t *testing.T) {
-		t.Parallel()
-
-		metricReader := metric.NewManualReader()
-
-		// Create a temporary file for the router config
-		configFile := t.TempDir() + "/config.json"
-
-		// Initial config with just the employees subgraph
-		writeTestConfig(t, "initial", configFile)
-
-		testenv.Run(t, &testenv.Config{
-			MetricReader: metricReader,
-			RouterOptions: []core.Option{
-				core.WithConfigVersionHeader(true),
-				core.WithExecutionConfig(&core.ExecutionConfig{
-					Path:          configFile,
-					Watch:         true,
-					WatchInterval: 100 * time.Millisecond,
-				}),
-			},
-		}, func(t *testing.T, xEnv *testenv.Environment) {
-			xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
-				Query: `query { hello }`,
-			})
-			rm := metricdata.ResourceMetrics{}
-			err := metricReader.Collect(context.Background(), &rm)
-			require.NoError(t, err)
-			scopeMetric := *GetMetricScopeByName(rm.ScopeMetrics, "cosmo.router")
-
-			beforeUpdate := metricdata.Metrics{
-				Name:        "router.info",
-				Description: "Router configuration info.",
-				Unit:        "",
-				Data: metricdata.Gauge[int64]{
-					DataPoints: []metricdata.DataPoint[int64]{
-						{
-							Value: 1,
-							Attributes: attribute.NewSet(
-								otel.WgRouterConfigVersion.String("initial"),
-								otel.WgRouterVersion.String("dev"),
-							),
-						},
-					},
-				},
-			}
-
-			metricdatatest.AssertEqual(t, beforeUpdate, scopeMetric.Metrics[6], metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue())
-
-			writeTestConfig(t, "updated", configFile)
-
-			require.EventuallyWithT(t, func(collectT *assert.CollectT) {
-				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
-					Query: `query { hello }`,
-				})
-				require.Equal(collectT, "updated", res.Response.Header.Get("X-Router-Config-Version"))
-
-				rm := metricdata.ResourceMetrics{}
-				err := metricReader.Collect(context.Background(), &rm)
-				require.NoError(collectT, err)
-				scopeMetricAfterUpdate := *GetMetricScopeByName(rm.ScopeMetrics, "cosmo.router")
-				afterUpdate := metricdata.Metrics{
-					Name:        "router.info",
-					Description: "Router configuration info.",
-					Unit:        "",
-					Data: metricdata.Gauge[int64]{
-						DataPoints: []metricdata.DataPoint[int64]{
-							{
-								Value: 1,
-								Attributes: attribute.NewSet(
-									otel.WgRouterConfigVersion.String("updated"),
-									otel.WgRouterVersion.String("dev"),
-								),
-							},
-						},
-					},
-				}
-
-				metricdatatest.AssertEqual(t, afterUpdate, scopeMetricAfterUpdate.Metrics[6], metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue())
-			}, 2*time.Second, 100*time.Millisecond)
-		})
-	})
-
 	t.Run("Swap config must not interrupt existing client traffic. All requests are served successfully", func(t *testing.T) {
 		t.Parallel()
 
@@ -570,6 +487,91 @@ func TestSwapConfig(t *testing.T) {
 			}()
 
 			require.Eventually(t, done.Load, time.Second*20, time.Millisecond*100)
+		})
+	})
+}
+
+func TestFlakyConfigHotReloadPoller(t *testing.T) {
+	t.Run("verify the config version is updated after config reload", func(t *testing.T) {
+		t.Parallel()
+
+		metricReader := metric.NewManualReader()
+
+		// Create a temporary file for the router config
+		configFile := t.TempDir() + "/config.json"
+
+		// Initial config with just the employees subgraph
+		writeTestConfig(t, "initial", configFile)
+
+		testenv.Run(t, &testenv.Config{
+			MetricReader: metricReader,
+			RouterOptions: []core.Option{
+				core.WithConfigVersionHeader(true),
+				core.WithExecutionConfig(&core.ExecutionConfig{
+					Path:          configFile,
+					Watch:         true,
+					WatchInterval: 100 * time.Millisecond,
+				}),
+			},
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+				Query: `query { hello }`,
+			})
+			rm := metricdata.ResourceMetrics{}
+			err := metricReader.Collect(context.Background(), &rm)
+			require.NoError(t, err)
+			scopeMetric := *GetMetricScopeByName(rm.ScopeMetrics, "cosmo.router")
+
+			beforeUpdate := metricdata.Metrics{
+				Name:        "router.info",
+				Description: "Router configuration info.",
+				Unit:        "",
+				Data: metricdata.Gauge[int64]{
+					DataPoints: []metricdata.DataPoint[int64]{
+						{
+							Value: 1,
+							Attributes: attribute.NewSet(
+								otel.WgRouterConfigVersion.String("initial"),
+								otel.WgRouterVersion.String("dev"),
+							),
+						},
+					},
+				},
+			}
+
+			metricdatatest.AssertEqual(t, beforeUpdate, scopeMetric.Metrics[6], metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue())
+
+			writeTestConfig(t, "updated", configFile)
+
+			require.EventuallyWithT(t, func(collectT *assert.CollectT) {
+				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+					Query: `query { hello }`,
+				})
+				require.Equal(collectT, "updated", res.Response.Header.Get("X-Router-Config-Version"))
+
+				rm := metricdata.ResourceMetrics{}
+				err := metricReader.Collect(context.Background(), &rm)
+				require.NoError(collectT, err)
+				scopeMetricAfterUpdate := *GetMetricScopeByName(rm.ScopeMetrics, "cosmo.router")
+				afterUpdate := metricdata.Metrics{
+					Name:        "router.info",
+					Description: "Router configuration info.",
+					Unit:        "",
+					Data: metricdata.Gauge[int64]{
+						DataPoints: []metricdata.DataPoint[int64]{
+							{
+								Value: 1,
+								Attributes: attribute.NewSet(
+									otel.WgRouterConfigVersion.String("updated"),
+									otel.WgRouterVersion.String("dev"),
+								),
+							},
+						},
+					},
+				}
+
+				metricdatatest.AssertEqual(t, afterUpdate, scopeMetricAfterUpdate.Metrics[6], metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue())
+			}, 2*time.Second, 100*time.Millisecond)
 		})
 	})
 }


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

## Motivation and Context

This PR retries a config poller test that may be flaky.

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->