### PR TITLE
feat(core): wire ApplicationStart/Stop hooks into RouterSupervisor li…

### DIFF
--- a/router/core/entities.go
+++ b/router/core/entities.go
@@ -1,0 +1,26 @@
+package core
+
+import (
+    "go.uber.org/zap"
+	"github.com/wundergraph/cosmo/router/pkg/config"
+)
+
+/* hook specific entities that are implemented by the core module system */
+
+// ApplicationParams is passed to ApplicationStartHook/ApplicationStopHook
+type ApplicationParams struct {
+	Config *config.Config
+	Logger *zap.Logger
+}
+
+
+/* common entities for the core module system */
+
+// ExitError is a struct for holding the exit code and error of the router
+type ExitError struct {
+	Code int
+	Err  error
+}
+
+func (e *ExitError) Error() string { return e.Err.Error() }
+  

--- a/router/core/hooks.go
+++ b/router/core/hooks.go
@@ -13,11 +13,11 @@ type ApplicationLifecycleHook interface {
 }
 
 type ApplicationStartHook interface {
-	OnApplicationStart(ctx context.Context)
+	OnApplicationStart(ctx context.Context, params *ApplicationParams) error
 }
 
 type ApplicationStopHook interface {
-	OnApplicationStop(ctx context.Context)
+	OnApplicationStop(ctx context.Context, params *ApplicationParams, exitError *ExitError) error
 }
 
 // GraphQL Server Lifecycle Hooks
@@ -27,11 +27,11 @@ type GraphQLServerLifecycleHook interface {
 }
 
 type GraphQLServerStartHook interface {
-	OnGraphQLServerStart(ctx context.Context)
+	OnGraphQLServerStart(ctx context.Context) error
 }
 
 type GraphQLServerStopHook interface {
-	OnGraphQLServerStop(ctx context.Context)
+	OnGraphQLServerStop(ctx context.Context) error	
 }
 
 // Router Lifecycle Hooks

--- a/router/core/modules_v1_test.go
+++ b/router/core/modules_v1_test.go
@@ -25,7 +25,7 @@ func (m *testModule1) MyModule() MyModuleInfo {
 func (m *testModule1) Provision(ctx context.Context) error { return nil }
 func (m *testModule1) Cleanup() error { return nil }
 
-func (m *testModule1) OnApplicationStart(ctx context.Context) {}
+func (m *testModule1) OnApplicationStart(ctx context.Context, params *ApplicationParams) error { return nil }
 
 type testModule2 struct {}
 
@@ -41,8 +41,8 @@ func (m *testModule2) MyModule() MyModuleInfo {
 func (m *testModule2) Provision(ctx context.Context) error { return nil }
 func (m *testModule2) Cleanup() error { return nil }
 
-func (m *testModule2) OnApplicationStart(ctx context.Context) {}
-func (m *testModule2) OnApplicationStop(ctx context.Context) {}
+func (m *testModule2) OnApplicationStart(ctx context.Context, params *ApplicationParams) error { return nil }
+func (m *testModule2) OnApplicationStop(ctx context.Context, params *ApplicationParams, exitError *ExitError) error { return nil }
 
 type testModule3 struct {}
 
@@ -57,8 +57,8 @@ func (m *testModule3) MyModule() MyModuleInfo {
 func (m *testModule3) Provision(ctx context.Context) error { return nil }
 func (m *testModule3) Cleanup() error { return nil }
 
-func (m *testModule3) OnApplicationStart(ctx context.Context) {}
-func (m *testModule3) OnApplicationStop(ctx context.Context) {}
+func (m *testModule3) OnApplicationStart(ctx context.Context, params *ApplicationParams) error { return nil }
+func (m *testModule3) OnApplicationStop(ctx context.Context, params *ApplicationParams, exitError *ExitError) error { return nil }
 
 
 type testModule4 struct {}


### PR DESCRIPTION
…fecycle

<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

## Motivation and Context

The PR implements https://linear.app/wundergraph/issue/MOD-6, it:
- Defines the object to be exposed at Application lifecycle hooks: ApplicationParams and ExitError 
- Integrates hoos into the RouterSupervisor.Start() (stop) flow. ensuring that:
  * OnApplicationStart hooks fire exactly once, immediately after modules are provisioned (via createRouter()), before the first router server starts.
  * OnApplicationStop hooks fire exactly once, on process exit (after the final stopRouter()), even if shutdown was driven by an error.
  * An ExitError is passed into OnApplicationStop, so modules can inspect or emit the error.

## Changes:

Supervisor

- Convert Start() to use a named err error return and defer a cleanup block that always fires OnApplicationStop(ctx, params, &exitErr).
- Populate ExitError.Code/.Err for each early-failure path (loadConfig(), createRouter(), startRouter(), stopRouter()).
- Fire OnApplicationStart(ctx, params) once after createRouter().

Hooks API

- Update ApplicationStopHook signature to accept exitErr *ExitError (containing both code & error) and ApplicationStartHook to accept params *ApplicationParams.

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please describe in detail the impact of this change. Attach screenshots if applicable.
-->

## Checklist

- [x] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [x] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->