### PR TITLE
fix: cleanup flaky line for router build test

### DIFF
--- a/router/pkg/config/config_test.go
+++ b/router/pkg/config/config_test.go
@@ -1053,7 +1053,6 @@ listen_addr: "localhost:3007"
 		require.ErrorContains(t, err, "- at '/execution_config': oneOf failed, none matched")
 		require.ErrorContains(t, err, "- at '/execution_config': additional properties 'storage' not allowed")
 		require.ErrorContains(t, err, "- at '/execution_config': additional properties 'file' not allowed")
-		require.ErrorContains(t, err, "- at '/execution_config': additional properties 'file', 'storage' not allowed")
 	})
 
 }


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

## Motivation and Context

There is a line which causes unexpected failures because the asserted error would return "file, storage" for the most part but occasionally would switch the order of the attributes. The hypothesis is this is due to how merging works as it uses maps whose order is not guaranteed in go.

Either way as this line is asserted separately for file and storage we skip it.

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->