### PR TITLE
feat: restore legacy support for check endpoints

### DIFF
--- a/controlplane/src/core/bufservices/cache-warmer/pushCacheWarmerOperation.ts
+++ b/controlplane/src/core/bufservices/cache-warmer/pushCacheWarmerOperation.ts
@@ -61,7 +61,8 @@ export function pushCacheWarmerOperation(
       };
     }
 
-    if (!authContext.rbac.hasFederatedGraphWriteAccess(federatedGraph)) {
+    // Only check for permission when we are not supposed to use the legacy flow
+    if (!authContext.rbac.useLegacyFlow && !authContext.rbac.hasFederatedGraphWriteAccess(federatedGraph)) {
       throw new UnauthorizedError();
     }
 

--- a/controlplane/src/core/bufservices/contract/updateContract.ts
+++ b/controlplane/src/core/bufservices/contract/updateContract.ts
@@ -99,7 +99,8 @@ export function updateContract(
       };
     }
 
-    if (!authContext.rbac.hasFederatedGraphWriteAccess(graph)) {
+    // Only check for permission when we are not supposed to use the legacy flow
+    if (!authContext.rbac.useLegacyFlow && !authContext.rbac.hasFederatedGraphWriteAccess(graph)) {
       throw new UnauthorizedError();
     }
 

--- a/controlplane/src/core/bufservices/federated-graph/checkFederatedGraph.ts
+++ b/controlplane/src/core/bufservices/federated-graph/checkFederatedGraph.ts
@@ -52,7 +52,8 @@ export function checkFederatedGraph(
       };
     }
 
-    if (!authContext.rbac.hasFederatedGraphWriteAccess(federatedGraph)) {
+    // Only check for permission when we are not supposed to use the legacy flow
+    if (!authContext.rbac.useLegacyFlow && !authContext.rbac.hasFederatedGraphWriteAccess(federatedGraph)) {
       throw new UnauthorizedError();
     }
 

--- a/controlplane/src/core/bufservices/federated-graph/generateRouterToken.ts
+++ b/controlplane/src/core/bufservices/federated-graph/generateRouterToken.ts
@@ -44,7 +44,8 @@ export function generateRouterToken(
       };
     }
 
-    if (!authContext.rbac.hasFederatedGraphWriteAccess(federatedGraph)) {
+    // Only check for permission when we are not supposed to use the legacy flow
+    if (!authContext.rbac.useLegacyFlow && !authContext.rbac.hasFederatedGraphWriteAccess(federatedGraph)) {
       throw new UnauthorizedError();
     }
 

--- a/controlplane/src/core/bufservices/monograph/publishMonograph.ts
+++ b/controlplane/src/core/bufservices/monograph/publishMonograph.ts
@@ -60,7 +60,8 @@ export function publishMonograph(
       };
     }
 
-    if (!authContext.rbac.hasFederatedGraphWriteAccess(graph)) {
+    // Only check for permission when we are not supposed to use the legacy flow
+    if (!authContext.rbac.useLegacyFlow && !authContext.rbac.hasFederatedGraphWriteAccess(graph)) {
       throw new UnauthorizedError();
     }
 

--- a/controlplane/src/core/bufservices/monograph/updateMonograph.ts
+++ b/controlplane/src/core/bufservices/monograph/updateMonograph.ts
@@ -92,7 +92,8 @@ export function updateMonograph(
         };
       }
 
-      if (!authContext.rbac.hasFederatedGraphWriteAccess(graph)) {
+      // Only check for permission when we are not supposed to use the legacy flow
+      if (!authContext.rbac.useLegacyFlow && !authContext.rbac.hasFederatedGraphWriteAccess(graph)) {
         throw new UnauthorizedError();
       }
 

--- a/controlplane/src/core/bufservices/proposal/createProposal.ts
+++ b/controlplane/src/core/bufservices/proposal/createProposal.ts
@@ -93,7 +93,8 @@ export function createProposal(
       };
     }
 
-    if (!authContext.rbac.hasFederatedGraphWriteAccess(federatedGraph)) {
+    // Only check for permission when we are not supposed to use the legacy flow
+    if (!authContext.rbac.useLegacyFlow && !authContext.rbac.hasFederatedGraphWriteAccess(federatedGraph)) {
       throw new UnauthorizedError();
     }
 

--- a/controlplane/src/core/bufservices/proposal/updateProposal.ts
+++ b/controlplane/src/core/bufservices/proposal/updateProposal.ts
@@ -121,7 +121,8 @@ export function updateProposal(
       };
     }
 
-    if (!authContext.rbac.hasFederatedGraphWriteAccess(federatedGraph)) {
+    // Only check for permission when we are not supposed to use the legacy flow
+    if (!authContext.rbac.useLegacyFlow && !authContext.rbac.hasFederatedGraphWriteAccess(federatedGraph)) {
       throw new UnauthorizedError();
     }
 

--- a/controlplane/src/core/bufservices/subgraph/checkSubgraphSchema.ts
+++ b/controlplane/src/core/bufservices/subgraph/checkSubgraphSchema.ts
@@ -131,8 +131,11 @@ export function checkSubgraphSchema(
       };
     }
 
-    if (!subgraph) {
-      if (!authContext.rbac.canCreateSubGraph(namespace)) {
+    if (subgraph && !authContext.rbac.useLegacyFlow && !authContext.rbac.canCreateSubGraph(namespace)) {
+      // Only check for permission when we are not supposed to use the legacy flow
+      throw new UnauthorizedError();
+    } else if (!subgraph) {
+      if (!authContext.rbac.useLegacyFlow && !authContext.rbac.canCreateSubGraph(namespace)) {
         throw new UnauthorizedError();
       }
 
@@ -171,8 +174,6 @@ export function checkSubgraphSchema(
           compositionWarnings: [],
         };
       }
-    } else if (!authContext.rbac.hasSubGraphWriteAccess(subgraph)) {
-      throw new UnauthorizedError();
     }
 
     const subgraphName = subgraph?.name || req.subgraphName;

--- a/controlplane/src/core/bufservices/subgraph/checkSubgraphSchema.ts
+++ b/controlplane/src/core/bufservices/subgraph/checkSubgraphSchema.ts
@@ -131,7 +131,7 @@ export function checkSubgraphSchema(
       };
     }
 
-    if (subgraph && !authContext.rbac.useLegacyFlow && !authContext.rbac.canCreateSubGraph(namespace)) {
+    if (subgraph && !authContext.rbac.useLegacyFlow && !authContext.rbac.hasSubGraphWriteAccess(subgraph)) {
       // Only check for permission when we are not supposed to use the legacy flow
       throw new UnauthorizedError();
     } else if (!subgraph) {

--- a/controlplane/src/core/errors/errors.ts
+++ b/controlplane/src/core/errors/errors.ts
@@ -22,7 +22,7 @@ export class AuthorizationError extends ServiceError {}
 
 export class UnauthorizedError extends AuthorizationError {
   constructor() {
-    super(EnumStatusCode.ERROR_NOT_AUTHORIZED, 'The user doesnt have the permissions to perform this operation');
+    super(EnumStatusCode.ERROR_NOT_AUTHORIZED, 'The user does not have the permissions to perform this operation');
   }
 }
 

--- a/controlplane/src/core/services/RBACEvaluator.ts
+++ b/controlplane/src/core/services/RBACEvaluator.ts
@@ -22,6 +22,7 @@ interface Target {
 }
 
 export class RBACEvaluator {
+  readonly useLegacyFlow: boolean;
   readonly roles: OrganizationRole[];
   private readonly rules: ReadonlyMap<OrganizationRole, RuleData>;
 
@@ -40,6 +41,8 @@ export class RBACEvaluator {
     private readonly userId?: string,
     readonly isApiKey?: boolean,
   ) {
+    this.useLegacyFlow = groups.length === 0;
+
     const flattenRules = groups.flatMap((group) => group.rules);
     const rulesGroupedByRole = Object.groupBy(flattenRules, (rule) => rule.role);
 

--- a/controlplane/test/check-subgraph-schema.test.ts
+++ b/controlplane/test/check-subgraph-schema.test.ts
@@ -75,6 +75,11 @@ describe('CheckSubgraphSchema', (ctx) => {
 
     expect(resp.response?.code).toBe(EnumStatusCode.OK);
 
+    authenticator.changeUserWithSuppliedContext({
+      ...users.adminAliceCompanyA,
+      rbac: createTestRBACEvaluator(createTestGroup({ role }))
+    });
+
     // test for no changes in schema
     let checkResp = await client.checkSubgraphSchema({
       subgraphName,
@@ -85,10 +90,58 @@ describe('CheckSubgraphSchema', (ctx) => {
     expect(checkResp.breakingChanges.length).toBe(0);
     expect(checkResp.nonBreakingChanges.length).toBe(0);
 
+    // test for breaking changes in schema
+    checkResp = await client.checkSubgraphSchema({
+      subgraphName,
+      namespace: 'default',
+      schema: Uint8Array.from(Buffer.from('type Query { name: String! }')),
+    });
+    expect(checkResp.response?.code).toBe(EnumStatusCode.OK);
+    expect(checkResp.breakingChanges.length).not.toBe(0);
+    expect(checkResp.breakingChanges[0].changeType).toBe(SchemaChangeType.FIELD_REMOVED);
+    expect(checkResp.nonBreakingChanges.length).not.toBe(0);
+    expect(checkResp.nonBreakingChanges[0].changeType).toBe(SchemaChangeType.FIELD_ADDED);
+
+    await server.close();
+  });
+
+  test('Should allow legacy fallback when checking graph', async (role) => {
+    const { client, server, authenticator, users } = await SetupTest({ dbname, chClient });
+
+    const subgraphName = genID('subgraph1');
+    const label = genUniqueLabel();
+
+    let resp = await client.createFederatedSubgraph({
+      name: subgraphName,
+      namespace: 'default',
+      labels: [label],
+      routingUrl: 'http://localhost:8080',
+    });
+
+    expect(resp.response?.code).toBe(EnumStatusCode.OK);
+
+    resp = await client.publishFederatedSubgraph({
+      name: subgraphName,
+      namespace: 'default',
+      schema: 'type Query { hello: String! }',
+    });
+
+    expect(resp.response?.code).toBe(EnumStatusCode.OK);
+
     authenticator.changeUserWithSuppliedContext({
       ...users.adminAliceCompanyA,
-      rbac: createTestRBACEvaluator(createTestGroup({ role }))
+      rbac: createTestRBACEvaluator()
     });
+
+    // test for no changes in schema
+    let checkResp = await client.checkSubgraphSchema({
+      subgraphName,
+      namespace: 'default',
+      schema: Uint8Array.from(Buffer.from('type Query { hello: String! }')),
+    });
+    expect(checkResp.response?.code).toBe(EnumStatusCode.OK);
+    expect(checkResp.breakingChanges.length).toBe(0);
+    expect(checkResp.nonBreakingChanges.length).toBe(0);
 
     // test for breaking changes in schema
     checkResp = await client.checkSubgraphSchema({

--- a/controlplane/test/graph-pruning.test.ts
+++ b/controlplane/test/graph-pruning.test.ts
@@ -130,7 +130,7 @@ describe('Graph Pruning Tests', (ctx) => {
     });
 
     expect(response.response?.code).toBe(EnumStatusCode.ERROR_NOT_AUTHORIZED);
-    expect(response.response?.details).toBe('The user doesnt have the permissions to perform this operation');
+    expect(response.response?.details).toBe('The user does not have the permissions to perform this operation');
 
     await server.close();
   });
@@ -227,7 +227,7 @@ describe('Graph Pruning Tests', (ctx) => {
 
     expect(configureGraphPruningConfigResponse.response?.code).toBe(EnumStatusCode.ERROR_NOT_AUTHORIZED);
     expect(configureGraphPruningConfigResponse.response?.details).toBe(
-      'The user doesnt have the permissions to perform this operation',
+      'The user does not have the permissions to perform this operation',
     );
 
     await server.close();

--- a/controlplane/test/oidc-provider.test.ts
+++ b/controlplane/test/oidc-provider.test.ts
@@ -67,7 +67,7 @@ describe('OIDC provider', (ctx) => {
     });
     expect(createOIDCProviderResponse.response?.code).toBe(EnumStatusCode.ERROR_NOT_AUTHORIZED);
     expect(createOIDCProviderResponse.response?.details).toBe(
-      'The user doesnt have the permissions to perform this operation',
+      'The user does not have the permissions to perform this operation',
     );
 
     authenticator.changeUser(TestUser.viewerTimCompanyA);
@@ -86,7 +86,7 @@ describe('OIDC provider', (ctx) => {
     });
     expect(createOIDCProviderResponse.response?.code).toBe(EnumStatusCode.ERROR_NOT_AUTHORIZED);
     expect(createOIDCProviderResponse.response?.details).toBe(
-      'The user doesnt have the permissions to perform this operation',
+      'The user does not have the permissions to perform this operation',
     );
 
     await server.close();
@@ -162,7 +162,7 @@ describe('OIDC provider', (ctx) => {
     let deleteOIDCProviderResponse = await client.deleteOIDCProvider({});
     expect(deleteOIDCProviderResponse.response?.code).toBe(EnumStatusCode.ERROR_NOT_AUTHORIZED);
     expect(deleteOIDCProviderResponse.response?.details).toBe(
-      'The user doesnt have the permissions to perform this operation',
+      'The user does not have the permissions to perform this operation',
     );
 
     authenticator.changeUser(TestUser.viewerTimCompanyA);
@@ -170,7 +170,7 @@ describe('OIDC provider', (ctx) => {
     deleteOIDCProviderResponse = await client.deleteOIDCProvider({});
     expect(deleteOIDCProviderResponse.response?.code).toBe(EnumStatusCode.ERROR_NOT_AUTHORIZED);
     expect(deleteOIDCProviderResponse.response?.details).toBe(
-      'The user doesnt have the permissions to perform this operation',
+      'The user does not have the permissions to perform this operation',
     );
 
     await server.close();
@@ -272,7 +272,7 @@ describe('OIDC provider', (ctx) => {
     });
     expect(updateMappersResponse.response?.code).toBe(EnumStatusCode.ERROR_NOT_AUTHORIZED);
     expect(updateMappersResponse.response?.details).toBe(
-      'The user doesnt have the permissions to perform this operation',
+      'The user does not have the permissions to perform this operation',
     );
 
     authenticator.changeUser(TestUser.viewerTimCompanyA);
@@ -291,7 +291,7 @@ describe('OIDC provider', (ctx) => {
     });
     expect(updateMappersResponse.response?.code).toBe(EnumStatusCode.ERROR_NOT_AUTHORIZED);
     expect(updateMappersResponse.response?.details).toBe(
-      'The user doesnt have the permissions to perform this operation',
+      'The user does not have the permissions to perform this operation',
     );
 
     await server.close();

--- a/controlplane/test/organization-groups.test.ts
+++ b/controlplane/test/organization-groups.test.ts
@@ -244,7 +244,7 @@ describe('Group membership tests', () => {
       groupId: developerGroup.groupId,
     });
     expect(updateGroupResponse.response?.code).toBe(EnumStatusCode.ERROR_NOT_AUTHORIZED);
-    expect(updateGroupResponse.response?.details).toBe('The user doesnt have the permissions to perform this operation',);
+    expect(updateGroupResponse.response?.details).toBe('The user does not have the permissions to perform this operation',);
 
     await server.close();
   });

--- a/controlplane/test/rbac-evaluator.test.ts
+++ b/controlplane/test/rbac-evaluator.test.ts
@@ -21,6 +21,7 @@ describe('RBAC Evaluator', () => {
     const rbac = createTestRBACEvaluator();
 
     expect(rbac.groups).toHaveLength(0);
+    expect(rbac.useLegacyFlow).toBe(true);
     expect(rbac.isOrganizationAdmin).toBe(false);
     expect(rbac.isOrganizationAdminOrDeveloper).toBe(false);
     expect(rbac.isOrganizationApiKeyManager).toBe(false);
@@ -45,6 +46,7 @@ describe('RBAC Evaluator', () => {
     const rbac = createTestRBACEvaluator(orgAdmin, createTestGroup({ role: 'graph-admin' }));
 
     expect(rbac.groups).toHaveLength(2);
+    expect(rbac.useLegacyFlow).toBe(false);
     expect(rbac.roles).toHaveLength(2);
     expect(rbac.roles.includes('organization-admin'));
     expect(rbac.roles.includes('graph-admin'));
@@ -60,6 +62,7 @@ describe('RBAC Evaluator', () => {
     );
 
     expect(rbac.groups).toHaveLength(4);
+    expect(rbac.useLegacyFlow).toBe(false);
     expect(rbac.roles).toHaveLength(3);
     expect(rbac.roles.includes('graph-admin'));
     expect(rbac.roles.includes('graph-viewer'));


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

## Motivation and Context

Due to an oversight in the new RBAC implementation, we were not allowing legacy API keys to perform checks.

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please describe in detail the impact of this change. Attach screenshots if applicable.
-->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [x] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->