### PR TITLE
feat(core): introduce pluggable module registry and lifecycle hooks

### DIFF
--- a/router/core/hooks.go
+++ b/router/core/hooks.go
@@ -1,0 +1,245 @@
+package core
+
+import (
+	"context"
+
+	"github.com/wundergraph/cosmo/router/internal/utils"
+)
+
+// Application Lifecycle Hooks
+type ApplicationLifecycleHook interface {
+	ApplicationStartHook
+	ApplicationStopHook
+}
+
+type ApplicationStartHook interface {
+	OnApplicationStart(ctx context.Context)
+}
+
+type ApplicationStopHook interface {
+	OnApplicationStop(ctx context.Context)
+}
+
+// GraphQL Server Lifecycle Hooks
+type GraphQLServerLifecycleHook interface {
+	GraphQLServerStartHook
+	GraphQLServerStopHook
+}
+
+type GraphQLServerStartHook interface {
+	OnGraphQLServerStart(ctx context.Context)
+}
+
+type GraphQLServerStopHook interface {
+	OnGraphQLServerStop(ctx context.Context)
+}
+
+// Router Lifecycle Hooks
+type RouterRequestHook interface {
+	OnRouterRequest(ctx context.Context)
+}
+
+type RouterResponseHook interface {
+	OnRouterResponse(ctx context.Context)
+}
+
+type RouterLifecycleHook interface {
+	RouterRequestHook
+	RouterResponseHook
+}
+
+// Subgraph Lifecycle Hooks
+type SubgraphRequestHook interface {
+	OnSubgraphRequest(ctx context.Context)
+}
+
+type SubgraphResponseHook interface {
+	OnSubgraphResponse(ctx context.Context)
+}
+
+type SubgraphLifecycleHook interface {
+	SubgraphRequestHook
+	SubgraphResponseHook
+}
+
+// Operation Lifecycle Hooks
+type OperationLifecycleHook interface {
+	OperationParseLifecycleHook
+	OperationNormalizeLifecycleHook
+	OperationValidateLifecycleHook
+	OperationPlanLifecycleHook
+	OperationExecuteLifecycleHook
+}
+
+type OperationParseLifecycleHook interface {
+	OperationPreParseHook
+	OperationPostParseHook
+}
+
+type OperationPreParseHook interface {
+	OnOperationPreParse(ctx context.Context)
+}
+
+type OperationPostParseHook interface {
+	OnOperationPostParse(ctx context.Context)
+}
+
+type OperationNormalizeLifecycleHook interface {
+	OperationPreNormalizeHook
+	OperationPostNormalizeHook
+}
+
+type OperationPreNormalizeHook interface {
+	OnOperationPreNormalize(ctx context.Context)
+}
+
+type OperationPostNormalizeHook interface {
+	OnOperationPostNormalize(ctx context.Context)
+}
+
+type OperationValidateLifecycleHook interface {
+	OperationPreValidateHook
+	OperationPostValidateHook
+}
+
+type OperationPreValidateHook interface {
+	OnOperationPreValidate(ctx context.Context)
+}
+
+type OperationPostValidateHook interface {
+	OnOperationPostValidate(ctx context.Context)
+}
+
+type OperationPlanLifecycleHook interface {
+	OperationPrePlanHook
+	OperationPostPlanHook
+}
+
+type OperationPrePlanHook interface {
+	OnOperationPrePlan(ctx context.Context)
+}
+
+type OperationPostPlanHook interface {
+	OnOperationPostPlan(ctx context.Context)
+}
+
+type OperationExecuteLifecycleHook interface {
+	OperationPreExecuteHook
+	OperationPostExecuteHook
+}
+
+type OperationPreExecuteHook interface {
+	OnOperationPreExecute(ctx context.Context)
+}
+
+type OperationPostExecuteHook interface {
+	OnOperationPostExecute(ctx context.Context)
+}
+
+// hookRegistry holds the list of hooks for each type.
+type hookRegistry struct {
+	applicationStartHooks *utils.OrderedSet[ApplicationStartHook]
+	applicationStopHooks  *utils.OrderedSet[ApplicationStopHook]
+
+	graphQLServerStartHooks *utils.OrderedSet[GraphQLServerStartHook]
+	graphQLServerStopHooks  *utils.OrderedSet[GraphQLServerStopHook]
+
+	routerRequestHooks  *utils.OrderedSet[RouterRequestHook]
+	routerResponseHooks *utils.OrderedSet[RouterResponseHook]
+
+	subgraphRequestHooks  *utils.OrderedSet[SubgraphRequestHook]
+	subgraphResponseHooks *utils.OrderedSet[SubgraphResponseHook]
+
+	operationPreParseHooks  *utils.OrderedSet[OperationPreParseHook]
+	operationPostParseHooks *utils.OrderedSet[OperationPostParseHook]
+
+	operationPreNormalizeHooks  *utils.OrderedSet[OperationPreNormalizeHook]
+	operationPostNormalizeHooks *utils.OrderedSet[OperationPostNormalizeHook]
+
+	operationPreValidateHooks  *utils.OrderedSet[OperationPreValidateHook]
+	operationPostValidateHooks *utils.OrderedSet[OperationPostValidateHook]
+
+	operationPrePlanHooks  *utils.OrderedSet[OperationPrePlanHook]
+	operationPostPlanHooks *utils.OrderedSet[OperationPostPlanHook]
+
+	operationPreExecuteHooks  *utils.OrderedSet[OperationPreExecuteHook]
+	operationPostExecuteHooks *utils.OrderedSet[OperationPostExecuteHook]
+}
+
+// newHookRegistry initializes with empty sets.
+func newHookRegistry() *hookRegistry {
+	return &hookRegistry{
+		applicationStartHooks:       utils.NewOrderedSet[ApplicationStartHook](),
+		applicationStopHooks:        utils.NewOrderedSet[ApplicationStopHook](),
+
+		graphQLServerStartHooks:     utils.NewOrderedSet[GraphQLServerStartHook](),
+		graphQLServerStopHooks:      utils.NewOrderedSet[GraphQLServerStopHook](),
+
+		routerRequestHooks:          utils.NewOrderedSet[RouterRequestHook](),
+		routerResponseHooks:         utils.NewOrderedSet[RouterResponseHook](),
+
+		subgraphRequestHooks:        utils.NewOrderedSet[SubgraphRequestHook](),
+		subgraphResponseHooks:       utils.NewOrderedSet[SubgraphResponseHook](),
+
+		operationPreParseHooks:      utils.NewOrderedSet[OperationPreParseHook](),
+		operationPostParseHooks:     utils.NewOrderedSet[OperationPostParseHook](),
+
+		operationPreNormalizeHooks:  utils.NewOrderedSet[OperationPreNormalizeHook](),
+		operationPostNormalizeHooks: utils.NewOrderedSet[OperationPostNormalizeHook](),
+
+		operationPreValidateHooks:   utils.NewOrderedSet[OperationPreValidateHook](),
+		operationPostValidateHooks:  utils.NewOrderedSet[OperationPostValidateHook](),
+
+		operationPrePlanHooks:       utils.NewOrderedSet[OperationPrePlanHook](),
+		operationPostPlanHooks:      utils.NewOrderedSet[OperationPostPlanHook](),
+
+		operationPreExecuteHooks:    utils.NewOrderedSet[OperationPreExecuteHook](),
+		operationPostExecuteHooks:   utils.NewOrderedSet[OperationPostExecuteHook](),
+	}
+}
+
+// registerHook is a helper to add any hook type if implemented.
+func registerHook[H comparable](inst any, set *utils.OrderedSet[H]) {
+	if h, ok := inst.(H); ok {
+		set.Add(h)
+	}
+}
+
+// AddApplicationLifecycle wires up start/stop hooks.
+func (hr *hookRegistry) AddApplicationLifecycle(inst any) {
+	registerHook(inst, hr.applicationStartHooks)
+	registerHook(inst, hr.applicationStopHooks)
+}
+
+// AddGraphQLServerLifecycle wires up GraphQL server start/stop hooks.
+func (hr *hookRegistry) AddGraphQLServerLifecycle(inst any) {
+	registerHook(inst, hr.graphQLServerStartHooks)
+	registerHook(inst, hr.graphQLServerStopHooks)
+}
+
+// AddRouterLifecycle wires up router request/response hooks.
+func (hr *hookRegistry) AddRouterLifecycle(inst any) {
+	registerHook(inst, hr.routerRequestHooks)
+	registerHook(inst, hr.routerResponseHooks)
+}
+
+// AddSubgraphLifecycle wires up subgraph request/response hooks.
+func (hr *hookRegistry) AddSubgraphLifecycle(inst any) {
+	registerHook(inst, hr.subgraphRequestHooks)
+	registerHook(inst, hr.subgraphResponseHooks)
+}
+
+// AddOperationLifecycle wires up all operation lifecycle hooks.
+func (hr *hookRegistry) AddOperationLifecycle(inst any) {
+	registerHook(inst, hr.operationPreParseHooks)	
+	registerHook(inst, hr.operationPostParseHooks)
+	registerHook(inst, hr.operationPreNormalizeHooks)
+	registerHook(inst, hr.operationPostNormalizeHooks)
+	registerHook(inst, hr.operationPreValidateHooks)
+	registerHook(inst, hr.operationPostValidateHooks)
+	registerHook(inst, hr.operationPrePlanHooks)
+	registerHook(inst, hr.operationPostPlanHooks)
+	registerHook(inst, hr.operationPreExecuteHooks)
+	registerHook(inst, hr.operationPostExecuteHooks)
+}
+

--- a/router/core/modules_v1.go
+++ b/router/core/modules_v1.go
@@ -1,0 +1,166 @@
+package core
+
+import (
+	"fmt"
+	"math"
+	"time"
+	"sort"
+	"sync"
+	"context"
+	"go.uber.org/zap"
+)
+
+type moduleRegistry struct {
+	mu sync.RWMutex
+	modules map[string]MyModuleInfo
+}
+// NewModuleRegistry returns an empty, thread-safe module registry.
+// Call this in tests (and anywhere you need isolation) instead of using the global.
+func newModuleRegistry() *moduleRegistry {
+	return &moduleRegistry{
+		modules: make(map[string]MyModuleInfo),
+	}
+}
+
+// defaultModuleRegistry is the package-level registry used by RegisterMyModule.
+// For unit tests you should use newModuleRegistry() to get a fresh instance and avoid shared state.
+var defaultModuleRegistry = newModuleRegistry()
+
+
+type MyModuleInfo struct {
+	// ID is the unique identifier for a module, it must be unique across all modules.
+	ID string
+	// Priority decideds the order of execution of the module.
+	// The smaller the number, the higher the priority, the earlier the module is executed.
+	// For example, a priority of 0 is the highest priority.
+	// Modules with the same priority are executed in the order they are registered.
+	// If Priority is nil, the module is considered to have the lowest priority.
+	Priority *int
+	// New creates a new instance of the module.
+	New func() MyModule
+}
+
+type MyModule interface {
+	MyModule() MyModuleInfo
+	// Provisioner is called before the server starts
+	// It allows you to initialize your module e.g. create a database connection
+	// or load a configuration file
+	Provision(ctx context.Context) error
+	// Cleanup is called after the server stops
+	// It allows you to clean up your module e.g. close a database connection
+	Cleanup() error
+}
+
+// RegisterMyModule registers a new MyModule instance.
+// The registration order matters. Modules with the same priority 
+// are executed in the order they are registered.
+// It panics if the module is already registered.
+func RegisterMyModule(instance MyModule) {
+	defaultModuleRegistry.registerMyModule(instance)
+}
+
+func (r *moduleRegistry) registerMyModule(instance MyModule) {
+	m := instance.MyModule()
+
+	if m.ID == "" {
+		panic("MyModule.ID is required")
+	}
+	if val := m.New(); val == nil {
+		panic("MyModuleInfo.New must return a non-nil module instance")
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, ok := r.modules[m.ID]; ok {
+		panic(fmt.Sprintf("MyModule already registered: %s", m.ID))
+	}
+	r.modules[m.ID] = m
+}
+
+// sortMyModules sorts the modules by priority, 0 is the highest priority, is the first to be executed.
+// If two modules have the same priority, they are sorted by registration order.
+// If a module has no priority, it is considered to have the lowest priority.
+func sortMyModules(modules []MyModuleInfo) []MyModuleInfo {
+	sort.Slice(modules, func(i, j int) bool {
+		var priorityI, priorityJ int = math.MaxInt, math.MaxInt
+		if modules[i].Priority != nil {
+			priorityI = *modules[i].Priority
+		}
+		if modules[j].Priority != nil {
+			priorityJ = *modules[j].Priority
+		}
+
+		return priorityI < priorityJ
+	})
+	return modules
+}
+
+// getMyModules returns all registered modules sorted by priority
+func (r *moduleRegistry) getMyModules() []MyModuleInfo {
+    r.mu.RLock()
+    defer r.mu.RUnlock()
+
+    modules := make([]MyModuleInfo, 0, len(r.modules))
+    for _, m := range r.modules {
+        modules = append(modules, m)
+    }
+    return sortMyModules(modules)
+}
+
+// coreModuleHooks manages module initialization and hook registration.
+type coreModuleHooks struct {
+	moduleInstances []MyModule
+	hookRegistry *hookRegistry
+	logger *zap.Logger
+}
+
+func newCoreModuleHooks(logger *zap.Logger) *coreModuleHooks {
+	return &coreModuleHooks{
+		hookRegistry: newHookRegistry(),
+		logger: logger,
+	}
+}
+
+// initCoreModuleHooks instantiates each module, provisions it,
+// registers any implemented hooks, and saves the hook registry.
+func (c *coreModuleHooks) initCoreModuleHooks(ctx context.Context, modules []MyModuleInfo) error {
+	hookRegistry := newHookRegistry()
+	var instances []MyModule
+
+	for _, info := range modules {
+		now := time.Now()
+		moduleInstance := info.New()
+
+		if err := moduleInstance.Provision(ctx); err != nil {
+			return fmt.Errorf("failed to provision module %s: %w", info.ID, err)
+		}
+
+		hookRegistry.AddApplicationLifecycle(moduleInstance)
+		hookRegistry.AddGraphQLServerLifecycle(moduleInstance)
+		hookRegistry.AddRouterLifecycle(moduleInstance)
+		hookRegistry.AddSubgraphLifecycle(moduleInstance)
+		hookRegistry.AddOperationLifecycle(moduleInstance)
+
+		c.logger.Info("Core Module System: Module registered",
+			zap.String("id", string(info.ID)),
+			zap.String("duration", time.Since(now).String()),
+		)
+
+		instances = append(instances, moduleInstance)
+	}
+
+	c.hookRegistry = hookRegistry
+	c.moduleInstances = instances
+
+	return nil
+}
+
+func (c *coreModuleHooks) cleanupCoreModuleHooks(ctx context.Context) error {
+	for _, moduleInstance := range c.moduleInstances {
+		if err := moduleInstance.Cleanup(); err != nil {
+			return fmt.Errorf("failed to cleanup module %s: %w", moduleInstance.MyModule().ID, err)
+		}
+	}
+	return nil
+}

--- a/router/core/modules_v1_test.go
+++ b/router/core/modules_v1_test.go
@@ -1,0 +1,238 @@
+package core
+
+import (
+	"testing"
+	"context"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wundergraph/cosmo/router/internal/utils"
+
+	"go.uber.org/zap/zaptest"
+)
+
+
+type testModule1 struct {}
+
+func (m *testModule1) MyModule() MyModuleInfo {
+	return MyModuleInfo{
+		ID: "testModule1",
+		Priority: utils.Ptr(0),
+		New: func() MyModule {
+			return &testModule1{}
+		},
+	}
+}
+func (m *testModule1) Provision(ctx context.Context) error { return nil }
+func (m *testModule1) Cleanup() error { return nil }
+
+func (m *testModule1) OnApplicationStart(ctx context.Context) {}
+
+type testModule2 struct {}
+
+func (m *testModule2) MyModule() MyModuleInfo {
+	return MyModuleInfo{
+		ID: "testModule2",
+		Priority: utils.Ptr(1),
+		New: func() MyModule {
+			return &testModule2{}
+		},
+	}
+}
+func (m *testModule2) Provision(ctx context.Context) error { return nil }
+func (m *testModule2) Cleanup() error { return nil }
+
+func (m *testModule2) OnApplicationStart(ctx context.Context) {}
+func (m *testModule2) OnApplicationStop(ctx context.Context) {}
+
+type testModule3 struct {}
+
+func (m *testModule3) MyModule() MyModuleInfo {
+	return MyModuleInfo{
+		Priority: utils.Ptr(1),
+		New: func() MyModule {
+			return &testModule3{}
+		},
+	}
+}
+func (m *testModule3) Provision(ctx context.Context) error { return nil }
+func (m *testModule3) Cleanup() error { return nil }
+
+func (m *testModule3) OnApplicationStart(ctx context.Context) {}
+func (m *testModule3) OnApplicationStop(ctx context.Context) {}
+
+
+type testModule4 struct {}
+
+func (m *testModule4) MyModule() MyModuleInfo {
+	return MyModuleInfo{
+		ID: "testModule4",
+		Priority: utils.Ptr(1),
+	}
+}
+func (m *testModule4) Provision(ctx context.Context) error { return nil }
+func (m *testModule4) Cleanup() error { return nil }
+
+// interface guards
+var _ ApplicationStartHook = (*testModule1)(nil)
+
+// registers the applicationStartHook only once
+var _ ApplicationStartHook = (*testModule2)(nil)
+var _ ApplicationLifecycleHook = (*testModule2)(nil)
+
+var _ ApplicationStartHook = (*testModule3)(nil)
+var _ ApplicationStopHook = (*testModule3)(nil)
+
+func TestRegisterMyModule(t *testing.T) {
+	t.Parallel()
+
+	m1 := &testModule1{}
+	m2 := &testModule2{}
+	m3 := &testModule3{}		
+	m4 := &testModule4{}
+	m5 := &testModule1{}
+	t.Run("success", func(t *testing.T) {
+		testModuleRegistry := newModuleRegistry()
+
+		testModuleRegistry.registerMyModule(m1)
+		testModuleRegistry.registerMyModule(m2)
+
+		require.Equal(t, "testModule1", testModuleRegistry.modules["testModule1"].ID)
+		require.Equal(t, "testModule2", testModuleRegistry.modules["testModule2"].ID)
+	})
+
+	t.Run("panic_if_module_id_is_empty", func(t *testing.T) {
+		testModuleRegistry := newModuleRegistry()
+
+		require.Panics(t, func() {
+			testModuleRegistry.registerMyModule(m3)
+		})
+	})
+
+	t.Run("panic_if_module_new_returns_nil", func(t *testing.T) {
+		testModuleRegistry := newModuleRegistry()
+
+		require.Panics(t, func() {
+			testModuleRegistry.registerMyModule(m4)
+		})
+	})
+
+	t.Run("panic_if_module_id_is_not_unique", func(t *testing.T) {
+		testModuleRegistry := newModuleRegistry()
+
+		require.Panics(t, func() {
+			testModuleRegistry.registerMyModule(m1)
+			testModuleRegistry.registerMyModule(m5)
+		})
+	})
+}
+
+func TestSortMyModules(t *testing.T) {
+	t.Parallel()
+
+	module0 := MyModuleInfo{
+		ID:       "module0",
+		Priority: utils.Ptr(0),
+	}
+
+	module1 := MyModuleInfo{
+		ID:       "module1",
+		Priority: utils.Ptr(1),
+	}
+
+	module2 := MyModuleInfo{
+		ID:       "module2",
+		Priority: utils.Ptr(2),
+	}
+
+	module3 := MyModuleInfo{
+		ID:  "module3",
+		Priority: utils.Ptr(0),
+	}
+
+	moduleNilPriority := MyModuleInfo{	
+		ID:  "moduleNil",
+	}
+
+	t.Run("success", func(t *testing.T) {
+		modules := []MyModuleInfo{
+			moduleNilPriority,
+			module2,
+			module0,
+			module1,
+		}
+		result := sortMyModules(modules)
+
+		expected := []MyModuleInfo{
+			module0,
+			module1,
+			module2,
+			moduleNilPriority,
+		}
+
+		require.EqualValues(t, expected, result)
+	})
+
+	t.Run("same_priority", func(t *testing.T) {
+		modules := []MyModuleInfo{
+			module3,
+			module0,
+		}
+		result := sortMyModules(modules)
+
+		expected := []MyModuleInfo{
+			module3,
+			module0,
+		}
+
+		require.EqualValues(t, expected, result)
+	})
+
+	t.Run("no_modules_not_panic", func(t *testing.T) {
+		modules := []MyModuleInfo{}
+		require.Equal(t, []MyModuleInfo{}, sortMyModules(modules))
+	})
+}
+
+func TestInitMyModules(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		modules := []MyModuleInfo{
+		{
+			ID: "testModule1",
+			New: func() MyModule {
+				return &testModule1{}
+			},
+		},
+		{
+			ID: "testModule3",
+			New: func() MyModule {
+				return &testModule3{}
+			},
+		},
+	}
+		cm := newCoreModuleHooks(zaptest.NewLogger(t))
+		err := cm.initCoreModuleHooks(context.Background(), modules)
+		require.NoError(t, err)
+
+		require.Equal(t, 2, len(cm.hookRegistry.applicationStartHooks.Values()))
+		require.Equal(t, 1, len(cm.hookRegistry.applicationStopHooks.Values()))
+	})
+
+	t.Run("success_deduplicate_hooks", func(t *testing.T) {		
+		modules := []MyModuleInfo{
+		{
+			ID: "testModule2",
+			New: func() MyModule {
+				return &testModule2{}
+			},
+		},
+	}
+		cm := newCoreModuleHooks(zaptest.NewLogger(t))	
+		err := cm.initCoreModuleHooks(context.Background(), modules)
+		require.NoError(t, err)
+
+		require.Equal(t, 1, len(cm.hookRegistry.applicationStartHooks.Values()))
+		require.Equal(t, 1, len(cm.hookRegistry.applicationStopHooks.Values()))
+	})
+}

--- a/router/internal/utils/ordered_set.go
+++ b/router/internal/utils/ordered_set.go
@@ -1,0 +1,61 @@
+package utils
+
+type OrderedSet[T comparable] struct {
+	elements []T
+	index    map[T]struct{}
+}
+
+// NewOrderedSet creates and returns a new OrderedSet.
+func NewOrderedSet[T comparable]() *OrderedSet[T] {
+	return &OrderedSet[T]{
+		elements: make([]T, 0),
+		index:    make(map[T]struct{}),
+	}
+}
+
+// Add inserts elem into the set if it's not already present.
+func (s *OrderedSet[T]) Add(elem T) {
+	if _, exists := s.index[elem]; !exists {
+		s.index[elem] = struct{}{}
+		s.elements = append(s.elements, elem)
+	}
+}
+
+// Remove deletes elem from the set if it exists, preserving order of other elements.
+func (s *OrderedSet[T]) Remove(elem T) {
+	if _, exists := s.index[elem]; exists {
+		delete(s.index, elem)
+		// rebuild slice without the removed element
+		for i, v := range s.elements {
+			if v == elem {
+				s.elements = append(s.elements[:i], s.elements[i+1:]...)
+				break
+			}
+		}
+	}
+}
+
+// Contains returns true if elem is in the set.
+func (s *OrderedSet[T]) Contains(elem T) bool {
+	_, exists := s.index[elem]
+	return exists
+}
+
+// Values returns a slice of elements in insertion order.
+// The returned slice is a copy; modifying it won't affect the set.
+func (s *OrderedSet[T]) Values() []T {
+	dup := make([]T, len(s.elements))
+	copy(dup, s.elements)
+	return dup
+}
+
+// Len returns the number of elements in the set.
+func (s *OrderedSet[T]) Len() int {
+	return len(s.elements)
+}
+
+// Clear removes all elements from the set.
+func (s *OrderedSet[T]) Clear() {
+	s.elements = make([]T, 0)
+	s.index = make(map[T]struct{})
+}

--- a/router/internal/utils/ptrs.go
+++ b/router/internal/utils/ptrs.go
@@ -1,0 +1,6 @@
+package utils
+
+func Ptr[T any](v T) *T {
+	return &v
+}
+


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

## Motivation and Context

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please describe in detail the impact of this change. Attach screenshots if applicable.
-->

This PR lays the groundwork for the open core module system (ADR: https://github.com/wundergraph/cosmo/pull/1863/files)  by introducing:

**Module Registry (moduleRegistry)**

- Thread-safe registration via RegisterMyModule and retrieval of MyModuleInfo (ID, priority, constructor).

- Priority-based sorting ensures deterministic execution order. 

**Hook Registry (hookRegistry)**

- Aggregates implementations of each lifecycle interface into OrderedSets for deduplication and ordering.

- Supports five phases with pre/post granularity:
  * Application start/stop
  * GraphQL server start/stop
  * Router request/response
  * Subgraph request/response
  * Operation parse/normalize/validate/plan/execute

**CoreModules Orchestration**

The newCoreModules constructor and its initMyModules method perform the following, in order:
  * Instantiate all modules in sorted (priority) order
  * Provision each module
  * Register each module’s hooks with the hook registry
  * Expose the populated registry for the router to invoke
 
After the server shuts down, cleanupCoreModuleHooks cleans up each provisioned module.

**Utility**

OrderedSet[T] (in router/internal/utils/ordered_set.go) preserves insertion order and prevents duplicates.

Pointer helper functions (ptrs.go) simplify optional priority handling.

**Unit Tests**

modules_v1_test.go verifies that modules implementing specific hook interfaces are correctly registered into the appropriate sets.

**Followups**
Add the exact contract of the first pair of hooks and invoke in router execution. Add integration test for it.

## Checklist

- [x] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->

Local e2e tests to ensure no regression.
<img width="719" alt="Screenshot 2025-05-23 at 3 14 55 PM" src="https://github.com/user-attachments/assets/9ed3ed3f-f10b-4e0e-94de-d2f02236e480" />



