### PR TITLE
feat: add subgraph expressions and tracing attributes

### DIFF
--- a/router-tests/structured_logging_test.go
+++ b/router-tests/structured_logging_test.go
@@ -2142,101 +2142,6 @@ func TestFlakyAccessLogs(t *testing.T) {
 			})
 		})
 
-		t.Run("validate that expressions dont get processed yet in the subgraph logger", func(t *testing.T) {
-			t.Parallel()
-
-			testenv.Run(t, &testenv.Config{
-				SubgraphAccessLogsEnabled: true,
-				AccessLogFields: []config.CustomAttribute{
-					{
-						Key: "request_error",
-						ValueFrom: &config.CustomDynamicAttribute{
-							ContextField: core.ContextFieldRequestError,
-						},
-					},
-				},
-				SubgraphAccessLogFields: []config.CustomAttribute{
-					{
-						Key: "service_name",
-						ValueFrom: &config.CustomDynamicAttribute{
-							RequestHeader: "service-name",
-						},
-					},
-					{
-						Key: "response_header",
-						ValueFrom: &config.CustomDynamicAttribute{
-							ResponseHeader: "response-header-name",
-						},
-					},
-					{
-						Key: "custom_error_message",
-						ValueFrom: &config.CustomDynamicAttribute{
-							Expression: "request.error ?? 'request-data'",
-						},
-					},
-				},
-				LogObservation: testenv.LogObservationConfig{
-					Enabled:  true,
-					LogLevel: zapcore.InfoLevel,
-				},
-				RouterOptions: []core.Option{
-					core.WithHeaderRules(config.HeaderRules{
-						All: &config.GlobalHeaderRule{
-							Request: []*config.RequestHeaderRule{
-								{
-									Operation: config.HeaderRuleOperationPropagate,
-									Named:     "service-name",
-								},
-							},
-						},
-					}),
-				},
-				Subgraphs: testenv.SubgraphsConfig{
-					Products: testenv.SubgraphConfig{
-						Middleware: func(_ http.Handler) http.Handler {
-							return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-								w.Header().Set("Content-Type", "application/json")
-								w.WriteHeader(http.StatusForbidden)
-								_, _ = w.Write([]byte(`{"errors":[{"message":"Unauthorized","extensions":{"code":"UNAUTHORIZED"}}]}`))
-							})
-						},
-					},
-				},
-			}, func(t *testing.T, xEnv *testenv.Environment) {
-				xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
-					Query:  `query employees { employees { id details { forename surname } notes } }`,
-					Header: map[string][]string{"service-name": {"service-name"}},
-				})
-				requestLog := xEnv.Observer().FilterMessage("/graphql")
-				productContext := requestLog.All()[1].ContextMap()
-
-				additionalExpectedKeys := []string{
-					"user_agent",
-					"trace_id",
-					"hostname",
-					"latency",
-					"config_version",
-					"request_id",
-					"pid",
-					"url",
-				}
-
-				productSubgraphVals := map[string]interface{}{
-					"log_type":      "client/subgraph",
-					"subgraph_name": "products",
-					"subgraph_id":   "3",
-					"status":        int64(403),
-					"method":        "POST",
-					"path":          "/graphql",
-					"query":         "", // http query is empty
-					"ip":            "[REDACTED]",
-					"service_name":  "service-name", // From request header
-					// custom_error_message is removed
-				}
-				checkValues(t, productContext, productSubgraphVals, additionalExpectedKeys)
-			})
-		})
-
 		t.Run("validate the evaluation of the body.raw expression for a query", func(t *testing.T) {
 			t.Parallel()
 
@@ -2785,6 +2690,123 @@ func TestFlakyAccessLogs(t *testing.T) {
 				assert.Empty(t, batchOperationId)
 			},
 		)
+	})
+
+	t.Run("verify subgraph expressions", func(t *testing.T) {
+		t.Run("verify connAcquireDuration value is attached", func(t *testing.T) {
+			t.Parallel()
+
+			testenv.Run(t, &testenv.Config{
+				SubgraphAccessLogsEnabled: true,
+				SubgraphAccessLogFields: []config.CustomAttribute{
+					{
+						Key: "conn_acquire_duration",
+						ValueFrom: &config.CustomDynamicAttribute{
+							Expression: "subgraph.request.clientTrace.connAcquireDuration",
+						},
+					},
+				},
+				LogObservation: testenv.LogObservationConfig{
+					Enabled:  true,
+					LogLevel: zapcore.InfoLevel,
+				},
+			}, func(t *testing.T, xEnv *testenv.Environment) {
+				xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+					Query: `query myQuery { employees { id } }`,
+				})
+				requestLog := xEnv.Observer().FilterMessage("/graphql")
+				requestLogAll := requestLog.All()
+				requestContextMap := requestLogAll[0].ContextMap()
+
+				connAcquireDuration, ok := requestContextMap["conn_acquire_duration"].(float64)
+				require.True(t, ok)
+
+				require.Greater(t, connAcquireDuration, 0.0)
+			})
+		})
+
+		t.Run("verify connAcquireDuration value is attached for multiple subgraph calls", func(t *testing.T) {
+			t.Parallel()
+
+			testenv.Run(t, &testenv.Config{
+				SubgraphAccessLogsEnabled: true,
+				SubgraphAccessLogFields: []config.CustomAttribute{
+					{
+						Key: "conn_acquire_duration",
+						ValueFrom: &config.CustomDynamicAttribute{
+							Expression: "subgraph.request.clientTrace.connAcquireDuration",
+						},
+					},
+				},
+				LogObservation: testenv.LogObservationConfig{
+					Enabled:  true,
+					LogLevel: zapcore.InfoLevel,
+				},
+			}, func(t *testing.T, xEnv *testenv.Environment) {
+				xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+					Query: `query myQuery { employees { id isAvailable } }`,
+				})
+				requestLog := xEnv.Observer().FilterMessage("/graphql")
+				requestLogAll := requestLog.All()
+
+				employeeSubgraphLogs := requestLogAll[0]
+				connAcquireDuration1, ok := employeeSubgraphLogs.ContextMap()["conn_acquire_duration"].(float64)
+				require.True(t, ok)
+				require.Greater(t, connAcquireDuration1, 0.0)
+
+				availabilitySubgraphLogs := requestLogAll[1]
+				connAcquireDuration2, ok := availabilitySubgraphLogs.ContextMap()["conn_acquire_duration"].(float64)
+				require.True(t, ok)
+				require.Greater(t, connAcquireDuration2, 0.0)
+			})
+		})
+
+		t.Run("verify subgraph error in expressions", func(t *testing.T) {
+			t.Parallel()
+
+			testenv.Run(t, &testenv.Config{
+				SubgraphAccessLogsEnabled: true,
+				SubgraphAccessLogFields: []config.CustomAttribute{
+					{
+						Key: "conn_acquire_duration",
+						ValueFrom: &config.CustomDynamicAttribute{
+							Expression: "subgraph.request.error != nil ? subgraph.request.clientTrace.connAcquireDuration : ''",
+						},
+					},
+				},
+				LogObservation: testenv.LogObservationConfig{
+					Enabled:  true,
+					LogLevel: zapcore.InfoLevel,
+				},
+				Subgraphs: testenv.SubgraphsConfig{
+					Availability: testenv.SubgraphConfig{
+						Middleware: func(_ http.Handler) http.Handler {
+							return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+								w.Header().Set("Content-Type", "application/json")
+								w.WriteHeader(http.StatusForbidden)
+								_, _ = w.Write([]byte(`{"errors":[{"message":"Unauthorized","extensions":{"code":"UNAUTHORIZED"}}]}`))
+							})
+						},
+					},
+				},
+			}, func(t *testing.T, xEnv *testenv.Environment) {
+				xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+					Query: `query myQuery { employees { id isAvailable } }`,
+				})
+				requestLog := xEnv.Observer().FilterMessage("/graphql")
+				requestLogAll := requestLog.All()
+
+				employeeSubgraphLogs := requestLogAll[0]
+				_, ok := employeeSubgraphLogs.ContextMap()["conn_acquire_duration"]
+				require.False(t, ok)
+
+				availabilitySubgraphLogs := requestLogAll[1]
+				connAcquireDuration2, ok := availabilitySubgraphLogs.ContextMap()["conn_acquire_duration"].(float64)
+				require.True(t, ok)
+				require.Greater(t, connAcquireDuration2, 0.0)
+			})
+		})
+
 	})
 
 }

--- a/router-tests/structured_logging_test.go
+++ b/router-tests/structured_logging_test.go
@@ -2807,7 +2807,7 @@ func TestFlakyAccessLogs(t *testing.T) {
 			})
 		})
 
-		t.Run("verify cleanup of expression attributes", func(t *testing.T) {
+		t.Run("verify cleanup of attributes which contains expression and other attributes", func(t *testing.T) {
 			t.Parallel()
 
 			key := "conn_acquire_duration"

--- a/router-tests/telemetry/telemetry_test.go
+++ b/router-tests/telemetry/telemetry_test.go
@@ -9521,7 +9521,7 @@ func TestFlakyTelemetry(t *testing.T) {
 			})
 		})
 
-		t.Run("verify custom tracing expressions", func(t *testing.T) {
+		t.Run("verify custom tracing expressions without and with auth", func(t *testing.T) {
 			t.Parallel()
 
 			claimKeyWithAuth := "extraclaim"

--- a/router-tests/testenv/testenv.go
+++ b/router-tests/testenv/testenv.go
@@ -288,6 +288,7 @@ type Config struct {
 	TraceExporter                      trace.SpanExporter
 	CustomMetricAttributes             []config.CustomAttribute
 	CustomTelemetryAttributes          []config.CustomAttribute
+	CustomTracingAttributes            []config.CustomAttribute
 	CustomResourceAttributes           []config.CustomStaticAttribute
 	MetricReader                       metric.Reader
 	PrometheusRegistry                 *prometheus.Registry
@@ -1373,6 +1374,10 @@ func configureRouter(listenerAddr string, testConfig *Config, routerConfig *node
 
 	if testConfig.CustomTelemetryAttributes != nil {
 		routerOpts = append(routerOpts, core.WithTelemetryAttributes(testConfig.CustomTelemetryAttributes))
+	}
+
+	if testConfig.CustomTracingAttributes != nil {
+		routerOpts = append(routerOpts, core.WithTracingAttributes(testConfig.CustomTracingAttributes))
 	}
 
 	var prometheusConfig rmetric.PrometheusConfig

--- a/router/core/access_log_field_handler_test.go
+++ b/router/core/access_log_field_handler_test.go
@@ -32,6 +32,7 @@ func TestAccessLogsFieldHandler(t *testing.T) {
 			nil,
 			req,
 			nil,
+			nil,
 		)
 
 		require.Len(t, response, 1)
@@ -67,6 +68,7 @@ func TestAccessLogsFieldHandler(t *testing.T) {
 			exprAttributes,
 			nil,
 			req,
+			nil,
 			nil,
 		)
 
@@ -115,6 +117,7 @@ func TestAccessLogsFieldHandler(t *testing.T) {
 			exprAttributes,
 			nil,
 			req,
+			nil,
 			nil,
 		)
 

--- a/router/core/attribute_expressions.go
+++ b/router/core/attribute_expressions.go
@@ -18,6 +18,8 @@ type attributeExpressions struct {
 	// expressionsWithAuth is a map of expressions that can be used to resolve dynamic attributes and acces the auth
 	// argument
 	expressionsWithAuth map[string]*vm.Program
+
+	expressionsWithSubgraph map[string]*vm.Program
 }
 
 type VisitorCheckForRequestAuthAccess struct {
@@ -48,15 +50,19 @@ func (v *VisitorCheckForRequestAuthAccess) Visit(node *ast.Node) {
 func newAttributeExpressions(attr []config.CustomAttribute, exprManager *expr.Manager) (*attributeExpressions, error) {
 	attrExprMap := make(map[string]*vm.Program)
 	attrExprMapWithAuth := make(map[string]*vm.Program)
+	attrExprMapSubgraph := make(map[string]*vm.Program)
 
 	for _, a := range attr {
 		if a.ValueFrom != nil && a.ValueFrom.Expression != "" {
 			usesAuth := VisitorCheckForRequestAuthAccess{}
-			prog, err := exprManager.CompileExpression(a.ValueFrom.Expression, reflect.String, &usesAuth)
+			usesSubgraph := expr.UsesSubgraph{}
+			prog, err := exprManager.CompileExpression(a.ValueFrom.Expression, reflect.String, &usesAuth, &usesSubgraph)
 			if err != nil {
 				return nil, fmt.Errorf("custom attribute error, unable to compile '%s' with expression '%s': %s", a.Key, a.ValueFrom.Expression, err)
 			}
-			if usesAuth.HasAuth {
+			if usesSubgraph.UsesSubgraph {
+				attrExprMapSubgraph[a.Key] = prog
+			} else if usesAuth.HasAuth {
 				attrExprMapWithAuth[a.Key] = prog
 			} else {
 				attrExprMap[a.Key] = prog
@@ -65,19 +71,20 @@ func newAttributeExpressions(attr []config.CustomAttribute, exprManager *expr.Ma
 	}
 
 	return &attributeExpressions{
-		expressions:         attrExprMap,
-		expressionsWithAuth: attrExprMapWithAuth,
+		expressions:             attrExprMap,
+		expressionsWithAuth:     attrExprMapWithAuth,
+		expressionsWithSubgraph: attrExprMapSubgraph,
 	}, nil
 }
 
-func expressionAttributes(expressions map[string]*vm.Program, reqCtx *requestContext) ([]attribute.KeyValue, error) {
-	if reqCtx == nil {
+func expressionAttributes(expressions map[string]*vm.Program, exprCtx *expr.Context) ([]attribute.KeyValue, error) {
+	if exprCtx == nil {
 		return nil, nil
 	}
 
 	var result []attribute.KeyValue
 	for exprKey, exprVal := range expressions {
-		val, err := reqCtx.ResolveStringExpression(exprVal)
+		val, err := expr.ResolveStringExpression(exprVal, *exprCtx)
 		if err != nil {
 			return nil, err
 		}
@@ -87,10 +94,14 @@ func expressionAttributes(expressions map[string]*vm.Program, reqCtx *requestCon
 	return result, nil
 }
 
-func (r *attributeExpressions) expressionsAttributes(reqCtx *requestContext) ([]attribute.KeyValue, error) {
-	return expressionAttributes(r.expressions, reqCtx)
+func (r *attributeExpressions) expressionsAttributes(exprCtx *expr.Context) ([]attribute.KeyValue, error) {
+	return expressionAttributes(r.expressions, exprCtx)
 }
 
-func (r *attributeExpressions) expressionsAttributesWithAuth(reqCtx *requestContext) ([]attribute.KeyValue, error) {
-	return expressionAttributes(r.expressionsWithAuth, reqCtx)
+func (r *attributeExpressions) expressionsAttributesWithAuth(exprCtx *expr.Context) ([]attribute.KeyValue, error) {
+	return expressionAttributes(r.expressionsWithAuth, exprCtx)
+}
+
+func (r *attributeExpressions) expressionsAttributesWithSubgraph(exprCtx *expr.Context) ([]attribute.KeyValue, error) {
+	return expressionAttributes(r.expressionsWithSubgraph, exprCtx)
 }

--- a/router/core/attribute_expressions_test.go
+++ b/router/core/attribute_expressions_test.go
@@ -120,12 +120,12 @@ func TestNewAttributeExpressions_SplitsExpressionsUsingAuth(t *testing.T) {
 		},
 	}
 
-	val, err := attrExpr.expressionsAttributes(&reqCtx)
+	val, err := attrExpr.expressionsAttributes(&reqCtx.expressionContext)
 	assert.NoError(t, err)
 	require.Len(t, val, 1)
 	assert.Equal(t, "/some/path", val[0].Value.AsString())
 
-	val2, err2 := attrExpr.expressionsAttributesWithAuth(&reqCtx)
+	val2, err2 := attrExpr.expressionsAttributesWithAuth(&reqCtx.expressionContext)
 	assert.NoError(t, err2)
 	require.Len(t, val2, 1)
 	assert.Equal(t, "yes", val2[0].Value.AsString())

--- a/router/core/batch_test.go
+++ b/router/core/batch_test.go
@@ -2,11 +2,8 @@ package core
 
 import (
 	"bytes"
-	"fmt"
-	"github.com/cespare/xxhash/v2"
 	"github.com/stretchr/testify/require"
 	"io"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -153,21 +150,6 @@ func TestBatch(t *testing.T) {
 		require.Equal(t, "", string(readString))
 	})
 
-	t.Run("test testcase", func(t *testing.T) {
-		t.Parallel()
-
-		stringBody := "awesome"
-
-		digest := xxhash.New()
-		digest.WriteString(stringBody)
-		operationHashBatch := strconv.FormatUint(digest.Sum64(), 10)
-		fmt.Println(operationHashBatch)
-
-		digest.Reset()
-		digest.WriteString(stringBody)
-		operationHashBatch = strconv.FormatUint(digest.Sum64(), 10)
-		fmt.Println(operationHashBatch)
-	})
 }
 
 func randomString(n int, generateRune rune) string {

--- a/router/core/engine_loader_hooks.go
+++ b/router/core/engine_loader_hooks.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/wundergraph/cosmo/router/internal/httpclient"
 	"github.com/wundergraph/cosmo/router/internal/requestlogger"
+	"github.com/wundergraph/cosmo/router/internal/traceclient"
 	"github.com/wundergraph/cosmo/router/internal/unique"
 	"github.com/wundergraph/cosmo/router/pkg/metric"
 	rotel "github.com/wundergraph/cosmo/router/pkg/otel"
@@ -37,31 +37,44 @@ type engineLoaderHooks struct {
 	tracer       trace.Tracer
 	metricStore  metric.Store
 	accessLogger *requestlogger.SubgraphAccessLogger
+
+	tracingAttributeExpressions   *attributeExpressions
+	telemetryAttributeExpressions *attributeExpressions
+	metricAttributeExpressions    *attributeExpressions
 }
 
 type engineLoaderHooksRequestContext struct {
 	startTime time.Time
 }
 
-func NewEngineRequestHooks(metricStore metric.Store, logger *requestlogger.SubgraphAccessLogger, tracerProvider *sdktrace.TracerProvider) resolve.LoaderHooks {
+func NewEngineRequestHooks(
+	metricStore metric.Store,
+	logger *requestlogger.SubgraphAccessLogger,
+	tracerProvider *sdktrace.TracerProvider,
+	tracingAttributes *attributeExpressions,
+	telemetryAttributes *attributeExpressions,
+	metricAttributes *attributeExpressions,
+) resolve.LoaderHooks {
+	var tracer trace.Tracer
 	if tracerProvider != nil {
-		return &engineLoaderHooks{
-			tracer: tracerProvider.Tracer(
-				EngineLoaderHooksScopeName,
-				trace.WithInstrumentationVersion(EngineLoaderHooksScopeVersion),
-			),
-			metricStore:  metricStore,
-			accessLogger: logger,
-		}
+		tracer = tracerProvider.Tracer(
+			EngineLoaderHooksScopeName,
+			trace.WithInstrumentationVersion(EngineLoaderHooksScopeVersion),
+		)
+	} else {
+		tracer = otel.GetTracerProvider().Tracer(
+			EngineLoaderHooksScopeName,
+			trace.WithInstrumentationVersion(EngineLoaderHooksScopeVersion),
+		)
 	}
 
 	return &engineLoaderHooks{
-		tracer: otel.GetTracerProvider().Tracer(
-			EngineLoaderHooksScopeName,
-			trace.WithInstrumentationVersion(EngineLoaderHooksScopeVersion),
-		),
-		metricStore:  metricStore,
-		accessLogger: logger,
+		tracer:                        tracer,
+		metricStore:                   metricStore,
+		telemetryAttributeExpressions: telemetryAttributes,
+		tracingAttributeExpressions:   tracingAttributes,
+		metricAttributeExpressions:    metricAttributes,
+		accessLogger:                  logger,
 	}
 }
 
@@ -73,12 +86,12 @@ func (f *engineLoaderHooks) OnLoad(ctx context.Context, ds resolve.DataSourceInf
 
 	start := time.Now()
 
+	ctx = context.WithValue(ctx, traceclient.CurrentSubgraphContextKey{}, ds.Name)
+
 	reqContext := getRequestContext(ctx)
 	if reqContext == nil {
 		return ctx
 	}
-
-	ctx = context.WithValue(ctx, httpclient.CurrentSubgraphContextKey{}, ds.Name)
 
 	ctx, _ = f.tracer.Start(ctx, "Engine - Fetch",
 		trace.WithAttributes([]attribute.KeyValue{
@@ -130,10 +143,40 @@ func (f *engineLoaderHooks) OnFinished(ctx context.Context, ds resolve.DataSourc
 	traceAttrs = append(traceAttrs, rotel.WgComponentName.String("engine-loader"))
 	traceAttrs = append(traceAttrs, commonAttrs...)
 
+	exprCtx := reqContext.expressionContext.Clone()
+	exprCtx.Subgraph.Id = ds.ID
+	exprCtx.Subgraph.Name = ds.Name
+	exprCtx.Subgraph.Request.Error = WrapExprError(responseInfo.Err)
+
 	metricAttrs := *reqContext.telemetry.AcquireAttributes()
 	defer reqContext.telemetry.ReleaseAttributes(&metricAttrs)
 	metricAttrs = append(metricAttrs, reqContext.telemetry.metricAttrs...)
 	metricAttrs = append(metricAttrs, commonAttrs...)
+
+	if f.telemetryAttributeExpressions != nil {
+		telemetryValues, err := f.telemetryAttributeExpressions.expressionsAttributesWithSubgraph(exprCtx)
+		if err != nil {
+			reqContext.Logger().Warn("failed to resolve expression for telemetry", zap.Error(err))
+		}
+		traceAttrs = append(traceAttrs, telemetryValues...)
+		metricAttrs = append(metricAttrs, telemetryValues...)
+	}
+
+	if f.tracingAttributeExpressions != nil {
+		tracingValues, err := f.tracingAttributeExpressions.expressionsAttributesWithSubgraph(exprCtx)
+		if err != nil {
+			reqContext.Logger().Warn("failed to resolve expression for tracing", zap.Error(err))
+		}
+		traceAttrs = append(traceAttrs, tracingValues...)
+	}
+
+	if f.metricAttributeExpressions != nil {
+		metricValues, err := f.metricAttributeExpressions.expressionsAttributesWithSubgraph(exprCtx)
+		if err != nil {
+			reqContext.Logger().Warn("failed to resolve expression for metrics", zap.Error(err))
+		}
+		metricAttrs = append(metricAttrs, metricValues...)
+	}
 
 	metricAddOpt := otelmetric.WithAttributeSet(attribute.NewSet(metricAttrs...))
 
@@ -146,7 +189,7 @@ func (f *engineLoaderHooks) OnFinished(ctx context.Context, ds resolve.DataSourc
 		}
 		path := ds.Name
 		if responseInfo.Request != nil {
-			fields = append(fields, f.accessLogger.RequestFields(responseInfo, fields)...)
+			fields = append(fields, f.accessLogger.RequestFields(responseInfo, exprCtx)...)
 			if responseInfo.Request.URL != nil {
 				path = responseInfo.Request.URL.Path
 			}

--- a/router/core/errors.go
+++ b/router/core/errors.go
@@ -343,3 +343,10 @@ func (e *ExprWrapError) Error() string {
 	}
 	return e.Err.Error()
 }
+
+func WrapExprError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &ExprWrapError{Err: err}
+}

--- a/router/core/graph_server.go
+++ b/router/core/graph_server.go
@@ -971,6 +971,8 @@ func (s *graphServer) buildGraphMux(ctx context.Context,
 				return nil, fmt.Errorf("failed building router access log expressions: %w", err)
 			}
 
+			s.accessLogsConfig.SubgraphAttributes = requestlogger.CleanupExpressionAttributes(s.accessLogsConfig.SubgraphAttributes)
+
 			subgraphAccessLogger = requestlogger.NewSubgraphAccessLogger(
 				s.accessLogsConfig.Logger,
 				requestlogger.SubgraphOptions{

--- a/router/core/graph_server.go
+++ b/router/core/graph_server.go
@@ -1011,6 +1011,11 @@ func (s *graphServer) buildGraphMux(ctx context.Context,
 
 	enableTraceClient := s.connectionMetrics != nil || exprManager.VisitorManager.IsSubgraphTraceUsedInExpressions()
 
+	var baseConnMetricStore rmetric.ConnectionMetricStore = &rmetric.NoopConnectionMetricStore{}
+	if s.connectionMetrics != nil {
+		baseConnMetricStore = s.connectionMetrics
+	}
+
 	ecb := &ExecutorConfigurationBuilder{
 		introspection:       s.introspection,
 		baseURL:             s.baseURL,
@@ -1030,7 +1035,7 @@ func (s *graphServer) buildGraphMux(ctx context.Context,
 			PreHandlers:              s.preOriginHandlers,
 			PostHandlers:             s.postOriginHandlers,
 			MetricStore:              gm.metricStore,
-			ConnectionMetricStore:    s.connectionMetrics,
+			ConnectionMetricStore:    baseConnMetricStore,
 			RetryOptions: retrytransport.RetryOptions{
 				Enabled:       s.retryOptions.Enabled,
 				MaxRetryCount: s.retryOptions.MaxRetryCount,

--- a/router/core/ratelimiter.go
+++ b/router/core/ratelimiter.go
@@ -97,7 +97,7 @@ func (c *CosmoRateLimiter) generateKey(ctx *resolve.Context) (string, error) {
 	if rc == nil {
 		return "", errors.New("no request context")
 	}
-	str, err := rc.ResolveStringExpression(c.keySuffixProgram)
+	str, err := expr.ResolveStringExpression(c.keySuffixProgram, rc.expressionContext)
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve key suffix expression: %w", err)
 	}

--- a/router/core/request_context_fields.go
+++ b/router/core/request_context_fields.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"fmt"
+	"github.com/wundergraph/cosmo/router/internal/expr"
 	"net/http"
 	"strconv"
 	"time"
@@ -96,28 +97,36 @@ func RouterAccessLogsFieldHandler(
 	passedErr any,
 	request *http.Request,
 	responseHeader *http.Header,
+	_ *expr.Context,
 ) []zapcore.Field {
 	resFields := make([]zapcore.Field, 0, len(attributes))
 
 	reqContext, resFields := processRequestIDField(request, resFields)
 	resFields = processCustomAttributes(attributes, responseHeader, resFields, request, reqContext, passedErr)
-	resFields = processExpressionAttributes(logger, exprAttributes, reqContext, resFields)
+
+	if reqContext != nil {
+		copyContext := reqContext.expressionContext.Clone()
+		copyContext.Request.Error = WrapExprError(reqContext.expressionContext.Request.Error)
+		resFields = processExpressionAttributes(logger, exprAttributes, resFields, copyContext)
+	}
 
 	return resFields
 }
 
 func SubgraphAccessLogsFieldHandler(
-	_ *zap.Logger,
+	logger *zap.Logger,
 	attributes []config.CustomAttribute,
-	_ []requestlogger.ExpressionAttribute,
+	exprAttributes []requestlogger.ExpressionAttribute,
 	passedErr any,
 	request *http.Request,
 	responseHeader *http.Header,
+	overrideExprCtx *expr.Context,
 ) []zapcore.Field {
 	resFields := make([]zapcore.Field, 0, len(attributes))
 
 	reqContext, resFields := processRequestIDField(request, resFields)
 	resFields = processCustomAttributes(attributes, responseHeader, resFields, request, reqContext, passedErr)
+	resFields = processExpressionAttributes(logger, exprAttributes, resFields, overrideExprCtx)
 
 	return resFields
 }
@@ -138,15 +147,14 @@ func processRequestIDField(request *http.Request, resFields []zapcore.Field) (*r
 	return reqContext, resFields
 }
 
-func processExpressionAttributes(logger *zap.Logger, exprAttributes []requestlogger.ExpressionAttribute, reqContext *requestContext, resFields []zapcore.Field) []zapcore.Field {
-	// If the request context was processed as nil (e.g. :- request was nil in the caller)
-	// do not proceed to process exprAttributes
-	if reqContext == nil {
-		return resFields
-	}
-
+func processExpressionAttributes(
+	logger *zap.Logger,
+	exprAttributes []requestlogger.ExpressionAttribute,
+	resFields []zapcore.Field,
+	overrideExprContext *expr.Context,
+) []zapcore.Field {
 	for _, exprField := range exprAttributes {
-		result, err := reqContext.ResolveAnyExpressionWithWrappedError(exprField.Expr)
+		result, err := expr.ResolveAnyExpression(exprField.Expr, *overrideExprContext)
 		if err != nil {
 			logger.Error("unable to process expression for access logs", zap.String("fieldKey", exprField.Key), zap.Error(err))
 			continue

--- a/router/core/router.go
+++ b/router/core/router.go
@@ -226,6 +226,7 @@ type (
 		tlsServerConfig               *tls.Config
 		tlsConfig                     *TlsConfig
 		telemetryAttributes           []config.CustomAttribute
+		tracingAttributes             []config.CustomAttribute
 		tracePropagators              []propagation.TextMapPropagator
 		compositePropagator           propagation.TextMapPropagator
 		// Poller
@@ -1949,6 +1950,12 @@ func WithTLSConfig(cfg *TlsConfig) Option {
 func WithTelemetryAttributes(attributes []config.CustomAttribute) Option {
 	return func(r *Router) {
 		r.telemetryAttributes = attributes
+	}
+}
+
+func WithTracingAttributes(attributes []config.CustomAttribute) Option {
+	return func(r *Router) {
+		r.tracingAttributes = attributes
 	}
 }
 

--- a/router/core/supervisor_instance.go
+++ b/router/core/supervisor_instance.go
@@ -218,6 +218,7 @@ func optionsFromResources(logger *zap.Logger, config *config.Config) []Option {
 		WithTracing(TraceConfigFromTelemetry(&config.Telemetry)),
 		WithMetrics(MetricConfigFromTelemetry(&config.Telemetry)),
 		WithTelemetryAttributes(config.Telemetry.Attributes),
+		WithTracingAttributes(config.Telemetry.Tracing.Attributes),
 		WithEngineExecutionConfig(config.EngineExecutionConfiguration),
 		WithCacheControlPolicy(config.CacheControl),
 		WithSecurityConfig(config.SecurityConfiguration),

--- a/router/core/transport.go
+++ b/router/core/transport.go
@@ -65,7 +65,7 @@ func NewCustomTransport(
 	baseRoundTripper http.RoundTripper,
 	retryOptions retrytransport.RetryOptions,
 	metricStore metric.Store,
-	connectionMetricStore *metric.ConnectionMetrics,
+	connectionMetricStore metric.ConnectionMetricStore,
 	enableSingleFlight bool,
 	enableTraceClient bool,
 ) *CustomTransport {
@@ -330,7 +330,7 @@ type TransportFactory struct {
 	retryOptions                  retrytransport.RetryOptions
 	localhostFallbackInsideDocker bool
 	metricStore                   metric.Store
-	connectionMetricStore         *metric.ConnectionMetrics
+	connectionMetricStore         metric.ConnectionMetricStore
 	logger                        *zap.Logger
 	tracerProvider                *sdktrace.TracerProvider
 	tracePropagators              propagation.TextMapPropagator
@@ -346,7 +346,7 @@ type TransportOptions struct {
 	RetryOptions                  retrytransport.RetryOptions
 	LocalhostFallbackInsideDocker bool
 	MetricStore                   metric.Store
-	ConnectionMetricStore         *metric.ConnectionMetrics
+	ConnectionMetricStore         metric.ConnectionMetricStore
 	Logger                        *zap.Logger
 	TracerProvider                *sdktrace.TracerProvider
 	TracePropagators              propagation.TextMapPropagator

--- a/router/core/transport.go
+++ b/router/core/transport.go
@@ -76,6 +76,9 @@ func NewCustomTransport(
 	if enableTraceClient {
 		getExprContext := func(ctx context.Context) *expr.Context {
 			reqContext := getRequestContext(ctx)
+			if reqContext == nil {
+				return &expr.Context{}
+			}
 			return &reqContext.expressionContext
 		}
 		baseRoundTripper = traceclient.NewTraceInjectingRoundTripper(baseRoundTripper, connectionMetricStore, getExprContext)

--- a/router/internal/expr/expr.go
+++ b/router/internal/expr/expr.go
@@ -32,7 +32,31 @@ const ExprRequestAuthKey = "auth"
 
 // Context is the context for expressions parser when evaluating dynamic expressions
 type Context struct {
-	Request Request `expr:"request"` // if changing the expr tag, the ExprRequestKey should be updated
+	Request  Request  `expr:"request"` // if changing the expr tag, the ExprRequestKey should be updated
+	Subgraph Subgraph `expr:"subgraph"`
+}
+
+// Clone creates a deep copy of the Context
+func (copyCtx Context) Clone() *Context {
+	// the method receiver copyCtx is already a copy
+	// so we just need to make sure any pointer values are copied
+	scopes := make([]string, len(copyCtx.Request.Auth.Scopes))
+	copy(scopes, copyCtx.Request.Auth.Scopes)
+	copyCtx.Request.Auth.Scopes = scopes
+
+	claims := make(map[string]any, len(copyCtx.Request.Auth.Claims))
+	for k, v := range copyCtx.Request.Auth.Claims {
+		claims[k] = v
+	}
+	copyCtx.Request.Auth.Claims = claims
+
+	query := make(map[string]string, len(copyCtx.Request.URL.Query))
+	for k, v := range copyCtx.Request.URL.Query {
+		claims[k] = v
+	}
+	copyCtx.Request.URL.Query = query
+
+	return &copyCtx
 }
 
 // Request is the context for the request object in expressions. Be aware, that only value receiver methods
@@ -91,6 +115,22 @@ type RequestAuth struct {
 	Type            string         `expr:"type"`
 	Claims          map[string]any `expr:"claims"`
 	Scopes          []string       `expr:"scopes"`
+}
+
+type SubgraphRequest struct {
+	Error       error       `expr:"error"`
+	ClientTrace ClientTrace `expr:"clientTrace"`
+}
+
+type ClientTrace struct {
+	ConnectionAcquireDuration float64 `expr:"connAcquireDuration"`
+}
+
+// Subgraph Related
+type Subgraph struct {
+	Id      string          `expr:"id"`
+	Name    string          `expr:"name"`
+	Request SubgraphRequest `expr:"request"`
 }
 
 // Get returns the value of the header with the given key. If the header is not present, an empty string is returned.

--- a/router/internal/expr/expr_test.go
+++ b/router/internal/expr/expr_test.go
@@ -1,0 +1,58 @@
+package expr
+
+import (
+	"github.com/stretchr/testify/require"
+	"reflect"
+	"testing"
+)
+
+func TestExpr(t *testing.T) {
+	t.Parallel()
+
+	t.Run("clone where context is not a ptr", func(t *testing.T) {
+		t.Parallel()
+
+		exprContext := Context{}
+		clone := exprContext.Clone()
+
+		require.False(t, &exprContext == clone)
+	})
+
+	t.Run("clone where context is a ptr", func(t *testing.T) {
+		t.Parallel()
+
+		exprContext := &Context{}
+		ptrCopy := exprContext
+		require.True(t, ptrCopy == exprContext)
+
+		clone := exprContext.Clone()
+		require.False(t, exprContext == clone)
+	})
+
+	t.Run("clone slices and maps", func(t *testing.T) {
+		t.Parallel()
+
+		claims := map[string]any{
+			"key": "value",
+		}
+		strings := []string{"value"}
+
+		exprContext := Context{
+			Request: Request{
+				Auth: RequestAuth{
+					Claims: claims,
+					Scopes: strings,
+				},
+			},
+		}
+		partialClone := exprContext
+		require.True(t, reflect.ValueOf(exprContext.Request.Auth.Claims).Pointer() == reflect.ValueOf(partialClone.Request.Auth.Claims).Pointer())
+		require.True(t, reflect.ValueOf(exprContext.Request.Auth.Scopes).Pointer() == reflect.ValueOf(partialClone.Request.Auth.Scopes).Pointer())
+		require.True(t, reflect.ValueOf(exprContext.Request.URL.Query).Pointer() == reflect.ValueOf(partialClone.Request.URL.Query).Pointer())
+
+		properClone := exprContext.Clone()
+		require.False(t, reflect.ValueOf(exprContext.Request.Auth.Claims).Pointer() == reflect.ValueOf(properClone.Request.Auth.Claims).Pointer())
+		require.False(t, reflect.ValueOf(exprContext.Request.Auth.Scopes).Pointer() == reflect.ValueOf(properClone.Request.Auth.Scopes).Pointer())
+		require.False(t, reflect.ValueOf(exprContext.Request.URL.Query).Pointer() == reflect.ValueOf(properClone.Request.URL.Query).Pointer())
+	})
+}

--- a/router/internal/expr/uses_subgraph.go
+++ b/router/internal/expr/uses_subgraph.go
@@ -1,0 +1,42 @@
+package expr
+
+import "github.com/expr-lang/expr/ast"
+
+const (
+	nodeName = "subgraph"
+)
+
+// This visitor is used to identify if expressions should be executed in a subgraph context
+type UsesSubgraph struct {
+	UsesSubgraph bool
+}
+
+func (v *UsesSubgraph) Visit(baseNode *ast.Node) {
+	if baseNode == nil || v.UsesSubgraph {
+		return
+	}
+
+	// Check if it's an identifier node
+	identifierNode, ok := (*baseNode).(*ast.IdentifierNode)
+	if ok && identifierNode.Value == nodeName {
+		v.UsesSubgraph = true
+		return
+	}
+
+	// Check if it's a member access
+	memberNode, ok := (*baseNode).(*ast.MemberNode)
+	if !ok {
+		return
+	}
+
+	// Check if the node itself is "subgraph"
+	if identifierNode, ok := memberNode.Node.(*ast.IdentifierNode); ok && identifierNode.Value == nodeName {
+		v.UsesSubgraph = true
+		return
+	}
+
+	// Continue traversing
+	if memberNode.Node != nil {
+		v.Visit(&memberNode.Node)
+	}
+}

--- a/router/internal/expr/uses_subgraph_test.go
+++ b/router/internal/expr/uses_subgraph_test.go
@@ -1,0 +1,97 @@
+package expr
+
+import (
+	"testing"
+
+	"github.com/expr-lang/expr/ast"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUsesSubgraph(t *testing.T) {
+	t.Run("nil node", func(t *testing.T) {
+		visitor := &UsesSubgraph{}
+		visitor.Visit(nil)
+		assert.False(t, visitor.UsesSubgraph)
+	})
+
+	t.Run("direct subgraph identifier", func(t *testing.T) {
+		visitor := &UsesSubgraph{}
+		node := ast.Node(&ast.IdentifierNode{
+			Value: "subgraph",
+		})
+		visitor.Visit(&node)
+		assert.True(t, visitor.UsesSubgraph)
+	})
+
+	t.Run("subgraph member access", func(t *testing.T) {
+		visitor := &UsesSubgraph{}
+		node := ast.Node(&ast.MemberNode{
+			Node: &ast.IdentifierNode{
+				Value: "subgraph",
+			},
+			Property: &ast.StringNode{
+				Value: "someProperty",
+			},
+		})
+		visitor.Visit(&node)
+		assert.True(t, visitor.UsesSubgraph)
+	})
+
+	t.Run("nested member access", func(t *testing.T) {
+		visitor := &UsesSubgraph{}
+		node := ast.Node(&ast.MemberNode{
+			Node: &ast.MemberNode{
+				Node: &ast.IdentifierNode{
+					Value: "subgraph",
+				},
+				Property: &ast.StringNode{
+					Value: "inner",
+				},
+			},
+			Property: &ast.StringNode{
+				Value: "outer",
+			},
+		})
+		visitor.Visit(&node)
+		assert.True(t, visitor.UsesSubgraph)
+	})
+
+	t.Run("non-subgraph identifier", func(t *testing.T) {
+		visitor := &UsesSubgraph{}
+		node := ast.Node(&ast.IdentifierNode{
+			Value: "other",
+		})
+		visitor.Visit(&node)
+		assert.False(t, visitor.UsesSubgraph)
+	})
+
+	t.Run("non-subgraph member access", func(t *testing.T) {
+		visitor := &UsesSubgraph{}
+		node := ast.Node(&ast.MemberNode{
+			Node: &ast.IdentifierNode{
+				Value: "other",
+			},
+			Property: &ast.StringNode{
+				Value: "property",
+			},
+		})
+		visitor.Visit(&node)
+		assert.False(t, visitor.UsesSubgraph)
+	})
+
+	t.Run("non-subgraph member access with use subgraph true", func(t *testing.T) {
+		visitor := &UsesSubgraph{
+			UsesSubgraph: true,
+		}
+		node := ast.Node(&ast.MemberNode{
+			Node: &ast.IdentifierNode{
+				Value: "other",
+			},
+			Property: &ast.StringNode{
+				Value: "property",
+			},
+		})
+		visitor.Visit(&node)
+		assert.True(t, visitor.UsesSubgraph)
+	})
+}

--- a/router/internal/expr/uses_subgraph_trace.go
+++ b/router/internal/expr/uses_subgraph_trace.go
@@ -1,0 +1,65 @@
+package expr
+
+import (
+	"github.com/expr-lang/expr/ast"
+)
+
+// This visitor is used to identify if we should enable client tracing because clientTrace
+// has been accessed in an expression
+type UsesSubgraphTrace struct {
+	UsesSubgraphTrace bool
+}
+
+func (v *UsesSubgraphTrace) Visit(baseNode *ast.Node) {
+	if baseNode == nil || v.UsesSubgraphTrace {
+		return
+	}
+
+	// Check if it's a member access
+	memberNode, ok := (*baseNode).(*ast.MemberNode)
+	if !ok {
+		return
+	}
+
+	// First check the current node's property
+	propertyNode, ok := memberNode.Property.(*ast.StringNode)
+	if ok && propertyNode.Value == "clientTrace" {
+		// Check if this trace is accessed through subgraph.operation
+		if v.isSubgraphOperation(memberNode.Node) {
+			v.UsesSubgraphTrace = true
+			return
+		}
+	}
+
+	// Then check the node itself and its children
+	if memberNode.Node != nil {
+		// Check if the node itself is a member access with "trace"
+		if nextMember, ok := memberNode.Node.(*ast.MemberNode); ok {
+			if nextProperty, ok := nextMember.Property.(*ast.StringNode); ok && nextProperty.Value == "clientTrace" {
+				if v.isSubgraphOperation(nextMember.Node) {
+					v.UsesSubgraphTrace = true
+					return
+				}
+			}
+		}
+		// Continue traversing
+		v.Visit(&memberNode.Node)
+	}
+}
+
+func (v *UsesSubgraphTrace) isSubgraphOperation(node ast.Node) bool {
+	memberNode, ok := node.(*ast.MemberNode)
+	if !ok {
+		return false
+	}
+
+	// Check if the property is "request"
+	requestProperty, ok := memberNode.Property.(*ast.StringNode)
+	if !ok || requestProperty.Value != "request" {
+		return false
+	}
+
+	// Check if the node is "subgraph"
+	subgraphNode, ok := memberNode.Node.(*ast.IdentifierNode)
+	return ok && subgraphNode.Value == "subgraph"
+}

--- a/router/internal/expr/uses_subgraph_trace_test.go
+++ b/router/internal/expr/uses_subgraph_trace_test.go
@@ -1,0 +1,108 @@
+package expr
+
+import (
+	"testing"
+
+	"github.com/expr-lang/expr/ast"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUsesSubgraphTrace(t *testing.T) {
+	t.Run("nil node", func(t *testing.T) {
+		visitor := &UsesSubgraphTrace{}
+		visitor.Visit(nil)
+		assert.False(t, visitor.UsesSubgraphTrace)
+	})
+
+	t.Run("subgraph request client trace", func(t *testing.T) {
+		visitor := &UsesSubgraphTrace{}
+		node := ast.Node(&ast.MemberNode{
+			Node: &ast.MemberNode{
+				Node: &ast.IdentifierNode{
+					Value: "subgraph",
+				},
+				Property: &ast.StringNode{
+					Value: "request",
+				},
+			},
+			Property: &ast.StringNode{
+				Value: "clientTrace",
+			},
+		})
+		visitor.Visit(&node)
+		assert.True(t, visitor.UsesSubgraphTrace)
+	})
+
+	t.Run("non-subgraph client trace", func(t *testing.T) {
+		visitor := &UsesSubgraphTrace{}
+		node := ast.Node(&ast.IdentifierNode{
+			Value: "other",
+		})
+		visitor.Visit(&node)
+		assert.False(t, visitor.UsesSubgraphTrace)
+	})
+
+	t.Run("subgraph non-request client trace", func(t *testing.T) {
+		visitor := &UsesSubgraphTrace{}
+		node := ast.Node(&ast.MemberNode{
+			Node: &ast.MemberNode{
+				Node: &ast.IdentifierNode{
+					Value: "subgraph",
+				},
+				Property: &ast.StringNode{
+					Value: "other",
+				},
+			},
+			Property: &ast.StringNode{
+				Value: "clientTrace",
+			},
+		})
+		visitor.Visit(&node)
+		assert.False(t, visitor.UsesSubgraphTrace)
+	})
+
+	t.Run("subgraph non-request client trace when UsesSubgraphTrace is true already", func(t *testing.T) {
+		visitor := &UsesSubgraphTrace{
+			UsesSubgraphTrace: true,
+		}
+		node := ast.Node(&ast.MemberNode{
+			Node: &ast.MemberNode{
+				Node: &ast.IdentifierNode{
+					Value: "subgraph",
+				},
+				Property: &ast.StringNode{
+					Value: "other",
+				},
+			},
+			Property: &ast.StringNode{
+				Value: "clientTrace",
+			},
+		})
+		visitor.Visit(&node)
+		assert.True(t, visitor.UsesSubgraphTrace)
+	})
+
+	t.Run("nested client trace", func(t *testing.T) {
+		visitor := &UsesSubgraphTrace{}
+		node := ast.Node(&ast.MemberNode{
+			Node: &ast.MemberNode{
+				Node: &ast.MemberNode{
+					Node: &ast.IdentifierNode{
+						Value: "subgraph",
+					},
+					Property: &ast.StringNode{
+						Value: "request",
+					},
+				},
+				Property: &ast.StringNode{
+					Value: "clientTrace",
+				},
+			},
+			Property: &ast.StringNode{
+				Value: "someProperty",
+			},
+		})
+		visitor.Visit(&node)
+		assert.True(t, visitor.UsesSubgraphTrace)
+	})
+}

--- a/router/internal/expr/visitor_group.go
+++ b/router/internal/expr/visitor_group.go
@@ -6,6 +6,7 @@ type visitorKind uint
 
 const (
 	usesBodyKey visitorKind = iota
+	usesSubgraphTraceKey
 )
 
 // VisitorGroup is a struct that holds all the VisitorManager that are used to compile the expressions
@@ -19,7 +20,8 @@ type visitorGroup struct {
 func createVisitorMGroup() *visitorGroup {
 	return &visitorGroup{
 		globalVisitors: map[visitorKind]ast.Visitor{
-			usesBodyKey: &UsesBody{},
+			usesBodyKey:          &UsesBody{},
+			usesSubgraphTraceKey: &UsesSubgraphTrace{},
 		},
 	}
 }
@@ -27,4 +29,9 @@ func createVisitorMGroup() *visitorGroup {
 func (c *visitorGroup) IsBodyUsedInExpressions() bool {
 	body := c.globalVisitors[usesBodyKey].(*UsesBody)
 	return body.UsesBody
+}
+
+func (c *visitorGroup) IsSubgraphTraceUsedInExpressions() bool {
+	body := c.globalVisitors[usesSubgraphTraceKey].(*UsesSubgraphTrace)
+	return body.UsesSubgraphTrace
 }

--- a/router/internal/requestlogger/requestlogger.go
+++ b/router/internal/requestlogger/requestlogger.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"github.com/wundergraph/cosmo/router/internal/errors"
+	"github.com/wundergraph/cosmo/router/internal/expr"
 	"github.com/wundergraph/cosmo/router/pkg/config"
 	"github.com/wundergraph/cosmo/router/pkg/logging"
 	rtrace "github.com/wundergraph/cosmo/router/pkg/trace"
@@ -24,6 +25,7 @@ type ContextFunc func(
 	err any,
 	r *http.Request,
 	rh *http.Header,
+	overrideExprCtx *expr.Context,
 ) []zapcore.Field
 
 // Option provides a functional approach to define
@@ -146,7 +148,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			// This is only called on panic so it is safe to call it here again
 			// to gather all the fields that are needed for logging
 			if h.accessLogger.fieldsHandler != nil {
-				fields = append(fields, h.accessLogger.fieldsHandler(h.logger, h.accessLogger.attributes, h.accessLogger.exprAttributes, err, r, nil)...)
+				fields = append(fields, h.accessLogger.fieldsHandler(h.logger, h.accessLogger.attributes, h.accessLogger.exprAttributes, err, r, nil, nil)...)
 			}
 
 			if brokenPipe {
@@ -175,7 +177,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if h.accessLogger.fieldsHandler != nil {
-		resFields = append(resFields, h.accessLogger.fieldsHandler(h.logger, h.accessLogger.attributes, h.accessLogger.exprAttributes, nil, r, nil)...)
+		resFields = append(resFields, h.accessLogger.fieldsHandler(h.logger, h.accessLogger.attributes, h.accessLogger.exprAttributes, nil, r, nil, nil)...)
 	}
 
 	h.logger.Info(path, append(fields, resFields...)...)

--- a/router/internal/requestlogger/subgraphlogger.go
+++ b/router/internal/requestlogger/subgraphlogger.go
@@ -1,6 +1,7 @@
 package requestlogger
 
 import (
+	"github.com/wundergraph/cosmo/router/internal/expr"
 	"github.com/wundergraph/cosmo/router/pkg/config"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
 	"go.uber.org/zap"
@@ -29,6 +30,7 @@ type SubgraphOptions struct {
 	FieldsHandler         ContextFunc
 	Fields                []zapcore.Field
 	Attributes            []config.CustomAttribute
+	ExprAttributes        []ExpressionAttribute
 }
 
 func NewSubgraphAccessLogger(logger *zap.Logger, opts SubgraphOptions) *SubgraphAccessLogger {
@@ -40,11 +42,12 @@ func NewSubgraphAccessLogger(logger *zap.Logger, opts SubgraphOptions) *Subgraph
 			traceID:               true,
 			fieldsHandler:         opts.FieldsHandler,
 			attributes:            opts.Attributes,
+			exprAttributes:        opts.ExprAttributes,
 		},
 	}
 }
 
-func (h *SubgraphAccessLogger) RequestFields(respInfo *resolve.ResponseInfo, subgraphFields []zap.Field) []zap.Field {
+func (h *SubgraphAccessLogger) RequestFields(respInfo *resolve.ResponseInfo, overrideExprCtx *expr.Context) []zap.Field {
 	if respInfo == nil {
 		return []zap.Field{}
 	}
@@ -54,7 +57,7 @@ func (h *SubgraphAccessLogger) RequestFields(respInfo *resolve.ResponseInfo, sub
 		fields = append(fields, zap.String("url", respInfo.Request.URL.String()))
 	}
 	if h.accessLogger.fieldsHandler != nil {
-		fields = append(fields, h.accessLogger.fieldsHandler(h.logger, h.accessLogger.attributes, h.accessLogger.exprAttributes, respInfo.Err, respInfo.Request, &respInfo.ResponseHeaders)...)
+		fields = append(fields, h.accessLogger.fieldsHandler(h.logger, h.accessLogger.attributes, h.accessLogger.exprAttributes, respInfo.Err, respInfo.Request, &respInfo.ResponseHeaders, overrideExprCtx)...)
 	}
 
 	return fields

--- a/router/pkg/config/config.go
+++ b/router/pkg/config/config.go
@@ -73,6 +73,7 @@ type Tracing struct {
 	Exporters           []TracingExporter   `yaml:"exporters"`
 	Propagation         PropagationConfig   `yaml:"propagation"`
 	ResponseTraceHeader ResponseTraceHeader `yaml:"response_trace_id"`
+	Attributes          []CustomAttribute   `yaml:"attributes"`
 
 	TracingGlobalFeatures `yaml:",inline"`
 }

--- a/router/pkg/config/config.schema.json
+++ b/router/pkg/config/config.schema.json
@@ -720,6 +720,10 @@
                               "request_error",
                               "response_error_message"
                             ]
+                          },
+                          "expression": {
+                            "type": "string",
+                            "description": "The name of the request header from which to extract the value."
                           }
                         }
                       }
@@ -926,6 +930,42 @@
                   "type": "string",
                   "default": "x-wg-trace-id",
                   "description": "The name of the header which the holds the trace_id. The default value is x-wg-trace-id."
+                }
+              }
+            },
+            "attributes": {
+              "type": "array",
+              "description": "Custom span attributes for subgraphs",
+              "items": {
+                "type": "object",
+                "description": "The configuration for custom span attributes for subgraph tracing.",
+                "additionalProperties": false,
+                "required": [
+                  "key"
+                ],
+                "properties": {
+                  "key": {
+                    "type": "string",
+                    "description": "The key of the field."
+                  },
+                  "value_from": {
+                    "type": "object",
+                    "description": "Defines a source for the field value e.g. from a request header. If both default and value_from are set, value_from has precedence.",
+                    "additionalProperties": false,
+                    "properties": {
+                      "expression": {
+                        "type": "string",
+                        "description": "The name of the request header from which to extract the value. The value is only extracted when a request context is available otherwise the default value is used."
+                      }
+                    },
+                    "oneOf": [
+                      {
+                        "required": [
+                          "expression"
+                        ]
+                      }
+                    ]
+                  }
                 }
               }
             }

--- a/router/pkg/config/fixtures/full.yaml
+++ b/router/pkg/config/fixtures/full.yaml
@@ -130,6 +130,10 @@ telemetry:
         export_timeout: 30s
         path: '/v1/traces'
         headers: {}
+    attributes:
+      - key: "wg.tracing.custom.conn.subgraph.hostport"
+        value_from:
+          expression: "subgraph.name"
 
   # OpenTelemetry Metrics
   metrics:

--- a/router/pkg/config/testdata/config_defaults.json
+++ b/router/pkg/config/testdata/config_defaults.json
@@ -25,6 +25,7 @@
         "Enabled": false,
         "HeaderName": "x-wg-trace-id"
       },
+      "Attributes": null,
       "ExportGraphQLVariables": false,
       "WithNewRoot": false
     },

--- a/router/pkg/config/testdata/config_full.json
+++ b/router/pkg/config/testdata/config_full.json
@@ -35,6 +35,18 @@
         "Enabled": false,
         "HeaderName": "x-wg-trace-id"
       },
+      "Attributes": [
+        {
+          "Key": "wg.tracing.custom.conn.subgraph.hostport",
+          "Default": "",
+          "ValueFrom": {
+            "RequestHeader": "",
+            "ContextField": "",
+            "ResponseHeader": "",
+            "Expression": "subgraph.name"
+          }
+        }
+      ],
       "ExportGraphQLVariables": true,
       "WithNewRoot": false
     },

--- a/router/pkg/metric/noop_connection_metrics.go
+++ b/router/pkg/metric/noop_connection_metrics.go
@@ -2,6 +2,7 @@ package metric
 
 import (
 	"context"
+	"go.opentelemetry.io/otel/attribute"
 	otelmetric "go.opentelemetry.io/otel/metric"
 )
 
@@ -22,3 +23,10 @@ func (h *noopConnectionMetricProvider) Flush(ctx context.Context) error {
 func (h *noopConnectionMetricProvider) Shutdown() error {
 	return nil
 }
+
+type NoopConnectionMetricStore struct{}
+
+func (h *NoopConnectionMetricStore) MeasureConnectionAcquireDuration(ctx context.Context, duration float64, attrs ...attribute.KeyValue) {
+}
+func (h *NoopConnectionMetricStore) Flush(ctx context.Context) error    { return nil }
+func (h *NoopConnectionMetricStore) Shutdown(ctx context.Context) error { return nil }


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

## Motivation and Context

This PR adds subgraph expressions and tracing attributes. 

**Subgraph ExpressionContext**
The following is introduced. We only have a minimal expression context for subgraph as it stands. We introduce the following

```
subgraph:
  id # subgraph id
  name #subgraph name
  request
    error #subgraph error if any occurred
    clientTrace # we can add any future trace related params here without polluting the request interface
      connAcquireDuration
```

**Add Tracing Attributes**
We already have `metric` and `telemetry` attributes, however we do not have `tracing` attributes, which can only be used to add values to `tracing` or `spans`. This is introduced as customers might be interested in how long a `connectionAcquire` took for a subgraph.

**Process subgraph expressions for telemetry**
Like we have `attributesWithAuth` we introduce `attributesWithSubgraph` which is essentially attributes that use `subgraph` in the expression context. We separate these values out for all three of telemetry / tracing and metric attributes and process them for every subgraph call.

**Process Subgraph Expressions In Logs And Tracing/Telemetry Attributes**
We have expressions for router access logs, however we do not use expressions for the subgraph access logger right now, we add this feature and allow users to define `subgraph` access log expressions.

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->