### PR TITLE
fix: check auth in the cli for a few plugin commands

### DIFF
--- a/cli/src/commands/router/index.ts
+++ b/cli/src/commands/router/index.ts
@@ -40,7 +40,11 @@ export default (opts: BaseCommandOptions) => {
   );
 
   cmd.hook('preAction', async (thisCmd) => {
-    if (['compose', 'download-binary', 'compatibility-version', 'plugin'].includes(thisCmd.args[0])) {
+    if (['compose', 'download-binary', 'compatibility-version'].includes(thisCmd.args[0])) {
+      return;
+    }
+
+    if (thisCmd.args[0] === 'plugin' && ['build', 'generate', 'init', 'test'].includes(thisCmd.args[1])) {
       return;
     }
     await checkAuth();


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Streamlined CLI experience: no login required for compose, download-binary, compatibility-version, and plugin build/generate/init/test commands.
- Bug Fixes
  - Corrected authentication behavior: other plugin subcommands now properly require login.
  - No changes to CLI command syntax or flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [x] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).