### PR TITLE
feat: update the limits of plugins

### DIFF
--- a/controlplane/src/bin/billing.json
+++ b/controlplane/src/bin/billing.json
@@ -28,6 +28,11 @@
         {
           "id": "field-pruning-grace-period",
           "limit": 0
+        },
+        {
+          "id": "plugins",
+          "description": "3 Plugins",
+          "limit": 3
         }
       ]
     },
@@ -72,8 +77,8 @@
         },
         {
           "id": "plugins",
-          "description": "3 Plugins",
-          "limit": 3
+          "description": "10 Plugins",
+          "limit": 10
         }
       ]
     },
@@ -124,8 +129,8 @@
         },
         {
           "id": "plugins",
-          "description": "15 Plugins",
-          "limit": 15
+          "description": "20 Plugins",
+          "limit": 20
         }
       ]
     },
@@ -173,7 +178,7 @@
         {
           "id": "plugins",
           "description": "Unlimited Plugins",
-          "limit": 20
+          "limit": 30
         }
       ]
     }

--- a/controlplane/test/feature-subgraph/create-feature-subgraph.test.ts
+++ b/controlplane/test/feature-subgraph/create-feature-subgraph.test.ts
@@ -418,7 +418,7 @@ describe('Create feature subgraph tests', () => {
   test('that creating a feature subgraph from a plugin base fails when plugin limit is reached', async () => {
     const { client, server } = await SetupTest({
       dbname,
-      setupBilling: { plan: 'launch@1' }, // Launch plan allows max 3 plugins
+      setupBilling: { plan: 'developer@1' }, // Developer plan allows max 3 plugins
     });
 
     const basePluginName = genID('basePlugin');

--- a/controlplane/test/plugin/validate-and-fetch-plugin-data.test.ts
+++ b/controlplane/test/plugin/validate-and-fetch-plugin-data.test.ts
@@ -137,13 +137,28 @@ describe('ValidateAndFetchPluginData', () => {
       setupBilling: { plan: 'developer@1' }, // Developer plan has 0 plugin limit
     });
 
-    const pluginName = genID('plugin');
-    const label = genUniqueLabel('test');
+    // Create 3 plugins successfully
+    for (let i = 1; i <= 3; i++) {
+      const pluginName = genID(`plugin-${i}`);
+      const pluginLabel = genUniqueLabel(`team-${i}`);
+
+      const createPluginSubgraphResp = await client.createFederatedSubgraph({
+        name: pluginName,
+        namespace: DEFAULT_NAMESPACE,
+        type: SubgraphType.GRPC_PLUGIN,
+        labels: [pluginLabel],
+      });
+
+      expect(createPluginSubgraphResp.response?.code).toBe(EnumStatusCode.OK);
+    }
+
+    const fourthPluginName = genID('plugin-4');
+    const fourthPluginLabel = genUniqueLabel('team-4');
 
     const response = await client.validateAndFetchPluginData({
-      name: pluginName,
+      name: fourthPluginName,
       namespace: DEFAULT_NAMESPACE,
-      labels: [label],
+      labels: [fourthPluginLabel],
     });
 
     expect(response.response?.code).toBe(EnumStatusCode.ERR_LIMIT_REACHED);


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Developer plan now includes Plugins (up to 3).
  - Launch plan plugin limit increased to 10.
  - Scale plan plugin limit increased to 20.
  - Enterprise plan plugin capacity increased while remaining effectively unlimited for users.
- Tests
  - Updated tests to reflect new plugin limits across plans.
  - Added scenarios validating limit enforcement during creation and publish flows.
  - Ensured non-plugin subgraphs are unaffected by plugin limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [x] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [x] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).
