### PR TITLE
feat: use nested list element to handle nullability properly

### DIFF
--- a/protographic/src/sdl-to-proto-visitor.ts
+++ b/protographic/src/sdl-to-proto-visitor.ts
@@ -1589,30 +1589,26 @@ Example:
       lines.push(...this.formatComment(`Wrapper message for a list of ${baseType.name}.`, 0));
     }
 
-    lines.push(`message ${wrapperName} {`);
-
     const formatIndent = (indent: number, content: string) => {
       return '  '.repeat(indent) + content;
     };
 
+    lines.push(`message ${wrapperName} {`);
+    let innerWrapperName = '';
     if (level > 1) {
-      // Nested structure for deep lists
-      const innerWrapperName = `${'ListOf'.repeat(level - 1)}${baseType.name}`;
-      lines.push(
-        formatIndent(1, `message List {`),
-        formatIndent(2, `repeated ${innerWrapperName} items = 1;`),
-        formatIndent(1, `}`),
-      );
-
-      // Wrapper types always use deterministic field numbers - 'list' field is always 1
-      lines.push(formatIndent(1, `List list = 1;`));
+      innerWrapperName = `${'ListOf'.repeat(level - 1)}${baseType.name}`;
     } else {
-      // Simple repeated field for level 1 - 'items' field is always 1
-      const protoType = this.getProtoTypeFromGraphQL(baseType, true);
-      lines.push(formatIndent(1, `repeated ${protoType.typeName} items = 1;`));
+      innerWrapperName = this.getProtoTypeFromGraphQL(baseType, true).typeName;
     }
 
-    lines.push('}', '');
+    lines.push(
+      formatIndent(1, `message List {`),
+      formatIndent(2, `repeated ${innerWrapperName} items = 1;`),
+      formatIndent(1, `}`),
+      formatIndent(1, `List list = 1;`),
+      formatIndent(0, `}`),
+    );
+
     return lines;
   }
 

--- a/protographic/tests/sdl-to-proto/01-basic-types.test.ts
+++ b/protographic/tests/sdl-to-proto/01-basic-types.test.ts
@@ -142,9 +142,11 @@ describe('SDL to Proto - Basic Types', () => {
 
       // Wrapper message for a list of String.
       message ListOfString {
-        repeated string items = 1;
+        message List {
+          repeated string items = 1;
+        }
+        List list = 1;
       }
-
       // Request message for stringList operation.
       message QueryStringListRequest {
       }
@@ -247,9 +249,11 @@ describe('SDL to Proto - Basic Types', () => {
 
       // Wrapper message for a list of User.
       message ListOfUser {
-        repeated User items = 1;
+        message List {
+          repeated User items = 1;
+        }
+        List list = 1;
       }
-
       // Request message for user operation.
       message QueryUserRequest {
         string id = 1;
@@ -478,14 +482,18 @@ describe('SDL to Proto - Basic Types', () => {
 
       // Wrapper message for a list of Float.
       message ListOfFloat {
-        repeated double items = 1;
+        message List {
+          repeated double items = 1;
+        }
+        List list = 1;
       }
-
       // Wrapper message for a list of Int.
       message ListOfInt {
-        repeated int32 items = 1;
+        message List {
+          repeated int32 items = 1;
+        }
+        List list = 1;
       }
-
       // Wrapper message for a list of Float.
       message ListOfListOfFloat {
         message List {
@@ -493,7 +501,6 @@ describe('SDL to Proto - Basic Types', () => {
         }
         List list = 1;
       }
-
       // Wrapper message for a list of Int.
       message ListOfListOfInt {
         message List {
@@ -501,7 +508,6 @@ describe('SDL to Proto - Basic Types', () => {
         }
         List list = 1;
       }
-
       // Wrapper message for a list of Point.
       message ListOfListOfPoint {
         message List {
@@ -509,17 +515,20 @@ describe('SDL to Proto - Basic Types', () => {
         }
         List list = 1;
       }
-
       // Wrapper message for a list of Point.
       message ListOfPoint {
-        repeated Point items = 1;
+        message List {
+          repeated Point items = 1;
+        }
+        List list = 1;
       }
-
       // Wrapper message for a list of String.
       message ListOfString {
-        repeated string items = 1;
+        message List {
+          repeated string items = 1;
+        }
+        List list = 1;
       }
-
       // Request message for getMatrix operation.
       message QueryGetMatrixRequest {
       }
@@ -703,14 +712,18 @@ describe('SDL to Proto - Basic Types', () => {
 
       // Wrapper message for a list of TreeNode.
       message ListOfTreeNode {
-        repeated TreeNode items = 1;
+        message List {
+          repeated TreeNode items = 1;
+        }
+        List list = 1;
       }
-
       // Wrapper message for a list of User.
       message ListOfUser {
-        repeated User items = 1;
+        message List {
+          repeated User items = 1;
+        }
+        List list = 1;
       }
-
       // Request message for user operation.
       message QueryUserRequest {
         string id = 1;

--- a/protographic/tests/sdl-to-proto/02-complex-types.test.ts
+++ b/protographic/tests/sdl-to-proto/02-complex-types.test.ts
@@ -38,9 +38,11 @@ describe('SDL to Proto - Complex Types', () => {
 
       // Wrapper message for a list of User.
       message ListOfUser {
-        repeated User items = 1;
+        message List {
+          repeated User items = 1;
+        }
+        List list = 1;
       }
-
       // Request message for usersByRole operation.
       message QueryUsersByRoleRequest {
         UserRole role = 1;
@@ -231,9 +233,11 @@ describe('SDL to Proto - Complex Types', () => {
 
       // Wrapper message for a list of TreeNode.
       message ListOfTreeNode {
-        repeated TreeNode items = 1;
+        message List {
+          repeated TreeNode items = 1;
+        }
+        List list = 1;
       }
-
       // Request message for rootNode operation.
       message QueryRootNodeRequest {
       }
@@ -305,14 +309,18 @@ describe('SDL to Proto - Complex Types', () => {
 
       // Wrapper message for a list of AddressInput.
       message ListOfAddressInput {
-        repeated AddressInput items = 1;
+        message List {
+          repeated AddressInput items = 1;
+        }
+        List list = 1;
       }
-
       // Wrapper message for a list of User.
       message ListOfUser {
-        repeated User items = 1;
+        message List {
+          repeated User items = 1;
+        }
+        List list = 1;
       }
-
       // Request message for users operation.
       message QueryUsersRequest {
         UserFilterInput filter = 1;

--- a/protographic/tests/sdl-to-proto/05-edge-cases.test.ts
+++ b/protographic/tests/sdl-to-proto/05-edge-cases.test.ts
@@ -366,19 +366,25 @@ describe('SDL to Proto - Edge Cases and Error Handling', () => {
 
       // Wrapper message for a list of Comment.
       message ListOfComment {
-        repeated Comment items = 1;
+        message List {
+          repeated Comment items = 1;
+        }
+        List list = 1;
       }
-
       // Wrapper message for a list of Post.
       message ListOfPost {
-        repeated Post items = 1;
+        message List {
+          repeated Post items = 1;
+        }
+        List list = 1;
       }
-
       // Wrapper message for a list of String.
       message ListOfString {
-        repeated string items = 1;
+        message List {
+          repeated string items = 1;
+        }
+        List list = 1;
       }
-
       // Key message for User entity lookup
       message LookupUserByIdRequestKey {
         // Key field for User entity lookup.

--- a/protographic/tests/sdl-to-proto/06-field-ordering.test.ts
+++ b/protographic/tests/sdl-to-proto/06-field-ordering.test.ts
@@ -1154,19 +1154,38 @@ describe('Field Ordering and Preservation', () => {
       const root1 = loadProtoFromText(proto1);
 
       // Verify wrapper types exist and get their field numbers
-      const listOfStringFields = getFieldNumbersFromMessage(root1, 'ListOfString');
-      const listOfIntFields = getFieldNumbersFromMessage(root1, 'ListOfInt');
-      const listOfUserFields = getFieldNumbersFromMessage(root1, 'ListOfUser');
+      const listOfStringWrapperFields = getFieldNumbersFromMessage(root1, 'ListOfString');
+      const listOfIntWrapperFields = getFieldNumbersFromMessage(root1, 'ListOfInt');
+      const listOfUserWrapperFields = getFieldNumbersFromMessage(root1, 'ListOfUser');
 
-      // Store original field numbers for wrapper types
-      const stringItemsNumber = listOfStringFields['items'];
-      const intItemsNumber = listOfIntFields['items'];
-      const userItemsNumber = listOfUserFields['items'];
+      // Get the inner List type field numbers for items
+      const stringListType = root1.lookupType('ListOfString').lookupType('List');
+      const intListType = root1.lookupType('ListOfInt').lookupType('List');
+      const userListType = root1.lookupType('ListOfUser').lookupType('List');
+      
+      const stringListFields = getFieldNumbersFromMessage(stringListType.root, 'List');
+      const intListFields = getFieldNumbersFromMessage(intListType.root, 'List');
+      const userListFields = getFieldNumbersFromMessage(userListType.root, 'List');
 
-      // Verify all wrapper types have the 'items' field with field number 1
-      expect(stringItemsNumber).toBe(1);
-      expect(intItemsNumber).toBe(1);
-      expect(userItemsNumber).toBe(1);
+      // Store original field numbers for wrapper types (outer 'list' field)
+      const stringWrapperListFieldNumber = listOfStringWrapperFields['list'];
+      const intWrapperListFieldNumber = listOfIntWrapperFields['list'];
+      const userWrapperListFieldNumber = listOfUserWrapperFields['list'];
+
+      // Store original field numbers for inner List types ('items' field)
+      const stringListItemsFieldNumber = stringListFields['items'];
+      const intListItemsFieldNumber = intListFields['items'];
+      const userListItemsFieldNumber = userListFields['items'];
+
+      // Verify all wrapper types have the 'list' field with field number 1
+      expect(stringWrapperListFieldNumber).toBe(1);
+      expect(intWrapperListFieldNumber).toBe(1);
+      expect(userWrapperListFieldNumber).toBe(1);
+
+      // Verify all inner List types have the 'items' field with field number 1
+      expect(stringListItemsFieldNumber).toBe(1);
+      expect(intListItemsFieldNumber).toBe(1);
+      expect(userListItemsFieldNumber).toBe(1);
 
       // Get the generated lock data
       const lockData = visitor1.getGeneratedLockData();
@@ -1206,18 +1225,35 @@ describe('Field Ordering and Preservation', () => {
       const root2 = loadProtoFromText(proto2);
 
       // Verify existing wrapper types preserved their field numbers
-      const listOfStringFields2 = getFieldNumbersFromMessage(root2, 'ListOfString');
-      const listOfIntFields2 = getFieldNumbersFromMessage(root2, 'ListOfInt');
-      const listOfUserFields2 = getFieldNumbersFromMessage(root2, 'ListOfUser');
-      const listOfFloatFields2 = getFieldNumbersFromMessage(root2, 'ListOfFloat');
+      const listOfStringWrapperFields2 = getFieldNumbersFromMessage(root2, 'ListOfString');
+      const listOfIntWrapperFields2 = getFieldNumbersFromMessage(root2, 'ListOfInt');
+      const listOfUserWrapperFields2 = getFieldNumbersFromMessage(root2, 'ListOfUser');
+      const listOfFloatWrapperFields2 = getFieldNumbersFromMessage(root2, 'ListOfFloat');
 
-      // Verify field numbers are preserved
-      expect(listOfStringFields2['items']).toBe(stringItemsNumber);
-      expect(listOfIntFields2['items']).toBe(intItemsNumber);
-      expect(listOfUserFields2['items']).toBe(userItemsNumber);
+      // Get the inner List type field numbers for items verification
+      const stringListType2 = root2.lookupType('ListOfString').lookupType('List');
+      const intListType2 = root2.lookupType('ListOfInt').lookupType('List');
+      const userListType2 = root2.lookupType('ListOfUser').lookupType('List');
+      const floatListType2 = root2.lookupType('ListOfFloat').lookupType('List');
+      
+      const stringListFields2 = getFieldNumbersFromMessage(stringListType2.root, 'List');
+      const intListFields2 = getFieldNumbersFromMessage(intListType2.root, 'List');
+      const userListFields2 = getFieldNumbersFromMessage(userListType2.root, 'List');
+      const floatListFields2 = getFieldNumbersFromMessage(floatListType2.root, 'List');
 
-      // Verify new wrapper type has field number 1
-      expect(listOfFloatFields2['items']).toBe(1);
+      // Verify wrapper field numbers are preserved (outer 'list' field)
+      expect(listOfStringWrapperFields2['list']).toBe(stringWrapperListFieldNumber);
+      expect(listOfIntWrapperFields2['list']).toBe(intWrapperListFieldNumber);
+      expect(listOfUserWrapperFields2['list']).toBe(userWrapperListFieldNumber);
+
+      // Verify inner List field numbers are preserved ('items' field)
+      expect(stringListFields2['items']).toBe(stringListItemsFieldNumber);
+      expect(intListFields2['items']).toBe(intListItemsFieldNumber);
+      expect(userListFields2['items']).toBe(userListItemsFieldNumber);
+
+      // Verify new wrapper types have field number 1
+      expect(listOfFloatWrapperFields2['list']).toBe(1);
+      expect(floatListFields2['items']).toBe(1);
     });
 
     test('should preserve field numbers for nested list wrapper types', () => {
@@ -1247,26 +1283,37 @@ describe('Field Ordering and Preservation', () => {
       const root1 = loadProtoFromText(proto1);
 
       // Verify nested wrapper types exist and get their field numbers
-      const listOfListOfStringFields = getFieldNumbersFromMessage(root1, 'ListOfListOfString');
-      const listOfListOfIntFields = getFieldNumbersFromMessage(root1, 'ListOfListOfInt');
+      const listOfListOfStringWrapperFields = getFieldNumbersFromMessage(root1, 'ListOfListOfString');
+      const listOfListOfIntWrapperFields = getFieldNumbersFromMessage(root1, 'ListOfListOfInt');
 
-      // For nested wrappers, they should have a 'list' field (not 'items')
-      const stringListNumber = listOfListOfStringFields['list'];
-      const intListNumber = listOfListOfIntFields['list'];
+      // For nested wrappers, they should have a 'list' field at the outer level
+      const nestedStringWrapperListFieldNumber = listOfListOfStringWrapperFields['list'];
+      const nestedIntWrapperListFieldNumber = listOfListOfIntWrapperFields['list'];
 
       // Verify nested wrapper types have the 'list' field with field number 1
-      expect(stringListNumber).toBe(1);
-      expect(intListNumber).toBe(1);
+      expect(nestedStringWrapperListFieldNumber).toBe(1);
+      expect(nestedIntWrapperListFieldNumber).toBe(1);
 
-      // Also verify the inner simple wrapper types exist
-      const listOfStringFields = getFieldNumbersFromMessage(root1, 'ListOfString');
-      const listOfIntFields = getFieldNumbersFromMessage(root1, 'ListOfInt');
+      // Also verify the inner simple wrapper types exist and get their field numbers
+      const listOfStringWrapperFields = getFieldNumbersFromMessage(root1, 'ListOfString');
+      const listOfIntWrapperFields = getFieldNumbersFromMessage(root1, 'ListOfInt');
 
-      const stringItemsNumber = listOfStringFields['items'];
-      const intItemsNumber = listOfIntFields['items'];
+      // Get the inner List type field numbers for items
+      const stringListType = root1.lookupType('ListOfString').lookupType('List');
+      const intListType = root1.lookupType('ListOfInt').lookupType('List');
+      
+      const stringListFields = getFieldNumbersFromMessage(stringListType.root, 'List');
+      const intListFields = getFieldNumbersFromMessage(intListType.root, 'List');
 
-      expect(stringItemsNumber).toBe(1);
-      expect(intItemsNumber).toBe(1);
+      const simpleStringWrapperListFieldNumber = listOfStringWrapperFields['list'];
+      const simpleIntWrapperListFieldNumber = listOfIntWrapperFields['list'];
+      const stringListItemsFieldNumber = stringListFields['items'];
+      const intListItemsFieldNumber = intListFields['items'];
+
+      expect(simpleStringWrapperListFieldNumber).toBe(1);
+      expect(simpleIntWrapperListFieldNumber).toBe(1);
+      expect(stringListItemsFieldNumber).toBe(1);
+      expect(intListItemsFieldNumber).toBe(1);
 
       // Get the generated lock data
       const lockData = visitor1.getGeneratedLockData();
@@ -1306,25 +1353,37 @@ describe('Field Ordering and Preservation', () => {
       const root2 = loadProtoFromText(proto2);
 
       // Verify existing wrapper types preserved their field numbers
-      const listOfListOfStringFields2 = getFieldNumbersFromMessage(root2, 'ListOfListOfString');
-      const listOfListOfIntFields2 = getFieldNumbersFromMessage(root2, 'ListOfListOfInt');
-      const listOfListOfUserFields2 = getFieldNumbersFromMessage(root2, 'ListOfListOfUser');
+      const listOfListOfStringWrapperFields2 = getFieldNumbersFromMessage(root2, 'ListOfListOfString');
+      const listOfListOfIntWrapperFields2 = getFieldNumbersFromMessage(root2, 'ListOfListOfInt');
+      const listOfListOfUserWrapperFields2 = getFieldNumbersFromMessage(root2, 'ListOfListOfUser');
 
-      // Verify existing field numbers are preserved
-      expect(listOfListOfStringFields2['list']).toBe(stringListNumber);
-      expect(listOfListOfIntFields2['list']).toBe(intListNumber);
+      // Verify existing nested wrapper field numbers are preserved
+      expect(listOfListOfStringWrapperFields2['list']).toBe(nestedStringWrapperListFieldNumber);
+      expect(listOfListOfIntWrapperFields2['list']).toBe(nestedIntWrapperListFieldNumber);
 
       // Verify new nested wrapper type has field number 1
-      expect(listOfListOfUserFields2['list']).toBe(1);
+      expect(listOfListOfUserWrapperFields2['list']).toBe(1);
 
       // Verify simple wrapper types are still preserved
-      const listOfStringFields2 = getFieldNumbersFromMessage(root2, 'ListOfString');
-      const listOfIntFields2 = getFieldNumbersFromMessage(root2, 'ListOfInt');
-      const listOfUserFields2 = getFieldNumbersFromMessage(root2, 'ListOfUser');
+      const listOfStringWrapperFields2 = getFieldNumbersFromMessage(root2, 'ListOfString');
+      const listOfIntWrapperFields2 = getFieldNumbersFromMessage(root2, 'ListOfInt');
+      const listOfUserWrapperFields2 = getFieldNumbersFromMessage(root2, 'ListOfUser');
 
-      expect(listOfStringFields2['items']).toBe(stringItemsNumber);
-      expect(listOfIntFields2['items']).toBe(intItemsNumber);
-      expect(listOfUserFields2['items']).toBe(1); // New simple wrapper for User
+      // Get the inner List type field numbers for verification
+      const stringListType2 = root2.lookupType('ListOfString').lookupType('List');
+      const intListType2 = root2.lookupType('ListOfInt').lookupType('List');
+      const userListType2 = root2.lookupType('ListOfUser').lookupType('List');
+      
+      const stringListFields2 = getFieldNumbersFromMessage(stringListType2.root, 'List');
+      const intListFields2 = getFieldNumbersFromMessage(intListType2.root, 'List');
+      const userListFields2 = getFieldNumbersFromMessage(userListType2.root, 'List');
+
+      expect(listOfStringWrapperFields2['list']).toBe(simpleStringWrapperListFieldNumber);
+      expect(listOfIntWrapperFields2['list']).toBe(simpleIntWrapperListFieldNumber);
+      expect(stringListFields2['items']).toBe(stringListItemsFieldNumber);
+      expect(intListFields2['items']).toBe(intListItemsFieldNumber);
+      expect(listOfUserWrapperFields2['list']).toBe(1); // New simple wrapper for User
+      expect(userListFields2['items']).toBe(1); // New simple wrapper inner List for User
     });
 
     test('should handle mixed simple and nested wrapper types with field preservation', () => {
@@ -1356,22 +1415,35 @@ describe('Field Ordering and Preservation', () => {
       const root1 = loadProtoFromText(proto1);
 
       // Get field numbers for all wrapper types
-      const listOfStringFields = getFieldNumbersFromMessage(root1, 'ListOfString');
-      const listOfListOfStringFields = getFieldNumbersFromMessage(root1, 'ListOfListOfString');
-      const listOfUserFields = getFieldNumbersFromMessage(root1, 'ListOfUser');
-      const listOfListOfUserFields = getFieldNumbersFromMessage(root1, 'ListOfListOfUser');
+      const listOfStringWrapperFields = getFieldNumbersFromMessage(root1, 'ListOfString');
+      const listOfListOfStringWrapperFields = getFieldNumbersFromMessage(root1, 'ListOfListOfString');
+      const listOfUserWrapperFields = getFieldNumbersFromMessage(root1, 'ListOfUser');
+      const listOfListOfUserWrapperFields = getFieldNumbersFromMessage(root1, 'ListOfListOfUser');
 
-      // Store original field numbers
-      const stringItemsNumber = listOfStringFields['items'];
-      const stringListNumber = listOfListOfStringFields['list'];
-      const userItemsNumber = listOfUserFields['items'];
-      const userListNumber = listOfListOfUserFields['list'];
+      // Get the inner List type field numbers for items
+      const stringListType = root1.lookupType('ListOfString').lookupType('List');
+      const userListType = root1.lookupType('ListOfUser').lookupType('List');
+      
+      const stringListFields = getFieldNumbersFromMessage(stringListType.root, 'List');
+      const userListFields = getFieldNumbersFromMessage(userListType.root, 'List');
 
-      // Verify correct field types for different wrapper levels
-      expect(stringItemsNumber).toBe(1); // Simple wrapper has 'items'
-      expect(stringListNumber).toBe(1); // Nested wrapper has 'list'
-      expect(userItemsNumber).toBe(1); // Simple wrapper has 'items'
-      expect(userListNumber).toBe(1); // Nested wrapper has 'list'
+      // Store original field numbers for wrapper types (outer 'list' field)
+      const simpleStringWrapperListFieldNumber = listOfStringWrapperFields['list'];
+      const simpleUserWrapperListFieldNumber = listOfUserWrapperFields['list'];
+      const nestedStringWrapperListFieldNumber = listOfListOfStringWrapperFields['list'];
+      const nestedUserWrapperListFieldNumber = listOfListOfUserWrapperFields['list'];
+
+      // Store original field numbers for inner List types ('items' field)
+      const stringListItemsFieldNumber = stringListFields['items'];
+      const userListItemsFieldNumber = userListFields['items'];
+
+      // Verify correct field numbers for different wrapper levels
+      expect(simpleStringWrapperListFieldNumber).toBe(1); // Simple wrapper outer 'list' field
+      expect(stringListItemsFieldNumber).toBe(1); // Simple wrapper inner 'items' field
+      expect(nestedStringWrapperListFieldNumber).toBe(1); // Nested wrapper outer 'list' field
+      expect(simpleUserWrapperListFieldNumber).toBe(1); // Simple wrapper outer 'list' field
+      expect(nestedUserWrapperListFieldNumber).toBe(1); // Nested wrapper outer 'list' field
+      expect(userListItemsFieldNumber).toBe(1); // Simple wrapper inner 'items' field
 
       // Get the generated lock data
       const lockData = visitor1.getGeneratedLockData();
@@ -1414,18 +1486,32 @@ describe('Field Ordering and Preservation', () => {
       const root2 = loadProtoFromText(proto2);
 
       // Verify preserved wrapper types maintain their field numbers
-      const listOfStringFields2 = getFieldNumbersFromMessage(root2, 'ListOfString');
-      const listOfUserFields2 = getFieldNumbersFromMessage(root2, 'ListOfUser');
-      const listOfListOfUserFields2 = getFieldNumbersFromMessage(root2, 'ListOfListOfUser');
-      const listOfIntFields2 = getFieldNumbersFromMessage(root2, 'ListOfInt');
+      const listOfStringWrapperFields2 = getFieldNumbersFromMessage(root2, 'ListOfString');
+      const listOfUserWrapperFields2 = getFieldNumbersFromMessage(root2, 'ListOfUser');
+      const listOfListOfUserWrapperFields2 = getFieldNumbersFromMessage(root2, 'ListOfListOfUser');
+      const listOfIntWrapperFields2 = getFieldNumbersFromMessage(root2, 'ListOfInt');
 
-      // Verify field numbers are preserved
-      expect(listOfStringFields2['items']).toBe(stringItemsNumber);
-      expect(listOfUserFields2['items']).toBe(userItemsNumber);
-      expect(listOfListOfUserFields2['list']).toBe(userListNumber);
+      // Get the inner List type field numbers for verification
+      const stringListType2 = root2.lookupType('ListOfString').lookupType('List');
+      const userListType2 = root2.lookupType('ListOfUser').lookupType('List');
+      const intListType2 = root2.lookupType('ListOfInt').lookupType('List');
+      
+      const stringListFields2 = getFieldNumbersFromMessage(stringListType2.root, 'List');
+      const userListFields2 = getFieldNumbersFromMessage(userListType2.root, 'List');
+      const intListFields2 = getFieldNumbersFromMessage(intListType2.root, 'List');
 
-      // Verify new wrapper type has field number 1
-      expect(listOfIntFields2['items']).toBe(1);
+      // Verify wrapper field numbers are preserved (outer 'list' field)
+      expect(listOfStringWrapperFields2['list']).toBe(simpleStringWrapperListFieldNumber);
+      expect(listOfUserWrapperFields2['list']).toBe(simpleUserWrapperListFieldNumber);
+      expect(listOfListOfUserWrapperFields2['list']).toBe(nestedUserWrapperListFieldNumber);
+
+      // Verify inner List field numbers are preserved ('items' field)
+      expect(stringListFields2['items']).toBe(stringListItemsFieldNumber);
+      expect(userListFields2['items']).toBe(userListItemsFieldNumber);
+
+      // Verify new wrapper types have field number 1
+      expect(listOfIntWrapperFields2['list']).toBe(1);
+      expect(intListFields2['items']).toBe(1);
 
       // Verify removed wrapper type is not present
       // Check if the removed wrapper type exists in the proto

--- a/protographic/tests/sdl-to-proto/06-field-ordering.test.ts
+++ b/protographic/tests/sdl-to-proto/06-field-ordering.test.ts
@@ -1162,7 +1162,7 @@ describe('Field Ordering and Preservation', () => {
       const stringListType = root1.lookupType('ListOfString').lookupType('List');
       const intListType = root1.lookupType('ListOfInt').lookupType('List');
       const userListType = root1.lookupType('ListOfUser').lookupType('List');
-      
+
       const stringListFields = getFieldNumbersFromMessage(stringListType.root, 'List');
       const intListFields = getFieldNumbersFromMessage(intListType.root, 'List');
       const userListFields = getFieldNumbersFromMessage(userListType.root, 'List');
@@ -1235,7 +1235,7 @@ describe('Field Ordering and Preservation', () => {
       const intListType2 = root2.lookupType('ListOfInt').lookupType('List');
       const userListType2 = root2.lookupType('ListOfUser').lookupType('List');
       const floatListType2 = root2.lookupType('ListOfFloat').lookupType('List');
-      
+
       const stringListFields2 = getFieldNumbersFromMessage(stringListType2.root, 'List');
       const intListFields2 = getFieldNumbersFromMessage(intListType2.root, 'List');
       const userListFields2 = getFieldNumbersFromMessage(userListType2.root, 'List');
@@ -1301,7 +1301,7 @@ describe('Field Ordering and Preservation', () => {
       // Get the inner List type field numbers for items
       const stringListType = root1.lookupType('ListOfString').lookupType('List');
       const intListType = root1.lookupType('ListOfInt').lookupType('List');
-      
+
       const stringListFields = getFieldNumbersFromMessage(stringListType.root, 'List');
       const intListFields = getFieldNumbersFromMessage(intListType.root, 'List');
 
@@ -1373,7 +1373,7 @@ describe('Field Ordering and Preservation', () => {
       const stringListType2 = root2.lookupType('ListOfString').lookupType('List');
       const intListType2 = root2.lookupType('ListOfInt').lookupType('List');
       const userListType2 = root2.lookupType('ListOfUser').lookupType('List');
-      
+
       const stringListFields2 = getFieldNumbersFromMessage(stringListType2.root, 'List');
       const intListFields2 = getFieldNumbersFromMessage(intListType2.root, 'List');
       const userListFields2 = getFieldNumbersFromMessage(userListType2.root, 'List');
@@ -1423,7 +1423,7 @@ describe('Field Ordering and Preservation', () => {
       // Get the inner List type field numbers for items
       const stringListType = root1.lookupType('ListOfString').lookupType('List');
       const userListType = root1.lookupType('ListOfUser').lookupType('List');
-      
+
       const stringListFields = getFieldNumbersFromMessage(stringListType.root, 'List');
       const userListFields = getFieldNumbersFromMessage(userListType.root, 'List');
 
@@ -1495,7 +1495,7 @@ describe('Field Ordering and Preservation', () => {
       const stringListType2 = root2.lookupType('ListOfString').lookupType('List');
       const userListType2 = root2.lookupType('ListOfUser').lookupType('List');
       const intListType2 = root2.lookupType('ListOfInt').lookupType('List');
-      
+
       const stringListFields2 = getFieldNumbersFromMessage(stringListType2.root, 'List');
       const userListFields2 = getFieldNumbersFromMessage(userListType2.root, 'List');
       const intListFields2 = getFieldNumbersFromMessage(intListType2.root, 'List');

--- a/protographic/tests/sdl-to-proto/11-lists.test.ts
+++ b/protographic/tests/sdl-to-proto/11-lists.test.ts
@@ -67,40 +67,44 @@ describe('SDL to Proto Lists', () => {
     expectValidProto(protoText);
 
     expect(protoText).toMatchInlineSnapshot(`
-          "syntax = "proto3";
-          package service.v1;
+      "syntax = "proto3";
+      package service.v1;
 
-          // Service definition for DefaultService
-          service DefaultService {
-            rpc QueryGetUser(QueryGetUserRequest) returns (QueryGetUserResponse) {}
-          }
+      // Service definition for DefaultService
+      service DefaultService {
+        rpc QueryGetUser(QueryGetUserRequest) returns (QueryGetUserResponse) {}
+      }
 
-          // Wrapper message for a list of String.
-          message ListOfString {
-            repeated string items = 1;
-          }
+      // Wrapper message for a list of String.
+      message ListOfString {
+        message List {
+          repeated string items = 1;
+        }
+        List list = 1;
+      }
+      // Wrapper message for a list of User.
+      message ListOfUser {
+        message List {
+          repeated User items = 1;
+        }
+        List list = 1;
+      }
+      // Request message for getUser operation.
+      message QueryGetUserRequest {
+      }
+      // Response message for getUser operation.
+      message QueryGetUserResponse {
+        User get_user = 1;
+      }
 
-          // Wrapper message for a list of User.
-          message ListOfUser {
-            repeated User items = 1;
-          }
-
-          // Request message for getUser operation.
-          message QueryGetUserRequest {
-          }
-          // Response message for getUser operation.
-          message QueryGetUserResponse {
-            User get_user = 1;
-          }
-
-          message User {
-            string id = 1;
-            string first_name = 2;
-            ListOfString middle_names = 3;
-            string last_name = 4;
-            ListOfUser friends = 5;
-          }"
-        `);
+      message User {
+        string id = 1;
+        string first_name = 2;
+        ListOfString middle_names = 3;
+        string last_name = 4;
+        ListOfUser friends = 5;
+      }"
+    `);
   });
 
   it('should correctly generate protobuf for types with a nested non nullable list', () => {
@@ -135,7 +139,6 @@ describe('SDL to Proto Lists', () => {
         }
         List list = 1;
       }
-
       // Wrapper message for a list of User.
       message ListOfListOfUser {
         message List {
@@ -143,17 +146,20 @@ describe('SDL to Proto Lists', () => {
         }
         List list = 1;
       }
-
       // Wrapper message for a list of String.
       message ListOfString {
-        repeated string items = 1;
+        message List {
+          repeated string items = 1;
+        }
+        List list = 1;
       }
-
       // Wrapper message for a list of User.
       message ListOfUser {
-        repeated User items = 1;
+        message List {
+          repeated User items = 1;
+        }
+        List list = 1;
       }
-
       // Request message for getUser operation.
       message QueryGetUserRequest {
       }
@@ -202,7 +208,6 @@ describe('SDL to Proto Lists', () => {
         }
         List list = 1;
       }
-
       // Wrapper message for a list of User.
       message ListOfListOfUser {
         message List {
@@ -210,17 +215,20 @@ describe('SDL to Proto Lists', () => {
         }
         List list = 1;
       }
-
       // Wrapper message for a list of String.
       message ListOfString {
-        repeated string items = 1;
+        message List {
+          repeated string items = 1;
+        }
+        List list = 1;
       }
-
       // Wrapper message for a list of User.
       message ListOfUser {
-        repeated User items = 1;
+        message List {
+          repeated User items = 1;
+        }
+        List list = 1;
       }
-
       // Request message for getUser operation.
       message QueryGetUserRequest {
       }
@@ -272,7 +280,6 @@ describe('SDL to Proto Lists', () => {
         }
         List list = 1;
       }
-
       // Wrapper message for a list of User.
       message ListOfListOfUser {
         message List {
@@ -280,17 +287,20 @@ describe('SDL to Proto Lists', () => {
         }
         List list = 1;
       }
-
       // Wrapper message for a list of String.
       message ListOfString {
-        repeated string items = 1;
+        message List {
+          repeated string items = 1;
+        }
+        List list = 1;
       }
-
       // Wrapper message for a list of User.
       message ListOfUser {
-        repeated User items = 1;
+        message List {
+          repeated User items = 1;
+        }
+        List list = 1;
       }
-
       // Request message for getUser operation.
       message QueryGetUserRequest {
       }
@@ -350,12 +360,13 @@ describe('SDL to Proto Lists', () => {
         }
         List list = 1;
       }
-
       // Wrapper message for a list of Status.
       message ListOfStatus {
-        repeated Status items = 1;
+        message List {
+          repeated Status items = 1;
+        }
+        List list = 1;
       }
-
       // Request message for getUser operation.
       message QueryGetUserRequest {
       }
@@ -428,12 +439,13 @@ describe('SDL to Proto Lists', () => {
         }
         List list = 1;
       }
-
       // Wrapper message for a list of Node.
       message ListOfNode {
-        repeated Node items = 1;
+        message List {
+          repeated Node items = 1;
+        }
+        List list = 1;
       }
-
       // Request message for getTimeline operation.
       message QueryGetTimelineRequest {
       }
@@ -513,12 +525,13 @@ describe('SDL to Proto Lists', () => {
         }
         List list = 1;
       }
-
       // Wrapper message for a list of SearchResult.
       message ListOfSearchResult {
-        repeated SearchResult items = 1;
+        message List {
+          repeated SearchResult items = 1;
+        }
+        List list = 1;
       }
-
       // Request message for search operation.
       message QuerySearchRequest {
       }
@@ -593,24 +606,32 @@ describe('SDL to Proto Lists', () => {
 
       // Wrapper message for a list of DateTime.
       message ListOfDateTime {
-        repeated string items = 1;
+        message List {
+          repeated string items = 1;
+        }
+        List list = 1;
       }
-
       // Wrapper message for a list of Float.
       message ListOfFloat {
-        repeated double items = 1;
+        message List {
+          repeated double items = 1;
+        }
+        List list = 1;
       }
-
       // Wrapper message for a list of Int.
       message ListOfInt {
-        repeated int32 items = 1;
+        message List {
+          repeated int32 items = 1;
+        }
+        List list = 1;
       }
-
       // Wrapper message for a list of JSON.
       message ListOfJSON {
-        repeated string items = 1;
+        message List {
+          repeated string items = 1;
+        }
+        List list = 1;
       }
-
       // Wrapper message for a list of String.
       message ListOfListOfString {
         message List {
@@ -618,12 +639,13 @@ describe('SDL to Proto Lists', () => {
         }
         List list = 1;
       }
-
       // Wrapper message for a list of String.
       message ListOfString {
-        repeated string items = 1;
+        message List {
+          repeated string items = 1;
+        }
+        List list = 1;
       }
-
       // Request message for getUser operation.
       message QueryGetUserRequest {
       }
@@ -688,7 +710,6 @@ describe('SDL to Proto Lists', () => {
         }
         List list = 1;
       }
-
       // Wrapper message for a list of String.
       message ListOfListOfListOfListOfString {
         message List {
@@ -696,7 +717,6 @@ describe('SDL to Proto Lists', () => {
         }
         List list = 1;
       }
-
       // Wrapper message for a list of User.
       message ListOfListOfListOfListOfUser {
         message List {
@@ -704,7 +724,6 @@ describe('SDL to Proto Lists', () => {
         }
         List list = 1;
       }
-
       // Wrapper message for a list of String.
       message ListOfListOfListOfString {
         message List {
@@ -712,7 +731,6 @@ describe('SDL to Proto Lists', () => {
         }
         List list = 1;
       }
-
       // Wrapper message for a list of User.
       message ListOfListOfListOfUser {
         message List {
@@ -720,7 +738,6 @@ describe('SDL to Proto Lists', () => {
         }
         List list = 1;
       }
-
       // Wrapper message for a list of String.
       message ListOfListOfString {
         message List {
@@ -728,7 +745,6 @@ describe('SDL to Proto Lists', () => {
         }
         List list = 1;
       }
-
       // Wrapper message for a list of User.
       message ListOfListOfUser {
         message List {
@@ -736,17 +752,20 @@ describe('SDL to Proto Lists', () => {
         }
         List list = 1;
       }
-
       // Wrapper message for a list of String.
       message ListOfString {
-        repeated string items = 1;
+        message List {
+          repeated string items = 1;
+        }
+        List list = 1;
       }
-
       // Wrapper message for a list of User.
       message ListOfUser {
-        repeated User items = 1;
+        message List {
+          repeated User items = 1;
+        }
+        List list = 1;
       }
-
       // Request message for getMatrix operation.
       message QueryGetMatrixRequest {
       }
@@ -827,17 +846,20 @@ describe('SDL to Proto Lists', () => {
         }
         List list = 1;
       }
-
       // Wrapper message for a list of String.
       message ListOfString {
-        repeated string items = 1;
+        message List {
+          repeated string items = 1;
+        }
+        List list = 1;
       }
-
       // Wrapper message for a list of UpdateUserInput.
       message ListOfUpdateUserInput {
-        repeated UpdateUserInput items = 1;
+        message List {
+          repeated UpdateUserInput items = 1;
+        }
+        List list = 1;
       }
-
       // Request message for getUser operation.
       message QueryGetUserRequest {
       }
@@ -977,14 +999,18 @@ describe('SDL to Proto Lists', () => {
 
       // Wrapper message for a list of ID.
       message ListOfID {
-        repeated string items = 1;
+        message List {
+          repeated string items = 1;
+        }
+        List list = 1;
       }
-
       // Wrapper message for a list of Item.
       message ListOfItem {
-        repeated Item items = 1;
+        message List {
+          repeated Item items = 1;
+        }
+        List list = 1;
       }
-
       // Wrapper message for a list of Item.
       message ListOfListOfItem {
         message List {
@@ -992,7 +1018,6 @@ describe('SDL to Proto Lists', () => {
         }
         List list = 1;
       }
-
       // Wrapper message for a list of Item.
       message ListOfListOfListOfItem {
         message List {
@@ -1000,7 +1025,6 @@ describe('SDL to Proto Lists', () => {
         }
         List list = 1;
       }
-
       // Wrapper message for a list of Priority.
       message ListOfListOfListOfListOfPriority {
         message List {
@@ -1008,7 +1032,6 @@ describe('SDL to Proto Lists', () => {
         }
         List list = 1;
       }
-
       // Wrapper message for a list of Priority.
       message ListOfListOfListOfPriority {
         message List {
@@ -1016,7 +1039,6 @@ describe('SDL to Proto Lists', () => {
         }
         List list = 1;
       }
-
       // Wrapper message for a list of Priority.
       message ListOfListOfPriority {
         message List {
@@ -1024,7 +1046,6 @@ describe('SDL to Proto Lists', () => {
         }
         List list = 1;
       }
-
       // Wrapper message for a list of String.
       message ListOfListOfString {
         message List {
@@ -1032,22 +1053,27 @@ describe('SDL to Proto Lists', () => {
         }
         List list = 1;
       }
-
       // Wrapper message for a list of Node.
       message ListOfNode {
-        repeated Node items = 1;
+        message List {
+          repeated Node items = 1;
+        }
+        List list = 1;
       }
-
       // Wrapper message for a list of Priority.
       message ListOfPriority {
-        repeated Priority items = 1;
+        message List {
+          repeated Priority items = 1;
+        }
+        List list = 1;
       }
-
       // Wrapper message for a list of String.
       message ListOfString {
-        repeated string items = 1;
+        message List {
+          repeated string items = 1;
+        }
+        List list = 1;
       }
-
       // Request message for getComplex operation.
       message QueryGetComplexRequest {
         FilterInput filter = 1;
@@ -1167,7 +1193,6 @@ describe('SDL to Proto Lists', () => {
         }
         List list = 1;
       }
-
       // Wrapper message for a list of User.
       message ListOfListOfUser {
         message List {
@@ -1175,17 +1200,20 @@ describe('SDL to Proto Lists', () => {
         }
         List list = 1;
       }
-
       // Wrapper message for a list of String.
       message ListOfString {
-        repeated string items = 1;
+        message List {
+          repeated string items = 1;
+        }
+        List list = 1;
       }
-
       // Wrapper message for a list of User.
       message ListOfUser {
-        repeated User items = 1;
+        message List {
+          repeated User items = 1;
+        }
+        List list = 1;
       }
-
       // Request message for getEdgeCases operation.
       message QueryGetEdgeCasesRequest {
       }
@@ -1273,14 +1301,18 @@ describe('SDL to Proto Lists', () => {
 
       // Wrapper message for a list of Category.
       message ListOfCategory {
-        repeated Category items = 1;
+        message List {
+          repeated Category items = 1;
+        }
+        List list = 1;
       }
-
       // Wrapper message for a list of Comment.
       message ListOfComment {
-        repeated Comment items = 1;
+        message List {
+          repeated Comment items = 1;
+        }
+        List list = 1;
       }
-
       // Wrapper message for a list of Category.
       message ListOfListOfCategory {
         message List {
@@ -1288,7 +1320,6 @@ describe('SDL to Proto Lists', () => {
         }
         List list = 1;
       }
-
       // Wrapper message for a list of Comment.
       message ListOfListOfComment {
         message List {
@@ -1296,7 +1327,6 @@ describe('SDL to Proto Lists', () => {
         }
         List list = 1;
       }
-
       // Wrapper message for a list of User.
       message ListOfListOfUser {
         message List {
@@ -1304,12 +1334,13 @@ describe('SDL to Proto Lists', () => {
         }
         List list = 1;
       }
-
       // Wrapper message for a list of User.
       message ListOfUser {
-        repeated User items = 1;
+        message List {
+          repeated User items = 1;
+        }
+        List list = 1;
       }
-
       // Request message for getUser operation.
       message QueryGetUserRequest {
       }
@@ -1439,19 +1470,25 @@ describe('SDL to Proto Lists', () => {
 
       // Wrapper message for a list of Float.
       message ListOfFloat {
-        repeated double items = 1;
+        message List {
+          repeated double items = 1;
+        }
+        List list = 1;
       }
-
       // Wrapper message for a list of ID.
       message ListOfID {
-        repeated string items = 1;
+        message List {
+          repeated string items = 1;
+        }
+        List list = 1;
       }
-
       // Wrapper message for a list of Int.
       message ListOfInt {
-        repeated int32 items = 1;
+        message List {
+          repeated int32 items = 1;
+        }
+        List list = 1;
       }
-
       // Wrapper message for a list of TagInput.
       message ListOfListOfTagInput {
         message List {
@@ -1459,7 +1496,6 @@ describe('SDL to Proto Lists', () => {
         }
         List list = 1;
       }
-
       // Wrapper message for a list of UserFilterInput.
       message ListOfListOfUserFilterInput {
         message List {
@@ -1467,27 +1503,34 @@ describe('SDL to Proto Lists', () => {
         }
         List list = 1;
       }
-
       // Wrapper message for a list of SortInput.
       message ListOfSortInput {
-        repeated SortInput items = 1;
+        message List {
+          repeated SortInput items = 1;
+        }
+        List list = 1;
       }
-
       // Wrapper message for a list of String.
       message ListOfString {
-        repeated string items = 1;
+        message List {
+          repeated string items = 1;
+        }
+        List list = 1;
       }
-
       // Wrapper message for a list of TagInput.
       message ListOfTagInput {
-        repeated TagInput items = 1;
+        message List {
+          repeated TagInput items = 1;
+        }
+        List list = 1;
       }
-
       // Wrapper message for a list of UserFilterInput.
       message ListOfUserFilterInput {
-        repeated UserFilterInput items = 1;
+        message List {
+          repeated UserFilterInput items = 1;
+        }
+        List list = 1;
       }
-
       // Request message for searchUsers operation.
       message QuerySearchUsersRequest {
         SearchInput input = 1;
@@ -1645,19 +1688,25 @@ describe('SDL to Proto Lists', () => {
 
       // Wrapper message for a list of CategoryInput.
       message ListOfCategoryInput {
-        repeated CategoryInput items = 1;
+        message List {
+          repeated CategoryInput items = 1;
+        }
+        List list = 1;
       }
-
       // Wrapper message for a list of CommentInput.
       message ListOfCommentInput {
-        repeated CommentInput items = 1;
+        message List {
+          repeated CommentInput items = 1;
+        }
+        List list = 1;
       }
-
       // Wrapper message for a list of FilterNodeInput.
       message ListOfFilterNodeInput {
-        repeated FilterNodeInput items = 1;
+        message List {
+          repeated FilterNodeInput items = 1;
+        }
+        List list = 1;
       }
-
       // Wrapper message for a list of CategoryInput.
       message ListOfListOfCategoryInput {
         message List {
@@ -1665,7 +1714,6 @@ describe('SDL to Proto Lists', () => {
         }
         List list = 1;
       }
-
       // Wrapper message for a list of CommentInput.
       message ListOfListOfCommentInput {
         message List {
@@ -1673,7 +1721,6 @@ describe('SDL to Proto Lists', () => {
         }
         List list = 1;
       }
-
       // Wrapper message for a list of FilterNodeInput.
       message ListOfListOfFilterNodeInput {
         message List {
@@ -1681,7 +1728,6 @@ describe('SDL to Proto Lists', () => {
         }
         List list = 1;
       }
-
       // Request message for getCategory operation.
       message QueryGetCategoryRequest {
       }
@@ -1873,7 +1919,6 @@ describe('SDL to Proto Lists', () => {
         }
         List list = 1;
       }
-
       // Wrapper message for a list of String.
       message ListOfListOfString {
         message List {
@@ -1881,7 +1926,6 @@ describe('SDL to Proto Lists', () => {
         }
         List list = 1;
       }
-
       // Wrapper message for a list of TreeNode.
       message ListOfListOfTreeNode {
         message List {
@@ -1889,7 +1933,6 @@ describe('SDL to Proto Lists', () => {
         }
         List list = 1;
       }
-
       // Wrapper message for a list of TreeNodeInput.
       message ListOfListOfTreeNodeInput {
         message List {
@@ -1897,32 +1940,41 @@ describe('SDL to Proto Lists', () => {
         }
         List list = 1;
       }
-
       // Wrapper message for a list of MetadataInput.
       message ListOfMetadataInput {
-        repeated MetadataInput items = 1;
+        message List {
+          repeated MetadataInput items = 1;
+        }
+        List list = 1;
       }
-
       // Wrapper message for a list of ProcessingResult.
       message ListOfProcessingResult {
-        repeated ProcessingResult items = 1;
+        message List {
+          repeated ProcessingResult items = 1;
+        }
+        List list = 1;
       }
-
       // Wrapper message for a list of String.
       message ListOfString {
-        repeated string items = 1;
+        message List {
+          repeated string items = 1;
+        }
+        List list = 1;
       }
-
       // Wrapper message for a list of TreeNode.
       message ListOfTreeNode {
-        repeated TreeNode items = 1;
+        message List {
+          repeated TreeNode items = 1;
+        }
+        List list = 1;
       }
-
       // Wrapper message for a list of TreeNodeInput.
       message ListOfTreeNodeInput {
-        repeated TreeNodeInput items = 1;
+        message List {
+          repeated TreeNodeInput items = 1;
+        }
+        List list = 1;
       }
-
       // Request message for getTree operation.
       message QueryGetTreeRequest {
       }


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the structure of list wrapper messages in generated protobuf definitions to consistently use a nested message pattern, where each wrapper now contains an inner message with repeated items and a single field referencing this inner message.

* **Tests**
  * Updated test snapshots and assertions to reflect the new nested message structure for list wrappers.
  * Enhanced test coverage to verify field numbers and structure for both outer wrapper messages and their nested inner messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).