### PR TITLE
chore: remove enabled plugin config

### DIFF
--- a/router-tests/lifecycle/supervisor_test.go
+++ b/router-tests/lifecycle/supervisor_test.go
@@ -23,14 +23,14 @@ func TestRouterSupervisor(t *testing.T) {
 	go xEnv.RouterSupervisor.Start()
 
 	// Ready 1
-	err = xEnv.WaitForServer(context.Background(), xEnv.RouterURL+"/health/ready", 250, 30)
+	err = xEnv.WaitForServer(context.Background(), xEnv.RouterURL+"/health/ready", 2000, 30)
 	require.NoError(t, err, "ready 1 timed out")
 
 	// Reload the router
 	xEnv.RouterSupervisor.Reload()
 
 	// Ready 2
-	err = xEnv.WaitForServer(context.Background(), xEnv.RouterURL+"/health/ready", 500, 30)
+	err = xEnv.WaitForServer(context.Background(), xEnv.RouterURL+"/health/ready", 2000, 30)
 	require.NoError(t, err, "ready 2 timed out")
 
 	// Shutdown the router and all the httptest servers

--- a/router/core/graph_server.go
+++ b/router/core/graph_server.go
@@ -1277,7 +1277,7 @@ func (s *graphServer) buildSubgraphGRPCClients(ctx context.Context, config *node
 		if pluginConfig := grpcConfig.GetPlugin(); pluginConfig != nil {
 			basePath := ""
 
-			if s.plugins.Enabled {
+			if s.plugins.Path != "" {
 				basePath = s.plugins.Path
 			}
 

--- a/router/pkg/config/config.go
+++ b/router/pkg/config/config.go
@@ -905,8 +905,7 @@ type MCPServer struct {
 }
 
 type PluginsConfiguration struct {
-	Enabled bool   `yaml:"enabled" envDefault:"false" env:"PLUGINS_ENABLED"`
-	Path    string `yaml:"path" envDefault:"plugins" env:"PLUGINS_PATH"`
+	Path string `yaml:"path" envDefault:"plugins" env:"PLUGINS_PATH"`
 }
 
 type Config struct {

--- a/router/pkg/config/config.schema.json
+++ b/router/pkg/config/config.schema.json
@@ -2691,11 +2691,6 @@
       "description": "The configuration for the router gRPC plugins.",
       "additionalProperties": false,
       "properties": {
-        "enabled": {
-          "type": "boolean",
-          "default": false,
-          "description": "Enable the router plugins. If the value is true, the router plugins are enabled."
-        },
         "path": {
           "type": "string",
           "description": "The path to the plugins directory. The plugins directory is used to load the plugins.",

--- a/router/pkg/config/fixtures/full.yaml
+++ b/router/pkg/config/fixtures/full.yaml
@@ -7,7 +7,6 @@ graph:
   token: 'mytoken'
 
 plugins:
-  enabled: true
   path: "some/path/to/plugins"
 
 log_level: "info"

--- a/router/pkg/config/testdata/config_defaults.json
+++ b/router/pkg/config/testdata/config_defaults.json
@@ -475,7 +475,6 @@
     "Version": ""
   },
   "Plugins": {
-    "Enabled": false,
     "Path": "plugins"
   },
   "WatchConfig": {

--- a/router/pkg/config/testdata/config_full.json
+++ b/router/pkg/config/testdata/config_full.json
@@ -800,7 +800,6 @@
     "Version": "Client_Version"
   },
   "Plugins": {
-    "Enabled": true,
     "Path": "some/path/to/plugins"
   },
   "WatchConfig": {


### PR DESCRIPTION
## Motivation and Context

The enabled option doesn't really make sense in this case. Currently we have a default hello-world plugin and this would cause it not to load when this config is disabled

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->