### PR TITLE
fix: extra volume mounts not rendered properly

### DIFF
--- a/helm/cosmo/charts/router/Chart.yaml
+++ b/helm/cosmo/charts/router/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.1
+version: 0.10.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/cosmo/charts/router/README.md
+++ b/helm/cosmo/charts/router/README.md
@@ -1,6 +1,6 @@
 # router
 
-![Version: 0.10.1](https://img.shields.io/badge/Version-0.10.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.197.1](https://img.shields.io/badge/AppVersion-0.197.1-informational?style=flat-square)
+![Version: 0.10.2](https://img.shields.io/badge/Version-0.10.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.197.1](https://img.shields.io/badge/AppVersion-0.197.1-informational?style=flat-square)
 
 This is the official Helm Chart for the WunderGraph Cosmo Router.
 

--- a/helm/cosmo/charts/router/templates/deployment.yaml
+++ b/helm/cosmo/charts/router/templates/deployment.yaml
@@ -203,7 +203,7 @@ spec:
               subPath: execution-config.json
             {{- end }}
             {{- if .Values.extraVolumeMounts }}
-            {{- .Values.extraVolumeMounts | nindent 12 }}
+            {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
             {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
@@ -223,7 +223,7 @@ spec:
             name: {{ include "router.fullname" . }}
         {{- end }}
         {{- if .Values.extraVolumes }}
-        {{- .Values.extraVolumes | nindent 8 }}
+        {{- toYaml .Values.extraVolumes | nindent 8 }}
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
## Motivation and Context

This pull request includes updates to the Helm chart for the `router` component, focusing on versioning and YAML rendering improvements. The most important changes include incrementing the chart version and ensuring proper YAML formatting for additional volumes and volume mounts.

### Versioning Updates:
* [`helm/cosmo/charts/router/Chart.yaml`](diffhunk://#diff-48692f19ca9f4f61361e95b52c5eb8f50336046ac4c88b821d0637c9ebd09464L18-R18): Incremented the chart version from `0.10.1` to `0.10.2` to reflect changes made in the chart templates.

### YAML Rendering Improvements:
* [`helm/cosmo/charts/router/templates/deployment.yaml`](diffhunk://#diff-e6aabf4b8e03c68dedebad1cf7d36b587209346ec3aba11cba92d927bd8ace5dL206-R206): Updated the rendering of `extraVolumeMounts` to use `toYaml` for proper YAML formatting.
* [`helm/cosmo/charts/router/templates/deployment.yaml`](diffhunk://#diff-e6aabf4b8e03c68dedebad1cf7d36b587209346ec3aba11cba92d927bd8ace5dL226-R226): Updated the rendering of `extraVolumes` to use `toYaml` for consistent YAML formatting.

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->