### PR TITLE
feat(cli): add generate-only-proto option for gRPC plugin build

### DIFF
--- a/cli/src/commands/router/plugin/commands/build.ts
+++ b/cli/src/commands/router/plugin/commands/build.ts
@@ -8,7 +8,7 @@ import { renderResultTree } from '../helper.js';
 import {
   buildBinaries,
   checkAndInstallTools,
-  generateGRPCCode,
+  generateGRPCGoCode,
   generateProtoAndMapping,
   HOST_PLATFORM,
   installGoDependencies,
@@ -19,7 +19,11 @@ export default (opts: BaseCommandOptions) => {
   const command = new Command('build');
   command.description('Build a gRPC router plugin');
   command.argument('[directory]', 'Directory of the plugin', '.');
-  command.option('--generate-only', 'Generate only the proto and mapping files, do not compile the plugin');
+  command.option(
+    '--generate-only-proto',
+    'Generate only the proto and mapping files. Do not generate Go code or compile the plugin',
+  );
+  command.option('--generate-only', 'Generate only proto, mapping files, and Go code. Do not compile the plugin');
   command.option('--debug', 'Build the binary with debug information', false);
   command.option('--platform [platforms...]', 'Platform-architecture combinations (e.g., darwin-arm64 linux-amd64)', [
     HOST_PLATFORM,
@@ -60,15 +64,17 @@ export default (opts: BaseCommandOptions) => {
       // Generate proto and mapping files
       await generateProtoAndMapping(pluginDir, goModulePath, spinner);
 
-      // Generate gRPC code
-      await generateGRPCCode(pluginDir, spinner);
+      if (!options.generateOnlyProto) {
+        // Generate gRPC Go code
+        await generateGRPCGoCode(pluginDir, spinner);
 
-      if (!options.generateOnly) {
-        // Install Go dependencies
-        await installGoDependencies(pluginDir, spinner);
+        if (!options.generateOnly) {
+          // Install Go dependencies
+          await installGoDependencies(pluginDir, spinner);
 
-        // Build binaries for all platforms
-        await buildBinaries(pluginDir, platforms, options.debug, spinner);
+          // Build binaries for all platforms
+          await buildBinaries(pluginDir, platforms, options.debug, spinner);
+        }
       }
 
       // Calculate and format elapsed time

--- a/cli/src/commands/router/plugin/toolchain.ts
+++ b/cli/src/commands/router/plugin/toolchain.ts
@@ -393,10 +393,10 @@ export async function generateProtoAndMapping(pluginDir: string, goModulePath: s
 }
 
 /**
- * Generate gRPC code using protoc
+ * Generate gRPC Go code using protoc
  */
-export async function generateGRPCCode(pluginDir: string, spinner: any) {
-  spinner.text = 'Generating gRPC code...\n';
+export async function generateGRPCGoCode(pluginDir: string, spinner: any) {
+  spinner.text = 'Generating gRPC Go code...\n';
 
   const env = getToolsEnv();
   const protocPath = getToolPath('protoc');


### PR DESCRIPTION
This allows users to generate just the proto files without the overhead of Go code generation and compilation, useful for workflows that only need the proto definitions.

## Motivation and Context

Some build environments already have a toolchain set up to compile Proto files. This change allows us to make less assumptions about the underlying environment and instead just to execute the Proto transpliation.

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [x] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).