### PR TITLE
fix: build nonroot image in release workflow

### DIFF
--- a/.github/workflows/dummy-ci.yaml
+++ b/.github/workflows/dummy-ci.yaml
@@ -5,9 +5,17 @@ on:
   pull_request:
     paths:
       - 'scripts/**'
+      - '.github/workflows/image-release.yml'
 jobs:
   build_test:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
-      - run: echo Nothing to do
+      - uses: actions/checkout@v4
+      - name: Download actionlint
+        id: get_actionlint
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+        shell: bash
+      - name: Check workflow files
+        run: ${{ steps.get_actionlint.outputs.executable }} -color
+        shell: bash

--- a/.github/workflows/dummy-ci.yaml
+++ b/.github/workflows/dummy-ci.yaml
@@ -11,11 +11,4 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Download actionlint
-        id: get_actionlint
-        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
-        shell: bash
-      - name: Check workflow files
-        run: ${{ steps.get_actionlint.outputs.executable }} -color
-        shell: bash
+      - run: echo Nothing to do

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -40,6 +40,9 @@ jobs:
     if: github.ref_name == github.event.repository.default_branch
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      matrix:
+        docker_build_target: [ '', 'nonroot' ]
     permissions:
       contents: read
       packages: write
@@ -61,6 +64,8 @@ jobs:
         with:
           images: |
             ${{ env.REGISTRY }}/${{ github.repository }}/${{ inputs.name }}
+          flavor: |
+            suffix=${{ matrix.docker_build_target != '' && format('-{0}', matrix.docker_build_target) || '' }},onlatest=true
           tags: |
             type=ref,event=branch
             type=sha
@@ -101,6 +106,7 @@ jobs:
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}/${{ inputs.name }}:buildcache
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}/${{ inputs.name }}:buildcache,mode=max
           platforms: linux/amd64,linux/arm64
+          target: ${{ matrix.docker_build_target }}
           outputs:
             type=image,name=target,annotation-index.org.opencontainers.image.description=${{ inputs.name }}
             type=image,name=target,annotation-index.org.opencontainers.image.source=https://github.com/wundergraph/cosmo


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Docker image release workflow to build and release both standard and "nonroot" image variants.
  * Improved workflow to automatically tag images with appropriate suffixes based on the build target.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).