### PR TITLE
improvements(cli): Fixed the issues with -s, -e, -l, -f options of "changelog" command and added improvements for the same

### DIFF
--- a/cli/src/commands/graph/common/changelog.ts
+++ b/cli/src/commands/graph/common/changelog.ts
@@ -1,7 +1,7 @@
 import { writeFile } from 'node:fs/promises';
 import { EnumStatusCode } from '@wundergraph/cosmo-connect/dist/common/common_pb';
 import { Command, program } from 'commander';
-import { endOfDay, formatISO, startOfDay, subDays } from 'date-fns';
+import { endOfDay, formatISO, startOfDay, subDays, format, parse, isValid } from 'date-fns';
 import pc from 'picocolors';
 import { resolve } from 'pathe';
 import { getBaseHeaders } from '../../../core/config.js';
@@ -19,6 +19,24 @@ type OutputFile = {
   }[];
 }[];
 
+const logInfo = (msg: string) => console.log(pc.yellow(msg));
+const exitWithError = (msg: string) => program.error(pc.red(msg));
+
+const parseAndValidateDate = (input: string, label: string): Date => {
+  const parsed = parse(input, 'yyyy-MM-dd', new Date());
+  if (!isValid(parsed)) {
+    exitWithError(`Invalid ${label} date "${input}". Please use YYYY-MM-DD format.`);
+  }
+  return parsed;
+};
+const parseAndValidateNumber = (input: string, label: string): number => {
+  const num = Number(input);
+  if (!Number.isFinite(num) || num < 0) {
+    exitWithError(`Invalid ${label} "${input}". Please provide a positive number.`);
+  }
+  return num;
+};
+
 export default (opts: CommonGraphCommandOptions) => {
   const graphType = opts.isMonograph ? 'monograph' : 'federated graph';
 
@@ -28,27 +46,42 @@ export default (opts: CommonGraphCommandOptions) => {
   command.option('-n, --namespace [string]', `The namespace of the ${graphType}.`);
   command.option('-l, --limit [number]', 'Limit of entries. Defaults to 10', '10');
   command.option('-f, --offset [number]', 'Offset of entries. Defaults to 0', '0');
-  command.option('-s, --start [date]', 'Start date. Defaults to 3 days back');
-  command.option('-e, --end [date]', 'End date. Defaults to today');
-  command.option('-o, --out [string]', 'Destination file for changelog. Defaults to changelog.json', 'changelog.json');
+  command.option('-s, --start [date]', 'Start date (YYYY-MM-DD). Defaults to 3 days back');
+  command.option('-e, --end [date]', 'End date (YYYY-MM-DD). Defaults to today');
+  command.option('-o, --out [string]', 'Destination file. Defaults to changelog.json', 'changelog.json');
   command.action(async (name, options) => {
-    let startDate = subDays(new Date(), 3);
-    let endDate = new Date();
+    const limit = parseAndValidateNumber(options.limit, 'limit');
+    const offset = parseAndValidateNumber(options.offset, 'offset');
+    let endDate = options.end ? parseAndValidateDate(options.end, 'end') : new Date();
+    const startDate = options.start ? parseAndValidateDate(options.start, 'start') : subDays(endDate, 3);
 
-    if (options.start) {
-      startDate = new Date(options.start);
+    if (options.end && !options.start) {
+      logInfo(
+        `Only end date provided. Defaulting start date to "${format(startDate, 'dd-MMM-yyyy')}", end date is "${format(endDate, 'dd-MMM-yyyy')}"`,
+      );
+    } else if (options.start && !options.end) {
+      endDate = subDays(startDate, -3);
+      logInfo(
+        `Only start date provided. Defaulting end date to "${format(endDate, 'dd-MMM-yyyy')}", start date is "${format(startDate, 'dd-MMM-yyyy')}"`,
+      );
+    } else if (!options.start) {
+      logInfo(`Using default start date: "${format(startDate, 'dd-MMM-yyyy')}"`);
     }
-    if (options.end) {
-      endDate = new Date(options.end);
+
+    if (!options.end && !options.start) {
+      logInfo(`Using default end date: "${format(endDate, 'dd-MMM-yyyy')}"`);
+    }
+
+    if (startDate > endDate) {
+      exitWithError(
+        `Start date "${format(startDate, 'yyyy-MM-dd')}" cannot be after end date "${format(endDate, 'yyyy-MM-dd')}".`,
+      );
     }
 
     const resp = await opts.client.platform.getFederatedGraphChangelog(
       {
         name,
-        pagination: {
-          limit: Number(options.limit),
-          offset: Number(options.offset),
-        },
+        pagination: { limit, offset },
         dateRange: {
           start: formatISO(startOfDay(startDate)),
           end: formatISO(endOfDay(endDate)),
@@ -76,6 +109,7 @@ export default (opts: CommonGraphCommandOptions) => {
           }) as OutputFile[number],
       );
       await writeFile(resolve(options.out), JSON.stringify(output));
+      console.log(pc.green(`Successfully wrote changelog to '${options.out}'`));
     } else {
       let message = `Failed to fetch changelog for ${pc.bold(name)}.`;
       if (resp.response?.details) {


### PR DESCRIPTION
## Solution Implemented

- [x] Add success log message after writing the changelog file to clearly confirm successful output.
- [x] Log fallback date range when --start or --end is not provided, using console.log with a formatted date range.
- [x] Add early validation for --start and --end using a strict regex (YYYY-MM-DD) and a leap year–aware validator.
- [x] Update fallback logic for --start only: If --start is provided and --end is not, set endDate to 3 days after startDate.
- [x] Fix fallback for --end only: If --end is provided and --start is missing, set startDate to 3 days before endDate.
- [x] Add validation to ensure startDate <= endDate: Fail gracefully if this check fails, and show a clear error message.
- [x] Validate numeric input for --limit and --offset, with meaningful error messages if invalid values are passed.
- [x] Improve error handling and messaging for all invalid dates to prevent RangeError and user confusion.

## Motivation and Context

#1922 

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).