### PR TITLE
feat: add audience validation

### DIFF
--- a/router-tests/authentication_test.go
+++ b/router-tests/authentication_test.go
@@ -2465,6 +2465,8 @@ func TestAudienceValidation(t *testing.T) {
 	})
 
 	t.Run("authentication validation is ignored when expected aud is not provided", func(t *testing.T) {
+		t.Parallel()
+		
 		tokenAudiences := []bool{true, true}
 
 		authServer, err := jwks.NewServer(t)

--- a/router-tests/authentication_test.go
+++ b/router-tests/authentication_test.go
@@ -683,6 +683,27 @@ func TestAuthenticationWithCustomHeaders(t *testing.T) {
 func TestHttpJwksAuthorization(t *testing.T) {
 	t.Parallel()
 
+	t.Run("startup should fail when duplicate URLs are specified", func(t *testing.T) {
+		t.Parallel()
+
+		authServer, err := jwks.NewServer(t)
+		require.NoError(t, err)
+		t.Cleanup(authServer.Close)
+
+		_, err = authentication.NewJwksTokenDecoder(NewContextWithCancel(t), zap.NewNop(), []authentication.JWKSConfig{
+			{
+				URL:             authServer.JWKSURL(),
+				RefreshInterval: 2 * time.Second,
+			},
+			{
+				URL:             authServer.JWKSURL(),
+				RefreshInterval: 2 * time.Second,
+			},
+		})
+
+		require.ErrorContains(t, err, "duplicate JWK URL found")
+	})
+
 	t.Run("authentication should fail with no token", func(t *testing.T) {
 		t.Parallel()
 
@@ -765,7 +786,10 @@ func TestHttpJwksAuthorization(t *testing.T) {
 		t.Cleanup(authServer2.Close)
 		require.NoError(t, err)
 
-		token, err := authServer2.Token(nil)
+		// aud claim
+		token, err := authServer2.Token(map[string]any{
+			"aud": "https://example.com",
+		})
 		require.NoError(t, err)
 
 		authenticators := ConfigureAuthWithJwksConfig(t, []authentication.JWKSConfig{
@@ -807,6 +831,28 @@ func TestHttpJwksAuthorization(t *testing.T) {
 }
 
 func TestNonHttpAuthorization(t *testing.T) {
+	t.Run("startup should fail when duplicate key ids are manually specified", func(t *testing.T) {
+		t.Parallel()
+
+		secret := "example secret"
+		kid := "givenKID"
+
+		_, err := authentication.NewJwksTokenDecoder(NewContextWithCancel(t), zap.NewNop(), []authentication.JWKSConfig{
+			{
+				Secret:    secret,
+				Algorithm: string(jwkset.AlgHS256),
+				KeyId:     kid,
+			},
+			{
+				Secret:    secret,
+				Algorithm: string(jwkset.AlgHS256),
+				KeyId:     kid,
+			},
+		})
+
+		require.ErrorContains(t, err, "duplicate JWK keyid specified found")
+	})
+
 	t.Run("authentication should succeed with a valid HS256 token", func(t *testing.T) {
 		t.Parallel()
 
@@ -820,7 +866,7 @@ func TestNonHttpAuthorization(t *testing.T) {
 			},
 		})
 
-		token := generateToken(t, kid, secret, jwt.SigningMethodHS256)
+		token := generateToken(t, kid, secret, jwt.SigningMethodHS256, nil)
 
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
@@ -863,7 +909,7 @@ func TestNonHttpAuthorization(t *testing.T) {
 			},
 		})
 
-		token := generateToken(t, kid, secret, jwt.SigningMethodHS256)
+		token := generateToken(t, kid, secret, jwt.SigningMethodHS256, nil)
 
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
@@ -902,7 +948,7 @@ func TestNonHttpAuthorization(t *testing.T) {
 			},
 		})
 
-		token := generateToken(t, "differentKID", secret, jwt.SigningMethodHS256)
+		token := generateToken(t, "differentKID", secret, jwt.SigningMethodHS256, nil)
 
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
@@ -2028,6 +2074,434 @@ func TestAuthenticationOverWebsocket(t *testing.T) {
 	})
 }
 
+func TestAudienceValidation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("authentication fails when there is no audience match", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("with slice of string audiences in the token", func(t *testing.T) {
+			t.Parallel()
+
+			t.Run("with http based configuration", func(t *testing.T) {
+				t.Parallel()
+
+				tokenAudiences := []string{"aud1", "aud2"}
+
+				authServer, err := jwks.NewServer(t)
+				require.NoError(t, err)
+				t.Cleanup(authServer.Close)
+
+				token, err := authServer.Token(map[string]any{"aud": tokenAudiences})
+				require.NoError(t, err)
+
+				authenticators := ConfigureAuthWithJwksConfig(t, []authentication.JWKSConfig{
+					{
+						URL:             authServer.JWKSURL(),
+						RefreshInterval: time.Second * 5,
+						Audiences:       []string{"aud3", "aud5"},
+					},
+				})
+
+				testenv.Run(t, &testenv.Config{
+					RouterOptions: []core.Option{
+						core.WithAccessController(core.NewAccessController(authenticators, true)),
+					},
+				}, func(t *testing.T, xEnv *testenv.Environment) {
+					// Operations with a token should succeed
+					header := http.Header{
+						"Authorization": []string{"Bearer " + token},
+					}
+					res, err := xEnv.MakeRequest(http.MethodPost, "/graphql", header, strings.NewReader(employeesQuery))
+					require.NoError(t, err)
+					defer res.Body.Close()
+					require.Equal(t, http.StatusUnauthorized, res.StatusCode)
+					require.Equal(t, "", res.Header.Get(xAuthenticatedByHeader))
+					data, err := io.ReadAll(res.Body)
+					require.NoError(t, err)
+					require.JSONEq(t, unauthorizedExpectedData, string(data))
+				})
+			})
+
+			t.Run("with secret based configuration", func(t *testing.T) {
+				t.Parallel()
+
+				tokenAudiences := []string{"aud1", "aud2"}
+
+				secret := "example secret"
+				kid := "givenKID"
+				authenticators := ConfigureAuthWithJwksConfig(t, []authentication.JWKSConfig{
+					{
+						Secret:    secret,
+						Algorithm: string(jwkset.AlgHS256),
+						KeyId:     kid,
+						Audiences: []string{"aud3", "aud5"},
+					},
+				})
+
+				token := generateToken(t, kid, secret, jwt.SigningMethodHS256, jwt.MapClaims{
+					"aud": tokenAudiences,
+				})
+
+				testenv.Run(t, &testenv.Config{
+					RouterOptions: []core.Option{
+						core.WithAccessController(core.NewAccessController(authenticators, true)),
+					},
+				}, func(t *testing.T, xEnv *testenv.Environment) {
+					// Operations with a token should succeed
+					header := http.Header{
+						"Authorization": []string{"Bearer " + token},
+					}
+					res, err := xEnv.MakeRequest(http.MethodPost, "/graphql", header, strings.NewReader(employeesQuery))
+					require.NoError(t, err)
+					defer res.Body.Close()
+					require.Equal(t, http.StatusUnauthorized, res.StatusCode)
+					require.Equal(t, "", res.Header.Get(xAuthenticatedByHeader))
+					data, err := io.ReadAll(res.Body)
+					require.NoError(t, err)
+					require.JSONEq(t, unauthorizedExpectedData, string(data))
+				})
+			})
+		})
+
+		t.Run("with single string audience in the token", func(t *testing.T) {
+			t.Parallel()
+
+			t.Run("with http based configuration", func(t *testing.T) {
+				t.Parallel()
+
+				tokenAudiences := "aud1"
+
+				authServer, err := jwks.NewServer(t)
+				require.NoError(t, err)
+				t.Cleanup(authServer.Close)
+
+				token, err := authServer.Token(map[string]any{"aud": tokenAudiences})
+				require.NoError(t, err)
+
+				authenticators := ConfigureAuthWithJwksConfig(t, []authentication.JWKSConfig{
+					{
+						URL:             authServer.JWKSURL(),
+						RefreshInterval: time.Second * 5,
+						Audiences:       []string{"aud3", "aud5"},
+					},
+				})
+
+				testenv.Run(t, &testenv.Config{
+					RouterOptions: []core.Option{
+						core.WithAccessController(core.NewAccessController(authenticators, true)),
+					},
+				}, func(t *testing.T, xEnv *testenv.Environment) {
+					// Operations with a token should succeed
+					header := http.Header{
+						"Authorization": []string{"Bearer " + token},
+					}
+					res, err := xEnv.MakeRequest(http.MethodPost, "/graphql", header, strings.NewReader(employeesQuery))
+					require.NoError(t, err)
+					defer res.Body.Close()
+					require.Equal(t, http.StatusUnauthorized, res.StatusCode)
+					require.Equal(t, "", res.Header.Get(xAuthenticatedByHeader))
+					data, err := io.ReadAll(res.Body)
+					require.NoError(t, err)
+					require.JSONEq(t, unauthorizedExpectedData, string(data))
+				})
+			})
+
+			t.Run("with secret based configuration", func(t *testing.T) {
+				t.Parallel()
+
+				tokenAudience := "aud1"
+
+				secret := "example secret"
+				kid := "givenKID"
+				authenticators := ConfigureAuthWithJwksConfig(t, []authentication.JWKSConfig{
+					{
+						Secret:    secret,
+						Algorithm: string(jwkset.AlgHS256),
+						KeyId:     kid,
+						Audiences: []string{"aud3", "aud5"},
+					},
+				})
+
+				token := generateToken(t, kid, secret, jwt.SigningMethodHS256, jwt.MapClaims{
+					"aud": tokenAudience,
+				})
+
+				testenv.Run(t, &testenv.Config{
+					RouterOptions: []core.Option{
+						core.WithAccessController(core.NewAccessController(authenticators, true)),
+					},
+				}, func(t *testing.T, xEnv *testenv.Environment) {
+					// Operations with a token should succeed
+					header := http.Header{
+						"Authorization": []string{"Bearer " + token},
+					}
+					res, err := xEnv.MakeRequest(http.MethodPost, "/graphql", header, strings.NewReader(employeesQuery))
+					require.NoError(t, err)
+					defer res.Body.Close()
+					require.Equal(t, http.StatusUnauthorized, res.StatusCode)
+					require.Equal(t, "", res.Header.Get(xAuthenticatedByHeader))
+					data, err := io.ReadAll(res.Body)
+					require.NoError(t, err)
+					require.JSONEq(t, unauthorizedExpectedData, string(data))
+				})
+			})
+		})
+	})
+
+	t.Run("authentication succeeds when there is an audience match", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("with slice of string audiences in the token", func(t *testing.T) {
+			t.Parallel()
+
+			t.Run("with http based configuration", func(t *testing.T) {
+				t.Parallel()
+
+				matchingAudience := "matchingAudience"
+				tokenAudiences := []string{matchingAudience, "aud5"}
+
+				authServer, err := jwks.NewServer(t)
+				require.NoError(t, err)
+				t.Cleanup(authServer.Close)
+
+				token, err := authServer.Token(map[string]any{"aud": tokenAudiences})
+				require.NoError(t, err)
+
+				authenticators := ConfigureAuthWithJwksConfig(t, []authentication.JWKSConfig{
+					{
+						URL:             authServer.JWKSURL(),
+						RefreshInterval: time.Second * 5,
+						Audiences:       []string{matchingAudience, "aud5"},
+					},
+				})
+
+				testenv.Run(t, &testenv.Config{
+					RouterOptions: []core.Option{
+						core.WithAccessController(core.NewAccessController(authenticators, true)),
+					},
+				}, func(t *testing.T, xEnv *testenv.Environment) {
+					// Operations with a token should succeed
+					header := http.Header{
+						"Authorization": []string{"Bearer " + token},
+					}
+					res, err := xEnv.MakeRequest(http.MethodPost, "/graphql", header, strings.NewReader(employeesQuery))
+					require.NoError(t, err)
+					defer res.Body.Close()
+					require.Equal(t, http.StatusOK, res.StatusCode)
+					require.Equal(t, JwksName, res.Header.Get(xAuthenticatedByHeader))
+					data, err := io.ReadAll(res.Body)
+					require.NoError(t, err)
+					require.Equal(t, employeesExpectedData, string(data))
+				})
+			})
+
+			t.Run("with secret based configuration", func(t *testing.T) {
+				t.Parallel()
+
+				matchingAud := "matchingAud"
+				tokenAudiences := []string{matchingAud, "aud2"}
+
+				secret := "example secret"
+				kid := "givenKID"
+				authenticators := ConfigureAuthWithJwksConfig(t, []authentication.JWKSConfig{
+					{
+						Secret:    secret,
+						Algorithm: string(jwkset.AlgHS256),
+						KeyId:     kid,
+						Audiences: []string{matchingAud, "aud5"},
+					},
+				})
+
+				token := generateToken(t, kid, secret, jwt.SigningMethodHS256, jwt.MapClaims{
+					"aud": tokenAudiences,
+				})
+
+				testenv.Run(t, &testenv.Config{
+					RouterOptions: []core.Option{
+						core.WithAccessController(core.NewAccessController(authenticators, true)),
+					},
+				}, func(t *testing.T, xEnv *testenv.Environment) {
+					// Operations with a token should succeed
+					header := http.Header{
+						"Authorization": []string{"Bearer " + token},
+					}
+					res, err := xEnv.MakeRequest(http.MethodPost, "/graphql", header, strings.NewReader(employeesQuery))
+					require.NoError(t, err)
+					defer res.Body.Close()
+					require.Equal(t, http.StatusOK, res.StatusCode)
+					require.Equal(t, JwksName, res.Header.Get(xAuthenticatedByHeader))
+					data, err := io.ReadAll(res.Body)
+					require.NoError(t, err)
+					require.Equal(t, employeesExpectedData, string(data))
+				})
+			})
+		})
+
+		t.Run("with single string audience in the token", func(t *testing.T) {
+			t.Parallel()
+
+			t.Run("with http based configuration", func(t *testing.T) {
+				t.Parallel()
+
+				matchingAudience := "matchingAudience"
+
+				authServer, err := jwks.NewServer(t)
+				require.NoError(t, err)
+				t.Cleanup(authServer.Close)
+
+				token, err := authServer.Token(map[string]any{"aud": matchingAudience})
+				require.NoError(t, err)
+
+				authenticators := ConfigureAuthWithJwksConfig(t, []authentication.JWKSConfig{
+					{
+						URL:             authServer.JWKSURL(),
+						RefreshInterval: time.Second * 5,
+						Audiences:       []string{matchingAudience, "aud5"},
+					},
+				})
+
+				testenv.Run(t, &testenv.Config{
+					RouterOptions: []core.Option{
+						core.WithAccessController(core.NewAccessController(authenticators, true)),
+					},
+				}, func(t *testing.T, xEnv *testenv.Environment) {
+					// Operations with a token should succeed
+					header := http.Header{
+						"Authorization": []string{"Bearer " + token},
+					}
+					res, err := xEnv.MakeRequest(http.MethodPost, "/graphql", header, strings.NewReader(employeesQuery))
+					require.NoError(t, err)
+					defer res.Body.Close()
+					require.Equal(t, http.StatusOK, res.StatusCode)
+					require.Equal(t, JwksName, res.Header.Get(xAuthenticatedByHeader))
+					data, err := io.ReadAll(res.Body)
+					require.NoError(t, err)
+					require.Equal(t, employeesExpectedData, string(data))
+				})
+			})
+
+			t.Run("with secret based configuration", func(t *testing.T) {
+				t.Parallel()
+
+				matchingAud := "matchingAudience"
+
+				secret := "example secret"
+				kid := "givenKID"
+				authenticators := ConfigureAuthWithJwksConfig(t, []authentication.JWKSConfig{
+					{
+						Secret:    secret,
+						Algorithm: string(jwkset.AlgHS256),
+						KeyId:     kid,
+						Audiences: []string{matchingAud, "aud5"},
+					},
+				})
+
+				token := generateToken(t, kid, secret, jwt.SigningMethodHS256, jwt.MapClaims{
+					"aud": matchingAud,
+				})
+
+				testenv.Run(t, &testenv.Config{
+					RouterOptions: []core.Option{
+						core.WithAccessController(core.NewAccessController(authenticators, true)),
+					},
+				}, func(t *testing.T, xEnv *testenv.Environment) {
+					// Operations with a token should succeed
+					header := http.Header{
+						"Authorization": []string{"Bearer " + token},
+					}
+					res, err := xEnv.MakeRequest(http.MethodPost, "/graphql", header, strings.NewReader(employeesQuery))
+					require.NoError(t, err)
+					defer res.Body.Close()
+					require.Equal(t, http.StatusOK, res.StatusCode)
+					require.Equal(t, JwksName, res.Header.Get(xAuthenticatedByHeader))
+					data, err := io.ReadAll(res.Body)
+					require.NoError(t, err)
+					require.Equal(t, employeesExpectedData, string(data))
+				})
+			})
+		})
+	})
+
+	t.Run("authentication fails when audience is invalid format", func(t *testing.T) {
+		t.Parallel()
+
+		tokenAudiences := []bool{true, true}
+
+		authServer, err := jwks.NewServer(t)
+		require.NoError(t, err)
+		t.Cleanup(authServer.Close)
+
+		token, err := authServer.Token(map[string]any{"aud": tokenAudiences})
+		require.NoError(t, err)
+
+		authenticators := ConfigureAuthWithJwksConfig(t, []authentication.JWKSConfig{
+			{
+				URL:             authServer.JWKSURL(),
+				RefreshInterval: time.Second * 5,
+				Audiences:       []string{"aud3", "aud5"},
+			},
+		})
+
+		testenv.Run(t, &testenv.Config{
+			RouterOptions: []core.Option{
+				core.WithAccessController(core.NewAccessController(authenticators, true)),
+			},
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			// Operations with a token should succeed
+			header := http.Header{
+				"Authorization": []string{"Bearer " + token},
+			}
+			res, err := xEnv.MakeRequest(http.MethodPost, "/graphql", header, strings.NewReader(employeesQuery))
+			require.NoError(t, err)
+			defer res.Body.Close()
+			require.Equal(t, http.StatusUnauthorized, res.StatusCode)
+			require.Equal(t, "", res.Header.Get(xAuthenticatedByHeader))
+			data, err := io.ReadAll(res.Body)
+			require.NoError(t, err)
+			require.JSONEq(t, unauthorizedExpectedData, string(data))
+		})
+
+	})
+
+	t.Run("authentication validation is ignored when expected aud is not provided", func(t *testing.T) {
+		tokenAudiences := []bool{true, true}
+
+		authServer, err := jwks.NewServer(t)
+		require.NoError(t, err)
+		t.Cleanup(authServer.Close)
+
+		token, err := authServer.Token(map[string]any{"aud": tokenAudiences})
+		require.NoError(t, err)
+
+		authenticators := ConfigureAuthWithJwksConfig(t, []authentication.JWKSConfig{
+			{
+				URL:             authServer.JWKSURL(),
+				RefreshInterval: time.Second * 5,
+			},
+		})
+
+		testenv.Run(t, &testenv.Config{
+			RouterOptions: []core.Option{
+				core.WithAccessController(core.NewAccessController(authenticators, true)),
+			},
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			// Operations with a token should succeed
+			header := http.Header{
+				"Authorization": []string{"Bearer " + token},
+			}
+			res, err := xEnv.MakeRequest(http.MethodPost, "/graphql", header, strings.NewReader(employeesQuery))
+			require.NoError(t, err)
+			defer res.Body.Close()
+			require.Equal(t, http.StatusOK, res.StatusCode)
+			require.Equal(t, JwksName, res.Header.Get(xAuthenticatedByHeader))
+			data, err := io.ReadAll(res.Body)
+			require.NoError(t, err)
+			require.Equal(t, employeesExpectedData, string(data))
+		})
+	})
+}
+
 func toJWKSConfig(url string, refresh time.Duration, allowedAlgorithms ...string) authentication.JWKSConfig {
 	return authentication.JWKSConfig{
 		URL:               url,
@@ -2036,8 +2510,11 @@ func toJWKSConfig(url string, refresh time.Duration, allowedAlgorithms ...string
 	}
 }
 
-func generateToken(t *testing.T, kid string, secret string, signingMethod *jwt.SigningMethodHMAC) string {
-	token := jwt.New(signingMethod)
+func generateToken(t *testing.T, kid string, secret string, signingMethod *jwt.SigningMethodHMAC, claims jwt.MapClaims) string {
+	if claims == nil {
+		claims = jwt.MapClaims{}
+	}
+	token := jwt.NewWithClaims(signingMethod, claims)
 	token.Header[jwkset.HeaderKID] = kid
 	jwtValue, err := token.SignedString([]byte(secret))
 	require.NoError(t, err)

--- a/router-tests/authentication_test.go
+++ b/router-tests/authentication_test.go
@@ -2464,9 +2464,9 @@ func TestAudienceValidation(t *testing.T) {
 
 	})
 
-	t.Run("authentication validation is ignored when expected aud is not provided", func(t *testing.T) {
+	t.Run("audience validation is ignored when expected aud is not provided", func(t *testing.T) {
 		t.Parallel()
-		
+
 		tokenAudiences := []bool{true, true}
 
 		authServer, err := jwks.NewServer(t)

--- a/router/core/supervisor_instance.go
+++ b/router/core/supervisor_instance.go
@@ -259,6 +259,8 @@ func setupAuthenticators(ctx context.Context, logger *zap.Logger, cfg *config.Co
 			Secret:    jwks.Secret,
 			Algorithm: jwks.Algorithm,
 			KeyId:     jwks.KeyId,
+
+			Audiences: jwks.Audiences,
 		})
 	}
 

--- a/router/pkg/authentication/authentication.go
+++ b/router/pkg/authentication/authentication.go
@@ -77,6 +77,8 @@ func (a *authentication) Scopes() []string {
 	return strings.Split(scopes, " ")
 }
 
+var errUnacceptableAud = errors.New("audience match not found")
+
 // Authenticate tries to authenticate the given Provider using the given authenticators. If any of
 // the authenticators succeeds, the Authentication result is returned with no error. If the Provider
 // has no authentication information, the Authentication result is nil with no error. If the authentication

--- a/router/pkg/authentication/jwks_token_decoder.go
+++ b/router/pkg/authentication/jwks_token_decoder.go
@@ -106,7 +106,7 @@ func NewJwksTokenDecoder(ctx context.Context, logger *zap.Logger, configs []JWKS
 		} else if c.Secret != "" {
 			key := AudKey{kid: c.KeyId}
 			if _, ok := audiencesMap[key]; ok {
-				return nil, fmt.Errorf("duplicate JWK keyid specified found: %s", c.URL)
+				return nil, fmt.Errorf("duplicate JWK keyid specified found: %s", c.KeyId)
 			}
 
 			given := jwkset.NewMemoryStorage()
@@ -147,7 +147,6 @@ func NewJwksTokenDecoder(ctx context.Context, logger *zap.Logger, configs []JWKS
 				PrioritizeHTTP: false,
 			}
 
-			audiencesMap[key] = c.Audiences
 			jwks, err := createKeyFunc(ctx, jwksetHTTPClientOptions)
 			if err != nil {
 				return nil, err
@@ -161,7 +160,7 @@ func NewJwksTokenDecoder(ctx context.Context, logger *zap.Logger, configs []JWKS
 		for key, keyFunc := range keyFuncMap {
 			pub, err := keyFunc.Keyfunc(token)
 			if err != nil {
-				errors.Join(err, errJoin)
+				errJoin = errors.Join(errJoin, err)
 				continue
 			}
 

--- a/router/pkg/config/config.go
+++ b/router/pkg/config/config.go
@@ -467,8 +467,8 @@ type JWKSConfiguration struct {
 	// For secret based where we need to create a jwk  entry with
 	// a key id and algorithm
 	Secret    string `yaml:"secret"`
-	Algorithm string `yaml:"algorithm"`
-	KeyId     string `yaml:"key_id"`
+	Algorithm string `yaml:"symmetric_algorithm"`
+	KeyId     string `yaml:"header_key_id"`
 
 	// Common
 	Audiences []string `yaml:"audiences"`

--- a/router/pkg/config/config.go
+++ b/router/pkg/config/config.go
@@ -467,6 +467,9 @@ type JWKSConfiguration struct {
 	Secret    string `yaml:"secret"`
 	Algorithm string `yaml:"algorithm"`
 	KeyId     string `yaml:"key_id"`
+
+	// Common
+	Audiences []string `yaml:"audiences"`
 }
 
 type HeaderSource struct {

--- a/router/pkg/config/config.schema.json
+++ b/router/pkg/config/config.schema.json
@@ -1640,6 +1640,13 @@
                     "description": "The URL of the JWKs. The JWKs are used to verify the JWT (JSON Web Token). The URL is specified as a string with the format 'scheme://host:port'.",
                     "format": "http-url"
                   },
+                  "audiences": {
+                    "type": "array",
+                    "description": "The audiences of the JWKs. The audiences are used to verify the JWT (JSON Web Token). The audiences are specified as a list of strings.",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
                   "secret": {
                     "type": "string",
                     "description": "The secret of the JWKs"

--- a/router/pkg/config/config.schema.json
+++ b/router/pkg/config/config.schema.json
@@ -1662,7 +1662,7 @@
                   },
                   "symmetric_algorithm": {
                     "type": "string",
-                    "description": "The algorithm used",
+                    "description": "The symmetric algorithm used",
                     "enum": [
                       "HS256",
                       "HS384",
@@ -1671,7 +1671,7 @@
                   },
                   "header_key_id": {
                     "type": "string",
-                    "description": "The secret of the JWKs"
+                    "description": "The KID header of the JWK token created using the secret"
                   },
                   "algorithms": {
                     "type": "array",
@@ -1679,6 +1679,9 @@
                     "items": {
                       "type": "string",
                       "enum": [
+                        "HS256",
+                        "HS384",
+                        "HS512",
                         "RS256",
                         "RS384",
                         "RS512",

--- a/router/pkg/config/config.schema.json
+++ b/router/pkg/config/config.schema.json
@@ -1660,7 +1660,7 @@
                     "type": "string",
                     "description": "The secret of the JWKs"
                   },
-                  "algorithm": {
+                  "symmetric_algorithm": {
                     "type": "string",
                     "description": "The algorithm used",
                     "enum": [
@@ -1669,7 +1669,7 @@
                       "HS512"
                     ]
                   },
-                  "key_id": {
+                  "header_key_id": {
                     "type": "string",
                     "description": "The secret of the JWKs"
                   },
@@ -1704,10 +1704,10 @@
                 "oneOf": [
                   {
                     "required": ["url"],
-                    "not": { "anyOf": [{ "required": ["secret"] }, { "required": ["algorithm"] }, { "required": ["key_id"] }] }
+                    "not": { "anyOf": [{ "required": ["secret"] }, { "required": ["symmetric_algorithm"] }, { "required": ["header_key_id"] }] }
                   },
                   {
-                    "required": ["secret", "algorithm", "key_id"],
+                    "required": ["secret", "symmetric_algorithm", "header_key_id"],
                     "not": { "anyOf": [{ "required": ["url"] }, { "required": ["algorithms"] }, { "required": ["refresh_interval"] }] }
                   }
                 ]

--- a/router/pkg/config/config_test.go
+++ b/router/pkg/config/config_test.go
@@ -1227,9 +1227,9 @@ version: "1"
 authentication:
   jwt:
     jwks:
-      - key_id: "givenKID"
+      - header_key_id: "givenKID"
         secret: "example secret"
-        algorithm: HS512
+        symmetric_algorithm: HS512
 
 `)
 		_, err := LoadConfig([]string{f})
@@ -1245,11 +1245,11 @@ version: "1"
 authentication:
   jwt:
     jwks:
-      - key_id: "givenKID"
+      - header_key_id: "givenKID"
         url: "http://url/valid.json"
         algorithms: []
         secret: "example secret"
-        algorithm: HS512
+        symmetric_algorithm: HS512
 `)
 		_, err := LoadConfig([]string{f})
 		require.ErrorContains(t, err, "at '/authentication/jwt/jwks/")
@@ -1270,7 +1270,7 @@ authentication:
 `)
 		_, err := LoadConfig([]string{f})
 		require.ErrorContains(t, err, "at '/authentication/jwt/jwks/")
-		require.ErrorContains(t, err, "missing properties 'algorithm', 'key_id'")
+		require.ErrorContains(t, err, "missing properties 'symmetric_algorithm', 'header_key_id'")
 
 	})
 

--- a/router/pkg/config/testdata/config_full.json
+++ b/router/pkg/config/testdata/config_full.json
@@ -470,7 +470,8 @@
           "RefreshInterval": 60000000000,
           "Secret": "",
           "Algorithm": "",
-          "KeyId": ""
+          "KeyId": "",
+          "Audiences": null
         },
         {
           "URL": "https://example.com/.well-known/jwks2.json",
@@ -481,7 +482,8 @@
           "RefreshInterval": 120000000000,
           "Secret": "",
           "Algorithm": "",
-          "KeyId": ""
+          "KeyId": "",
+          "Audiences": null
         },
         {
           "URL": "https://example.com/.well-known/jwks3.json",
@@ -489,7 +491,8 @@
           "RefreshInterval": 0,
           "Secret": "",
           "Algorithm": "",
-          "KeyId": ""
+          "KeyId": "",
+          "Audiences": null
         }
       ],
       "HeaderName": "Authorization",


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for specifying and validating JWT audiences in JWKS authentication configuration.
  * Audience validation now enforced for JWT tokens, improving security by ensuring tokens are intended for the configured audiences.

* **Bug Fixes**
  * Improved error handling for duplicate JWKS URLs and key IDs in configuration.

* **Tests**
  * Expanded test coverage for audience validation and duplicate JWKS/key ID detection in authentication setup.

* **Documentation**
  * Updated configuration schema and example files to include the new "audiences" field for JWKS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

> [!WARNING]  
> Potential Breaking Change: If you have the same KID manually specified (in the config) or are using the same URL, the router won't startup.

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->