### PR TITLE
feat(core): add RouterRequest/Response hooks and parameters

### DIFF
--- a/router-tests/modules_v1/my_custom_module/authorization_module.go
+++ b/router-tests/modules_v1/my_custom_module/authorization_module.go
@@ -1,0 +1,37 @@
+package my_custom_module
+
+import (
+	"errors"
+	"context"
+
+	"github.com/wundergraph/cosmo/router/core"
+)
+
+const authorizationModuleID = "authorizationModule"
+
+type AuthorizationModule struct {
+}
+
+func (m *AuthorizationModule) MyModule() core.MyModuleInfo {
+	return core.MyModuleInfo{
+		ID: authorizationModuleID,
+		New: func() core.MyModule {
+			return &AuthorizationModule{}
+		},
+	}
+}
+
+func (m *AuthorizationModule) Provision(ctx context.Context) error {
+	return nil
+}
+
+func (m *AuthorizationModule) Cleanup() error {
+	return nil
+}
+
+func (m *AuthorizationModule) OnRouterRequest(reqContext core.RequestContext, params *core.RouterRequestParams) error {
+	return errors.New("{\"error\":\"unauthorized\"}")
+}
+
+// interface guard
+var _ core.RouterRequestHook = (*AuthorizationModule)(nil)

--- a/router-tests/modules_v1/my_custom_module/overwrite_response_module.go
+++ b/router-tests/modules_v1/my_custom_module/overwrite_response_module.go
@@ -1,0 +1,49 @@
+package my_custom_module
+
+import (
+    "context"
+
+    "github.com/wundergraph/cosmo/router/core"
+    "go.uber.org/zap"
+)
+
+const myOverwriteResponseModuleID = "myOverwriteResponseModule"
+
+type MyOverwriteResponseModule struct {
+    
+}
+
+func (m *MyOverwriteResponseModule) MyModule() core.MyModuleInfo {
+	return core.MyModuleInfo{
+		ID: myOverwriteResponseModuleID,
+		New: func() core.MyModule {
+			return &MyOverwriteResponseModule{}
+		},
+	}
+}
+
+func (m *MyOverwriteResponseModule) Provision(ctx context.Context) error {    
+	return nil
+}
+func (m *MyOverwriteResponseModule) Cleanup() error {
+	return nil
+}
+
+func (m *MyOverwriteResponseModule) OnRouterRequest(reqContext core.RequestContext, params *core.RouterRequestParams) error {
+    params.Logger.Info("Incoming /graphql request", zap.String("method", params.HttpRequest.Method))
+
+    return nil
+}
+
+func (m *MyOverwriteResponseModule) OnRouterResponse(reqContext core.RequestContext, params *core.RouterResponseParams, exitErr *core.ExitError) error {
+    status := params.Controller.GetStatusCode()
+    params.Logger.Info("Outgoing /graphql response", zap.Int("status", status))
+ 
+    params.Controller.SetStatusCode(202)
+    params.Controller.SetBody([]byte(`{"error":"graphQL partial failure"}`))
+    
+    return nil
+}
+
+// Interface guard
+var _ core.RouterLifecycleHook = (*MyOverwriteResponseModule)(nil)

--- a/router-tests/modules_v1/router_lifecycle_test.go
+++ b/router-tests/modules_v1/router_lifecycle_test.go
@@ -1,0 +1,124 @@
+package my_custom_module
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"go.uber.org/zap/zapcore"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wundergraph/cosmo/router-tests/modules_v1/my_custom_module"
+	"github.com/wundergraph/cosmo/router-tests/testenv"
+	"github.com/wundergraph/cosmo/router/core"
+)
+
+func TestRouterLifecycleHooks(t *testing.T) {
+	t.Parallel()
+
+	t.Run("router_lifecycle_hooks_not_called_for_non_graphql_endpoint", func(t *testing.T) {
+		t.Parallel()
+
+		myLoggingModule := &my_custom_module.MyOverwriteResponseModule{}
+
+		testenv.Run(t, &testenv.Config{
+			RouterOptions: []core.Option{
+				core.WithMyCustomModules(myLoggingModule),
+			},
+			LogObservation: testenv.LogObservationConfig{
+				Enabled:  true,
+				LogLevel: zapcore.DebugLevel,
+			},
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			res, err := xEnv.MakeRequest(http.MethodPost, "/non-graphql-endpoint", nil, nil)
+			require.NoError(t, err)
+
+			requestLog := xEnv.Observer().FilterMessage("Firing RouterRequest hooks")
+			responseLog := xEnv.Observer().FilterMessage("Firing RouterResponse hooks")
+			assert.Len(t, requestLog.All(), 0)
+			assert.Len(t, responseLog.All(), 0)
+			assert.Equal(t, 404, res.StatusCode)
+		})
+	})
+
+	t.Run("no_regression_when_no_hooks_are_registered", func(t *testing.T) {
+		t.Parallel()
+
+		testenv.Run(t, &testenv.Config{
+			RouterOptions: []core.Option{},
+			LogObservation: testenv.LogObservationConfig{
+				Enabled:  true,
+				LogLevel: zapcore.DebugLevel,
+			},
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			res, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
+				Query:         `query MyQuery { employees { id } }`,
+				OperationName: json.RawMessage(`"MyQuery"`),
+			})
+			require.NoError(t, err)
+
+			requestLog := xEnv.Observer().FilterMessage("Firing RouterRequest hooks")
+			responseLog := xEnv.Observer().FilterMessage("Firing RouterResponse hooks")
+			assert.Len(t, requestLog.All(), 1)
+			assert.Len(t, responseLog.All(), 0)
+
+			assert.Equal(t, 200, res.Response.StatusCode)
+			assert.JSONEq(t, `{"data":{"employees":[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5},{"id":7},{"id":8},{"id":10},{"id":11},{"id":12}]}}`, res.Body)
+		})
+	})
+
+	t.Run("router_lifecycle_hooks_overwrites_response", func(t *testing.T) {
+		t.Parallel()
+
+		myLoggingModule := &my_custom_module.MyOverwriteResponseModule{}
+
+		testenv.Run(t, &testenv.Config{
+			RouterOptions: []core.Option{
+				core.WithMyCustomModules(myLoggingModule),
+			},
+			LogObservation: testenv.LogObservationConfig{
+				Enabled:  true,
+				LogLevel: zapcore.DebugLevel,
+			},
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			res, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
+				Query:         `query MyQuery { employees { id } }`,
+				OperationName: json.RawMessage(`"MyQuery"`),
+			})
+			require.NoError(t, err)
+
+			requestLog := xEnv.Observer().FilterMessage("Firing RouterRequest hooks")
+			responseLog := xEnv.Observer().FilterMessage("Firing RouterResponse hooks")
+			settingResponseLog := xEnv.Observer().FilterMessage("Setting response after RouterResponse hooks")
+
+			assert.Len(t, requestLog.All(), 1)
+			assert.Len(t, responseLog.All(), 1)
+			assert.Len(t, settingResponseLog.All(), 1)
+
+			assert.Equal(t, 202, res.Response.StatusCode)	
+			assert.JSONEq(t, `{"error":"graphQL partial failure"}`, res.Body)
+		})
+	})
+
+	t.Run("router_lifecycle_hooks_authorization", func(t *testing.T) {
+		t.Parallel()
+
+		myAuthorizationModule := &my_custom_module.AuthorizationModule{}
+
+		testenv.Run(t, &testenv.Config{
+			RouterOptions: []core.Option{
+				core.WithMyCustomModules(myAuthorizationModule),
+			},
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			res, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
+				Query:         `query MyQuery { employees { id } }`,
+				OperationName: json.RawMessage(`"MyQuery"`),
+			})
+			require.NoError(t, err)
+
+			assert.Equal(t, 403, res.Response.StatusCode)
+			assert.JSONEq(t, `{"error":"unauthorized"}`, res.Body)
+		})
+	})
+}

--- a/router/core/entities.go
+++ b/router/core/entities.go
@@ -28,6 +28,83 @@ type GraphQLServerParams struct {
 	Logger *zap.Logger
 }
 
+// RouterRequestParams is passed to RouterRequestHook
+type RouterRequestParams struct {
+	// the raw incoming HTTP request
+	HttpRequest *http.Request
+
+	Logger *zap.Logger
+}
+
+// RouterResponseParams is passed to RouterResponseHook
+type RouterResponseParams struct {
+	RouterRequestParams
+	// the original HTTP response
+	HttpResponse *http.Response
+	// Use the controller to inspect or mutate the response
+	// the mutated response will be the actual response sent to the client
+	Controller RouterResponseController
+}
+
+// RouterResponseController defines the things the hook can do
+type RouterResponseController interface {
+	// Get the status code of the response
+	GetStatusCode() int
+	// Set the status code of the response
+	SetStatusCode(newStatusCode int) error
+	// Get the body of the response
+	GetBody() []byte
+	// Set the body of the response
+	SetBody(body []byte) error
+	// Get the header map of the response
+	GetHeaderMap() http.Header
+	// Add a key-value pair to the response header map
+	AddHeader(key, value string) error
+	// Set the value of a key in the response header map
+	SetHeader(key, value string) error
+}
+
+type routerResponseController struct {
+    recorder responseRecorder
+}
+
+type responseRecorder struct {
+	HeaderMap http.Header
+	Body []byte
+	Code int
+}
+
+func (c *routerResponseController) GetStatusCode() int {
+	return c.recorder.Code
+}
+
+func (c *routerResponseController) SetStatusCode(newCode int) error {
+    c.recorder.Code = newCode
+    return nil
+}
+
+func (c *routerResponseController) GetHeaderMap() http.Header {
+	return c.recorder.HeaderMap
+}
+
+func (c *routerResponseController) AddHeader(key, value string) error {
+    c.recorder.HeaderMap.Add(key, value)
+    return nil
+}
+
+func (c *routerResponseController) SetHeader(key, value string) error {
+	c.recorder.HeaderMap.Set(key, value)
+	return nil
+}
+
+func (c *routerResponseController) GetBody() []byte {
+	return c.recorder.Body
+}
+
+func (c *routerResponseController) SetBody(body []byte) error {
+	c.recorder.Body = body
+	return nil
+}
 
 /* common entities for the open core module system */
 
@@ -38,4 +115,3 @@ type ExitError struct {
 }
 
 func (e *ExitError) Error() string { return e.Err.Error() }
-  

--- a/router/core/graph_server.go
+++ b/router/core/graph_server.go
@@ -245,7 +245,6 @@ func newGraphServer(ctx context.Context, r *Router, routerConfig *nodev1.RouterC
 	/**
 	* Middlewares
 	 */
-
 	// This recovery handler is used for everything before the graph mux to ensure that
 	// we can recover from panics and log them properly.
 	httpRouter.Use(recoveryhandler.New(recoveryhandler.WithLogHandler(func(w http.ResponseWriter, r *http.Request, err any) {
@@ -884,6 +883,9 @@ func (s *graphServer) buildGraphMux(ctx context.Context,
 	// Setup any router on request middlewares so that they can be used to manipulate
 	// other downstream internal middlewares such as tracing or authentication
 	httpRouter.Use(s.routerOnRequestHandlers...)
+
+	// Per request, we apply the router request hook and the router response hook
+	httpRouter.Use(RouterHooksMiddleware(s.graphqlPath, s.hookRegistry, s.logger))
 
 	/**
 	* Initialize base attributes from headers and other sources

--- a/router/core/hooks_test.go
+++ b/router/core/hooks_test.go
@@ -1,0 +1,106 @@
+package core
+
+import (
+	"testing"
+	"fmt"
+	"net/http"
+	"io"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
+	"github.com/wundergraph/cosmo/router/internal/utils"
+	"net/http/httptest"
+)
+
+func TestRouterHooksMiddleware(t *testing.T) {
+	t.Parallel()
+
+	t.Run("router_hooks_middleware_short_circuit_on_request_hook_error", func(t *testing.T) {
+		fakeHooks := &hookRegistry{
+			routerRequestHooks: utils.NewOrderedSet[RouterRequestHook](),
+			routerResponseHooks: utils.NewOrderedSet[RouterResponseHook](),
+		}
+
+		fakeHooks.routerRequestHooks.Add(&routerRequestHookMock{
+			fn: func(reqContext RequestContext, rp *RouterRequestParams) error {
+			return fmt.Errorf("blocker")
+		}})
+
+		nextCalled := false
+		nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			nextCalled = true
+			w.WriteHeader(200)
+			w.Write([]byte(`{"data":{"foo":"bar"}}`))
+		})
+
+		mw := RouterHooksMiddleware("/graphql", fakeHooks, zaptest.NewLogger(t))
+		server := httptest.NewServer(mw(nextHandler))
+		defer server.Close()
+	
+		resp, err := http.Get(server.URL + "/graphql")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+	
+		require.False(t, nextCalled, "next.ServeHTTP should not have been called")
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		assert.Contains(t, string(bodyBytes), "blocker")
+	})
+
+	t.Run("router_hooks_middleware_propagates_successful_request_to_next_and_runs_response_hook", func(t *testing.T) {
+		fakeHooks := &hookRegistry{
+			routerRequestHooks: utils.NewOrderedSet[RouterRequestHook](),
+			routerResponseHooks: utils.NewOrderedSet[RouterResponseHook](),
+		}
+
+		fakeHooks.routerRequestHooks.Add(&routerRequestHookMock{
+			fn: func(reqContext RequestContext, rp *RouterRequestParams) error {				
+				rp.Logger.Info("request hook saw:", zap.String("path", rp.HttpRequest.URL.Path))
+				return nil
+			}})
+
+		fakeHooks.routerResponseHooks.Add(&routerResponseHookMock{
+			fn: func(reqContext RequestContext, rp *RouterResponseParams, exitErr *ExitError) error {
+			rp.Controller.SetStatusCode(418)
+			rp.Controller.SetHeader("Content-Type", "text/plain")
+			rp.Controller.SetBody([]byte("testing"))
+			return nil
+		}})
+	
+		nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(200)
+			w.Write([]byte(`{"data":{"foo":"bar"}}`))
+		})
+	
+		mw := RouterHooksMiddleware("/graphql", fakeHooks, zaptest.NewLogger(t))
+		server := httptest.NewServer(mw(nextHandler))
+		defer server.Close()
+	
+		resp, err := http.Get(server.URL + "/graphql")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+	
+		assert.Equal(t, 418, resp.StatusCode)
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		assert.Equal(t, "testing", string(bodyBytes))
+	})
+}
+
+type routerRequestHookMock struct {
+	fn func(reqContext RequestContext, rp *RouterRequestParams) error
+}
+
+type routerResponseHookMock struct {
+	fn func(reqContext RequestContext, rp *RouterResponseParams, exitErr *ExitError) error
+}
+
+func (m *routerRequestHookMock) OnRouterRequest(reqContext RequestContext, rp *RouterRequestParams) error {
+	return m.fn(reqContext, rp)
+}
+
+func (m *routerResponseHookMock) OnRouterResponse(reqContext RequestContext, rp *RouterResponseParams, exitErr *ExitError) error {
+	return m.fn(reqContext, rp, exitErr)
+}

--- a/router/core/router.go
+++ b/router/core/router.go
@@ -539,7 +539,14 @@ func NewRouter(opts ...Option) (*Router, error) {
 // initCoreModuleSystem initializes the new module system
 func (r *Router) initCoreModuleSystem(ctx context.Context) error {
 	coreModuleHooks := newCoreModuleHooks(r.logger)
-	err := coreModuleHooks.initCoreModuleHooks(ctx, defaultModuleRegistry.getMyModules())
+
+	myModuleList := make([]MyModuleInfo, 0, len(defaultModuleRegistry.getMyModules())+len(r.myCustomModules))
+	myModuleList = append(myModuleList, defaultModuleRegistry.getMyModules()...)
+	for _, module := range r.myCustomModules {
+		myModuleList = append(myModuleList, module.MyModule())
+	}
+
+	err := coreModuleHooks.initCoreModuleHooks(ctx, myModuleList)
 	if err != nil {
 		return fmt.Errorf("failed to init core module hooks: %w", err)
 	}
@@ -1764,6 +1771,12 @@ func WithEngineExecutionConfig(cfg config.EngineExecutionConfiguration) Option {
 func WithCustomModules(modules ...Module) Option {
 	return func(r *Router) {
 		r.customModules = modules
+	}
+}
+
+func WithMyCustomModules(modules ...MyModule) Option {
+	return func(r *Router) {
+		r.myCustomModules = modules
 	}
 }
 

--- a/router/core/router_config.go
+++ b/router/core/router_config.go
@@ -101,6 +101,7 @@ type Config struct {
 	registrationInfo             *nodev1.RegistrationInfo
 	securityConfiguration        config.SecurityConfiguration
 	customModules                []Module
+	myCustomModules              []MyModule
 	engineExecutionConfiguration config.EngineExecutionConfiguration
 	// should be removed once the users have migrated to the new overrides config
 	overrideRoutingURLConfiguration config.OverrideRoutingURLConfiguration


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

## Motivation and Context

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please describe in detail the impact of this change. Attach screenshots if applicable.
-->

The PR introduces two new router‐level hooks that “bracket” the raw HTTP request/response cycle for /graphql endpoints. 
These hooks allow modules to add custom logic at the HTTP layer (e.g. authentication, logging, response sanitization), without stepping into the GraphQL execution pipeline itself. (A follow-up PR will add deeper GraphQL-operation-level hooks.)

The RouterResponseParameter exposes a Controller interface with methods to inspect or alter the httpResponse before it is returned to client. The altered response status code, header and body will be the final response to the client. 
This hides some of the complexity of response handling from the end user. It does come with a trade-off. Because we buffer the handler’s entire response into memory when the RouterReponseHooks are implemented , there is a small overhead—especially for very large responses. 
Please note, for batched operation, one can only alter the envelope-level response. To alter individual operation response, user should use OperationHooks instead.

```
// RouterResponseParams is passed to RouterResponseHook
type RouterResponseParams struct {
    RouterRequestParams
    // the original HTTP response
    HttpResponse *http.Response
    // Use the controller to inspect or mutate the response
    // the mutated response will be the actual response sent to the client
    Controller RouterResponseController
}

// RouterResponseController defines the things the hook can do
type RouterResponseController interface {
    // Get the status code of the response
    GetStatusCode() int
    // Set the status code of the response
    SetStatusCode(newStatusCode int) error
    // Get the body of the response
    GetBody() []byte
    // Set the body of the response
    SetBody(body []byte) error
    // Get the header map of the response
    GetHeaderMap() http.Header
    // Add a key-value pair to the response header map
    AddHeader(key, value string) error
    // Set the value of a key in the response header map
    SetHeader(key, value string) error
}
```

Added integration test for the modules and hooks.

## Checklist

- [x] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->