### PR TITLE
feat: rate limit config per key [WIP]

### DIFF
--- a/router/core/graph_server.go
+++ b/router/core/graph_server.go
@@ -1315,10 +1315,12 @@ func (s *graphServer) buildGraphMux(
 	if s.redisClient != nil {
 		handlerOpts.RateLimitConfig = s.rateLimit
 		handlerOpts.RateLimiter, err = NewCosmoRateLimiter(&CosmoRateLimiterOptions{
-			RedisClient:         s.redisClient,
-			Debug:               s.rateLimit.Debug,
-			RejectStatusCode:    s.rateLimit.SimpleStrategy.RejectStatusCode,
+			RedisClient: s.redisClient,
+			Debug:       s.rateLimit.Debug,
+			//RejectStatusCode:    s.rateLimit.SimpleStrategy.RejectStatusCode,
 			KeySuffixExpression: s.rateLimit.KeySuffixExpression,
+			RateLimitConfig:     s.rateLimit.SimpleStrategy,
+			BaseRateLimitKey:    s.rateLimit.Storage.KeyPrefix,
 			ExprManager:         exprManager,
 		})
 		if err != nil {

--- a/router/core/graphql_handler.go
+++ b/router/core/graphql_handler.go
@@ -269,12 +269,8 @@ func (h *GraphQLHandler) configureRateLimiting(ctx *resolve.Context) *resolve.Co
 	ctx.SetRateLimiter(h.rateLimiter)
 	ctx.RateLimitOptions = resolve.RateLimitOptions{
 		Enable:                          true,
-		IncludeStatsInResponseExtension: !h.rateLimitConfig.SimpleStrategy.HideStatsFromResponseExtension,
-		Rate:                            h.rateLimitConfig.SimpleStrategy.Rate,
-		Burst:                           h.rateLimitConfig.SimpleStrategy.Burst,
-		Period:                          h.rateLimitConfig.SimpleStrategy.Period,
-		RateLimitKey:                    h.rateLimitConfig.Storage.KeyPrefix,
-		RejectExceedingRequests:         h.rateLimitConfig.SimpleStrategy.RejectExceedingRequests,
+		IncludeStatsInResponseExtension: !h.rateLimitConfig.HideStatsFromResponseExtension,
+		//RateLimitKey:                    h.rateLimitConfig.Storage.KeyPrefix,
 		ErrorExtensionCode: resolve.RateLimitErrorExtensionCode{
 			Enabled: h.rateLimitConfig.ErrorExtensionCode.Enabled,
 			Code:    h.rateLimitConfig.ErrorExtensionCode.Code,
@@ -317,7 +313,7 @@ func (h *GraphQLHandler) WriteError(ctx *resolve.Context, err error, res *resolv
 				Code: h.rateLimitConfig.ErrorExtensionCode.Code,
 			}
 		}
-		if !h.rateLimitConfig.SimpleStrategy.HideStatsFromResponseExtension {
+		if !h.rateLimitConfig.HideStatsFromResponseExtension {
 			buf := bytes.NewBuffer(make([]byte, 0, 1024))
 			err = h.rateLimiter.RenderResponseExtension(ctx, buf)
 			if err != nil {

--- a/router/core/ratelimiter_test.go
+++ b/router/core/ratelimiter_test.go
@@ -40,7 +40,7 @@ func TestRateLimiterGenerateKey(t *testing.T) {
 		t.Parallel()
 		rl, err := NewCosmoRateLimiter(&CosmoRateLimiterOptions{})
 		assert.NoError(t, err)
-		key, err := rl.generateKey(expressionResolveContext(t, nil, nil))
+		key, err := rl.generateKey(expressionResolveContext(t, nil, nil), nil)
 		assert.NoError(t, err)
 		assert.Equal(t, "test", key)
 	})
@@ -51,9 +51,7 @@ func TestRateLimiterGenerateKey(t *testing.T) {
 			ExprManager:         expr.CreateNewExprManager(),
 		})
 		require.NoError(t, err)
-		key, err := rl.generateKey(
-			expressionResolveContext(t, http.Header{"Authorization": []string{"token"}}, nil),
-		)
+		key, err := rl.generateKey(expressionResolveContext(t, http.Header{"Authorization": []string{"token"}}, nil), nil)
 		assert.NoError(t, err)
 		assert.Equal(t, "test:token", key)
 	})
@@ -64,9 +62,7 @@ func TestRateLimiterGenerateKey(t *testing.T) {
 			ExprManager:         expr.CreateNewExprManager(),
 		})
 		assert.NoError(t, err)
-		key, err := rl.generateKey(
-			expressionResolveContext(t, http.Header{"Authorization": []string{"123"}}, nil),
-		)
+		key, err := rl.generateKey(expressionResolveContext(t, http.Header{"Authorization": []string{"123"}}, nil), nil)
 		assert.NoError(t, err)
 		assert.Equal(t, "test:123", key)
 	})
@@ -77,9 +73,7 @@ func TestRateLimiterGenerateKey(t *testing.T) {
 			ExprManager:         expr.CreateNewExprManager(),
 		})
 		assert.NoError(t, err)
-		key, err := rl.generateKey(
-			expressionResolveContext(t, http.Header{"Authorization": []string{"  token  "}}, nil),
-		)
+		key, err := rl.generateKey(expressionResolveContext(t, http.Header{"Authorization": []string{"  token  "}}, nil), nil)
 		assert.NoError(t, err)
 		assert.Equal(t, "test:token", key)
 	})
@@ -90,9 +84,7 @@ func TestRateLimiterGenerateKey(t *testing.T) {
 			ExprManager:         expr.CreateNewExprManager(),
 		})
 		assert.NoError(t, err)
-		key, err := rl.generateKey(
-			expressionResolveContext(t, nil, map[string]any{"sub": "token"}),
-		)
+		key, err := rl.generateKey(expressionResolveContext(t, nil, map[string]any{"sub": "token"}), nil)
 		assert.NoError(t, err)
 		assert.Equal(t, "test:token", key)
 	})
@@ -103,9 +95,7 @@ func TestRateLimiterGenerateKey(t *testing.T) {
 			ExprManager:         expr.CreateNewExprManager(),
 		})
 		assert.NoError(t, err)
-		key, err := rl.generateKey(
-			expressionResolveContext(t, nil, map[string]any{"sub": 123}),
-		)
+		key, err := rl.generateKey(expressionResolveContext(t, nil, map[string]any{"sub": 123}), nil)
 		assert.Error(t, err)
 		assert.Empty(t, key)
 	})
@@ -116,9 +106,7 @@ func TestRateLimiterGenerateKey(t *testing.T) {
 			ExprManager:         expr.CreateNewExprManager(),
 		})
 		assert.NoError(t, err)
-		key, err := rl.generateKey(
-			expressionResolveContext(t, http.Header{"X-Forwarded-For": []string{"192.168.0.1"}}, map[string]any{"sub": "token"}),
-		)
+		key, err := rl.generateKey(expressionResolveContext(t, http.Header{"X-Forwarded-For": []string{"192.168.0.1"}}, map[string]any{"sub": "token"}), nil)
 		assert.NoError(t, err)
 		assert.Equal(t, "test:token", key)
 	})
@@ -129,9 +117,7 @@ func TestRateLimiterGenerateKey(t *testing.T) {
 			ExprManager:         expr.CreateNewExprManager(),
 		})
 		assert.NoError(t, err)
-		key, err := rl.generateKey(
-			expressionResolveContext(t, http.Header{"X-Forwarded-For": []string{"192.168.0.1"}}, nil),
-		)
+		key, err := rl.generateKey(expressionResolveContext(t, http.Header{"X-Forwarded-For": []string{"192.168.0.1"}}, nil), nil)
 		assert.NoError(t, err)
 		assert.Equal(t, "test:192.168.0.1", key)
 	})

--- a/router/pkg/authentication/jwks_token_decoder.go
+++ b/router/pkg/authentication/jwks_token_decoder.go
@@ -96,7 +96,7 @@ func NewJwksTokenDecoder(ctx context.Context, logger *zap.Logger, configs []JWKS
 					c.URL: store,
 				},
 				PrioritizeHTTP:    true,
-				RefreshUnknownKID: rate.NewLimiter(rate.Every(5*time.Minute), 1),
+				RefreshUnknownKID: rate.NewLimiter(rate.Every(2*time.Second), 1),
 			}
 
 			jwks, err := createKeyFunc(ctx, jwksetHTTPClientOptions)

--- a/router/pkg/config/config.go
+++ b/router/pkg/config/config.go
@@ -507,6 +507,10 @@ type RateLimitConfiguration struct {
 	Debug               bool                        `yaml:"debug" envDefault:"false" env:"RATE_LIMIT_DEBUG"`
 	KeySuffixExpression string                      `yaml:"key_suffix_expression,omitempty" env:"RATE_LIMIT_KEY_SUFFIX_EXPRESSION"`
 	ErrorExtensionCode  RateLimitErrorExtensionCode `yaml:"error_extension_code"`
+
+	// This makes more sense here since it's a single value for the whole rate limit configuration
+	// Since we cannot have this per subgraph
+	HideStatsFromResponseExtension bool `yaml:"hide_stats_from_response_extension" envDefault:"false" env:"RATE_LIMIT_SIMPLE_HIDE_STATS_FROM_RESPONSE_EXTENSION"`
 }
 
 type RateLimitErrorExtensionCode struct {
@@ -521,12 +525,23 @@ type RedisConfiguration struct {
 }
 
 type RateLimitSimpleStrategy struct {
-	Rate                           int           `yaml:"rate" envDefault:"10" env:"RATE_LIMIT_SIMPLE_RATE"`
-	Burst                          int           `yaml:"burst" envDefault:"10" env:"RATE_LIMIT_SIMPLE_BURST"`
-	Period                         time.Duration `yaml:"period" envDefault:"1s" env:"RATE_LIMIT_SIMPLE_PERIOD"`
-	RejectExceedingRequests        bool          `yaml:"reject_exceeding_requests" envDefault:"false" env:"RATE_LIMIT_SIMPLE_REJECT_EXCEEDING_REQUESTS"`
-	RejectStatusCode               int           `yaml:"reject_status_code" envDefault:"200" env:"RATE_LIMIT_SIMPLE_REJECT_STATUS_CODE"`
-	HideStatsFromResponseExtension bool          `yaml:"hide_stats_from_response_extension" envDefault:"false" env:"RATE_LIMIT_SIMPLE_HIDE_STATS_FROM_RESPONSE_EXTENSION"`
+	RateLimitSimpleStrategyEntry
+	//Enabled                 bool                                    `yaml:"enabled" envDefault:"true" env:"RATE_LIMIT_SIMPLE_ENABLED"`
+	//Rate                    int                                     `yaml:"rate" envDefault:"10" env:"RATE_LIMIT_SIMPLE_RATE"`
+	//Burst                   int                                     `yaml:"burst" envDefault:"10" env:"RATE_LIMIT_SIMPLE_BURST"`
+	//Period                  time.Duration                           `yaml:"period" envDefault:"1s" env:"RATE_LIMIT_SIMPLE_PERIOD"`
+	//RejectExceedingRequests bool                                    `yaml:"reject_exceeding_requests" envDefault:"false" env:"RATE_LIMIT_SIMPLE_REJECT_EXCEEDING_REQUESTS"`
+	//RejectStatusCode        int                                     `yaml:"reject_status_code" envDefault:"200" env:"RATE_LIMIT_SIMPLE_REJECT_STATUS_CODE"`
+	KeyMapping map[string]RateLimitSimpleStrategyEntry `yaml:"key_mapping"`
+}
+
+type RateLimitSimpleStrategyEntry struct {
+	Enabled                 bool          `yaml:"enabled" envDefault:"true" env:"RATE_LIMIT_SIMPLE_ENABLED"`
+	Rate                    int           `yaml:"rate" envDefault:"10" env:"RATE_LIMIT_SIMPLE_RATE"`
+	Burst                   int           `yaml:"burst" envDefault:"10" env:"RATE_LIMIT_SIMPLE_BURST"`
+	Period                  time.Duration `yaml:"period" envDefault:"1s" env:"RATE_LIMIT_SIMPLE_PERIOD"`
+	RejectExceedingRequests bool          `yaml:"reject_exceeding_requests" envDefault:"false" env:"RATE_LIMIT_SIMPLE_REJECT_EXCEEDING_REQUESTS"`
+	RejectStatusCode        int           `yaml:"reject_status_code" envDefault:"200" env:"RATE_LIMIT_SIMPLE_REJECT_STATUS_CODE"`
 }
 
 type CDNConfiguration struct {

--- a/router/pkg/config/config.schema.json
+++ b/router/pkg/config/config.schema.json
@@ -1820,6 +1820,47 @@
               "type": "boolean",
               "default": false,
               "description": "Hide the rate limit stats from the response extension. If the value is true, the rate limit stats are not included in the response extension."
+            },
+            "key_mapping": {
+              "type": "object",
+              "description": "The configuration per key entry.",
+              "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "description": "The configuration for all subgraphs. The configuration is used to configure the traffic shaping for all subgraphs.",
+                "properties": {
+                  "enabled": {
+                    "type": "boolean",
+                    "description": "The rate at which the requests are allowed. The rate is specified as a number of requests per second."
+                  },
+                  "rate": {
+                    "type": "integer",
+                    "description": "The rate at which the requests are allowed. The rate is specified as a number of requests per second.",
+                    "minimum": 1
+                  },
+                  "burst": {
+                    "type": "integer",
+                    "description": "The maximum number of requests that are allowed to exceed the rate. The burst is specified as a number of requests.",
+                    "minimum": 1
+                  },
+                  "period": {
+                    "type": "string",
+                    "description": "The period of time over which the rate limit is enforced. The period is specified as a string with a number and a unit, e.g. 10ms, 1s, 1m, 1h. The supported units are 'ms', 's', 'm', 'h'.",
+                    "duration": {
+                      "minimum": "1s"
+                    }
+                  },
+                  "reject_exceeding_requests": {
+                    "type": "boolean",
+                    "description": "Reject the requests that exceed the rate limit. If the value is true, the requests that exceed the rate limit are rejected."
+                  },
+                  "reject_status_code": {
+                    "type": "integer",
+                    "description": "The status code to return when the request is rejected. The default value is 200 (OK) as we're returning a well formed GraphQL response.",
+                    "default": 200
+                  }
+                }
+              }
             }
           },
           "required": ["rate", "burst", "period"]


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

We currently have the ability to specify dynamic rate limiting keys, we want to be able to specify rate limits per subgraphs. Since the expression context can contain the subgraph name, we utilize that information to allow the user to specify a rate limit key using expressions, and specify configurations per keys.

Example Configuration

```
rate_limit:
  enabled: true
  storage:
    cluster_enabled: false # set to true to use a Redis Cluster
    urls:
      - redis://localhost:6379
  key_suffix_expression: "subgraph.name"
  simple_strategy:
    rate: 10
    burst: 10
    period: 10s
    key_mapping:
      employees:
        enabled: true
        rate: 1
        burst: 1
        period: 5s
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced support for per-key rate limiting configuration, allowing individual rate limit settings for different keys.
  * Added a global option to hide rate limit stats from response extensions.

* **Improvements**
  * Enhanced rate limiting flexibility with a new configuration structure, enabling more granular control.
  * Increased the refresh frequency for unknown JWKS key IDs, improving token validation responsiveness.

* **Bug Fixes**
  * Rate limiting logic now correctly skips or applies limits based on the enabled status of each configuration entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->