### PR TITLE
fix: use ms measurements instead of float seconds for conn_acquire_time

### DIFF
--- a/router-tests/telemetry/connection_metrics_test.go
+++ b/router-tests/telemetry/connection_metrics_test.go
@@ -119,7 +119,7 @@ func TestFlakyConnectionMetrics(t *testing.T) {
 				expected := metricdata.Metrics{
 					Name:        "router.http.client.connection.acquire_duration",
 					Description: "Total connection acquire duration",
-					Unit:        "s",
+					Unit:        "ms",
 					Data: metricdata.Histogram[float64]{
 						Temporality: metricdata.CumulativeTemporality,
 						DataPoints: []metricdata.HistogramDataPoint[float64]{

--- a/router/internal/traceclient/traceclient.go
+++ b/router/internal/traceclient/traceclient.go
@@ -112,7 +112,8 @@ func (t *TraceInjectingRoundTripper) processConnectionMetrics(ctx context.Contex
 	exprContext := t.getExprContext(ctx)
 
 	if trace.ConnectionGet != nil && trace.ConnectionAcquired != nil {
-		connAcquireTime := trace.ConnectionAcquired.Time.Sub(trace.ConnectionGet.Time).Seconds()
+		duration := trace.ConnectionAcquired.Time.Sub(trace.ConnectionGet.Time)
+		connAcquireTime := float64(duration) / float64(time.Millisecond)
 
 		exprContext.Subgraph.Request.ClientTrace.ConnectionAcquireDuration = connAcquireTime
 

--- a/router/pkg/metric/connection_measurements.go
+++ b/router/pkg/metric/connection_measurements.go
@@ -18,7 +18,7 @@ var (
 	}
 
 	connectionAcquireDurationOptions = []otelmetric.Float64HistogramOption{
-		otelmetric.WithUnit("s"),
+		otelmetric.WithUnit("ms"),
 		otelmetric.WithDescription("Total connection acquire duration"),
 	}
 


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

## Motivation and Context

This PR switches from float seconds to ms so that we can reuse the same ms buckets. 

Note that in a local / non stressed environment, acquiring cached connections will be less than 1 ms, meaning that all the entries in the bucket will be increased by 1.

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->