### PR TITLE
feat: add mcp config to helm chart

### DIFF
--- a/helm/cosmo/README.md
+++ b/helm/cosmo/README.md
@@ -244,5 +244,7 @@ This is the official Helm Chart for WunderGraph Cosmo - The Full Lifecycle Graph
 | router.prometheus.enabled | bool | `true` | Enables prometheus metrics support. Default is true. |
 | router.prometheus.path | string | `"/metrics"` | The HTTP path where metrics are exposed. Default is "/metrics". |
 | router.prometheus.port | int | `8088` | The port where metrics are exposed. Default is port 8088. |
+| router.mcp.enabled | bool | `false` | Enables MCP server support. Default is false. |
+| router.mcp.port | int | `5025` | The port where the MCP server is exposed. Default is port 5025. |
 | router.terminationGracePeriodSeconds | int | `60` |  |
 

--- a/helm/cosmo/charts/router/CHANGELOG.md
+++ b/helm/cosmo/charts/router/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.10.2](https://github.com/wundergraph/cosmo/compare/helm-cosmo-router@0.10.1...helm-cosmo-router@0.10.2) (2025-04-21)
+
+### Features
+
+* add optional MCP server configuration to router helm chart
+
 ## [0.10.1](https://github.com/wundergraph/cosmo/compare/helm-cosmo-router@0.10.0...helm-cosmo-router@0.10.1) (2025-04-14)
 
 

--- a/helm/cosmo/charts/router/Chart.yaml
+++ b/helm/cosmo/charts/router/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.1
+version: 0.10.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/cosmo/charts/router/README.md
+++ b/helm/cosmo/charts/router/README.md
@@ -1,6 +1,6 @@
 # router
 
-![Version: 0.10.1](https://img.shields.io/badge/Version-0.10.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.197.1](https://img.shields.io/badge/AppVersion-0.197.1-informational?style=flat-square)
+![Version: 0.10.2](https://img.shields.io/badge/Version-0.10.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.197.1](https://img.shields.io/badge/AppVersion-0.197.1-informational?style=flat-square)
 
 This is the official Helm Chart for the WunderGraph Cosmo Router.
 
@@ -30,6 +30,8 @@ This is the official Helm Chart for the WunderGraph Cosmo Router.
 | configuration.prometheus.enabled | bool | `true` | Enables prometheus metrics support. Default is true. |
 | configuration.prometheus.path | string | `"/metrics"` | The HTTP path where metrics are exposed. Default is "/metrics". |
 | configuration.prometheus.port | int | `8088` | The port where metrics are exposed. Default is port 8088. |
+| configuration.mcp.enabled | bool | `false` | Enables MCP server support. Default is false. |
+| configuration.mcp.port | int | `5025` | The port where the MCP server is exposed. Default is port 5025. |
 | configuration.routerConfigPath | string | `""` | The path to the router execution config file. Before, you have to mount the file as a volume and set the path here. A possible to solution could be to use an init container to download the file from a CDN. If set, polling of the config is disabled. |
 | deploymentStrategy | object | `{}` |  |
 | existingConfigmap | string | `""` | The name of the configmap to use for the router configuration. The key "config.yaml" is required in the configmap. If this is set, the commonConfiguration section is ignored. |

--- a/helm/cosmo/charts/router/templates/config-map.yaml
+++ b/helm/cosmo/charts/router/templates/config-map.yaml
@@ -27,3 +27,7 @@ data:
   prometheusListenAddr: "0.0.0.0:{{ .Values.configuration.prometheus.port }}"
   prometheusPath: "{{ .Values.configuration.prometheus.path }}"
   {{- end }}
+  mcpEnabled: "{{ .Values.configuration.mcp.enabled }}"
+  {{ if .Values.configuration.mcp.enabled }}
+  mcpListenAddr: "0.0.0.0:{{ .Values.configuration.mcp.port }}"
+  {{- end }}

--- a/helm/cosmo/charts/router/templates/deployment.yaml
+++ b/helm/cosmo/charts/router/templates/deployment.yaml
@@ -59,6 +59,11 @@ spec:
               containerPort: {{ .Values.configuration.prometheus.port }}
               protocol: TCP
             {{- end }}
+            {{ if .Values.configuration.mcp.enabled }}
+            - name: mcp
+              containerPort: {{ .Values.configuration.mcp.port }}
+              protocol: TCP
+            {{- end }}
           env:
             {{- if .Values.extraEnvVars }}
             {{- toYaml .Values.extraEnvVars | nindent 12 }}
@@ -169,6 +174,18 @@ spec:
                 configMapKeyRef:
                   name: {{ include "router.fullname" . }}
                   key: prometheusPath
+            {{- end }}
+            - name: MCP_ENABLED
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "router.fullname" . }}
+                  key: mcpEnabled
+            {{ if .Values.configuration.mcp.enabled }}
+            - name: MCP_SERVER_LISTEN_ADDR
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "router.fullname" . }}
+                  key: mcpListenAddr
             {{- end }}
           envFrom:
             {{- if .Values.extraEnvVarsCM }}

--- a/helm/cosmo/charts/router/templates/service.yaml
+++ b/helm/cosmo/charts/router/templates/service.yaml
@@ -21,5 +21,11 @@ spec:
       protocol: TCP
       name: metrics
     {{- end }}
+    {{ if .Values.configuration.mcp.enabled }}
+    - port: {{ .Values.configuration.mcp.port }}
+      targetPort: mcp
+      protocol: TCP
+      name: mcp
+    {{- end }}
   selector:
     {{- include "router.selectorLabels" . | nindent 4 }}

--- a/helm/cosmo/charts/router/values.yaml
+++ b/helm/cosmo/charts/router/values.yaml
@@ -238,3 +238,10 @@ configuration:
   httpProxy: ''
   # -- NO_PROXY is a comma-separated list of hosts or domains for which the proxy should not be used.
   noProxy: ''
+
+  # Use this section to disable/enable and configure the MCP server.
+  mcp:
+    # -- Enables MCP server support. Default is false.
+    enabled: false
+    # -- The port where the MCP server is exposed. Default is port 5025.
+    port: 5025

--- a/helm/cosmo/values.yaml
+++ b/helm/cosmo/values.yaml
@@ -280,6 +280,13 @@ router:
     # -- The HTTP path where metrics are exposed. Default is "/metrics".
     path: "/metrics"
 
+  # Use this section to disable/enable and configure the MCP server on the Cosmo Router.
+  mcp:
+    # -- Enables MCP server support. Default is false.
+    enabled: false
+    # -- The port where the MCP server is exposed. Default is port 5025.
+    port: 5025
+
 # Cosmo Open Telemetry Collector. For more options, please refer to the CHART.md
 otelcollector:
   # -- Add labels to all deployed resources


### PR DESCRIPTION
## Motivation and Context

This pull request introduces support for an optional MCP (Message Control Protocol) server in the WunderGraph Cosmo Router Helm Chart. It includes updates to configuration files, templates, and documentation to enable and configure the MCP server. The chart version has been incremented to `0.10.2`.

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

### MCP Server Support

* Added `mcp.enabled` and `mcp.port` configuration options to `values.yaml` for enabling and configuring the MCP server. Defaults are `false` and `5025`, respectively. (`helm/cosmo/charts/router/values.yaml`, [[1]](diffhunk://#diff-08f20f8b7156fb779bfc0ae32f3e3088c7dccb8ed5f942935c81aa596c2ad363R241-R247); `helm/cosmo/values.yaml`, [[2]](diffhunk://#diff-603c21e08b42912457d453c7b7bb91207dc5d2abdd978934d8193ef25c222edaR283-R289)
* Updated templates to include MCP server settings:
  - Config map now includes `mcpEnabled` and `mcpListenAddr` for MCP server configuration. (`helm/cosmo/charts/router/templates/config-map.yaml`, [helm/cosmo/charts/router/templates/config-map.yamlR30-R33](diffhunk://#diff-bc9e9e32bcea47b0105586864d87c53f3fbe043ead72c8e38f0c85245ce16f1aR30-R33))
  - Deployment template updated to expose MCP environment variables and container ports when enabled. (`helm/cosmo/charts/router/templates/deployment.yaml`, [[1]](diffhunk://#diff-e6aabf4b8e03c68dedebad1cf7d36b587209346ec3aba11cba92d927bd8ace5dR62-R66) [[2]](diffhunk://#diff-e6aabf4b8e03c68dedebad1cf7d36b587209346ec3aba11cba92d927bd8ace5dR178-R189)
  - Service template updated to expose the MCP server port. (`helm/cosmo/charts/router/templates/service.yaml`, [helm/cosmo/charts/router/templates/service.yamlR24-R29](diffhunk://#diff-e4d35bb3dcf31288645900683fb061e0daeb970b3fbc3e06d8818c434e29c8b8R24-R29))

### Documentation Updates

* Added documentation for MCP server configuration in `README.md` files. (`helm/cosmo/README.md`, [[1]](diffhunk://#diff-34aedcd17a51f815addb1acf5b680da11758d35bd8cf11f17c3040b1322a34c5R247-R248); `helm/cosmo/charts/router/README.md`, [[2]](diffhunk://#diff-ca94d6c332400177e736109d2bacf292b675e212039d92cfa5c42121121b7bceR33-R34)
* Updated the changelog to reflect the new MCP server feature. (`helm/cosmo/charts/router/CHANGELOG.md`, [helm/cosmo/charts/router/CHANGELOG.mdR3-R8](diffhunk://#diff-cfb9568eb73ccebd2a07adcc56ec20ab78c639f13ccf87083e93e7485b7fe434R3-R8))

### Version Updates

* Incremented chart version to `0.10.2` in `Chart.yaml` and updated version badge in `README.md`. (`helm/cosmo/charts/router/Chart.yaml`, [[1]](diffhunk://#diff-48692f19ca9f4f61361e95b52c5eb8f50336046ac4c88b821d0637c9ebd09464L18-R18); `helm/cosmo/charts/router/README.md`, [[2]](diffhunk://#diff-ca94d6c332400177e736109d2bacf292b675e212039d92cfa5c42121121b7bceL3-R3)