### PR TITLE
fix: add tracing by default and fix bugs

### DIFF
--- a/cli/src/commands/router/commands/plugin/commands/init.ts
+++ b/cli/src/commands/router/commands/plugin/commands/init.ts
@@ -27,9 +27,7 @@ export default (opts: BaseCommandOptions) => {
 
     const projectDir = resolve(cwd, options.directory, options.project);
 
-    const pluginDir = (options.project)
-      ? resolve(cwd, projectDir, 'plugins', name)
-      : resolve(cwd, projectDir, name);
+    const pluginDir = options.project ? resolve(cwd, projectDir, 'plugins', name) : resolve(cwd, projectDir, name);
 
     const originalPluginName = name;
 
@@ -101,6 +99,7 @@ export default (opts: BaseCommandOptions) => {
 
         // Create a project directory structure
         await mkdir(projectDir, { recursive: true });
+        await mkdir(resolve(projectDir, 'plugins'), { recursive: true });
 
         // Write router config to the project root
         await writeFile(resolve(projectDir, 'config.yaml'), ProjectTemplates.routerConfig);

--- a/cli/src/commands/router/commands/plugin/commands/init.ts
+++ b/cli/src/commands/router/commands/plugin/commands/init.ts
@@ -26,7 +26,11 @@ export default (opts: BaseCommandOptions) => {
     const cwd = process.cwd();
 
     const projectDir = resolve(cwd, options.directory, options.project);
-    const pluginDir = resolve(cwd, projectDir, name);
+
+    const pluginDir = (options.project)
+      ? resolve(cwd, projectDir, 'plugins', name)
+      : resolve(cwd, projectDir, name);
+
     const originalPluginName = name;
 
     name = upperFirst(camelCase(name));

--- a/cli/src/commands/router/commands/plugin/templates/plugin.ts
+++ b/cli/src/commands/router/commands/plugin/templates/plugin.ts
@@ -10,7 +10,7 @@ go 1.24.1
 
 require (
   github.com/stretchr/testify v1.10.0
-  github.com/wundergraph/cosmo/router-plugin v0.0.0-20250519204649-84818397f974 // v0.1.0
+  github.com/wundergraph/cosmo/router-plugin v0.0.0-20250824152218-8eebc34c4995 // v0.4.1
   google.golang.org/grpc v1.68.1
   google.golang.org/protobuf v1.36.5
 )
@@ -55,7 +55,7 @@ func main() {
     s.RegisterService(&service.{serviceName}_ServiceDesc, &{serviceName}{
       nextID: 1,
     })
-  })
+  }, routerplugin.WithTracing())
 
   if err != nil {
     log.Fatalf("failed to create router plugin: %v", err)


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

This PR Does the following
* Upgrades the router version
* Enables tracing by default
* Fixes a few issues on generating a project (right now we stick wtih not using the plugin folder)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generated router plugins now enable tracing by default, improving observability for emitted projects.
* **Refactor**
  * Plugin scaffolding now places generated plugins inside the project's plugins directory when a project is specified, adjusting output paths and creation behavior.
* **Chores**
  * Generated projects upgrade the router-plugin dependency to the newer v0.4.1 release for compatibility and fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->