### PR TITLE
fix(router): file mode duplicated prefix

### DIFF
--- a/router/core/supervisor_instance.go
+++ b/router/core/supervisor_instance.go
@@ -73,7 +73,7 @@ func newRouter(ctx context.Context, params RouterResources, additionalOptions ..
 		}
 
 		if cfg.AccessLogs.Output.File.Enabled {
-			f, err := logging.NewLogFile(cfg.AccessLogs.Output.File.Path, os.FileMode(cfg.AccessLogs.Output.File.FileMode))
+			f, err := logging.NewLogFile(cfg.AccessLogs.Output.File.Path, os.FileMode(cfg.AccessLogs.Output.File.Mode))
 			if err != nil {
 				return nil, fmt.Errorf("could not create log file: %w", err)
 			}

--- a/router/pkg/config/config.go
+++ b/router/pkg/config/config.go
@@ -881,7 +881,7 @@ type AccessLogsStdOutOutputConfig struct {
 type AccessLogsFileOutputConfig struct {
 	Enabled bool     `yaml:"enabled" env:"ACCESS_LOGS_OUTPUT_FILE_ENABLED" envDefault:"false"`
 	Path    string   `yaml:"path" env:"ACCESS_LOGS_FILE_OUTPUT_PATH" envDefault:"access.log"`
-	Mode    FileMode `yaml:"mode" env:"ACCESS_LOGS_FILE_OUTPUT_FILE_MODE" envDefault:"0640"`
+	Mode    FileMode `yaml:"mode" env:"ACCESS_LOGS_FILE_OUTPUT_MODE" envDefault:"0640"`
 }
 
 type AccessLogsRouterConfig struct {

--- a/router/pkg/config/config.go
+++ b/router/pkg/config/config.go
@@ -879,9 +879,9 @@ type AccessLogsStdOutOutputConfig struct {
 }
 
 type AccessLogsFileOutputConfig struct {
-	Enabled  bool     `yaml:"enabled" env:"ACCESS_LOGS_OUTPUT_FILE_ENABLED" envDefault:"false"`
-	Path     string   `yaml:"path" env:"ACCESS_LOGS_FILE_OUTPUT_PATH" envDefault:"access.log"`
-	FileMode FileMode `yaml:"file_mode" env:"ACCESS_LOGS_FILE_OUTPUT_FILE_MODE" envDefault:"0640"`
+	Enabled bool     `yaml:"enabled" env:"ACCESS_LOGS_OUTPUT_FILE_ENABLED" envDefault:"false"`
+	Path    string   `yaml:"path" env:"ACCESS_LOGS_FILE_OUTPUT_PATH" envDefault:"access.log"`
+	Mode    FileMode `yaml:"mode" env:"ACCESS_LOGS_FILE_OUTPUT_FILE_MODE" envDefault:"0640"`
 }
 
 type AccessLogsRouterConfig struct {

--- a/router/pkg/config/config.schema.json
+++ b/router/pkg/config/config.schema.json
@@ -677,7 +677,7 @@
                   "type": "string",
                   "description": "The path to the log file. The path is used to specify the path to the log file."
                 },
-                "file_mode": {
+                "mode": {
                   "type": "string",
                   "description": "The file mode (permissions) for the log file as an octal string. Must be exactly 3 octal digits (0-7), optionally prefixed with '0' (e.g., '640', '0640', '755', '0755'). The default value is '0640'.",
                   "default": "0640",

--- a/router/pkg/config/config_test.go
+++ b/router/pkg/config/config_test.go
@@ -1314,7 +1314,7 @@ access_logs:
 		c, err := LoadConfig([]string{f})
 		require.NoError(t, err)
 
-		require.Equal(t, FileMode(0640), c.Config.AccessLogs.Output.File.FileMode)
+		require.Equal(t, FileMode(0640), c.Config.AccessLogs.Output.File.Mode)
 	})
 
 	t.Run("verify file mode is parsed correctly with leading zero", func(t *testing.T) {
@@ -1334,7 +1334,7 @@ access_logs:
 		c, err := LoadConfig([]string{f})
 		require.NoError(t, err)
 
-		require.Equal(t, FileMode(0640), c.Config.AccessLogs.Output.File.FileMode)
+		require.Equal(t, FileMode(0640), c.Config.AccessLogs.Output.File.Mode)
 	})
 
 	t.Run("verify file mode throws an error when pattern is not matched", func(t *testing.T) {
@@ -1454,7 +1454,7 @@ access_logs:
 `)
 			c, err := LoadConfig([]string{f})
 			require.NoError(t, err, "Pattern '%s' should be valid but was rejected", tc.pattern)
-			require.Equal(t, tc.mode, c.Config.AccessLogs.Output.File.FileMode, "Pattern '%s' should parse to mode %o but got %o", tc.pattern, tc.mode, c.Config.AccessLogs.Output.File.FileMode)
+			require.Equal(t, tc.mode, c.Config.AccessLogs.Output.File.Mode, "Pattern '%s' should parse to mode %o but got %o", tc.pattern, tc.mode, c.Config.AccessLogs.Output.File.Mode)
 		}
 	})
 }

--- a/router/pkg/config/config_test.go
+++ b/router/pkg/config/config_test.go
@@ -1309,7 +1309,7 @@ access_logs:
     file:
       enabled: true
       path: ./access.log
-      file_mode: "640"
+      mode: "640"
 `)
 		c, err := LoadConfig([]string{f})
 		require.NoError(t, err)
@@ -1329,7 +1329,7 @@ access_logs:
     file:
       enabled: true
       path: ./access.log
-      file_mode: "0640"
+      mode: "0640"
 `)
 		c, err := LoadConfig([]string{f})
 		require.NoError(t, err)
@@ -1401,7 +1401,7 @@ access_logs:
     file:
       enabled: true
       path: ./access.log
-      file_mode: "`+pattern+`"
+      mode: "`+pattern+`"
 `)
 			_, err := LoadConfig([]string{f})
 			require.Error(t, err, "Pattern '%s' should be invalid but was accepted", pattern)
@@ -1450,7 +1450,7 @@ access_logs:
     file:
       enabled: true
       path: ./access.log
-      file_mode: "`+tc.pattern+`"
+      mode: "`+tc.pattern+`"
 `)
 			c, err := LoadConfig([]string{f})
 			require.NoError(t, err, "Pattern '%s' should be valid but was rejected", tc.pattern)

--- a/router/pkg/config/testdata/config_defaults.json
+++ b/router/pkg/config/testdata/config_defaults.json
@@ -192,7 +192,7 @@
       "File": {
         "Enabled": false,
         "Path": "access.log",
-        "FileMode": 416
+        "Mode": 416
       }
     },
     "Router": {

--- a/router/pkg/config/testdata/config_full.json
+++ b/router/pkg/config/testdata/config_full.json
@@ -389,7 +389,7 @@
       "File": {
         "Enabled": false,
         "Path": "access.log",
-        "FileMode": 416
+        "Mode": 416
       }
     },
     "Router": {


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Renamed the access log file permission configuration field from "file_mode" to "mode" across configuration files, environment variables, and schema.
  * Updated related test cases and configuration defaults to reflect the new field name.

* **Bug Fixes**
  * Corrected the file permission setting for access logs to use the updated configuration field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).