### PR TITLE
fix(helm/router): Make sure version label handles longer image versions

### DIFF
--- a/helm/cosmo/charts/router/templates/_helpers.tpl
+++ b/helm/cosmo/charts/router/templates/_helpers.tpl
@@ -56,7 +56,7 @@ Additional Labels that are just rendered in metadata.labels
 Common labels
 */}}
 {{- define "router.labels" -}}
-{{ $version := .Values.image.version | default .Chart.AppVersion -}}
+{{ $version := .Values.image.version | default .Chart.AppVersion | replace ":" "_" | trunc 63 -}}
 helm.sh/chart: {{ include "router.chart" . }}
 {{ include "router.selectorLabels" . }}
 app.kubernetes.io/version: {{ $version | quote }}


### PR DESCRIPTION
## Motivation and Context
Using too long image versions will cause invalid labels and an invalid helm release.

## Checklist

- [x] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).
