### PR TITLE
fix: update the registry url in the cli

### DIFF
--- a/cli/src/core/config.ts
+++ b/cli/src/core/config.ts
@@ -34,7 +34,7 @@ export const config = {
   checkAuthor: process.env.COSMO_VCS_AUTHOR || '',
   checkCommitSha: process.env.COSMO_VCS_COMMIT || '',
   checkBranch: process.env.COSMO_VCS_BRANCH || '',
-  pluginRegistryURL: process.env.PLUGIN_REGISTRY_URL || 'cosmo-registry.wundergraph-staging.workers.dev',
+  pluginRegistryURL: process.env.PLUGIN_REGISTRY_URL || 'cosmo-registry.wundergraph.com',
 };
 
 export const getBaseHeaders = (): HeadersInit => {


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the default plugin registry endpoint to the production service (cosmo-registry.wundergraph.com) when no environment override is set.
  * Users without PLUGIN_REGISTRY_URL will now connect to the production registry by default.
  * No changes to other configuration behaviors or headers.
  * No action required unless you rely on the previous staging endpoint; you can still override via PLUGIN_REGISTRY_URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [x] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->