### PR TITLE
feat: add proper enabled config for plugins

### DIFF
--- a/router/core/executor.go
+++ b/router/core/executor.go
@@ -61,10 +61,11 @@ type ExecutorBuildOptions struct {
 	ApolloCompatibilityFlags       config.ApolloCompatibilityFlags
 	ApolloRouterCompatibilityFlags config.ApolloRouterCompatibilityFlags
 	HeartbeatInterval              time.Duration
+	PluginsEnabled                 bool
 }
 
 func (b *ExecutorConfigurationBuilder) Build(ctx context.Context, opts *ExecutorBuildOptions) (*Executor, error) {
-	planConfig, err := b.buildPlannerConfiguration(ctx, opts.EngineConfig, opts.Subgraphs, opts.RouterEngineConfig, opts.PubSubProviders)
+	planConfig, err := b.buildPlannerConfiguration(ctx, opts.EngineConfig, opts.Subgraphs, opts.RouterEngineConfig, opts.PubSubProviders, opts.PluginsEnabled)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build planner configuration: %w", err)
 	}
@@ -273,7 +274,7 @@ func buildKafkaOptions(eventSource config.KafkaEventSource) ([]kgo.Opt, error) {
 	return opts, nil
 }
 
-func (b *ExecutorConfigurationBuilder) buildPlannerConfiguration(ctx context.Context, engineConfig *nodev1.EngineConfiguration, subgraphs []*nodev1.Subgraph, routerEngineCfg *RouterEngineConfiguration, pubSubProviders *EnginePubSubProviders) (*plan.Configuration, error) {
+func (b *ExecutorConfigurationBuilder) buildPlannerConfiguration(ctx context.Context, engineConfig *nodev1.EngineConfiguration, subgraphs []*nodev1.Subgraph, routerEngineCfg *RouterEngineConfiguration, pubSubProviders *EnginePubSubProviders, pluginsEnabled bool) (*plan.Configuration, error) {
 	// this loader is used to take the engine config and create a plan config
 	// the plan config is what the engine uses to turn a GraphQL Request into an execution plan
 	// the plan config is stateful as it carries connection pools and other things
@@ -293,7 +294,7 @@ func (b *ExecutorConfigurationBuilder) buildPlannerConfiguration(ctx context.Con
 	))
 
 	// this generates the plan config using the data source factories from the config package
-	planConfig, err := loader.Load(engineConfig, subgraphs, routerEngineCfg)
+	planConfig, err := loader.Load(engineConfig, subgraphs, routerEngineCfg, pluginsEnabled)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load configuration: %w", err)
 	}

--- a/router/core/factoryresolver.go
+++ b/router/core/factoryresolver.go
@@ -254,7 +254,7 @@ func mapProtoFilterToPlanFilter(input *nodev1.SubscriptionFilterCondition, outpu
 	return nil
 }
 
-func (l *Loader) Load(engineConfig *nodev1.EngineConfiguration, subgraphs []*nodev1.Subgraph, routerEngineConfig *RouterEngineConfiguration) (*plan.Configuration, error) {
+func (l *Loader) Load(engineConfig *nodev1.EngineConfiguration, subgraphs []*nodev1.Subgraph, routerEngineConfig *RouterEngineConfiguration, pluginsEnabled bool) (*plan.Configuration, error) {
 	var outConfig plan.Configuration
 	// attach field usage information to the plan
 	outConfig.DefaultFlushIntervalMillis = engineConfig.DefaultFlushInterval
@@ -312,6 +312,10 @@ func (l *Loader) Load(engineConfig *nodev1.EngineConfiguration, subgraphs []*nod
 			}
 
 		case nodev1.DataSourceKind_GRAPHQL:
+			if in.GetCustomGraphql().GetGrpc() != nil && !pluginsEnabled {
+				continue
+			}
+
 			header := http.Header{}
 			for s, httpHeader := range in.CustomGraphql.Fetch.Header {
 				for _, value := range httpHeader.Values {

--- a/router/core/graph_server.go
+++ b/router/core/graph_server.go
@@ -957,9 +957,12 @@ func (s *graphServer) buildGraphMux(ctx context.Context,
 		subgraphTippers[subgraph] = subgraphTransport
 	}
 
-	subgraphGRPCClients, err := s.buildSubgraphGRPCClients(ctx, engineConfig, configSubgraphs)
-	if err != nil {
-		return nil, fmt.Errorf("failed to build subgraph grpc clients: %w", err)
+	subgraphGRPCClients := make(map[string]grpc.ClientConnInterface)
+	if s.plugins.Enabled {
+		subgraphGRPCClients, err = s.buildSubgraphGRPCClients(ctx, engineConfig, configSubgraphs)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build subgraph grpc clients: %w", err)
+		}
 	}
 
 	ecb := &ExecutorConfigurationBuilder{
@@ -1008,6 +1011,7 @@ func (s *graphServer) buildGraphMux(ctx context.Context,
 			ApolloCompatibilityFlags:       s.apolloCompatibilityFlags,
 			ApolloRouterCompatibilityFlags: s.apolloRouterCompatibilityFlags,
 			HeartbeatInterval:              s.multipartHeartbeatInterval,
+			PluginsEnabled:                 s.plugins.Enabled,
 		},
 	)
 	if err != nil {

--- a/router/core/plan_generator.go
+++ b/router/core/plan_generator.go
@@ -275,7 +275,7 @@ func (pg *PlanGenerator) loadConfiguration(routerConfig *nodev1.RouterConfig, lo
 	})
 
 	// this generates the plan configuration using the data source factories from the config package
-	planConfig, err := loader.Load(routerConfig.GetEngineConfig(), routerConfig.GetSubgraphs(), &RouterEngineConfiguration{})
+	planConfig, err := loader.Load(routerConfig.GetEngineConfig(), routerConfig.GetSubgraphs(), &RouterEngineConfiguration{}, false) // TODO: configure plugins
 	if err != nil {
 		return fmt.Errorf("failed to load configuration: %w", err)
 	}

--- a/router/pkg/config/config.go
+++ b/router/pkg/config/config.go
@@ -905,8 +905,8 @@ type MCPServer struct {
 }
 
 type PluginsConfiguration struct {
-	Enabled bool   `yaml:"enabled" envDefault:"false" env:"PLUGINS_ENABLED"`
-	Path    string `yaml:"path" envDefault:"plugins" env:"PLUGINS_PATH"`
+	Enabled bool   `yaml:"enabled" envDefault:"false" env:"ENABLED"`
+	Path    string `yaml:"path" envDefault:"plugins" env:"PATH"`
 }
 
 type Config struct {
@@ -980,7 +980,7 @@ type Config struct {
 	ApolloRouterCompatibilityFlags ApolloRouterCompatibilityFlags  `yaml:"apollo_router_compatibility_flags"`
 	ClientHeader                   ClientHeader                    `yaml:"client_header"`
 
-	Plugins PluginsConfiguration `yaml:"plugins"`
+	Plugins PluginsConfiguration `yaml:"plugins" envPrefix:"PLUGINS_"`
 
 	WatchConfig WatchConfig `yaml:"watch_config" envPrefix:"WATCH_CONFIG_"`
 }

--- a/router/pkg/config/config.go
+++ b/router/pkg/config/config.go
@@ -905,7 +905,8 @@ type MCPServer struct {
 }
 
 type PluginsConfiguration struct {
-	Path string `yaml:"path" envDefault:"plugins" env:"PLUGINS_PATH"`
+	Enabled bool   `yaml:"enabled" envDefault:"false" env:"PLUGINS_ENABLED"`
+	Path    string `yaml:"path" envDefault:"plugins" env:"PLUGINS_PATH"`
 }
 
 type Config struct {

--- a/router/pkg/config/config.schema.json
+++ b/router/pkg/config/config.schema.json
@@ -2691,6 +2691,11 @@
       "description": "The configuration for the router gRPC plugins.",
       "additionalProperties": false,
       "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable the router gRPC plugins."
+        },
         "path": {
           "type": "string",
           "description": "The path to the plugins directory. The plugins directory is used to load the plugins.",

--- a/router/pkg/config/fixtures/full.yaml
+++ b/router/pkg/config/fixtures/full.yaml
@@ -7,6 +7,7 @@ graph:
   token: 'mytoken'
 
 plugins:
+  enabled: true
   path: "some/path/to/plugins"
 
 log_level: "info"

--- a/router/pkg/config/testdata/config_defaults.json
+++ b/router/pkg/config/testdata/config_defaults.json
@@ -475,6 +475,7 @@
     "Version": ""
   },
   "Plugins": {
+    "Enabled": false,
     "Path": "plugins"
   },
   "WatchConfig": {

--- a/router/pkg/config/testdata/config_full.json
+++ b/router/pkg/config/testdata/config_full.json
@@ -800,6 +800,7 @@
     "Version": "Client_Version"
   },
   "Plugins": {
+    "Enabled": true,
     "Path": "some/path/to/plugins"
   },
   "WatchConfig": {


### PR DESCRIPTION
## Motivation and Context

We recently removed the enabled flag for the plugins as it didn't make sense the way it was implemented. Instead of enabling only the configuration options this PR adds an implementation to handle enabling of plugins in general.

Enabled now will make sure that no plugins are loaded when enabled is set to false.

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->