### PR TITLE
feat: fallback to legacy read access check for api keys

### DIFF
--- a/controlplane/src/core/repositories/FeatureFlagRepository.ts
+++ b/controlplane/src/core/repositories/FeatureFlagRepository.ts
@@ -246,7 +246,7 @@ export class FeatureFlagRepository {
    * @private
    */
   private applyRbacConditionsToQuery(rbac: RBACEvaluator | undefined, conditions: (SQL<unknown> | undefined)[]) {
-    if (!rbac || rbac.isOrganizationAdminOrDeveloper) {
+    if (!rbac || rbac.isOrganizationAdminOrDeveloper || (rbac.isApiKey && rbac.groups.length === 0)) {
       return true;
     }
 

--- a/controlplane/src/core/repositories/NamespaceRepository.ts
+++ b/controlplane/src/core/repositories/NamespaceRepository.ts
@@ -117,7 +117,7 @@ export class NamespaceRepository {
     rbac: RBACEvaluator | undefined,
     conditions: (SQL<unknown> | undefined)[],
   ): Promise<void> {
-    if (!rbac || rbac.isOrganizationViewer) {
+    if (!rbac || rbac.isOrganizationViewer || (rbac.isApiKey && rbac.groups.length === 0)) {
       return;
     }
 

--- a/controlplane/src/core/repositories/SubgraphRepository.ts
+++ b/controlplane/src/core/repositories/SubgraphRepository.ts
@@ -583,7 +583,7 @@ export class SubgraphRepository {
    * @private
    */
   private applyRbacConditionsToQuery(rbac: RBACEvaluator | undefined, conditions: (SQL<unknown> | undefined)[]) {
-    if (!rbac || rbac.isOrganizationViewer) {
+    if (!rbac || rbac.isOrganizationViewer || (rbac.isApiKey && rbac.groups.length === 0)) {
       return true;
     }
 

--- a/controlplane/src/core/services/RBACEvaluator.ts
+++ b/controlplane/src/core/services/RBACEvaluator.ts
@@ -104,7 +104,7 @@ export class RBACEvaluator {
       return true;
     }
 
-    return this.isOrganizationViewer || (this.groups.length === 0 && this.isApiKey);
+    return this.isOrganizationViewer;
   }
 
   canCreateFederatedGraph(namespace: Namespace) {


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

## Motivation and Context

Restore legacy read access to API keys when no group have been assigned to them.

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please describe in detail the impact of this change. Attach screenshots if applicable.
-->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->