### PR TITLE
refactor(cli): improve gRPC service commands

### DIFF
--- a/cli/src/commands/grpc-service/commands/generate.ts
+++ b/cli/src/commands/grpc-service/commands/generate.ts
@@ -145,7 +145,6 @@ async function fetchLockData(lockFile: string): Promise<ProtoLock | undefined> {
   return existingLockData == null ? undefined : existingLockData;
 }
 
-// Usage of exists from node:fs is not recommended. Use access instead.
 async function exists(path: string): Promise<boolean> {
   try {
     await access(path, constants.R_OK);

--- a/cli/src/commands/grpc-service/utils/github-client.ts
+++ b/cli/src/commands/grpc-service/utils/github-client.ts
@@ -1,0 +1,53 @@
+import { Octokit } from '@octokit/rest';
+
+export const GITHUB_CONFIG = {
+  owner: 'wundergraph',
+  repo: 'cosmo-templates',
+  ref: 'main',
+  grpcServicePath: 'grpc-service',
+} as const;
+
+export function createGitHubClient(): Octokit {
+  return new Octokit({
+    log: {
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+    },
+  });
+}
+
+export async function fetchAvailableTemplates(): Promise<string[]> {
+  const octokit = createGitHubClient();
+  const { owner, repo, grpcServicePath } = GITHUB_CONFIG;
+
+  try {
+    const res = await octokit.repos.getContent({
+      owner,
+      repo,
+      path: grpcServicePath,
+    });
+
+    if (Array.isArray(res.data)) {
+      return res.data.filter((item: any) => item.type === 'dir').map((item: any) => item.name);
+    }
+  } catch (error) {
+    throw new Error(`Failed to fetch templates from GitHub: ${error instanceof Error ? error.message : String(error)}`);
+  }
+
+  return [];
+}
+
+export async function checkTemplateExists(template: string): Promise<boolean> {
+  const octokit = createGitHubClient();
+  const { owner, repo, grpcServicePath } = GITHUB_CONFIG;
+  const path = `${grpcServicePath}/${template}`;
+
+  try {
+    const res = await octokit.repos.getContent({ owner, repo, path });
+    return Array.isArray(res.data);
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
- Create shared GitHub API client utility with centralized configuration
- Standardize error handling patterns across all commands
- Improve TypeScript typing with proper Ora and error types
- Remove redundant template existence check in init command
- Extract common constants for GitHub repository configuration
- Remove unused variables and outdated comments
- Consolidate duplicate GitHub client instantiation

🤖 Generated with [Claude Code](https://claude.ai/code)

<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

@coderabbitai summary

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->