### PR TITLE
✨feat(auth): allow to insert additional labels in deployment

### DIFF
--- a/helm/cosmo/charts/router/templates/_helpers.tpl
+++ b/helm/cosmo/charts/router/templates/_helpers.tpl
@@ -44,6 +44,15 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{/*
+Additional Labels that are just rendered in metadata.labels
+*/}}
+{{- define "router.additionalLabels" -}}
+{{- range $key, $value := .Values.additionalLabels -}}
+{{ $key }}: {{ quote $value }}
+{{- end }}
+{{- end }}
+
+{{/*
 Common labels
 */}}
 {{- define "router.labels" -}}

--- a/helm/cosmo/charts/router/templates/deployment.yaml
+++ b/helm/cosmo/charts/router/templates/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     kapp.k14s.io/change-group: "cosmo.apps.router.wundergraph.com/deployment"
   labels:
     {{- include "router.labels" . | nindent 4 }}
+    {{- include "router.additionalLabels" . | nindent 4 }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}

--- a/helm/cosmo/charts/router/values.yaml
+++ b/helm/cosmo/charts/router/values.yaml
@@ -14,6 +14,9 @@ image:
 # -- Add labels to all deployed resources
 commonLabels: {}
 
+# -- Add labels to deployment metadata.labels
+additionalLabels: {}
+
 deploymentStrategy: {}
 
 imagePullSecrets: []


### PR DESCRIPTION
## Motivation and Context

We are using some k8s operator that do some special operations based on a particular label in .metadata.labels. When adding the label in commonLabels value, im getting an `MatchExpressions:[]v1.LabelSelectorRequirement(nil)}: field is immutable` on the spec.selector attibute. It is because the template is rendering the commonLabels in .spec.selector AND .metadata.labels at the same time.

We would like to have a way to just set the .metadata.labels