### PR TITLE
feat: support mcp in router helm chart

### DIFF
--- a/helm/cosmo/charts/router/Chart.yaml
+++ b/helm/cosmo/charts/router/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.2
+version: 0.11.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/cosmo/charts/router/README.md
+++ b/helm/cosmo/charts/router/README.md
@@ -1,6 +1,6 @@
 # router
 
-![Version: 0.10.2](https://img.shields.io/badge/Version-0.10.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.197.1](https://img.shields.io/badge/AppVersion-0.197.1-informational?style=flat-square)
+![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.197.1](https://img.shields.io/badge/AppVersion-0.197.1-informational?style=flat-square)
 
 This is the official Helm Chart for the WunderGraph Cosmo Router.
 
@@ -25,6 +25,8 @@ This is the official Helm Chart for the WunderGraph Cosmo Router.
 | configuration.httpProxy | string | `""` | The URL of the HTTP proxy server. Default is an empty string. |
 | configuration.httpsProxy | string | `""` | The URL of the HTTPS proxy server. Default is an empty string. |
 | configuration.logLevel | string | `"info"` | The log level of the router. Default to info if not set. |
+| configuration.mcp.enabled | bool | `false` | Enables MCP server support. Default is false. |
+| configuration.mcp.port | int | `5025` | The port where the MCP server is exposed. Default is port 5025. |
 | configuration.noProxy | string | `""` | NO_PROXY is a comma-separated list of hosts or domains for which the proxy should not be used. |
 | configuration.otelCollectorUrl | string | `""` | The URL of the Cosmo GraphQL OTEL Collector. Should be internal to the cluster. Default to cloud if not set. |
 | configuration.prometheus.enabled | bool | `true` | Enables prometheus metrics support. Default is true. |

--- a/helm/cosmo/charts/router/templates/config-map.yaml
+++ b/helm/cosmo/charts/router/templates/config-map.yaml
@@ -23,11 +23,11 @@ data:
   cdnUrl: "{{ .Values.configuration.cdnUrl }}"
   routerConfigPath: "{{ .Values.configuration.routerConfigPath }}"
   prometheusEnabled: "{{ .Values.configuration.prometheus.enabled }}"
-  {{ if .Values.configuration.prometheus.enabled }}
+  {{- if .Values.configuration.prometheus.enabled }}
   prometheusListenAddr: "0.0.0.0:{{ .Values.configuration.prometheus.port }}"
   prometheusPath: "{{ .Values.configuration.prometheus.path }}"
   {{- end }}
-  {{ if .Values.configuration.mcp.enabled }}
+  {{- if .Values.configuration.mcp.enabled }}
   mcpEnabled: "{{ .Values.configuration.mcp.enabled }}"
   mcpListenAddr: "0.0.0.0:{{ .Values.configuration.mcp.port }}"
   {{- end }}

--- a/helm/cosmo/charts/router/templates/config-map.yaml
+++ b/helm/cosmo/charts/router/templates/config-map.yaml
@@ -27,3 +27,7 @@ data:
   prometheusListenAddr: "0.0.0.0:{{ .Values.configuration.prometheus.port }}"
   prometheusPath: "{{ .Values.configuration.prometheus.path }}"
   {{- end }}
+  {{ if .Values.configuration.mcp.enabled }}
+  mcpEnabled: "{{ .Values.configuration.mcp.enabled }}"
+  mcpListenAddr: "0.0.0.0:{{ .Values.configuration.mcp.port }}"
+  {{- end }}

--- a/helm/cosmo/charts/router/templates/deployment.yaml
+++ b/helm/cosmo/charts/router/templates/deployment.yaml
@@ -68,11 +68,11 @@ spec:
             {{- if .Values.extraEnvVars }}
             {{- toYaml .Values.extraEnvVars | nindent 12 }}
             {{- end }}
-            {{ if .Values.configuration.executionConfig }}
+            {{- if .Values.configuration.executionConfig }}
             - name: ROUTER_CONFIG_PATH
               value: /execution-config.json
             {{- end }}
-            {{ if .Values.configuration.configPath }}
+            {{- if .Values.configuration.configPath }}
             - name: CONFIG_PATH
               value: {{ .Values.configuration.configPath }}
             {{- end }}
@@ -81,56 +81,56 @@ spec:
                 configMapKeyRef:
                   name: {{ include "router.fullname" . }}
                   key: listenAddress
-            {{ if .Values.configuration.devMode }}
+            {{- if .Values.configuration.devMode }}
             - name: DEV_MODE
               valueFrom:
                 configMapKeyRef:
                   name: {{ include "router.fullname" . }}
                   key: devMode
             {{- end }}
-            {{ if .Values.configuration.logLevel }}
+            {{- if .Values.configuration.logLevel }}
             - name: LOG_LEVEL
               valueFrom:
                 configMapKeyRef:
                   name: {{ include "router.fullname" . }}
                   key: logLevel
             {{- end }}
-            {{ if .Values.configuration.controlplaneUrl }}
+            {{- if .Values.configuration.controlplaneUrl }}
             - name: CONTROLPLANE_URL
               valueFrom:
                 configMapKeyRef:
                   name: {{ include "router.fullname" . }}
                   key: controlplaneUrl
             {{- end }}
-            {{ if .Values.configuration.graphqlMetricsCollectorUrl }}
+            {{- if .Values.configuration.graphqlMetricsCollectorUrl }}
             - name: GRAPHQL_METRICS_COLLECTOR_ENDPOINT
               valueFrom:
                 configMapKeyRef:
                   name: {{ include "router.fullname" . }}
                   key: graphqlMetricsCollectorUrl
             {{- end }}
-            {{ if .Values.configuration.otelCollectorUrl }}
+            {{- if .Values.configuration.otelCollectorUrl }}
             - name: DEFAULT_TELEMETRY_ENDPOINT
               valueFrom:
                 configMapKeyRef:
                   name: {{ include "router.fullname" . }}
                   key: otelCollectorUrl
             {{- end }}
-            {{ if .Values.configuration.cdnUrl }}
+            {{- if .Values.configuration.cdnUrl }}
             - name: CDN_URL
               valueFrom:
                 configMapKeyRef:
                   name: {{ include "router.fullname" . }}
                   key: cdnUrl
             {{- end }}
-            {{ if .Values.configuration.routerConfigPath }}
+            {{- if .Values.configuration.routerConfigPath }}
             - name: ROUTER_CONFIG_PATH
               valueFrom:
                 configMapKeyRef:
                   name: {{ include "router.fullname" . }}
                   key: routerConfigPath
             {{- end }}
-            {{ if .Values.configuration.graphApiToken }}
+            {{- if .Values.configuration.graphApiToken }}
             - name: GRAPH_API_TOKEN
               valueFrom:
                 secretKeyRef:
@@ -163,7 +163,7 @@ spec:
                 configMapKeyRef:
                   name: {{ include "router.fullname" . }}
                   key: prometheusEnabled
-            {{ if .Values.configuration.prometheus.enabled }}
+            {{- if .Values.configuration.prometheus.enabled }}
             - name: PROMETHEUS_LISTEN_ADDR
               valueFrom:
                 configMapKeyRef:
@@ -175,7 +175,7 @@ spec:
                   name: {{ include "router.fullname" . }}
                   key: prometheusPath
             {{- end }}
-            {{ if .Values.configuration.mcp.enabled }}
+            {{- if .Values.configuration.mcp.enabled }}
             - name: MCP_ENABLED
               valueFrom:
                 configMapKeyRef:
@@ -187,6 +187,7 @@ spec:
                   name: {{ include "router.fullname" . }}
                   key: mcpListenAddr
             {{- end }}
+          {{- if or .Values.extraEnvVarsCM .Values.extraEnvVarsSecret }}
           envFrom:
             {{- if .Values.extraEnvVarsCM }}
             - configMapRef:
@@ -196,11 +197,12 @@ spec:
             - secretRef:
                 name: {{ .Values.extraEnvVarsSecret }}
             {{- end }}
-          {{ with .Values.probes.liveness }}
+          {{- end }}
+          {{- with .Values.probes.liveness }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{ with .Values.probes.readiness }}
+          {{- with .Values.probes.readiness }}
           readinessProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/helm/cosmo/charts/router/templates/deployment.yaml
+++ b/helm/cosmo/charts/router/templates/deployment.yaml
@@ -59,6 +59,11 @@ spec:
               containerPort: {{ .Values.configuration.prometheus.port }}
               protocol: TCP
             {{- end }}
+            {{ if .Values.configuration.mcp.enabled }}
+            - name: mcp
+              containerPort: {{ .Values.configuration.mcp.port }}
+              protocol: TCP
+            {{- end }}
           env:
             {{- if .Values.extraEnvVars }}
             {{- toYaml .Values.extraEnvVars | nindent 12 }}
@@ -169,6 +174,18 @@ spec:
                 configMapKeyRef:
                   name: {{ include "router.fullname" . }}
                   key: prometheusPath
+            {{- end }}
+            {{ if .Values.configuration.mcp.enabled }}
+            - name: MCP_ENABLED
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "router.fullname" . }}
+                  key: mcpEnabled
+            - name: MCP_SERVER_LISTEN_ADDR
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "router.fullname" . }}
+                  key: mcpListenAddr
             {{- end }}
           envFrom:
             {{- if .Values.extraEnvVarsCM }}

--- a/helm/cosmo/charts/router/templates/service.yaml
+++ b/helm/cosmo/charts/router/templates/service.yaml
@@ -21,5 +21,11 @@ spec:
       protocol: TCP
       name: metrics
     {{- end }}
+    {{ if .Values.configuration.mcp.enabled }}
+    - port: {{ .Values.configuration.mcp.port }}
+      targetPort: mcp
+      protocol: TCP
+      name: mcp
+    {{- end }}
   selector:
     {{- include "router.selectorLabels" . | nindent 4 }}

--- a/helm/cosmo/charts/router/values.yaml
+++ b/helm/cosmo/charts/router/values.yaml
@@ -238,3 +238,10 @@ configuration:
   httpProxy: ''
   # -- NO_PROXY is a comma-separated list of hosts or domains for which the proxy should not be used.
   noProxy: ''
+  
+  # Use this section to disable/enable and configure the MCP server.
+  mcp:
+    # -- Enables MCP server support. Default is false.
+    enabled: false
+    # -- The port where the MCP server is exposed. Default is port 5025.
+    port: 5025


### PR DESCRIPTION
## Motivation and Context

This pull request introduces a new feature to enable and configure an MCP server in the Helm chart for the WunderGraph Cosmo Router. It also includes updates to the chart version and documentation. 

## Change summary
* Adds mcp config options to the router helm chart
* Bumped chart version to 0.11.0
* Improves formatting of rendered yaml

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->