### PR TITLE
fix(studio): fix broken doc links

### DIFF
--- a/studio/src/components/federatedgraphs-cards.tsx
+++ b/studio/src/components/federatedgraphs-cards.tsx
@@ -481,7 +481,7 @@ export const Empty = ({
           <a
             target="_blank"
             rel="noreferrer"
-            href={docsBaseURL + "/cli/federated-graphs/create"}
+            href={docsBaseURL + "/cli/federated-graph/create"}
             className="text-primary"
           >
             docs

--- a/studio/src/components/schema/empty-schema-state.tsx
+++ b/studio/src/components/schema/empty-schema-state.tsx
@@ -25,7 +25,7 @@ export const EmptySchema = ({ subgraphName }: { subgraphName?: string }) => {
             <a
               target="_blank"
               rel="noreferrer"
-              href={docsBaseURL + "/cli/subgraphs/publish"}
+              href={docsBaseURL + "/cli/subgraph/publish"}
               className="text-primary"
             >
               Learn more.

--- a/studio/src/components/subgraphs-table.tsx
+++ b/studio/src/components/subgraphs-table.tsx
@@ -109,7 +109,7 @@ export const Empty = ({
           <a
             target="_blank"
             rel="noreferrer"
-            href={docsBaseURL + "/cli/subgraphs/create"}
+            href={docsBaseURL + "/cli/subgraph/create"}
             className="text-primary"
           >
             Learn more.

--- a/studio/src/pages/[organizationSlug]/[namespace]/graph/[slug]/changelog/index.tsx
+++ b/studio/src/pages/[organizationSlug]/[namespace]/graph/[slug]/changelog/index.tsx
@@ -187,7 +187,7 @@ const ChangelogPage: NextPageWithLayout = () => {
               <a
                 target="_blank"
                 rel="noreferrer"
-                href={docsBaseURL + "/cli/subgraphs/publish"}
+                href={docsBaseURL + "/cli/subgraph/publish"}
                 className="text-primary"
               >
                 Learn more.

--- a/studio/src/pages/[organizationSlug]/[namespace]/graph/[slug]/checks/index.tsx
+++ b/studio/src/pages/[organizationSlug]/[namespace]/graph/[slug]/checks/index.tsx
@@ -130,7 +130,7 @@ const ChecksPage: NextPageWithLayout = () => {
             <a
               target="_blank"
               rel="noreferrer"
-              href={docsBaseURL + "/cli/subgraphs/check"}
+              href={docsBaseURL + "/cli/subgraph/check"}
               className="text-primary"
             >
               Learn more.

--- a/studio/src/pages/[organizationSlug]/[namespace]/graph/[slug]/clients.tsx
+++ b/studio/src/pages/[organizationSlug]/[namespace]/graph/[slug]/clients.tsx
@@ -245,7 +245,7 @@ const ClientOperations = () => {
               <a
                 target="_blank"
                 rel="noreferrer"
-                href={docsBaseURL + "/router/persisted-operations"}
+                href={docsBaseURL + "/router/persisted-queries/persisted-operations"}
                 className="text-primary"
               >
                 Learn more.
@@ -645,7 +645,7 @@ const ClientsPage: NextPageWithLayout = () => {
               <a
                 target="_blank"
                 rel="noreferrer"
-                href={docsBaseURL + "/router/persisted-operations"}
+                href={docsBaseURL + "/router/persisted-queries/persisted-operations"}
                 className="text-primary"
               >
                 Learn more.
@@ -661,7 +661,7 @@ const ClientsPage: NextPageWithLayout = () => {
               Create and view clients to which you can publish persisted
               operations.{" "}
               <Link
-                href={docsBaseURL + "/router/persisted-operations"}
+                href={docsBaseURL + "/router/persisted-queries/persisted-operations"}
                 className="text-primary"
                 target="_blank"
                 rel="noreferrer"

--- a/studio/src/pages/[organizationSlug]/[namespace]/subgraph/[subgraphSlug]/schema.tsx
+++ b/studio/src/pages/[organizationSlug]/[namespace]/subgraph/[subgraphSlug]/schema.tsx
@@ -87,7 +87,7 @@ const SubgraphSchemaPage: NextPageWithLayout = () => {
               <a
                 target="_blank"
                 rel="noreferrer"
-                href={docsBaseURL + "/cli/subgraphs/publish"}
+                href={docsBaseURL + "/cli/subgraph/publish"}
                 className="text-primary"
               >
                 Learn more.

--- a/studio/src/pages/[organizationSlug]/integrations.tsx
+++ b/studio/src/pages/[organizationSlug]/integrations.tsx
@@ -580,7 +580,7 @@ const IntegrationsPage: NextPageWithLayout = () => {
             <a
               target="_blank"
               rel="noreferrer"
-              href={docsBaseURL + "/studio/slack-integration"}
+              href={docsBaseURL + "/studio/alerts-and-notifications/slack-integration"}
               className="text-primary"
             >
               Learn more.
@@ -622,7 +622,7 @@ const IntegrationsPage: NextPageWithLayout = () => {
           Integrations are used to receive notifications on certain events from
           the platform.{" "}
           <Link
-            href={docsBaseURL + "/studio/slack-integration"}
+            href={docsBaseURL + "/studio/alerts-and-notifications/slack-integration"}
             className="text-primary"
             target="_blank"
             rel="noreferrer"

--- a/studio/src/pages/[organizationSlug]/webhooks.tsx
+++ b/studio/src/pages/[organizationSlug]/webhooks.tsx
@@ -381,7 +381,7 @@ const Webhook = ({
                       <a
                         target="_blank"
                         rel="noreferrer"
-                        href={docsBaseURL + "/studio/webhooks#verification"}
+                        href={docsBaseURL + "/studio/alerts-and-notifications/webhooks#verification"}
                         className="text-primary"
                       >
                         Learn more.
@@ -503,7 +503,7 @@ const WebhooksPage: NextPageWithLayout = () => {
             <a
               target="_blank"
               rel="noreferrer"
-              href={docsBaseURL + "/studio/webhooks"}
+              href={docsBaseURL + "/studio/alerts-and-notifications/webhooks"}
               className="text-primary"
             >
               Learn more.
@@ -521,7 +521,7 @@ const WebhooksPage: NextPageWithLayout = () => {
         <p className="ml-1 text-sm text-muted-foreground">
           Webhooks are used to receive certain events from the platform.{" "}
           <Link
-            href={docsBaseURL + "/studio/webhooks"}
+            href={docsBaseURL + "/studio/alerts-and-notifications/webhooks"}
             className="text-primary"
             target="_blank"
             rel="noreferrer"


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated multiple documentation links throughout the app to point to the correct and current URLs, ensuring users are directed to the intended resources for federated graphs, subgraphs, CLI commands, Slack integration, and webhooks. No other functionality or logic was changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [ ] ~~Tests or benchmarks have been added or updated.~~
- [x] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

Also opened https://github.com/wundergraph/cosmo-docs/pull/123 as that was another broken link I encountered while exploring Cosmo Cloud.