### PR TITLE
feat(core): add OperationParse/Normalize/Validate/Plan hooks

### DIFF
--- a/router-tests/modules_v1/my_custom_module/metrics_module.go
+++ b/router-tests/modules_v1/my_custom_module/metrics_module.go
@@ -1,0 +1,80 @@
+package my_custom_module
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+
+	"github.com/wundergraph/cosmo/router/core"
+)
+
+const metricsModuleID = "metricsModule"
+
+type MetricsModule struct {
+}
+
+func (m *MetricsModule) MyModule() core.MyModuleInfo {
+	return core.MyModuleInfo{
+		ID: metricsModuleID,
+		New: func() core.MyModule {
+			return &MetricsModule{}
+		},
+	}
+}
+
+func (m *MetricsModule) Provision(ctx context.Context) error {
+	return nil
+}
+
+func (m *MetricsModule) Cleanup() error {
+	return nil
+}
+
+func (m *MetricsModule) OnOperationPreParse(reqContext core.RequestContext, params *core.OperationPreParseParams) error {
+	params.Logger.Info("OnOperationPreParse", zap.Any("params", params))
+	params.Controller.SetSkipParse(false)
+	return nil
+}
+
+func (m *MetricsModule) OnOperationPostParse(reqContext core.RequestContext, params *core.OperationPostParseParams, exitError *core.ExitError) error {
+	params.Logger.Info("OnOperationPostParse", zap.Any("params", params))
+
+	return nil
+}
+
+func (m *MetricsModule) OnOperationPreNormalize(reqContext core.RequestContext, params *core.OperationPreNormalizeParams) error {	 
+	params.Logger.Info("OnOperationPreNormalize", zap.Any("params", params))
+	return nil
+}
+
+func (m *MetricsModule) OnOperationPostNormalize(reqContext core.RequestContext, params *core.OperationPostNormalizeParams, exitError *core.ExitError) error {
+	params.Logger.Info("OnOperationPostNormalize", zap.Any("params", params))
+	return nil
+}
+
+func (m *MetricsModule) OnOperationPreValidate(reqContext core.RequestContext, params *core.OperationPreValidateParams) error {
+	params.Logger.Info("OnOperationPreValidate", zap.Any("params", params))
+
+	return nil
+}
+
+func (m *MetricsModule) OnOperationPostValidate(reqContext core.RequestContext, params *core.OperationPostValidateParams, exitError *core.ExitError) error {
+	params.Logger.Info("OnOperationPostValidate", zap.Any("params", params))
+	return nil
+}
+
+func (m *MetricsModule) OnOperationPrePlan(reqContext core.RequestContext, params *core.OperationPrePlanParams) error {
+	params.Logger.Info("OnOperationPrePlan", zap.Any("params", params))
+	return nil
+}
+
+func (m *MetricsModule) OnOperationPostPlan(reqContext core.RequestContext, params *core.OperationPostPlanParams, exitError *core.ExitError) error {
+	params.Logger.Info("OnOperationPostPlan", zap.Any("params", params))
+	return nil
+}
+
+// interface guard
+var _ core.OperationParseLifecycleHook = &MetricsModule{}
+var _ core.OperationNormalizeLifecycleHook = &MetricsModule{}
+var _ core.OperationValidateLifecycleHook = &MetricsModule{}
+var _ core.OperationPlanLifecycleHook = &MetricsModule{}

--- a/router/core/entities.go
+++ b/router/core/entities.go
@@ -2,7 +2,7 @@ package core
 
 import (
 	"net/http"
-
+	"time"
 	nodev1 "github.com/wundergraph/cosmo/router/gen/proto/wg/cosmo/node/v1"
 	"github.com/wundergraph/cosmo/router/pkg/config"
 	"go.uber.org/zap"
@@ -143,6 +143,122 @@ func (c *operationRequestController) GetClientInfo() ClientInfo {
 // OperationResponseParams is passed to OperationResponseHook
 type OperationResponseParams struct {
 	OperationContextParams
+
+	Logger *zap.Logger
+}
+
+// OperationPreParseParams is passed to OperationPreParseHook
+type OperationPreParseParams struct {
+	OperationContextParams
+	// The controller defines the things the hook can do
+	// - GetSkipParse: get the existing value of the skip parse flag
+	// - SetSkipParse: set the new value of the skip parse flag
+	Controller OperationParseController
+
+	Logger *zap.Logger
+}
+
+type OperationParseController interface {
+	GetSkipParse() bool
+	SetSkipParse(skipParse bool) error
+}
+
+type operationParseController struct {
+	recorder operationParseRecorder
+}
+
+type operationParseRecorder struct {
+	SkipParse bool
+}
+
+func (c *operationParseController) GetSkipParse() bool {
+	return c.recorder.SkipParse
+}
+
+func (c *operationParseController) SetSkipParse(skipParse bool) error {
+	c.recorder.SkipParse = skipParse
+	return nil
+}
+
+// OperationPostParseParams is passed to OperationPostParseHook
+type OperationPostParseParams struct {
+	OperationContextParams
+	ParseLatency time.Duration
+
+	Logger *zap.Logger
+}
+
+// OperationPreNormalizeParams is passed to OperationPreNormalizeHook
+type OperationPreNormalizeParams struct {
+	OperationContextParams
+
+	Logger *zap.Logger
+}
+
+// OperationPostNormalizeParams is passed to OperationPostNormalizeHook
+type OperationPostNormalizeParams struct {
+	OperationContextParams
+	NormalizeCacheHit bool
+	NormalizeLatency time.Duration
+
+	Logger *zap.Logger
+}
+
+// OperationPreValidateParams is passed to OperationPreValidateHook
+type OperationPreValidateParams struct {
+	OperationContextParams
+	// The controller defines the things the hook can do
+	// - GetComplexityLimits: get the default or previously set complexity limits
+	// - SetComplexityLimits: set the new complexity limits if needed
+	Controller OperationValidateController
+
+	Logger *zap.Logger
+}
+
+type OperationValidateController interface {
+	GetComplexityLimits() *config.ComplexityLimits
+	SetComplexityLimits(complexityLimits *config.ComplexityLimits) error
+}
+
+type operationValidateController struct {
+	recorder operationValidateRecorder
+}
+
+type operationValidateRecorder struct {
+	ComplexityLimits *config.ComplexityLimits
+}
+
+func (c *operationValidateController) GetComplexityLimits() *config.ComplexityLimits {
+	return c.recorder.ComplexityLimits
+}
+
+func (c *operationValidateController) SetComplexityLimits(complexityLimits *config.ComplexityLimits) error {
+	c.recorder.ComplexityLimits = complexityLimits
+	return nil
+}
+
+// OperationPostValidateParams is passed to OperationPostValidateHook
+type OperationPostValidateParams struct {
+	OperationContextParams
+	ValidationLatency time.Duration
+	ValidationCacheHit bool
+
+	Logger *zap.Logger
+}
+
+// OperationPrePlanParams is passed to OperationPrePlanHook
+type OperationPrePlanParams struct {
+	OperationContextParams
+
+	Logger *zap.Logger
+}
+
+// OperationPostPlanParams is passed to OperationPostPlanHook
+type OperationPostPlanParams struct {
+	OperationContextParams
+	PlanCacheHit bool
+	PrintedPlan string
+	PlanLatency time.Duration
 
 	Logger *zap.Logger
 }

--- a/router/core/hooks.go
+++ b/router/core/hooks.go
@@ -101,11 +101,11 @@ type OperationParseLifecycleHook interface {
 }
 
 type OperationPreParseHook interface {
-	OnOperationPreParse(ctx context.Context)
+	OnOperationPreParse(reqContext RequestContext, params *OperationPreParseParams) error
 }
 
 type OperationPostParseHook interface {
-	OnOperationPostParse(ctx context.Context)
+	OnOperationPostParse(reqContext RequestContext, params *OperationPostParseParams, exitError *ExitError) error
 }
 
 type OperationNormalizeLifecycleHook interface {
@@ -114,11 +114,11 @@ type OperationNormalizeLifecycleHook interface {
 }
 
 type OperationPreNormalizeHook interface {
-	OnOperationPreNormalize(ctx context.Context)
+	OnOperationPreNormalize(reqContext RequestContext, params *OperationPreNormalizeParams) error
 }
 
 type OperationPostNormalizeHook interface {
-	OnOperationPostNormalize(ctx context.Context)
+	OnOperationPostNormalize(reqContext RequestContext, params *OperationPostNormalizeParams, exitError *ExitError) error
 }
 
 type OperationValidateLifecycleHook interface {
@@ -127,11 +127,11 @@ type OperationValidateLifecycleHook interface {
 }
 
 type OperationPreValidateHook interface {
-	OnOperationPreValidate(ctx context.Context)
+	OnOperationPreValidate(reqContext RequestContext, params *OperationPreValidateParams) error	
 }
 
 type OperationPostValidateHook interface {
-	OnOperationPostValidate(ctx context.Context)
+	OnOperationPostValidate(reqContext RequestContext, params *OperationPostValidateParams, exitError *ExitError) error
 }
 
 type OperationPlanLifecycleHook interface {
@@ -140,11 +140,11 @@ type OperationPlanLifecycleHook interface {
 }
 
 type OperationPrePlanHook interface {
-	OnOperationPrePlan(ctx context.Context) error
+	OnOperationPrePlan(reqContext RequestContext, params *OperationPrePlanParams) error
 }
 
 type OperationPostPlanHook interface {
-	OnOperationPostPlan(ctx context.Context) error
+	OnOperationPostPlan(reqContext RequestContext, params *OperationPostPlanParams, exitError *ExitError) error
 }
 
 type OperationExecuteLifecycleHook interface {


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

## Motivation and Context

The PR adds the following hooks. The controllers enable mutations in the operation processing flow.

OperationPreParseHook: fires once per request before parsing raw query text.
OperationPostParseHook: fires once per request after parsing into an AST

OperationPreNormalizeHook: fires before normalization
OperationPostNoamalizeHook: fires after normalization. 

OperationPreValidateHook: fires before validation. 
OperationPostValidateHook: fires after validation. 

OperationPrePlanHook: fires before generating the execution plan. 
OperationPostPlanHook: fires after the plan is built

<!--
Why is this change required? What problem does it solve? Which issues are linked?
Please describe in detail the impact of this change. Attach screenshots if applicable.
-->

## Checklist

- [x] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [x] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->