### PR TITLE
fix: don't reuse request field numbers when arguments are removed

### DIFF
--- a/protographic/src/sdl-to-proto-visitor.ts
+++ b/protographic/src/sdl-to-proto-visitor.ts
@@ -9,7 +9,6 @@ import {
   GraphQLList,
   GraphQLNamedType,
   GraphQLNonNull,
-  GraphQLNullableType,
   GraphQLObjectType,
   GraphQLSchema,
   GraphQLType,
@@ -845,10 +844,7 @@ Example:
     const lockData = this.lockManager.getLockData();
     const argNames = field.args.map((arg) => graphqlFieldToProtoField(arg.name));
 
-    if (lockData.messages[requestName]) {
-      const originalFieldNames = Object.keys(lockData.messages[requestName].fields);
-      this.trackRemovedFields(requestName, originalFieldNames, argNames);
-    }
+    this.lockManager.reconcileMessageFieldOrder(requestName, argNames);
 
     // Add a description comment for the request message
     if (this.includeComments) {
@@ -883,8 +879,11 @@ Example:
         const argType = this.getProtoTypeFromGraphQL(arg.type);
         const argProtoName = graphqlFieldToProtoField(arg.name);
 
-        // Get the field number from the messages structure using the original field name
-        const fieldNumber = lockData.messages[operationName]?.fields[argName];
+        const fieldNumber = this.getFieldNumber(
+          requestName,
+          argProtoName,
+          this.getNextAvailableFieldNumber(requestName),
+        );
 
         // Add argument description as comment
         if (arg.description) {

--- a/protographic/tests/sdl-to-proto/08-proto-lock-manager.test.ts
+++ b/protographic/tests/sdl-to-proto/08-proto-lock-manager.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import { ProtoLockManager } from '../../src/proto-lock';
+import { compileGraphQLToProto } from '../../src';
 
 describe('ProtoLockManager', () => {
   test('should correctly initialize lock data with ordered fields', () => {
@@ -185,5 +186,40 @@ describe('ProtoLockManager', () => {
     expect(lockData.messages.Message.reservedNumbers).toContain(2);
     expect(lockData.messages.Message.reservedNumbers).toContain(3);
     expect(lockData.messages.Message.reservedNumbers).toContain(4);
+  });
+
+  test('field indexes should not overlap when re-adding arguments', () => {
+    const schemaWithArgument = `
+      type Query {
+        hello(name: String!): String!
+      }
+    `;
+
+    const schemaWithoutArgument = `
+      type Query {
+        hello: String!
+      }
+    `;
+
+    const result1 = compileGraphQLToProto(schemaWithArgument);
+    expect(result1.lockData).not.toBeNull();
+
+    // Argument 'name' should be field 1 on the request message
+    expect(result1.lockData!.messages?.QueryHelloRequest?.fields?.name).toBe(1);
+
+    // Remove the name field from the arguments, and thus lock field 1 of the request message
+    const result2 = compileGraphQLToProto(schemaWithoutArgument, { lockData: result1.lockData! });
+    expect(result2.lockData).not.toBeNull();
+
+    // The index of the previous 'name' field on the request message should be reserved
+    expect(result2.lockData!.messages?.QueryHelloRequest?.reservedNumbers).toContain(1);
+
+    // Add the name argument back, should be index 2 now, we do not reuse indices
+    const result3 = compileGraphQLToProto(schemaWithArgument, { lockData: result2.lockData! });
+    expect(result3.lockData).not.toBeNull();
+
+    // Check that field 1 is still reserved, and that name is now field 2
+    expect(result3.lockData!.messages?.QueryHelloRequest?.reservedNumbers).toContain(1);
+    expect(result3.lockData!.messages?.QueryHelloRequest?.fields?.name, 'name field should be field 2').toBe(2);
   });
 });


### PR DESCRIPTION


<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of field numbering for GraphQL arguments to ensure removed field numbers are not reused, maintaining consistent and non-overlapping field assignments.

* **Tests**
  * Added tests to verify that field numbers for removed arguments remain reserved and are not reassigned when arguments are re-added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->