### PR TITLE
feat: add an RFC for subscription hydratation

### DIFF
--- a/rfc/hydrate-subscriptions.md
+++ b/rfc/hydrate-subscriptions.md
@@ -6,7 +6,7 @@ author: Alessandro Pagnin
 Upon initiation of an event driven federated subscripton, the router currently has to wait to receive a message from the message broker before any data at all would be returned.
 Users of EDFS have requested that the subscription serves a starting state prior to the first message being received.
 
-The current constraints of an Event Driven Graph is that each root field must return a named type that is one of two things:
+The current constraints of an Event Driven Graph is that each root field must return a named type that is one of three things:
 1. an Entity defined in the EDG;
 2. an Interface implemented by at least one Entity defined in the EDG;
 3. an Union (to check) whose members are all Entities defined in the EDG.
@@ -25,7 +25,6 @@ That requested data can be sent to the client prior to the delivery of the first
 - @edfs__prefetch
 - @edfs__initialResolve
 - @edfs__preload
-
 
 ```graphql
 directive @edfs__hydrateSubscription on ARGUMENT

--- a/rfc/hydrate-subscriptions.md
+++ b/rfc/hydrate-subscriptions.md
@@ -1,0 +1,218 @@
+---
+title: "@edfs__hydrateSubscription"
+author: Alessandro Pagnin
+---
+
+Upon initiation of an event driven federated subscripton, the router currently has to wait to receive a message from the message broker before any data at all would be returned.
+Users of EDFS have requested that the subscription serves a starting state prior to the first message being received.
+
+The current constraints of an Event Driven Graph is that each root field must return a named type that is one of two things:
+1. an Entity defined in the EDG;
+2. an Interface implemented by at least one Entity defined in the EDG;
+3. an Union (to check) whose members are all Entities defined in the EDG.
+
+Because we are always returning Entities, we are guaranteed primary keys defined on those Entities.
+
+Consequently, as long as the value(s) of the key(s) are provided we can make one or more Entity representation calls to resolve the requested data.
+
+That requested data can be sent to the client prior to the delivery of the first event from the message broker.
+
+# @edfs__hydrateSubscription
+
+## Potential other names
+
+- @edfs__initialState
+- @edfs__prefetch
+- @edfs__initialResolve
+- @edfs__preload
+
+
+```graphql
+directive @edfs__hydrateSubscription on ARGUMENT
+```
+
+This directive would rely on an argument supplying the necessary data to resolve the Entity.
+
+The argument should be an Input Object that is guaranteed to define two Input fields:
+1. `typeName`, which represents the `__typename` of the Entity being returned;
+2. `key`, which represents the structure of the Entity key.
+
+The input can also include an arbitrary number of other Input Fields as long as it defines the fields `key` and `typeName`.
+
+## Composition validation
+
+Check that the key structure matches at least one key of any Entity that could be returned by the rootField.
+Composition should fail if any keys don't match.
+
+If the argument is a list type, validate that the return type of the root field is also a list.
+
+## Runtime validations
+
+If the root field returns an abstract type, the typeName must reference an object that implements (interface) or is a member of (union) that abstract type in the EDG.
+
+## Potential runtime issues
+
+If the value of the key is invalid the entity representation call will return Null.
+However constraints of the EDG dictate the return type of a root field must be non-nullable.
+This could potentially close the subscription.
+
+# Examples
+
+## Single key, single entity returned
+
+This is the simplest example, where we have an input that refers to an Entity with a single key field. That same input is also used for the subjects argument.
+
+```graphql
+directive @edfs__hydrateSubscription on ARGUMENT
+
+type Subscription {
+    employeeUpdated(input: EmployeeInput! @edfs__hydrateSubscription): Employee! @edfs__natsSubscribe(subjects: ["employeeUpdated.{{ args.input.key }}"]) 
+}
+
+type Employee @key(fields: "id", resolvable: false) {
+  id: Int! @external
+}
+
+input EmployeeInput {
+    typeName: String! # The typename is necessary because of abstract types
+    key: Int!
+}
+```
+
+
+## Single key, multiple entities returned
+
+In this example we are returning more than one entity, and so the input is a list of `EmployeeInput`.
+
+```graphql
+directive @edfs__hydrateSubscription on ARGUMENT
+
+type Subscription {
+    employeesUpdated(input: [EmployeeInput]! @edfs__hydrateSubscription): [Employee!] @edfs__natsSubscribe(subjects: ["employeesUpdated"]) 
+}
+
+type Employee @key(fields: "id", resolvable: false) {
+  id: Int! @external
+}
+
+input EmployeeInput {
+    typeName: String! # The typename is necessary because of abstract types
+    key: Int!
+}
+```
+
+## Composite key, single entity returned
+
+In this example the Entity needs a Composite Key, and an Input type is created to replicate the key structure.
+
+```graphql
+directive @edfs__hydrateSubscription on ARGUMENT
+
+type Subscription {
+    employeeUpdated(input: EmployeeInput! @edfs__hydrateSubscription): Employee! @edfs__natsSubscribe(subjects: ["employeeUpdated.{{ args.input.key.id }}_{{ args.input.key.object.id }}"]) 
+}
+
+type Employee @key(fields: "id object { id }", resolvable: false){
+    id: Int! @external
+    object: Object! @external
+}
+
+type Object {
+    id: Int! @external
+}
+
+input EmployeeInput {
+    typeName: String! # The typename is necessary because of abstract types
+    key: EmployeeKey!
+}
+
+input EmployeeKey {
+    id: Int!
+    object: ObjectKey!
+}
+
+input ObjectKey {
+    id: Int!
+}
+```
+
+## Single key, additional input fields
+
+
+In this example, we show that arbitrary fields can be added to the input type, and used in the subjects argument.
+
+```graphql
+directive @edfs__hydrateSubscription on ARGUMENT
+
+type Subscription {
+    employeeUpdated(input: [EmployeeInput]! @edfs__hydrateSubscription): Employee! @edfs__natsSubscribe(subjects: ["employeeUpdated.{{ args.input.arbitrary }}"]) 
+}
+
+type Employee @key(fields: "id", resolvable: false) {
+  id: Int! @external
+}
+
+input EmployeeInput {
+    typeName: String! # The typename is necessary because of abstract types
+    key: Int!
+    arbitrary: String!
+}
+```
+
+## Single key, interface returned
+
+In this example we show how we can propagate an inital payload where the return type of the subscription is an abstract type. 
+
+```graphql
+directive @edfs__hydrateSubscription on ARGUMENT
+
+type Subscription {
+    employeeUpdated(input: EmployeeInput! @edfs__hydrateSubscription): Interface! @edfs__natsSubscribe(subjects: ["employeeUpdated.{{ args.input.key.id }}_{{ args.input.key.object.id }}"]) 
+}
+
+interface Interface {
+    id: Int!
+}
+
+type EmployeeA implements Interface @key(fields: "id", resolvable: false){
+  id: Int! @external
+}
+
+type EmployeeB implements Interface @key(fields: "id", resolvable: false){
+  id: Int! @external
+}
+
+input EmployeeInput {
+    typeName: String!
+    key: Int!
+}
+```
+
+## Single key, multiple interfaces returned
+
+In this example we show how we can propagate an inital payload where the return type of the subscription is a list of abstract type and, an additional input can be used to specify the subject argument.
+
+```graphql
+directive @edfs__hydrateSubscription on ARGUMENT
+
+type Subscription {
+    employeeUpdated(input: [EmployeeInput!]! @edfs__hydrateSubscription, subject: String): [Interface!]! @edfs__natsSubscribe(subjects: ["employeeUpdated.{{ args.subject }}"]) 
+}
+
+interface Interface {
+    id: Int!
+}
+
+type EmployeeA implements Interface @key(fields: "id", resolvable: false){
+  id: Int! @external
+}
+
+type EmployeeB implements Interface @key(fields: "id", resolvable: false){
+  id: Int! @external
+}
+
+input EmployeeInput {
+    typeName: String!
+    key: Int!
+}
+```

--- a/rfc/hydrate-subscriptions.md
+++ b/rfc/hydrate-subscriptions.md
@@ -1,5 +1,5 @@
 ---
-title: "@edfs__hydrateSubscription"
+title: "@openfed__hydrateSubscription"
 author: Alessandro Pagnin
 ---
 
@@ -17,17 +17,17 @@ Consequently, as long as the value(s) of the key(s) are provided we can make one
 
 That requested data can be sent to the client prior to the delivery of the first event from the message broker.
 
-# @edfs__hydrateSubscription
+# @openfed__hydrateSubscription
 
 ## Potential other names
 
-- @edfs__initialState
-- @edfs__prefetch
-- @edfs__initialResolve
-- @edfs__preload
+- @openfed__initialState
+- @openfed__prefetch
+- @openfed__initialResolve
+- @openfed__preload
 
 ```graphql
-directive @edfs__hydrateSubscription on ARGUMENT
+directive @openfed__hydrateSubscription on ARGUMENT
 ```
 
 This directive would rely on an argument supplying the necessary data to resolve the Entity.
@@ -62,10 +62,10 @@ This could potentially close the subscription.
 This is the simplest example, where we have an input that refers to an Entity with a single key field. That same input is also used for the subjects argument.
 
 ```graphql
-directive @edfs__hydrateSubscription on ARGUMENT
+directive @openfed__hydrateSubscription on ARGUMENT
 
 type Subscription {
-    employeeUpdated(input: EmployeeInput! @edfs__hydrateSubscription): Employee! @edfs__natsSubscribe(subjects: ["employeeUpdated.{{ args.input.key }}"]) 
+    employeeUpdated(input: EmployeeInput! @openfed__hydrateSubscription): Employee! @edfs__natsSubscribe(subjects: ["employeeUpdated.{{ args.input.key }}"]) 
 }
 
 type Employee @key(fields: "id", resolvable: false) {
@@ -84,10 +84,10 @@ input EmployeeInput {
 In this example we are returning more than one entity, and so the input is a list of `EmployeeInput`.
 
 ```graphql
-directive @edfs__hydrateSubscription on ARGUMENT
+directive @openfed__hydrateSubscription on ARGUMENT
 
 type Subscription {
-    employeesUpdated(input: [EmployeeInput]! @edfs__hydrateSubscription): [Employee!] @edfs__natsSubscribe(subjects: ["employeesUpdated"]) 
+    employeesUpdated(input: [EmployeeInput]! @openfed__hydrateSubscription): [Employee!] @edfs__natsSubscribe(subjects: ["employeesUpdated"]) 
 }
 
 type Employee @key(fields: "id", resolvable: false) {
@@ -105,10 +105,10 @@ input EmployeeInput {
 In this example the Entity needs a Composite Key, and an Input type is created to replicate the key structure.
 
 ```graphql
-directive @edfs__hydrateSubscription on ARGUMENT
+directive @openfed__hydrateSubscription on ARGUMENT
 
 type Subscription {
-    employeeUpdated(input: EmployeeInput! @edfs__hydrateSubscription): Employee! @edfs__natsSubscribe(subjects: ["employeeUpdated.{{ args.input.key.id }}_{{ args.input.key.object.id }}"]) 
+    employeeUpdated(input: EmployeeInput! @openfed__hydrateSubscription): Employee! @edfs__natsSubscribe(subjects: ["employeeUpdated.{{ args.input.key.id }}_{{ args.input.key.object.id }}"]) 
 }
 
 type Employee @key(fields: "id object { id }", resolvable: false){
@@ -141,10 +141,10 @@ input ObjectKey {
 In this example, we show that arbitrary fields can be added to the input type, and used in the subjects argument.
 
 ```graphql
-directive @edfs__hydrateSubscription on ARGUMENT
+directive @openfed__hydrateSubscription on ARGUMENT
 
 type Subscription {
-    employeeUpdated(input: [EmployeeInput]! @edfs__hydrateSubscription): Employee! @edfs__natsSubscribe(subjects: ["employeeUpdated.{{ args.input.arbitrary }}"]) 
+    employeeUpdated(input: [EmployeeInput]! @openfed__hydrateSubscription): Employee! @edfs__natsSubscribe(subjects: ["employeeUpdated.{{ args.input.arbitrary }}"]) 
 }
 
 type Employee @key(fields: "id", resolvable: false) {
@@ -163,10 +163,10 @@ input EmployeeInput {
 In this example we show how we can propagate an inital payload where the return type of the subscription is an abstract type. 
 
 ```graphql
-directive @edfs__hydrateSubscription on ARGUMENT
+directive @openfed__hydrateSubscription on ARGUMENT
 
 type Subscription {
-    employeeUpdated(input: EmployeeInput! @edfs__hydrateSubscription): Interface! @edfs__natsSubscribe(subjects: ["employeeUpdated.{{ args.input.key.id }}_{{ args.input.key.object.id }}"]) 
+    employeeUpdated(input: EmployeeInput! @openfed__hydrateSubscription): Interface! @edfs__natsSubscribe(subjects: ["employeeUpdated.{{ args.input.key.id }}_{{ args.input.key.object.id }}"]) 
 }
 
 interface Interface {
@@ -192,10 +192,10 @@ input EmployeeInput {
 In this example we show how we can propagate an inital payload where the return type of the subscription is a list of abstract type and, an additional input can be used to specify the subject argument.
 
 ```graphql
-directive @edfs__hydrateSubscription on ARGUMENT
+directive @openfed__hydrateSubscription on ARGUMENT
 
 type Subscription {
-    employeeUpdated(input: [EmployeeInput!]! @edfs__hydrateSubscription, subject: String): [Interface!]! @edfs__natsSubscribe(subjects: ["employeeUpdated.{{ args.subject }}"]) 
+    employeeUpdated(input: [EmployeeInput!]! @openfed__hydrateSubscription, subject: String): [Interface!]! @edfs__natsSubscribe(subjects: ["employeeUpdated.{{ args.subject }}"]) 
 }
 
 interface Interface {


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

## Motivation and Context 
<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please describe in detail the impact of this change. Attach screenshots if applicable.
-->

Users of EDFS have requested that the subscription serves a starting state prior to the first message being received.

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->