### PR TITLE
fix: let netpoll handle closing websockets

### DIFF
--- a/router-tests/websocket_test.go
+++ b/router-tests/websocket_test.go
@@ -2312,6 +2312,8 @@ func TestWebsocketClose(t *testing.T) {
 			})
 			require.NoError(t, err)
 
+			xEnv.WaitForConnectionCount(1, 10*time.Second)
+
 			// Process subscription updates
 			var receivedUpdates int
 			for receivedUpdates < totalUpdates {
@@ -2336,6 +2338,8 @@ func TestWebsocketClose(t *testing.T) {
 				assert.ErrorContains(t, err, "Downstream service error", "should have message 'Downstream service error'")
 				assert.True(t, websocket.IsCloseError(err, websocket.CloseGoingAway), "should be a 'going away' closure")
 			}
+
+			xEnv.WaitForConnectionCount(0, 10*time.Second)
 		})
 	})
 

--- a/router/core/websocket.go
+++ b/router/core/websocket.go
@@ -409,7 +409,7 @@ func (h *WebsocketHandler) handleUpgradeRequest(w http.ResponseWriter, r *http.R
 
 		// Export the token from the initial payload to the request header
 		if fromInitialPayloadConfig.ExportToken.Enabled {
-			var initialPayloadMap map[string]interface{}
+			var initialPayloadMap map[string]any
 			err := json.Unmarshal(handler.initialPayload, &initialPayloadMap)
 			if err != nil {
 				requestLogger.Error("Error parsing initial payload: %v", zap.Error(err))
@@ -546,7 +546,7 @@ func (h *WebsocketHandler) runPoller() {
 				h.logger.Warn("Net Poller wait", zap.Error(err))
 				continue
 			}
-			for i := 0; i < len(connections); i++ {
+			for i := range len(connections) {
 				if connections[i] == nil {
 					continue
 				}
@@ -1115,7 +1115,7 @@ func (h *WebSocketConnectionHandler) Initialize() (err error) {
 
 	// Update client info from initial payload if enabled
 	if h.clientInfoFromInitialPayload.Enabled && h.initialPayload != nil {
-		var initialPayloadMap map[string]interface{}
+		var initialPayloadMap map[string]any
 		err := json.Unmarshal(h.initialPayload, &initialPayloadMap)
 		if err != nil {
 			h.logger.Warn("Error parsing initial payload for client info", zap.Error(err))

--- a/router/internal/wsproto/absinthe.go
+++ b/router/internal/wsproto/absinthe.go
@@ -209,10 +209,6 @@ func (p *absintheWSProtocol) Close(code ws.StatusCode, reason string) error {
 		return err
 	}
 
-	if err := p.conn.Close(); err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/router/internal/wsproto/graphql_ws.go
+++ b/router/internal/wsproto/graphql_ws.go
@@ -121,10 +121,6 @@ func (p *graphQLWSProtocol) Close(code ws.StatusCode, reason string) error {
 		return err
 	}
 
-	if err := p.conn.Close(); err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/router/internal/wsproto/proto.go
+++ b/router/internal/wsproto/proto.go
@@ -3,6 +3,7 @@ package wsproto
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/gobwas/ws"
@@ -21,7 +22,7 @@ type Proto interface {
 	// Complete is sent to indicate the requested operation is done and no more results will come in
 	Complete(id string) error
 
-	// Close closes the connection with a close frame with the given code and reason
+	// Close sends a close frame with the given code and reason
 	Close(code ws.StatusCode, reason string) error
 }
 
@@ -29,7 +30,6 @@ type ProtoConn interface {
 	ReadJSON(v any) error
 	WriteJSON(v any) error
 	WriteCloseFrame(code ws.StatusCode, reason string) error
-	Close() error
 }
 
 // MessageType indicates the type of the message received from the client
@@ -58,12 +58,7 @@ func Subprotocols() []string {
 }
 
 func IsSupportedSubprotocol(subProtocol string) bool {
-	for _, s := range Subprotocols() {
-		if s == subProtocol {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(Subprotocols(), subProtocol)
 }
 
 func NewProtocol(subProtocol string, conn ProtoConn) (Proto, error) {

--- a/router/internal/wsproto/subscriptions_transport_ws.go
+++ b/router/internal/wsproto/subscriptions_transport_ws.go
@@ -126,10 +126,6 @@ func (p *subscriptionsTransportWSProtocol) Close(code ws.StatusCode, reason stri
 		return err
 	}
 
-	if err := p.conn.Close(); err != nil {
-		return err
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

## Motivation and Context

We had a subtle timing dependent bug due to closing connections from within ws proto handlers, these are closed by netpoll under better conditions when left alone. 

This fixes a bug where it could almost seem as though we had partial reconnect support because the subscription was not entirely removed before clients reconnected, and also fixes an issue where the engine stats were leaking connections.

After this change, when a subgraph goes down triggering a close event, clients are fully disconnected and state is cleared.

Also some unrelated "modernize" linter fixes, just leaving the place in better condition than I found it.

## Checklist

- [x] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [x] Tests or benchmarks have been added or updated.
- [x] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->