### PR TITLE
feat: expression support for retry condition

### DIFF
--- a/router-tests/error_handling_test.go
+++ b/router-tests/error_handling_test.go
@@ -1380,7 +1380,7 @@ func TestErrorPropagation(t *testing.T) {
 					EnableSingleFlight:     true,
 					MaxConcurrentResolvers: 1,
 				}),
-				core.WithSubgraphRetryOptions(false, 0, 0, 0, "", nil),
+				core.WithSubgraphRetryOptions(false, "", 0, 0, 0, "", nil),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			resp, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
@@ -1412,7 +1412,7 @@ func TestErrorPropagation(t *testing.T) {
 					EnableSingleFlight:     true,
 					MaxConcurrentResolvers: 1,
 				}),
-				core.WithSubgraphRetryOptions(false, 0, 0, 0, "", nil),
+				core.WithSubgraphRetryOptions(false, "", 0, 0, 0, "", nil),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			resp, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
@@ -1444,7 +1444,7 @@ func TestErrorPropagation(t *testing.T) {
 					EnableSingleFlight:     true,
 					MaxConcurrentResolvers: 1,
 				}),
-				core.WithSubgraphRetryOptions(false, 0, 0, 0, "", nil),
+				core.WithSubgraphRetryOptions(false, "", 0, 0, 0, "", nil),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			resp, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
@@ -1476,7 +1476,7 @@ func TestErrorPropagation(t *testing.T) {
 					EnableSingleFlight:     true,
 					MaxConcurrentResolvers: 1,
 				}),
-				core.WithSubgraphRetryOptions(false, 0, 0, 0, "", nil),
+				core.WithSubgraphRetryOptions(false, "", 0, 0, 0, "", nil),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			resp, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{

--- a/router-tests/error_handling_test.go
+++ b/router-tests/error_handling_test.go
@@ -1380,7 +1380,7 @@ func TestErrorPropagation(t *testing.T) {
 					EnableSingleFlight:     true,
 					MaxConcurrentResolvers: 1,
 				}),
-				core.WithSubgraphRetryOptions(false, 0, 0, 0, "", nil, nil),
+				core.WithSubgraphRetryOptions(false, 0, 0, 0, "", nil),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			resp, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
@@ -1412,7 +1412,7 @@ func TestErrorPropagation(t *testing.T) {
 					EnableSingleFlight:     true,
 					MaxConcurrentResolvers: 1,
 				}),
-				core.WithSubgraphRetryOptions(false, 0, 0, 0, "", nil, nil),
+				core.WithSubgraphRetryOptions(false, 0, 0, 0, "", nil),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			resp, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
@@ -1444,7 +1444,7 @@ func TestErrorPropagation(t *testing.T) {
 					EnableSingleFlight:     true,
 					MaxConcurrentResolvers: 1,
 				}),
-				core.WithSubgraphRetryOptions(false, 0, 0, 0, "", nil, nil),
+				core.WithSubgraphRetryOptions(false, 0, 0, 0, "", nil),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			resp, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
@@ -1476,7 +1476,7 @@ func TestErrorPropagation(t *testing.T) {
 					EnableSingleFlight:     true,
 					MaxConcurrentResolvers: 1,
 				}),
-				core.WithSubgraphRetryOptions(false, 0, 0, 0, "", nil, nil),
+				core.WithSubgraphRetryOptions(false, 0, 0, 0, "", nil),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			resp, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{

--- a/router-tests/error_handling_test.go
+++ b/router-tests/error_handling_test.go
@@ -1380,7 +1380,7 @@ func TestErrorPropagation(t *testing.T) {
 					EnableSingleFlight:     true,
 					MaxConcurrentResolvers: 1,
 				}),
-				core.WithSubgraphRetryOptions(false, 0, 0, 0, ""),
+				core.WithSubgraphRetryOptions(false, 0, 0, 0, "", nil, nil),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			resp, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
@@ -1412,7 +1412,7 @@ func TestErrorPropagation(t *testing.T) {
 					EnableSingleFlight:     true,
 					MaxConcurrentResolvers: 1,
 				}),
-				core.WithSubgraphRetryOptions(false, 0, 0, 0, ""),
+				core.WithSubgraphRetryOptions(false, 0, 0, 0, "", nil, nil),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			resp, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
@@ -1444,7 +1444,7 @@ func TestErrorPropagation(t *testing.T) {
 					EnableSingleFlight:     true,
 					MaxConcurrentResolvers: 1,
 				}),
-				core.WithSubgraphRetryOptions(false, 0, 0, 0, ""),
+				core.WithSubgraphRetryOptions(false, 0, 0, 0, "", nil, nil),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			resp, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
@@ -1476,7 +1476,7 @@ func TestErrorPropagation(t *testing.T) {
 					EnableSingleFlight:     true,
 					MaxConcurrentResolvers: 1,
 				}),
-				core.WithSubgraphRetryOptions(false, 0, 0, 0, ""),
+				core.WithSubgraphRetryOptions(false, 0, 0, 0, "", nil, nil),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			resp, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{

--- a/router-tests/error_handling_test.go
+++ b/router-tests/error_handling_test.go
@@ -1380,7 +1380,7 @@ func TestErrorPropagation(t *testing.T) {
 					EnableSingleFlight:     true,
 					MaxConcurrentResolvers: 1,
 				}),
-				core.WithSubgraphRetryOptions(false, 0, 0, 0),
+				core.WithSubgraphRetryOptions(false, 0, 0, 0, ""),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			resp, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
@@ -1412,7 +1412,7 @@ func TestErrorPropagation(t *testing.T) {
 					EnableSingleFlight:     true,
 					MaxConcurrentResolvers: 1,
 				}),
-				core.WithSubgraphRetryOptions(false, 0, 0, 0),
+				core.WithSubgraphRetryOptions(false, 0, 0, 0, ""),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			resp, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
@@ -1444,7 +1444,7 @@ func TestErrorPropagation(t *testing.T) {
 					EnableSingleFlight:     true,
 					MaxConcurrentResolvers: 1,
 				}),
-				core.WithSubgraphRetryOptions(false, 0, 0, 0),
+				core.WithSubgraphRetryOptions(false, 0, 0, 0, ""),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			resp, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
@@ -1476,7 +1476,7 @@ func TestErrorPropagation(t *testing.T) {
 					EnableSingleFlight:     true,
 					MaxConcurrentResolvers: 1,
 				}),
-				core.WithSubgraphRetryOptions(false, 0, 0, 0),
+				core.WithSubgraphRetryOptions(false, 0, 0, 0, ""),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			resp, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{

--- a/router-tests/go.mod
+++ b/router-tests/go.mod
@@ -70,7 +70,7 @@ require (
 	github.com/docker/docker-credential-helpers v0.9.3 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
-	github.com/expr-lang/expr v1.17.3 // indirect
+	github.com/expr-lang/expr v1.17.6 // indirect
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-chi/chi/v5 v5.2.2 // indirect

--- a/router-tests/go.sum
+++ b/router-tests/go.sum
@@ -85,8 +85,7 @@ github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
-github.com/expr-lang/expr v1.17.3 h1:myeTTuDFz7k6eFe/JPlep/UsiIjVhG61FMHFu63U7j0=
-github.com/expr-lang/expr v1.17.3/go.mod h1:8/vRC7+7HBzESEqt5kKpYXxrxkr31SaO8r40VO/1IT4=
+github.com/expr-lang/expr v1.17.6 h1:1h6i8ONk9cexhDmowO/A64VPxHScu7qfSl2k8OlINec=
 github.com/expr-lang/expr v1.17.6/go.mod h1:8/vRC7+7HBzESEqt5kKpYXxrxkr31SaO8r40VO/1IT4=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=

--- a/router-tests/go.sum
+++ b/router-tests/go.sum
@@ -87,6 +87,7 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/expr-lang/expr v1.17.3 h1:myeTTuDFz7k6eFe/JPlep/UsiIjVhG61FMHFu63U7j0=
 github.com/expr-lang/expr v1.17.3/go.mod h1:8/vRC7+7HBzESEqt5kKpYXxrxkr31SaO8r40VO/1IT4=
+github.com/expr-lang/expr v1.17.6/go.mod h1:8/vRC7+7HBzESEqt5kKpYXxrxkr31SaO8r40VO/1IT4=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=

--- a/router-tests/panic_test.go
+++ b/router-tests/panic_test.go
@@ -48,7 +48,7 @@ func TestEnginePanic(t *testing.T) {
 					EnableSingleFlight:     true,
 					MaxConcurrentResolvers: 1,
 				}),
-				core.WithSubgraphRetryOptions(false, 0, 0, 0),
+				core.WithSubgraphRetryOptions(false, 0, 0, 0, ""),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			res, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
@@ -80,7 +80,7 @@ func TestEnginePanic(t *testing.T) {
 					EnableSingleFlight: true,
 					ParseKitPoolSize:   1,
 				}),
-				core.WithSubgraphRetryOptions(false, 0, 0, 0),
+				core.WithSubgraphRetryOptions(false, 0, 0, 0, ""),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			res, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{

--- a/router-tests/panic_test.go
+++ b/router-tests/panic_test.go
@@ -48,7 +48,7 @@ func TestEnginePanic(t *testing.T) {
 					EnableSingleFlight:     true,
 					MaxConcurrentResolvers: 1,
 				}),
-				core.WithSubgraphRetryOptions(false, 0, 0, 0, ""),
+				core.WithSubgraphRetryOptions(false, 0, 0, 0, "", nil, nil),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			res, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
@@ -80,7 +80,7 @@ func TestEnginePanic(t *testing.T) {
 					EnableSingleFlight: true,
 					ParseKitPoolSize:   1,
 				}),
-				core.WithSubgraphRetryOptions(false, 0, 0, 0, ""),
+				core.WithSubgraphRetryOptions(false, 0, 0, 0, "", nil, nil),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			res, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{

--- a/router-tests/panic_test.go
+++ b/router-tests/panic_test.go
@@ -48,7 +48,7 @@ func TestEnginePanic(t *testing.T) {
 					EnableSingleFlight:     true,
 					MaxConcurrentResolvers: 1,
 				}),
-				core.WithSubgraphRetryOptions(false, 0, 0, 0, "", nil),
+				core.WithSubgraphRetryOptions(false, "", 0, 0, 0, "", nil),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			res, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
@@ -80,7 +80,7 @@ func TestEnginePanic(t *testing.T) {
 					EnableSingleFlight: true,
 					ParseKitPoolSize:   1,
 				}),
-				core.WithSubgraphRetryOptions(false, 0, 0, 0, "", nil),
+				core.WithSubgraphRetryOptions(false, "", 0, 0, 0, "", nil),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			res, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{

--- a/router-tests/panic_test.go
+++ b/router-tests/panic_test.go
@@ -48,7 +48,7 @@ func TestEnginePanic(t *testing.T) {
 					EnableSingleFlight:     true,
 					MaxConcurrentResolvers: 1,
 				}),
-				core.WithSubgraphRetryOptions(false, 0, 0, 0, "", nil, nil),
+				core.WithSubgraphRetryOptions(false, 0, 0, 0, "", nil),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			res, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
@@ -80,7 +80,7 @@ func TestEnginePanic(t *testing.T) {
 					EnableSingleFlight: true,
 					ParseKitPoolSize:   1,
 				}),
-				core.WithSubgraphRetryOptions(false, 0, 0, 0, "", nil, nil),
+				core.WithSubgraphRetryOptions(false, 0, 0, 0, "", nil),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			res, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{

--- a/router-tests/retry_test.go
+++ b/router-tests/retry_test.go
@@ -34,7 +34,7 @@ func TestRetry(t *testing.T) {
 		maxRetryCount := 3
 		expression := "true"
 
-		options := core.WithSubgraphRetryOptions(true, maxRetryCount, 10*time.Second, 200*time.Millisecond, expression, retryCounterFunc)
+		options := core.WithSubgraphRetryOptions(true, "", maxRetryCount, 10*time.Second, 200*time.Millisecond, expression, retryCounterFunc)
 
 		testenv.Run(t, &testenv.Config{
 			NoRetryClient:   true,
@@ -76,7 +76,7 @@ func TestRetry(t *testing.T) {
 		maxRetryCount := 3
 		expression := "false"
 
-		options := core.WithSubgraphRetryOptions(true, maxRetryCount, 10*time.Second, 200*time.Millisecond, expression, retryCounterFunc)
+		options := core.WithSubgraphRetryOptions(true, "", maxRetryCount, 10*time.Second, 200*time.Millisecond, expression, retryCounterFunc)
 
 		testenv.Run(t, &testenv.Config{
 			NoRetryClient:   true,
@@ -117,7 +117,7 @@ func TestRetry(t *testing.T) {
 		maxRetryCount := 3
 		expression := "true"
 
-		options := core.WithSubgraphRetryOptions(true, maxRetryCount, 10*time.Second, 200*time.Millisecond, expression, retryCounterFunc)
+		options := core.WithSubgraphRetryOptions(true, "", maxRetryCount, 10*time.Second, 200*time.Millisecond, expression, retryCounterFunc)
 
 		testenv.Run(t, &testenv.Config{
 			NoRetryClient:   true,
@@ -159,7 +159,7 @@ func TestRetry(t *testing.T) {
 		maxAttemptsBeforeServiceSucceeds := 2
 		expression := "true"
 
-		options := core.WithSubgraphRetryOptions(true, maxRetryCount, 10*time.Second, 200*time.Millisecond, expression, retryCounterFunc)
+		options := core.WithSubgraphRetryOptions(true, "", maxRetryCount, 10*time.Second, 200*time.Millisecond, expression, retryCounterFunc)
 
 		testenv.Run(t, &testenv.Config{
 			NoRetryClient:   true,
@@ -208,7 +208,7 @@ func TestRetry(t *testing.T) {
 		expression := "statusCode == 429"
 		headerRetryIntervalInSeconds := 1
 
-		options := core.WithSubgraphRetryOptions(true, maxRetryCount, 2000*time.Second, 100*time.Millisecond, expression, retryCounterFunc)
+		options := core.WithSubgraphRetryOptions(true, "", maxRetryCount, 2000*time.Second, 100*time.Millisecond, expression, retryCounterFunc)
 
 		testenv.Run(t, &testenv.Config{
 			NoRetryClient:   true,
@@ -260,7 +260,7 @@ func TestFlakyRetry(t *testing.T) {
 		maxDuration := 100 * time.Millisecond
 		expression := "true"
 
-		options := core.WithSubgraphRetryOptions(true, maxRetryCount, maxDuration, retryInterval, expression, retryCounterFunc)
+		options := core.WithSubgraphRetryOptions(true, "", maxRetryCount, maxDuration, retryInterval, expression, retryCounterFunc)
 
 		testenv.Run(t, &testenv.Config{
 			NoRetryClient:   true,
@@ -315,7 +315,7 @@ func TestFlakyRetry(t *testing.T) {
 			maxRetryCount := 3
 			expression := "statusCode == 429"
 
-			options := core.WithSubgraphRetryOptions(true, maxRetryCount, 1000*time.Millisecond, retryInterval, expression, retryCounterFunc)
+			options := core.WithSubgraphRetryOptions(true, "", maxRetryCount, 1000*time.Millisecond, retryInterval, expression, retryCounterFunc)
 
 			testenv.Run(t, &testenv.Config{
 				NoRetryClient:   true,
@@ -363,7 +363,7 @@ func TestFlakyRetry(t *testing.T) {
 			emptyRetryInterval := 0
 			retryInterval := 300 * time.Millisecond
 
-			options := core.WithSubgraphRetryOptions(true, maxRetryCount, 1000*time.Millisecond, retryInterval, expression, retryCounterFunc)
+			options := core.WithSubgraphRetryOptions(true, "", maxRetryCount, 1000*time.Millisecond, retryInterval, expression, retryCounterFunc)
 
 			testenv.Run(t, &testenv.Config{
 				NoRetryClient:   true,

--- a/router-tests/retry_test.go
+++ b/router-tests/retry_test.go
@@ -1,0 +1,393 @@
+package integration
+
+import (
+	"github.com/stretchr/testify/require"
+	"github.com/wundergraph/cosmo/router-tests/testenv"
+	"github.com/wundergraph/cosmo/router/core"
+	"github.com/wundergraph/cosmo/router/pkg/config"
+	"io"
+	"net/http"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func CreateRetryCounterFunc(counter *atomic.Int32) func(count int, req *http.Request, resp *http.Response, err error) {
+	return func(count int, req *http.Request, resp *http.Response, err error) {
+		counter.Add(1)
+	}
+}
+
+func TestRetry(t *testing.T) {
+	t.Parallel()
+
+	t.Run("verify retries when every retry results in a failure", func(t *testing.T) {
+		t.Parallel()
+
+		onRetryCounter := atomic.Int32{}
+		serviceCallsCounter := atomic.Int32{}
+		retryCounterFunc := CreateRetryCounterFunc(&onRetryCounter)
+
+		maxRetryCount := 3
+		retryInterval := 200 * time.Millisecond
+		maxDuration := 10 * time.Second
+		expression := "true"
+
+		options := core.WithSubgraphRetryOptions(true, maxRetryCount, maxDuration, retryInterval, expression, retryCounterFunc, nil)
+
+		testenv.Run(t, &testenv.Config{
+			NoRetryClient:   true,
+			AccessLogFields: []config.CustomAttribute{},
+			RouterOptions: []core.Option{
+				options,
+			},
+			Subgraphs: testenv.SubgraphsConfig{
+				Employees: testenv.SubgraphConfig{
+					Middleware: func(_ http.Handler) http.Handler {
+						return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+							w.WriteHeader(http.StatusBadGateway)
+							serviceCallsCounter.Add(1)
+						})
+					},
+				},
+			},
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			startTime := time.Now()
+			res, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
+				Query: `query employees { employees { id } }`,
+			})
+			doneTime := time.Now()
+
+			require.NoError(t, err)
+			require.Equal(t, `{"errors":[{"message":"Failed to fetch from Subgraph 'employees', Reason: empty response.","extensions":{"statusCode":502}}],"data":{"employees":null}}`, res.Body)
+
+			// We subtract one from the retry count as we only care about the interval counts
+			requestDuration := doneTime.Sub(startTime)
+			expectedDuration := time.Duration(maxRetryCount-1) * retryInterval
+			require.GreaterOrEqual(t, requestDuration, expectedDuration)
+
+			// The service will get one extra call, in addition to the first request
+			require.Equal(t, maxRetryCount, int(onRetryCounter.Load()))
+			require.Equal(t, maxRetryCount+1, int(serviceCallsCounter.Load()))
+		})
+	})
+
+	t.Run("verify retries when only first n retries results in a failure", func(t *testing.T) {
+		t.Parallel()
+
+		onRetryCounter := atomic.Int32{}
+		serviceCallsCounter := atomic.Int32{}
+		retryCounterFunc := CreateRetryCounterFunc(&onRetryCounter)
+
+		maxRetryCount := 5
+		maxAttemptsBeforeServiceSucceeds := 2
+		retryInterval := 200 * time.Millisecond
+		maxDuration := 10 * time.Second
+		expression := "true"
+
+		options := core.WithSubgraphRetryOptions(true, maxRetryCount, maxDuration, retryInterval, expression, retryCounterFunc, nil)
+
+		testenv.Run(t, &testenv.Config{
+			NoRetryClient:   true,
+			AccessLogFields: []config.CustomAttribute{},
+			RouterOptions: []core.Option{
+				options,
+			},
+			Subgraphs: testenv.SubgraphsConfig{
+				Employees: testenv.SubgraphConfig{
+					Middleware: func(_ http.Handler) http.Handler {
+						return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+							// When the Nth retry is executed only we want to run the request successfully
+							if onRetryCounter.Load() == int32(maxAttemptsBeforeServiceSucceeds) {
+								w.WriteHeader(http.StatusOK)
+								_, _ = w.Write([]byte(`{"data":{"employees":[{"id":1},{"id":2}]}}`))
+							} else {
+								w.WriteHeader(http.StatusBadGateway)
+							}
+							serviceCallsCounter.Add(1)
+						})
+					},
+				},
+			},
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			startTime := time.Now()
+			res, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
+				Query: `query employees { employees { id } }`,
+			})
+			doneTime := time.Now()
+			require.NoError(t, err)
+			require.Equal(t, `{"data":{"employees":[{"id":1},{"id":2}]}}`, res.Body)
+
+			// We subtract one from the retry count as we only care about the interval counts
+			requestDuration := doneTime.Sub(startTime)
+			expectedDuration := time.Duration(maxAttemptsBeforeServiceSucceeds-1) * retryInterval
+			require.GreaterOrEqual(t, requestDuration, expectedDuration)
+
+			// The service will get one extra call, in addition to the first request
+			require.Equal(t, maxAttemptsBeforeServiceSucceeds, int(onRetryCounter.Load()))
+			require.Equal(t, maxAttemptsBeforeServiceSucceeds+1, int(serviceCallsCounter.Load()))
+		})
+	})
+
+	t.Run("verify max duration is not exceeded on intervals", func(t *testing.T) {
+		t.Parallel()
+
+		onRetryCounter := atomic.Int32{}
+		retryCounterFunc := CreateRetryCounterFunc(&onRetryCounter)
+
+		maxRetryCount := 3
+		retryInterval := 300 * time.Millisecond
+		maxDuration := 100 * time.Millisecond
+		expression := "true"
+
+		options := core.WithSubgraphRetryOptions(true, maxRetryCount, maxDuration, retryInterval, expression, retryCounterFunc, nil)
+
+		testenv.Run(t, &testenv.Config{
+			NoRetryClient:   true,
+			AccessLogFields: []config.CustomAttribute{},
+			RouterOptions: []core.Option{
+				options,
+			},
+			Subgraphs: testenv.SubgraphsConfig{
+				Employees: testenv.SubgraphConfig{
+					Middleware: func(_ http.Handler) http.Handler {
+						return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+							w.WriteHeader(http.StatusBadGateway)
+						})
+					},
+				},
+			},
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			startTime := time.Now()
+			res, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
+				Query: `query employees { employees { id } }`,
+			})
+			doneTime := time.Now()
+
+			require.NoError(t, err)
+			require.Equal(t, `{"errors":[{"message":"Failed to fetch from Subgraph 'employees', Reason: empty response.","extensions":{"statusCode":502}}],"data":{"employees":null}}`, res.Body)
+
+			// We subtract one from the retry count as we only care about the interval counts
+			requestDuration := doneTime.Sub(startTime)
+
+			shouldBeLessThanDuration := (time.Duration(maxRetryCount-1) * retryInterval) - (20 * time.Millisecond)
+			require.Less(t, requestDuration, shouldBeLessThanDuration)
+
+			// We reduce by 50 for any timing flakiness
+			expectedMinDuration := (time.Duration(maxRetryCount-1) * maxDuration) - (50 * time.Millisecond)
+			require.GreaterOrEqual(t, requestDuration, expectedMinDuration)
+		})
+	})
+
+	t.Run("verify default failure still causes retries ignoring expression", func(t *testing.T) {
+		t.Parallel()
+
+		onRetryCounter := atomic.Int32{}
+		serviceCallsCounter := atomic.Int32{}
+		retryCounterFunc := CreateRetryCounterFunc(&onRetryCounter)
+
+		maxRetryCount := 3
+		expression := "false"
+
+		var rtWrapper RoundTripWrapper = func(request *http.Request) (*http.Response, error) {
+			serviceCallsCounter.Add(1)
+			return nil, io.ErrUnexpectedEOF
+		}
+
+		options := core.WithSubgraphRetryOptions(true, maxRetryCount, 10*time.Second, 200*time.Millisecond, expression, retryCounterFunc, rtWrapper)
+
+		testenv.Run(t, &testenv.Config{
+			NoRetryClient:   true,
+			AccessLogFields: []config.CustomAttribute{},
+			RouterOptions: []core.Option{
+				options,
+			},
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			res, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
+				Query: `query employees { employees { id } }`,
+			})
+			require.NoError(t, err)
+
+			require.Equal(t, `{"errors":[{"message":"Failed to fetch from Subgraph 'employees'."}],"data":{"employees":null}}`, res.Body)
+
+			require.Equal(t, maxRetryCount, int(onRetryCounter.Load()))
+			require.Equal(t, maxRetryCount+1, int(serviceCallsCounter.Load()))
+		})
+	})
+
+	t.Run("Verify retry interval for 429", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("when no Retry-After is set", func(t *testing.T) {
+			t.Parallel()
+
+			onRetryCounter := atomic.Int32{}
+			serviceCallsCounter := atomic.Int32{}
+			retryCounterFunc := CreateRetryCounterFunc(&onRetryCounter)
+
+			maxRetryCount := 3
+			expression := "statusCode == 429"
+			retryInterval := 300 * time.Millisecond
+
+			options := core.WithSubgraphRetryOptions(true, maxRetryCount, 1000*time.Millisecond, retryInterval, expression, retryCounterFunc, nil)
+
+			testenv.Run(t, &testenv.Config{
+				NoRetryClient:   true,
+				AccessLogFields: []config.CustomAttribute{},
+				RouterOptions: []core.Option{
+					options,
+				},
+				Subgraphs: testenv.SubgraphsConfig{
+					Employees: testenv.SubgraphConfig{
+						Middleware: func(_ http.Handler) http.Handler {
+							return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+								w.WriteHeader(http.StatusTooManyRequests)
+								serviceCallsCounter.Add(1)
+							})
+						},
+					},
+				},
+			}, func(t *testing.T, xEnv *testenv.Environment) {
+				startTime := time.Now()
+				res, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
+					Header: map[string][]string{
+						"service-name": {"service-name"},
+					},
+					Query: `query employees { employees { id } }`,
+				})
+				doneTime := time.Now()
+
+				require.NoError(t, err)
+				require.Equal(t, `{"errors":[{"message":"Failed to fetch from Subgraph 'employees', Reason: empty response.","extensions":{"statusCode":429}}],"data":{"employees":null}}`, res.Body)
+
+				// We subtract one from the retry count as we only care about the interval counts
+				requestDuration := doneTime.Sub(startTime)
+				expectedDuration := time.Duration(maxRetryCount-1) * retryInterval
+				require.GreaterOrEqual(t, requestDuration, expectedDuration)
+
+				// The service will get one extra call, in addition to the first request
+				require.Equal(t, maxRetryCount, int(onRetryCounter.Load()))
+				require.Equal(t, maxRetryCount+1, int(serviceCallsCounter.Load()))
+			})
+		})
+
+		t.Run("when zero Retry-After is set", func(t *testing.T) {
+			t.Parallel()
+
+			onRetryCounter := atomic.Int32{}
+			serviceCallsCounter := atomic.Int32{}
+			retryCounterFunc := CreateRetryCounterFunc(&onRetryCounter)
+
+			maxRetryCount := 3
+			expression := "statusCode == 429"
+			emptyRetryInterval := 0
+			retryInterval := 300 * time.Millisecond
+
+			options := core.WithSubgraphRetryOptions(true, maxRetryCount, 1000*time.Millisecond, retryInterval, expression, retryCounterFunc, nil)
+
+			testenv.Run(t, &testenv.Config{
+				NoRetryClient:   true,
+				AccessLogFields: []config.CustomAttribute{},
+				RouterOptions: []core.Option{
+					options,
+				},
+				Subgraphs: testenv.SubgraphsConfig{
+					Employees: testenv.SubgraphConfig{
+						Middleware: func(_ http.Handler) http.Handler {
+							return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+								w.WriteHeader(http.StatusTooManyRequests)
+								serviceCallsCounter.Add(1)
+							})
+						},
+					},
+				},
+			}, func(t *testing.T, xEnv *testenv.Environment) {
+				startTime := time.Now()
+				res, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
+					Header: map[string][]string{
+						"Retry-After": {
+							strconv.Itoa(emptyRetryInterval),
+						},
+					},
+					Query: `query employees { employees { id } }`,
+				})
+				doneTime := time.Now()
+
+				require.NoError(t, err)
+				require.Equal(t, `{"errors":[{"message":"Failed to fetch from Subgraph 'employees', Reason: empty response.","extensions":{"statusCode":429}}],"data":{"employees":null}}`, res.Body)
+
+				// We subtract one from the retry count as we only care about the interval counts
+				requestDuration := doneTime.Sub(startTime)
+				expectedDuration := time.Duration(maxRetryCount-1) * retryInterval
+				require.GreaterOrEqual(t, requestDuration, expectedDuration)
+
+				// The service will get one extra call, in addition to the first request
+				require.Equal(t, maxRetryCount, int(onRetryCounter.Load()))
+				require.Equal(t, maxRetryCount+1, int(serviceCallsCounter.Load()))
+			})
+		})
+
+		t.Run("when a nonzero Retry-After is set", func(t *testing.T) {
+			t.Parallel()
+
+			onRetryCounter := atomic.Int32{}
+			serviceCallsCounter := atomic.Int32{}
+			retryCounterFunc := CreateRetryCounterFunc(&onRetryCounter)
+
+			maxRetryCount := 3
+			expression := "statusCode == 429"
+			actualRetryInterval := int(100 * time.Millisecond)
+
+			options := core.WithSubgraphRetryOptions(true, maxRetryCount, 1000*time.Millisecond, 100*time.Millisecond, expression, retryCounterFunc, nil)
+
+			testenv.Run(t, &testenv.Config{
+				NoRetryClient:   true,
+				AccessLogFields: []config.CustomAttribute{},
+				RouterOptions: []core.Option{
+					options,
+				},
+				Subgraphs: testenv.SubgraphsConfig{
+					Employees: testenv.SubgraphConfig{
+						Middleware: func(_ http.Handler) http.Handler {
+							return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+								w.WriteHeader(http.StatusTooManyRequests)
+								serviceCallsCounter.Add(1)
+							})
+						},
+					},
+				},
+			}, func(t *testing.T, xEnv *testenv.Environment) {
+				startTime := time.Now()
+				res, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
+					Header: map[string][]string{
+						"Retry-After": {
+							strconv.Itoa(actualRetryInterval),
+						},
+					},
+					Query: `query employees { employees { id } }`,
+				})
+				doneTime := time.Now()
+
+				require.NoError(t, err)
+				require.Equal(t, `{"errors":[{"message":"Failed to fetch from Subgraph 'employees', Reason: empty response.","extensions":{"statusCode":429}}],"data":{"employees":null}}`, res.Body)
+
+				// We subtract one from the retry count as we only care about the interval counts
+				requestDuration := doneTime.Sub(startTime)
+				expectedDuration := time.Duration(maxRetryCount - 1*actualRetryInterval)
+				require.GreaterOrEqual(t, requestDuration, expectedDuration)
+
+				// The service will get one extra call, in addition to the first request
+				require.Equal(t, maxRetryCount, int(onRetryCounter.Load()))
+				require.Equal(t, maxRetryCount+1, int(serviceCallsCounter.Load()))
+			})
+		})
+	})
+
+}
+
+type RoundTripWrapper func(*http.Request) (*http.Response, error)
+
+func (rw RoundTripWrapper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return rw(req)
+}

--- a/router-tests/structured_logging_test.go
+++ b/router-tests/structured_logging_test.go
@@ -709,7 +709,7 @@ func TestFlakyAccessLogs(t *testing.T) {
 					EnableSingleFlight:     true,
 					MaxConcurrentResolvers: 1,
 				}),
-				core.WithSubgraphRetryOptions(false, 0, 0, 0, "", nil, nil),
+				core.WithSubgraphRetryOptions(false, 0, 0, 0, "", nil),
 			},
 			LogObservation: testenv.LogObservationConfig{
 				Enabled:  true,
@@ -828,7 +828,7 @@ func TestFlakyAccessLogs(t *testing.T) {
 					EnableSingleFlight:     true,
 					MaxConcurrentResolvers: 1,
 				}),
-				core.WithSubgraphRetryOptions(false, 0, 0, 0, "", nil, nil),
+				core.WithSubgraphRetryOptions(false, 0, 0, 0, "", nil),
 			},
 			LogObservation: testenv.LogObservationConfig{
 				Enabled:  true,
@@ -960,7 +960,7 @@ func TestFlakyAccessLogs(t *testing.T) {
 					EnableSingleFlight:     true,
 					MaxConcurrentResolvers: 1,
 				}),
-				core.WithSubgraphRetryOptions(false, 0, 0, 0, "", nil, nil),
+				core.WithSubgraphRetryOptions(false, 0, 0, 0, "", nil),
 			},
 			LogObservation: testenv.LogObservationConfig{
 				Enabled:  true,
@@ -1096,7 +1096,7 @@ func TestFlakyAccessLogs(t *testing.T) {
 					EnableSingleFlight:     true,
 					MaxConcurrentResolvers: 1,
 				}),
-				core.WithSubgraphRetryOptions(false, 0, 0, 0, "", nil, nil),
+				core.WithSubgraphRetryOptions(false, 0, 0, 0, "", nil),
 			},
 			LogObservation: testenv.LogObservationConfig{
 				Enabled:  true,
@@ -2211,7 +2211,7 @@ func TestFlakyAccessLogs(t *testing.T) {
 						EnableSingleFlight:     true,
 						MaxConcurrentResolvers: 1,
 					}),
-					core.WithSubgraphRetryOptions(false, 0, 0, 0, "", nil, nil),
+					core.WithSubgraphRetryOptions(false, 0, 0, 0, "", nil),
 				},
 				LogObservation: testenv.LogObservationConfig{
 					Enabled:  true,

--- a/router-tests/structured_logging_test.go
+++ b/router-tests/structured_logging_test.go
@@ -709,7 +709,7 @@ func TestFlakyAccessLogs(t *testing.T) {
 					EnableSingleFlight:     true,
 					MaxConcurrentResolvers: 1,
 				}),
-				core.WithSubgraphRetryOptions(false, 0, 0, 0),
+				core.WithSubgraphRetryOptions(false, 0, 0, 0, ""),
 			},
 			LogObservation: testenv.LogObservationConfig{
 				Enabled:  true,
@@ -828,7 +828,7 @@ func TestFlakyAccessLogs(t *testing.T) {
 					EnableSingleFlight:     true,
 					MaxConcurrentResolvers: 1,
 				}),
-				core.WithSubgraphRetryOptions(false, 0, 0, 0),
+				core.WithSubgraphRetryOptions(false, 0, 0, 0, ""),
 			},
 			LogObservation: testenv.LogObservationConfig{
 				Enabled:  true,
@@ -960,7 +960,7 @@ func TestFlakyAccessLogs(t *testing.T) {
 					EnableSingleFlight:     true,
 					MaxConcurrentResolvers: 1,
 				}),
-				core.WithSubgraphRetryOptions(false, 0, 0, 0),
+				core.WithSubgraphRetryOptions(false, 0, 0, 0, ""),
 			},
 			LogObservation: testenv.LogObservationConfig{
 				Enabled:  true,
@@ -1096,7 +1096,7 @@ func TestFlakyAccessLogs(t *testing.T) {
 					EnableSingleFlight:     true,
 					MaxConcurrentResolvers: 1,
 				}),
-				core.WithSubgraphRetryOptions(false, 0, 0, 0),
+				core.WithSubgraphRetryOptions(false, 0, 0, 0, ""),
 			},
 			LogObservation: testenv.LogObservationConfig{
 				Enabled:  true,
@@ -2211,7 +2211,7 @@ func TestFlakyAccessLogs(t *testing.T) {
 						EnableSingleFlight:     true,
 						MaxConcurrentResolvers: 1,
 					}),
-					core.WithSubgraphRetryOptions(false, 0, 0, 0),
+					core.WithSubgraphRetryOptions(false, 0, 0, 0, ""),
 				},
 				LogObservation: testenv.LogObservationConfig{
 					Enabled:  true,

--- a/router-tests/structured_logging_test.go
+++ b/router-tests/structured_logging_test.go
@@ -709,7 +709,7 @@ func TestFlakyAccessLogs(t *testing.T) {
 					EnableSingleFlight:     true,
 					MaxConcurrentResolvers: 1,
 				}),
-				core.WithSubgraphRetryOptions(false, 0, 0, 0, "", nil),
+				core.WithSubgraphRetryOptions(false, "", 0, 0, 0, "", nil),
 			},
 			LogObservation: testenv.LogObservationConfig{
 				Enabled:  true,
@@ -828,7 +828,7 @@ func TestFlakyAccessLogs(t *testing.T) {
 					EnableSingleFlight:     true,
 					MaxConcurrentResolvers: 1,
 				}),
-				core.WithSubgraphRetryOptions(false, 0, 0, 0, "", nil),
+				core.WithSubgraphRetryOptions(false, "", 0, 0, 0, "", nil),
 			},
 			LogObservation: testenv.LogObservationConfig{
 				Enabled:  true,
@@ -960,7 +960,7 @@ func TestFlakyAccessLogs(t *testing.T) {
 					EnableSingleFlight:     true,
 					MaxConcurrentResolvers: 1,
 				}),
-				core.WithSubgraphRetryOptions(false, 0, 0, 0, "", nil),
+				core.WithSubgraphRetryOptions(false, "", 0, 0, 0, "", nil),
 			},
 			LogObservation: testenv.LogObservationConfig{
 				Enabled:  true,
@@ -1096,7 +1096,7 @@ func TestFlakyAccessLogs(t *testing.T) {
 					EnableSingleFlight:     true,
 					MaxConcurrentResolvers: 1,
 				}),
-				core.WithSubgraphRetryOptions(false, 0, 0, 0, "", nil),
+				core.WithSubgraphRetryOptions(false, "", 0, 0, 0, "", nil),
 			},
 			LogObservation: testenv.LogObservationConfig{
 				Enabled:  true,
@@ -2211,7 +2211,7 @@ func TestFlakyAccessLogs(t *testing.T) {
 						EnableSingleFlight:     true,
 						MaxConcurrentResolvers: 1,
 					}),
-					core.WithSubgraphRetryOptions(false, 0, 0, 0, "", nil),
+					core.WithSubgraphRetryOptions(false, "", 0, 0, 0, "", nil),
 				},
 				LogObservation: testenv.LogObservationConfig{
 					Enabled:  true,

--- a/router-tests/structured_logging_test.go
+++ b/router-tests/structured_logging_test.go
@@ -709,7 +709,7 @@ func TestFlakyAccessLogs(t *testing.T) {
 					EnableSingleFlight:     true,
 					MaxConcurrentResolvers: 1,
 				}),
-				core.WithSubgraphRetryOptions(false, 0, 0, 0, ""),
+				core.WithSubgraphRetryOptions(false, 0, 0, 0, "", nil, nil),
 			},
 			LogObservation: testenv.LogObservationConfig{
 				Enabled:  true,
@@ -828,7 +828,7 @@ func TestFlakyAccessLogs(t *testing.T) {
 					EnableSingleFlight:     true,
 					MaxConcurrentResolvers: 1,
 				}),
-				core.WithSubgraphRetryOptions(false, 0, 0, 0, ""),
+				core.WithSubgraphRetryOptions(false, 0, 0, 0, "", nil, nil),
 			},
 			LogObservation: testenv.LogObservationConfig{
 				Enabled:  true,
@@ -960,7 +960,7 @@ func TestFlakyAccessLogs(t *testing.T) {
 					EnableSingleFlight:     true,
 					MaxConcurrentResolvers: 1,
 				}),
-				core.WithSubgraphRetryOptions(false, 0, 0, 0, ""),
+				core.WithSubgraphRetryOptions(false, 0, 0, 0, "", nil, nil),
 			},
 			LogObservation: testenv.LogObservationConfig{
 				Enabled:  true,
@@ -1096,7 +1096,7 @@ func TestFlakyAccessLogs(t *testing.T) {
 					EnableSingleFlight:     true,
 					MaxConcurrentResolvers: 1,
 				}),
-				core.WithSubgraphRetryOptions(false, 0, 0, 0, ""),
+				core.WithSubgraphRetryOptions(false, 0, 0, 0, "", nil, nil),
 			},
 			LogObservation: testenv.LogObservationConfig{
 				Enabled:  true,
@@ -2211,7 +2211,7 @@ func TestFlakyAccessLogs(t *testing.T) {
 						EnableSingleFlight:     true,
 						MaxConcurrentResolvers: 1,
 					}),
-					core.WithSubgraphRetryOptions(false, 0, 0, 0, ""),
+					core.WithSubgraphRetryOptions(false, 0, 0, 0, "", nil, nil),
 				},
 				LogObservation: testenv.LogObservationConfig{
 					Enabled:  true,

--- a/router-tests/telemetry/telemetry_test.go
+++ b/router-tests/telemetry/telemetry_test.go
@@ -8706,7 +8706,7 @@ func TestFlakyTelemetry(t *testing.T) {
 					},
 				},
 				RouterOptions: []core.Option{
-					core.WithSubgraphRetryOptions(false, 0, 0, 0),
+					core.WithSubgraphRetryOptions(false, 0, 0, 0, ""),
 				},
 				Subgraphs: testenv.SubgraphsConfig{
 					Products: testenv.SubgraphConfig{

--- a/router-tests/telemetry/telemetry_test.go
+++ b/router-tests/telemetry/telemetry_test.go
@@ -8706,7 +8706,7 @@ func TestFlakyTelemetry(t *testing.T) {
 					},
 				},
 				RouterOptions: []core.Option{
-					core.WithSubgraphRetryOptions(false, 0, 0, 0, "", nil),
+					core.WithSubgraphRetryOptions(false, "", 0, 0, 0, "", nil),
 				},
 				Subgraphs: testenv.SubgraphsConfig{
 					Products: testenv.SubgraphConfig{

--- a/router-tests/telemetry/telemetry_test.go
+++ b/router-tests/telemetry/telemetry_test.go
@@ -8706,7 +8706,7 @@ func TestFlakyTelemetry(t *testing.T) {
 					},
 				},
 				RouterOptions: []core.Option{
-					core.WithSubgraphRetryOptions(false, 0, 0, 0, ""),
+					core.WithSubgraphRetryOptions(false, 0, 0, 0, "", nil, nil),
 				},
 				Subgraphs: testenv.SubgraphsConfig{
 					Products: testenv.SubgraphConfig{

--- a/router-tests/telemetry/telemetry_test.go
+++ b/router-tests/telemetry/telemetry_test.go
@@ -8706,7 +8706,7 @@ func TestFlakyTelemetry(t *testing.T) {
 					},
 				},
 				RouterOptions: []core.Option{
-					core.WithSubgraphRetryOptions(false, 0, 0, 0, "", nil, nil),
+					core.WithSubgraphRetryOptions(false, 0, 0, 0, "", nil),
 				},
 				Subgraphs: testenv.SubgraphsConfig{
 					Products: testenv.SubgraphConfig{

--- a/router/core/context.go
+++ b/router/core/context.go
@@ -634,15 +634,6 @@ func (o *operationContext) QueryPlanStats() (QueryPlanStats, error) {
 	return qps, nil
 }
 
-// isMutationRequest returns true if the current request is a mutation request
-func isMutationRequest(ctx context.Context) bool {
-	op := getRequestContext(ctx)
-	if op == nil {
-		return false
-	}
-	return op.Operation().Type() == "mutation"
-}
-
 type SubgraphResolver struct {
 	subgraphsByURL map[string]*Subgraph
 	subgraphsByID  map[string]*Subgraph

--- a/router/core/graph_server.go
+++ b/router/core/graph_server.go
@@ -1157,7 +1157,7 @@ func (s *graphServer) buildGraphMux(
 	}
 
 	// Build retry options and handle any expression compilation errors
-	shouldRetryFunc, err := BuildRetryFunction(s.retryOptions.Expression, s.logger)
+	shouldRetryFunc, err := BuildRetryFunction(s.retryOptions.Expression)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build retry function: %w", err)
 	}

--- a/router/core/graph_server.go
+++ b/router/core/graph_server.go
@@ -1171,8 +1171,7 @@ func (s *graphServer) buildGraphMux(
 		Expression:    s.retryOptions.Expression,
 		ShouldRetry:   shouldRetryFunc,
 
-		OnRetry:           s.retryOptions.OnRetry,
-		RoundTripOverride: s.retryOptions.RoundTripOverride,
+		OnRetry: s.retryOptions.OnRetry,
 	}
 
 	ecb := &ExecutorConfigurationBuilder{

--- a/router/core/graph_server.go
+++ b/router/core/graph_server.go
@@ -1157,11 +1157,12 @@ func (s *graphServer) buildGraphMux(
 	}
 
 	// Build retry options and handle any expression compilation errors
-	shouldRetryFunc, err := BuildRetryFunction(s.retryOptions.Expression)
+	shouldRetryFunc, err := BuildRetryFunction(s.retryOptions)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build retry function: %w", err)
 	}
 
+	// Create copy to not mutate the original reference
 	retryOptions := retrytransport.RetryOptions{
 		Enabled:       s.retryOptions.Enabled,
 		MaxRetryCount: s.retryOptions.MaxRetryCount,
@@ -1169,6 +1170,9 @@ func (s *graphServer) buildGraphMux(
 		Interval:      s.retryOptions.Interval,
 		Expression:    s.retryOptions.Expression,
 		ShouldRetry:   shouldRetryFunc,
+
+		OnRetry:           s.retryOptions.OnRetry,
+		RoundTripOverride: s.retryOptions.RoundTripOverride,
 	}
 
 	ecb := &ExecutorConfigurationBuilder{

--- a/router/core/retry_builder.go
+++ b/router/core/retry_builder.go
@@ -21,7 +21,8 @@ var noopRetryFunc = func(err error, req *http.Request, resp *http.Response) bool
 }
 
 func ProcessRetryOptions(retryOpts retrytransport.RetryOptions) (*retrytransport.RetryOptions, error) {
-	if retryOpts.Algorithm != backoffJitter {
+	// We skip validating the algorithm if retries are disabled
+	if retryOpts.Enabled && retryOpts.Algorithm != backoffJitter {
 		return nil, fmt.Errorf("unsupported retry algorithm: %s", retryOpts.Algorithm)
 	}
 

--- a/router/core/retry_builder.go
+++ b/router/core/retry_builder.go
@@ -21,6 +21,12 @@ var noopRetryFunc = func(err error, req *http.Request, resp *http.Response) bool
 }
 
 func ProcessRetryOptions(retryOpts retrytransport.RetryOptions) (*retrytransport.RetryOptions, error) {
+	// Default to backOffJitter if no algorithm is specified
+	// This will occur either in tests or if the user explicitly makes it an empty string
+	if retryOpts.Algorithm == "" {
+		retryOpts.Algorithm = backoffJitter
+	}
+
 	// We skip validating the algorithm if retries are disabled
 	if retryOpts.Enabled && retryOpts.Algorithm != backoffJitter {
 		return nil, fmt.Errorf("unsupported retry algorithm: %s", retryOpts.Algorithm)

--- a/router/core/retry_builder_test.go
+++ b/router/core/retry_builder_test.go
@@ -449,6 +449,15 @@ func TestProcessRetryOptions(t *testing.T) {
 		assert.ErrorContains(t, err, expectedError)
 	})
 
+	t.Run("process invalid algorithm when retries are disabled", func(t *testing.T) {
+		algorithm := "abcdee"
+		_, err := ProcessRetryOptions(retrytransport.RetryOptions{
+			Enabled:   false,
+			Algorithm: algorithm,
+		})
+		assert.NoError(t, err)
+	})
+
 	t.Run("process invalid expression", func(t *testing.T) {
 		_, err := ProcessRetryOptions(retrytransport.RetryOptions{
 			Enabled:    true,

--- a/router/core/retry_expression_builder.go
+++ b/router/core/retry_expression_builder.go
@@ -33,7 +33,7 @@ func BuildRetryFunction(retryOpts retrytransport.RetryOptions) (retrytransport.S
 	// Create the retry expression manager
 	manager, err := expr.NewRetryExpressionManager(expression)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compile retry expression: %w", err)
+		return nil, fmt.Errorf("failed to create expression manager: %w", err)
 	}
 
 	// Return expression-based retry function

--- a/router/core/retry_expression_builder.go
+++ b/router/core/retry_expression_builder.go
@@ -12,8 +12,15 @@ import (
 const DefaultRetryExpression = "IsRetryableStatusCode() || IsConnectionError() || IsTimeout()"
 
 // BuildRetryFunction creates a ShouldRetry function based on the provided expression
-func BuildRetryFunction(expression string) (retrytransport.ShouldRetryFunc, error) {
+func BuildRetryFunction(retryOpts retrytransport.RetryOptions) (retrytransport.ShouldRetryFunc, error) {
+	// We do not need to build a retry function if retries are disabled
+	// This means that any bad expressions are ignored if retries are disabled
+	if !retryOpts.Enabled {
+		return nil, nil
+	}
+
 	// Use default expression if empty string is passed
+	expression := retryOpts.Expression
 	if expression == "" {
 		expression = DefaultRetryExpression
 	}

--- a/router/core/retry_expression_builder.go
+++ b/router/core/retry_expression_builder.go
@@ -10,7 +10,7 @@ import (
 	"go.uber.org/zap"
 )
 
-const DefaultRetryExpression = "IsRetryableStatusCode() || IsConnectionError() || IsTimeout()"
+const defaultRetryExpression = "IsRetryableStatusCode() || IsConnectionError() || IsTimeout()"
 
 var noopRetryFunc = func(err error, req *http.Request, resp *http.Response) bool {
 	return false
@@ -27,7 +27,7 @@ func BuildRetryFunction(retryOpts retrytransport.RetryOptions) (retrytransport.S
 	// Use default expression if empty string is passed
 	expression := retryOpts.Expression
 	if expression == "" {
-		expression = DefaultRetryExpression
+		expression = defaultRetryExpression
 	}
 
 	// Create the retry expression manager

--- a/router/core/retry_expression_builder.go
+++ b/router/core/retry_expression_builder.go
@@ -43,7 +43,6 @@ func BuildRetryFunction(expression string) (retrytransport.ShouldRetryFunc, erro
 		// Evaluate the expression
 		shouldRetry, evalErr := manager.ShouldRetry(ctx)
 		if evalErr != nil {
-
 			reqContext.logger.Error("Failed to evaluate retry expression",
 				zap.Error(evalErr),
 				zap.String("expression", expression),

--- a/router/core/retry_expression_builder.go
+++ b/router/core/retry_expression_builder.go
@@ -1,0 +1,50 @@
+package core
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/wundergraph/cosmo/router/internal/expr"
+	"github.com/wundergraph/cosmo/router/internal/retrytransport"
+	"go.uber.org/zap"
+)
+
+const DefaultRetryExpression = "IsRetryableStatusCode() || IsConnectionError() || IsTimeout()"
+
+// BuildRetryFunction creates a ShouldRetry function based on the provided expression
+func BuildRetryFunction(expression string, logger *zap.Logger) (retrytransport.ShouldRetryFunc, error) {
+	// Use default expression if empty string is passed
+	if expression == "" {
+		expression = DefaultRetryExpression
+	}
+
+	// Create the retry expression manager
+	manager, err := expr.NewRetryExpressionManager(expression)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compile retry expression: %w", err)
+	}
+
+	// Return expression-based retry function
+	return func(err error, req *http.Request, resp *http.Response) bool {
+		// Never retry mutations, regardless of expression result
+		if isMutationRequest(req.Context()) {
+			return false
+		}
+
+		// Create retry context
+		ctx := expr.LoadRetryContext(err, resp)
+
+		// Evaluate the expression
+		shouldRetry, evalErr := manager.ShouldRetry(ctx)
+		if evalErr != nil {
+			logger.Error("Failed to evaluate retry expression",
+				zap.Error(evalErr),
+				zap.String("expression", expression),
+			)
+			// Disable retries on evaluation error
+			return false
+		}
+
+		return shouldRetry
+	}, nil
+}

--- a/router/core/retry_expression_builder.go
+++ b/router/core/retry_expression_builder.go
@@ -12,12 +12,16 @@ import (
 
 const DefaultRetryExpression = "IsRetryableStatusCode() || IsConnectionError() || IsTimeout()"
 
+var noopRetryFunc = func(err error, req *http.Request, resp *http.Response) bool {
+	return false
+}
+
 // BuildRetryFunction creates a ShouldRetry function based on the provided expression
 func BuildRetryFunction(retryOpts retrytransport.RetryOptions) (retrytransport.ShouldRetryFunc, error) {
 	// We do not need to build a retry function if retries are disabled
 	// This means that any bad expressions are ignored if retries are disabled
 	if !retryOpts.Enabled {
-		return nil, nil
+		return noopRetryFunc, nil
 	}
 
 	// Use default expression if empty string is passed

--- a/router/core/retry_expression_builder_test.go
+++ b/router/core/retry_expression_builder_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/wundergraph/cosmo/router/internal/retrytransport"
 	"io"
 	"net/http"
+	"reflect"
 	"syscall"
 	"testing"
 
@@ -55,7 +56,10 @@ func TestBuildRetryFunction(t *testing.T) {
 			Expression: "invalid expression ++++++",
 		})
 		assert.NoError(t, err)
-		assert.Nil(t, fn)
+		assert.Equal(t,
+			reflect.ValueOf(noopRetryFunc).Pointer(),
+			reflect.ValueOf(fn).Pointer(),
+		)
 	})
 
 	t.Run("default expression behavior", func(t *testing.T) {

--- a/router/core/retry_expression_builder_test.go
+++ b/router/core/retry_expression_builder_test.go
@@ -1,0 +1,154 @@
+package core
+
+import (
+	"errors"
+	"net/http"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+func TestBuildRetryFunction(t *testing.T) {
+	logger := zap.NewNop()
+
+	t.Run("default expression behavior", func(t *testing.T) {
+		// Use the default expression that would be in the config
+		fn, err := BuildRetryFunction(DefaultRetryExpression, logger)
+		assert.NoError(t, err)
+		assert.NotNil(t, fn)
+
+		// Test default behavior - should retry on 500
+		req, _ := http.NewRequest("GET", "http://example.com", nil)
+		resp := &http.Response{StatusCode: 500}
+		assert.True(t, fn(nil, req, resp))
+
+		// Should not retry on 200
+		resp.StatusCode = 200
+		assert.False(t, fn(nil, req, resp))
+
+		// Note: Testing mutation behavior would require setting up a proper request context
+		// which is beyond the scope of this unit test. The mutation check is tested
+		// in integration tests.
+
+		// Test with errors - only expression-defined errors are handled here
+		req, _ = http.NewRequest("GET", "http://example.com", nil)
+		assert.True(t, fn(syscall.ETIMEDOUT, req, nil))
+		assert.True(t, fn(errors.New("connection refused"), req, nil))
+		assert.False(t, fn(errors.New("unexpected EOF"), req, nil)) // EOF is now handled at transport layer, not expression
+		assert.False(t, fn(errors.New("some other error"), req, nil))
+	})
+
+	t.Run("expression-based retry", func(t *testing.T) {
+		expression := "statusCode == 500 || statusCode == 503"
+		fn, err := BuildRetryFunction(expression, logger)
+		assert.NoError(t, err)
+		assert.NotNil(t, fn)
+
+		req, _ := http.NewRequest("GET", "http://example.com", nil)
+
+		// Should retry on 500
+		resp := &http.Response{StatusCode: 500}
+		assert.True(t, fn(nil, req, resp))
+
+		// Should retry on 503
+		resp.StatusCode = 503
+		assert.True(t, fn(nil, req, resp))
+
+		// Should not retry on 502
+		resp.StatusCode = 502
+		assert.False(t, fn(nil, req, resp))
+	})
+
+	t.Run("expression with error conditions", func(t *testing.T) {
+		expression := "IsTimeout() || statusCode == 503"
+		fn, err := BuildRetryFunction(expression, logger)
+		assert.NoError(t, err)
+		assert.NotNil(t, fn)
+
+		req, _ := http.NewRequest("GET", "http://example.com", nil)
+
+		// Should retry on timeout error
+		err = syscall.ETIMEDOUT
+		assert.True(t, fn(err, req, nil))
+
+		// Should retry on 503
+		resp := &http.Response{StatusCode: 503}
+		assert.True(t, fn(nil, req, resp))
+
+		// Should not retry on other errors
+		err = errors.New("some other error")
+		assert.False(t, fn(err, req, nil))
+	})
+
+	t.Run("invalid expression returns error", func(t *testing.T) {
+		expression := "invalid syntax +++"
+		fn, err := BuildRetryFunction(expression, logger)
+		assert.Error(t, err)
+		assert.Nil(t, fn)
+		assert.Contains(t, err.Error(), "failed to compile retry expression")
+	})
+
+	t.Run("empty expression uses default", func(t *testing.T) {
+		fn, err := BuildRetryFunction("", logger)
+		assert.NoError(t, err)
+		assert.NotNil(t, fn)
+
+		// Test with retryable status code
+		req, _ := http.NewRequest("GET", "http://example.com", nil)
+		resp := &http.Response{StatusCode: 502}
+		assert.True(t, fn(nil, req, resp))
+
+		// Test with connection error
+		err = errors.New("connection refused")
+		assert.True(t, fn(err, req, nil))
+
+		// Test with timeout error
+		err = syscall.ETIMEDOUT
+		assert.True(t, fn(err, req, nil))
+
+		// Test with non-retryable error
+		err = errors.New("some other error")
+		assert.False(t, fn(err, req, nil))
+	})
+
+	t.Run("expression that always returns true", func(t *testing.T) {
+		expression := "true" // Always retry
+		fn, err := BuildRetryFunction(expression, logger)
+		assert.NoError(t, err)
+		assert.NotNil(t, fn)
+
+		req, _ := http.NewRequest("GET", "http://example.com", nil)
+		resp := &http.Response{StatusCode: 500}
+
+		// Should retry when expression is true
+		assert.True(t, fn(nil, req, resp))
+
+		// Even for status codes that wouldn't normally retry
+		resp.StatusCode = 200
+		assert.True(t, fn(nil, req, resp))
+	})
+
+	t.Run("complex expression", func(t *testing.T) {
+		expression := "(statusCode >= 500 && statusCode < 600) || IsConnectionError()"
+		fn, err := BuildRetryFunction(expression, logger)
+		assert.NoError(t, err)
+		assert.NotNil(t, fn)
+
+		req, _ := http.NewRequest("GET", "http://example.com", nil)
+
+		// Test 5xx errors
+		resp := &http.Response{StatusCode: 503}
+		assert.True(t, fn(nil, req, resp))
+
+		// Test connection error
+		err = errors.New("connection refused")
+		assert.True(t, fn(err, req, nil))
+
+		// Test non-matching conditions
+		resp.StatusCode = 404
+		err = errors.New("some other error")
+		assert.False(t, fn(err, req, resp))
+	})
+}

--- a/router/core/retry_expression_builder_test.go
+++ b/router/core/retry_expression_builder_test.go
@@ -10,17 +10,54 @@ import (
 	"go.uber.org/zap"
 )
 
-func TestBuildRetryFunction(t *testing.T) {
+// Helper functions for creating proper request contexts
+
+func createOperationContext(opType string) *operationContext {
+	return &operationContext{
+		name:    "TestOperation",
+		opType:  opType,
+		hash:    12345,
+		content: "test content",
+	}
+}
+
+func createRequestWithContext(opType string) (*http.Request, *requestContext) {
+	req, _ := http.NewRequest("POST", "http://example.com/graphql", nil)
 	logger := zap.NewNop()
+
+	// Create operation context
+	operationCtx := createOperationContext(opType)
+
+	// Create request context using the buildRequestContext function
+	reqCtx := buildRequestContext(requestContextOptions{
+		operationContext: operationCtx,
+		requestLogger:    logger,
+		metricsEnabled:   false,
+		traceEnabled:     false,
+		mapper:           &attributeMapper{},
+		w:                nil,
+		r:                req,
+	})
+
+	// Attach the request context to the Go context
+	ctx := withRequestContext(req.Context(), reqCtx)
+	req = req.WithContext(ctx)
+
+	return req, reqCtx
+}
+
+func TestBuildRetryFunction(t *testing.T) {
 
 	t.Run("default expression behavior", func(t *testing.T) {
 		// Use the default expression that would be in the config
-		fn, err := BuildRetryFunction(DefaultRetryExpression, logger)
+		fn, err := BuildRetryFunction(DefaultRetryExpression)
 		assert.NoError(t, err)
 		assert.NotNil(t, fn)
 
+		// Create a request with proper query context
+		req, _ := createRequestWithContext(OperationTypeQuery)
+
 		// Test default behavior - should retry on 500
-		req, _ := http.NewRequest("GET", "http://example.com", nil)
 		resp := &http.Response{StatusCode: 500}
 		assert.True(t, fn(nil, req, resp))
 
@@ -28,12 +65,7 @@ func TestBuildRetryFunction(t *testing.T) {
 		resp.StatusCode = 200
 		assert.False(t, fn(nil, req, resp))
 
-		// Note: Testing mutation behavior would require setting up a proper request context
-		// which is beyond the scope of this unit test. The mutation check is tested
-		// in integration tests.
-
 		// Test with errors - only expression-defined errors are handled here
-		req, _ = http.NewRequest("GET", "http://example.com", nil)
 		assert.True(t, fn(syscall.ETIMEDOUT, req, nil))
 		assert.True(t, fn(errors.New("connection refused"), req, nil))
 		assert.False(t, fn(errors.New("unexpected EOF"), req, nil)) // EOF is now handled at transport layer, not expression
@@ -42,11 +74,12 @@ func TestBuildRetryFunction(t *testing.T) {
 
 	t.Run("expression-based retry", func(t *testing.T) {
 		expression := "statusCode == 500 || statusCode == 503"
-		fn, err := BuildRetryFunction(expression, logger)
+		fn, err := BuildRetryFunction(expression)
 		assert.NoError(t, err)
 		assert.NotNil(t, fn)
 
-		req, _ := http.NewRequest("GET", "http://example.com", nil)
+		// Create a request with proper query context
+		req, _ := createRequestWithContext(OperationTypeQuery)
 
 		// Should retry on 500
 		resp := &http.Response{StatusCode: 500}
@@ -63,11 +96,12 @@ func TestBuildRetryFunction(t *testing.T) {
 
 	t.Run("expression with error conditions", func(t *testing.T) {
 		expression := "IsTimeout() || statusCode == 503"
-		fn, err := BuildRetryFunction(expression, logger)
+		fn, err := BuildRetryFunction(expression)
 		assert.NoError(t, err)
 		assert.NotNil(t, fn)
 
-		req, _ := http.NewRequest("GET", "http://example.com", nil)
+		// Create a request with proper query context
+		req, _ := createRequestWithContext(OperationTypeQuery)
 
 		// Should retry on timeout error
 		err = syscall.ETIMEDOUT
@@ -84,19 +118,21 @@ func TestBuildRetryFunction(t *testing.T) {
 
 	t.Run("invalid expression returns error", func(t *testing.T) {
 		expression := "invalid syntax +++"
-		fn, err := BuildRetryFunction(expression, logger)
+		fn, err := BuildRetryFunction(expression)
 		assert.Error(t, err)
 		assert.Nil(t, fn)
 		assert.Contains(t, err.Error(), "failed to compile retry expression")
 	})
 
 	t.Run("empty expression uses default", func(t *testing.T) {
-		fn, err := BuildRetryFunction("", logger)
+		fn, err := BuildRetryFunction("")
 		assert.NoError(t, err)
 		assert.NotNil(t, fn)
 
+		// Create a request with proper query context
+		req, _ := createRequestWithContext(OperationTypeQuery)
+
 		// Test with retryable status code
-		req, _ := http.NewRequest("GET", "http://example.com", nil)
 		resp := &http.Response{StatusCode: 502}
 		assert.True(t, fn(nil, req, resp))
 
@@ -115,11 +151,12 @@ func TestBuildRetryFunction(t *testing.T) {
 
 	t.Run("expression that always returns true", func(t *testing.T) {
 		expression := "true" // Always retry
-		fn, err := BuildRetryFunction(expression, logger)
+		fn, err := BuildRetryFunction(expression)
 		assert.NoError(t, err)
 		assert.NotNil(t, fn)
 
-		req, _ := http.NewRequest("GET", "http://example.com", nil)
+		// Create a request with proper query context
+		req, _ := createRequestWithContext(OperationTypeQuery)
 		resp := &http.Response{StatusCode: 500}
 
 		// Should retry when expression is true
@@ -132,11 +169,12 @@ func TestBuildRetryFunction(t *testing.T) {
 
 	t.Run("complex expression", func(t *testing.T) {
 		expression := "(statusCode >= 500 && statusCode < 600) || IsConnectionError()"
-		fn, err := BuildRetryFunction(expression, logger)
+		fn, err := BuildRetryFunction(expression)
 		assert.NoError(t, err)
 		assert.NotNil(t, fn)
 
-		req, _ := http.NewRequest("GET", "http://example.com", nil)
+		// Create a request with proper query context
+		req, _ := createRequestWithContext(OperationTypeQuery)
 
 		// Test 5xx errors
 		resp := &http.Response{StatusCode: 503}
@@ -150,5 +188,176 @@ func TestBuildRetryFunction(t *testing.T) {
 		resp.StatusCode = 404
 		err = errors.New("some other error")
 		assert.False(t, fn(err, req, resp))
+	})
+
+	t.Run("mutation never retries with proper context", func(t *testing.T) {
+		// Use expression that would normally retry on 500 errors
+		expression := "statusCode >= 500 || IsTimeout() || IsConnectionError()"
+		fn, err := BuildRetryFunction(expression)
+		assert.NoError(t, err)
+		assert.NotNil(t, fn)
+
+		// Create a request with mutation context
+		req, _ := createRequestWithContext(OperationTypeMutation)
+
+		// Test with 500 status - should NOT retry because it's a mutation
+		resp := &http.Response{StatusCode: 500}
+		assert.False(t, fn(nil, req, resp))
+
+		// Test with timeout error - should NOT retry because it's a mutation
+		assert.False(t, fn(syscall.ETIMEDOUT, req, nil))
+
+		// Test with connection error - should NOT retry because it's a mutation
+		assert.False(t, fn(errors.New("connection refused"), req, nil))
+
+		// Test with expression that always returns true - should still NOT retry
+		alwaysRetryFn, err := BuildRetryFunction("true")
+		assert.NoError(t, err)
+		assert.False(t, alwaysRetryFn(nil, req, resp))
+	})
+
+	t.Run("query retries with proper context", func(t *testing.T) {
+		expression := "statusCode >= 500 || IsTimeout()"
+		fn, err := BuildRetryFunction(expression)
+		assert.NoError(t, err)
+		assert.NotNil(t, fn)
+
+		// Create a request with query context
+		req, _ := createRequestWithContext(OperationTypeQuery)
+
+		// Test with 500 status - should retry because it's a query
+		resp := &http.Response{StatusCode: 500}
+		assert.True(t, fn(nil, req, resp))
+
+		// Test with timeout error - should retry because it's a query
+		assert.True(t, fn(syscall.ETIMEDOUT, req, nil))
+
+		// Test with 200 status - should not retry even for query
+		resp.StatusCode = 200
+		assert.False(t, fn(nil, req, resp))
+	})
+
+	t.Run("subscription retries with proper context", func(t *testing.T) {
+		expression := "statusCode >= 500"
+		fn, err := BuildRetryFunction(expression)
+		assert.NoError(t, err)
+		assert.NotNil(t, fn)
+
+		// Create a request with subscription context
+		req, _ := createRequestWithContext(OperationTypeSubscription)
+
+		// Test with 500 status - should retry because it's a subscription (not mutation)
+		resp := &http.Response{StatusCode: 500}
+		assert.True(t, fn(nil, req, resp))
+
+		// Test with 200 status - should not retry
+		resp.StatusCode = 200
+		assert.False(t, fn(nil, req, resp))
+	})
+
+	t.Run("error logging with proper context", func(t *testing.T) {
+		// Test that error logging works with proper request context
+		expression := "statusCode >= 500"
+		fn, err := BuildRetryFunction(expression)
+		assert.NoError(t, err)
+		assert.NotNil(t, fn)
+
+		// Create request with proper context
+		req, _ := createRequestWithContext(OperationTypeQuery)
+
+		// Test that it works normally with proper context
+		resp := &http.Response{StatusCode: 500}
+		assert.True(t, fn(nil, req, resp))
+
+		resp.StatusCode = 200
+		assert.False(t, fn(nil, req, resp))
+	})
+
+	t.Run("request context with query operation", func(t *testing.T) {
+		expression := "statusCode >= 500"
+		fn, err := BuildRetryFunction(expression)
+		assert.NoError(t, err)
+		assert.NotNil(t, fn)
+
+		// Create request with proper query context
+		req, _ := createRequestWithContext(OperationTypeQuery)
+
+		// Should work with proper request context - expression should be evaluated normally
+		resp := &http.Response{StatusCode: 500}
+		assert.True(t, fn(nil, req, resp))
+
+		resp.StatusCode = 200
+		assert.False(t, fn(nil, req, resp))
+	})
+
+	t.Run("complex expression with mutation context", func(t *testing.T) {
+		// Complex expression that would normally retry in many cases
+		expression := "(statusCode >= 500 && statusCode < 600) || IsConnectionError() || IsTimeout() || statusCode == 429"
+		fn, err := BuildRetryFunction(expression)
+		assert.NoError(t, err)
+		assert.NotNil(t, fn)
+
+		// Create a request with mutation context
+		req, _ := createRequestWithContext(OperationTypeMutation)
+
+		// Test various conditions that would normally trigger retry
+		resp := &http.Response{StatusCode: 500}
+		assert.False(t, fn(nil, req, resp))
+
+		resp.StatusCode = 503
+		assert.False(t, fn(nil, req, resp))
+
+		resp.StatusCode = 429
+		assert.False(t, fn(nil, req, resp))
+
+		assert.False(t, fn(syscall.ETIMEDOUT, req, nil))
+		assert.False(t, fn(errors.New("connection refused"), req, nil))
+	})
+
+	t.Run("new operation with comprehensive retry conditions", func(t *testing.T) {
+		// Create a new comprehensive operation to test all retry scenarios
+		expression := "statusCode >= 500 || statusCode == 429 || IsTimeout() || IsConnectionError()"
+		fn, err := BuildRetryFunction(expression)
+		assert.NoError(t, err)
+		assert.NotNil(t, fn)
+
+		// Test query operation - should retry on all conditions
+		req, _ := createRequestWithContext(OperationTypeQuery)
+
+		// Test 5xx errors
+		resp := &http.Response{StatusCode: 500}
+		assert.True(t, fn(nil, req, resp))
+		resp.StatusCode = 503
+		assert.True(t, fn(nil, req, resp))
+
+		// Test rate limiting
+		resp.StatusCode = 429
+		assert.True(t, fn(nil, req, resp))
+
+		// Test timeouts
+		assert.True(t, fn(syscall.ETIMEDOUT, req, nil))
+
+		// Test connection errors
+		assert.True(t, fn(errors.New("connection refused"), req, nil))
+
+		// Test success - should not retry
+		resp.StatusCode = 200
+		assert.False(t, fn(nil, req, resp))
+
+		// Test client errors - should not retry
+		resp.StatusCode = 404
+		assert.False(t, fn(nil, req, resp))
+
+		// Now test the same conditions with a mutation - should never retry
+		mutationReq, _ := createRequestWithContext(OperationTypeMutation)
+
+		resp.StatusCode = 500
+		assert.False(t, fn(nil, mutationReq, resp))
+		resp.StatusCode = 503
+		assert.False(t, fn(nil, mutationReq, resp))
+		resp.StatusCode = 429
+		assert.False(t, fn(nil, mutationReq, resp))
+		assert.False(t, fn(syscall.ETIMEDOUT, mutationReq, nil))
+		assert.False(t, fn(errors.New("connection refused"), mutationReq, nil))
 	})
 }

--- a/router/core/retry_expression_builder_test.go
+++ b/router/core/retry_expression_builder_test.go
@@ -66,7 +66,7 @@ func TestBuildRetryFunction(t *testing.T) {
 		// Use the default expression that would be in the config
 		fn, err := BuildRetryFunction(retrytransport.RetryOptions{
 			Enabled:    true,
-			Expression: DefaultRetryExpression,
+			Expression: defaultRetryExpression,
 		})
 		assert.NoError(t, err)
 		assert.NotNil(t, fn)

--- a/router/core/retry_expression_builder_test.go
+++ b/router/core/retry_expression_builder_test.go
@@ -81,7 +81,7 @@ func TestBuildRetryFunction(t *testing.T) {
 		// Test with errors - only expression-defined errors are handled here
 		assert.True(t, fn(syscall.ETIMEDOUT, req, nil))
 		assert.True(t, fn(errors.New("connection refused"), req, nil))
-		assert.False(t, fn(errors.New("unexpected EOF"), req, nil)) // EOF is now handled at transport layer, not expression
+		assert.True(t, fn(errors.New("unexpected EOF"), req, nil)) // EOF is now handled at transport layer, not expression
 		assert.False(t, fn(errors.New("some other error"), req, nil))
 	})
 

--- a/router/core/router.go
+++ b/router/core/router.go
@@ -1752,10 +1752,18 @@ func WithSubgraphCircuitBreakerOptions(opts *SubgraphCircuitBreakerOptions) Opti
 	}
 }
 
-func WithSubgraphRetryOptions(enabled bool, maxRetryCount int, retryMaxDuration, retryInterval time.Duration, expression string, onRetryFunc retrytransport.OnRetryFunc) Option {
+func WithSubgraphRetryOptions(
+	enabled bool,
+	algorithm string,
+	maxRetryCount int,
+	retryMaxDuration, retryInterval time.Duration,
+	expression string,
+	onRetryFunc retrytransport.OnRetryFunc,
+) Option {
 	return func(r *Router) {
 		r.retryOptions = retrytransport.RetryOptions{
 			Enabled:       enabled,
+			Algorithm:     algorithm,
 			MaxRetryCount: maxRetryCount,
 			MaxDuration:   retryMaxDuration,
 			Interval:      retryInterval,

--- a/router/core/router.go
+++ b/router/core/router.go
@@ -1749,13 +1749,14 @@ func WithSubgraphCircuitBreakerOptions(opts *SubgraphCircuitBreakerOptions) Opti
 	}
 }
 
-func WithSubgraphRetryOptions(enabled bool, maxRetryCount int, retryMaxDuration, retryInterval time.Duration) Option {
+func WithSubgraphRetryOptions(enabled bool, maxRetryCount int, retryMaxDuration, retryInterval time.Duration, expression string) Option {
 	return func(r *Router) {
 		r.retryOptions = retrytransport.RetryOptions{
 			Enabled:       enabled,
 			MaxRetryCount: maxRetryCount,
 			MaxDuration:   retryMaxDuration,
 			Interval:      retryInterval,
+			Expression:    expression,
 		}
 	}
 }

--- a/router/core/router.go
+++ b/router/core/router.go
@@ -1749,7 +1749,14 @@ func WithSubgraphCircuitBreakerOptions(opts *SubgraphCircuitBreakerOptions) Opti
 	}
 }
 
-func WithSubgraphRetryOptions(enabled bool, maxRetryCount int, retryMaxDuration, retryInterval time.Duration, expression string) Option {
+func WithSubgraphRetryOptions(
+	enabled bool,
+	maxRetryCount int,
+	retryMaxDuration, retryInterval time.Duration,
+	expression string,
+	onRetryFunc retrytransport.OnRetryFunc,
+	roundTripOverride http.RoundTripper,
+) Option {
 	return func(r *Router) {
 		r.retryOptions = retrytransport.RetryOptions{
 			Enabled:       enabled,
@@ -1757,6 +1764,10 @@ func WithSubgraphRetryOptions(enabled bool, maxRetryCount int, retryMaxDuration,
 			MaxDuration:   retryMaxDuration,
 			Interval:      retryInterval,
 			Expression:    expression,
+
+			// Test case overrides
+			OnRetry:           onRetryFunc,
+			RoundTripOverride: roundTripOverride,
 		}
 	}
 }

--- a/router/core/router.go
+++ b/router/core/router.go
@@ -1749,14 +1749,7 @@ func WithSubgraphCircuitBreakerOptions(opts *SubgraphCircuitBreakerOptions) Opti
 	}
 }
 
-func WithSubgraphRetryOptions(
-	enabled bool,
-	maxRetryCount int,
-	retryMaxDuration, retryInterval time.Duration,
-	expression string,
-	onRetryFunc retrytransport.OnRetryFunc,
-	roundTripOverride http.RoundTripper,
-) Option {
+func WithSubgraphRetryOptions(enabled bool, maxRetryCount int, retryMaxDuration, retryInterval time.Duration, expression string, onRetryFunc retrytransport.OnRetryFunc) Option {
 	return func(r *Router) {
 		r.retryOptions = retrytransport.RetryOptions{
 			Enabled:       enabled,
@@ -1766,8 +1759,7 @@ func WithSubgraphRetryOptions(
 			Expression:    expression,
 
 			// Test case overrides
-			OnRetry:           onRetryFunc,
-			RoundTripOverride: roundTripOverride,
+			OnRetry: onRetryFunc,
 		}
 	}
 }

--- a/router/core/supervisor_instance.go
+++ b/router/core/supervisor_instance.go
@@ -195,6 +195,7 @@ func optionsFromResources(logger *zap.Logger, config *config.Config) []Option {
 		WithSubgraphCircuitBreakerOptions(NewSubgraphCircuitBreakerOptions(config.TrafficShaping)),
 		WithSubgraphRetryOptions(
 			config.TrafficShaping.All.BackoffJitterRetry.Enabled,
+			config.TrafficShaping.All.BackoffJitterRetry.Algorithm,
 			config.TrafficShaping.All.BackoffJitterRetry.MaxAttempts,
 			config.TrafficShaping.All.BackoffJitterRetry.MaxDuration,
 			config.TrafficShaping.All.BackoffJitterRetry.Interval,

--- a/router/core/supervisor_instance.go
+++ b/router/core/supervisor_instance.go
@@ -199,8 +199,7 @@ func optionsFromResources(logger *zap.Logger, config *config.Config) []Option {
 			config.TrafficShaping.All.BackoffJitterRetry.MaxDuration,
 			config.TrafficShaping.All.BackoffJitterRetry.Interval,
 			config.TrafficShaping.All.BackoffJitterRetry.Expression,
-			// This is only used for test cases
-			nil, nil,
+			nil,
 		),
 		WithCors(&cors.Config{
 			Enabled:          config.CORS.Enabled,

--- a/router/core/supervisor_instance.go
+++ b/router/core/supervisor_instance.go
@@ -199,6 +199,8 @@ func optionsFromResources(logger *zap.Logger, config *config.Config) []Option {
 			config.TrafficShaping.All.BackoffJitterRetry.MaxDuration,
 			config.TrafficShaping.All.BackoffJitterRetry.Interval,
 			config.TrafficShaping.All.BackoffJitterRetry.Expression,
+			// This is only used for test cases
+			nil, nil,
 		),
 		WithCors(&cors.Config{
 			Enabled:          config.CORS.Enabled,

--- a/router/core/supervisor_instance.go
+++ b/router/core/supervisor_instance.go
@@ -198,6 +198,7 @@ func optionsFromResources(logger *zap.Logger, config *config.Config) []Option {
 			config.TrafficShaping.All.BackoffJitterRetry.MaxAttempts,
 			config.TrafficShaping.All.BackoffJitterRetry.MaxDuration,
 			config.TrafficShaping.All.BackoffJitterRetry.Interval,
+			config.TrafficShaping.All.BackoffJitterRetry.Expression,
 		),
 		WithCors(&cors.Config{
 			Enabled:          config.CORS.Enabled,

--- a/router/go.mod
+++ b/router/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/caarlos0/env/v11 v11.3.1
 	github.com/cep21/circuit/v4 v4.0.0
 	github.com/dgraph-io/ristretto/v2 v2.1.0
-	github.com/expr-lang/expr v1.17.3
+	github.com/expr-lang/expr v1.17.6
 	github.com/goccy/go-json v0.10.3
 	github.com/google/go-containerregistry v0.20.3
 	github.com/google/uuid v1.6.0

--- a/router/go.sum
+++ b/router/go.sum
@@ -72,8 +72,8 @@ github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
-github.com/expr-lang/expr v1.17.3 h1:myeTTuDFz7k6eFe/JPlep/UsiIjVhG61FMHFu63U7j0=
-github.com/expr-lang/expr v1.17.3/go.mod h1:8/vRC7+7HBzESEqt5kKpYXxrxkr31SaO8r40VO/1IT4=
+github.com/expr-lang/expr v1.17.6 h1:1h6i8ONk9cexhDmowO/A64VPxHScu7qfSl2k8OlINec=
+github.com/expr-lang/expr v1.17.6/go.mod h1:8/vRC7+7HBzESEqt5kKpYXxrxkr31SaO8r40VO/1IT4=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=

--- a/router/internal/expr/retry_context.go
+++ b/router/internal/expr/retry_context.go
@@ -1,0 +1,152 @@
+package expr
+
+import (
+	"errors"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"syscall"
+)
+
+// RetryContext is the context for retry expressions
+type RetryContext struct {
+	StatusCode int    `expr:"statusCode"`
+	Error      string `expr:"error"`
+	// originalError stores the original error for proper type checking
+	// This field is not exposed to expressions
+	originalError error
+}
+
+// IsHttpReadTimeout returns true if the error is an HTTP-specific timeout
+// waiting for response headers from the server.
+func (ctx RetryContext) IsHttpReadTimeout() bool {
+	// Only check for HTTP-specific timeout awaiting response headers
+	if ctx.Error != "" {
+		errLower := strings.ToLower(ctx.Error)
+		return strings.Contains(errLower, "timeout awaiting response headers")
+	}
+
+	return false
+}
+
+// IsTimeout returns true if the error is any type of timeout error,
+// including HTTP read timeouts, network timeouts, deadline exceeded errors,
+// or direct syscall timeout errors.
+func (ctx RetryContext) IsTimeout() bool {
+	// Check for HTTP-specific read timeouts
+	if ctx.IsHttpReadTimeout() {
+		return true
+	}
+
+	// Check for net package timeout errors using the standard Go method
+	if ctx.originalError != nil {
+		if netErr, ok := ctx.originalError.(net.Error); ok && netErr.Timeout() {
+			return true
+		}
+		// Check for deadline exceeded errors
+		if errors.Is(ctx.originalError, os.ErrDeadlineExceeded) {
+			return true
+		}
+		// Also check for direct syscall timeout errors not wrapped in net.Error
+		if errors.Is(ctx.originalError, syscall.ETIMEDOUT) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// IsConnectionError returns true if the error is a connection-related error,
+// including connection refused, connection reset, DNS resolution failures,
+// or TLS handshake errors.
+func (ctx RetryContext) IsConnectionError() bool {
+	// Use existing helpers for specific connection errors
+	if ctx.IsConnectionRefused() || ctx.IsConnectionReset() {
+		return true
+	}
+
+	// Fall back to string matching for other connection errors not covered by specific helpers
+	if ctx.Error != "" {
+		errLower := strings.ToLower(ctx.Error)
+		return strings.Contains(errLower, "no such host") ||
+			strings.Contains(errLower, "handshake failure") ||
+			strings.Contains(errLower, "handshake timeout")
+	}
+
+	return false
+}
+
+// Is5xxError returns true if the HTTP status code is in the 5xx range,
+// indicating a server error.
+func (ctx RetryContext) Is5xxError() bool {
+	return ctx.StatusCode >= 500 && ctx.StatusCode < 600
+}
+
+// IsRetryableStatusCode returns true if the HTTP status code is generally
+// considered retryable, including 500, 502, 503, 504, and 429.
+func (ctx RetryContext) IsRetryableStatusCode() bool {
+	switch ctx.StatusCode {
+	case http.StatusInternalServerError,
+		http.StatusBadGateway,
+		http.StatusServiceUnavailable,
+		http.StatusGatewayTimeout,
+		http.StatusTooManyRequests:
+		return true
+	default:
+		return false
+	}
+}
+
+// IsConnectionRefused returns true if the error is specifically a connection
+// refused error (ECONNREFUSED), either through direct syscall error checking
+// or string matching.
+func (ctx RetryContext) IsConnectionRefused() bool {
+	if ctx.originalError != nil && errors.Is(ctx.originalError, syscall.ECONNREFUSED) {
+		return true
+	}
+
+	// Fall back to string matching
+	if ctx.Error != "" {
+		errLower := strings.ToLower(ctx.Error)
+		return strings.Contains(errLower, "connection refused")
+	}
+
+	return false
+}
+
+// IsConnectionReset returns true if the error is specifically a connection
+// reset error (ECONNRESET), either through direct syscall error checking
+// or string matching.
+func (ctx RetryContext) IsConnectionReset() bool {
+	if ctx.originalError != nil && errors.Is(ctx.originalError, syscall.ECONNRESET) {
+		return true
+	}
+
+	// Fall back to string matching
+	if ctx.Error != "" {
+		errLower := strings.ToLower(ctx.Error)
+		return strings.Contains(errLower, "connection reset")
+	}
+
+	return false
+}
+
+// LoadRetryContext creates a RetryContext from the given error and HTTP response.
+// It extracts the error message and status code to make them available for
+// retry condition evaluation in expressions.
+func LoadRetryContext(err error, resp *http.Response) RetryContext {
+	ctx := RetryContext{
+		originalError: err,
+	}
+
+	if err != nil {
+		ctx.Error = err.Error()
+	}
+
+	if resp != nil {
+		ctx.StatusCode = resp.StatusCode
+	}
+
+	return ctx
+}

--- a/router/internal/expr/retry_context.go
+++ b/router/internal/expr/retry_context.go
@@ -78,12 +78,6 @@ func (ctx RetryContext) IsConnectionError() bool {
 	return false
 }
 
-// Is5xxError returns true if the HTTP status code is in the 5xx range,
-// indicating a server error.
-func (ctx RetryContext) Is5xxError() bool {
-	return ctx.StatusCode >= 500 && ctx.StatusCode < 600
-}
-
 // IsRetryableStatusCode returns true if the HTTP status code is generally
 // considered retryable, including 500, 502, 503, and 504.
 func (ctx RetryContext) IsRetryableStatusCode() bool {

--- a/router/internal/expr/retry_context.go
+++ b/router/internal/expr/retry_context.go
@@ -41,7 +41,8 @@ func (ctx RetryContext) IsTimeout() bool {
 
 	// Check for net package timeout errors using the standard Go method
 	if ctx.originalError != nil {
-		if netErr, ok := ctx.originalError.(net.Error); ok && netErr.Timeout() {
+		var netErr net.Error
+		if errors.As(ctx.originalError, &netErr) && netErr.Timeout() {
 			return true
 		}
 		// Check for deadline exceeded errors

--- a/router/internal/expr/retry_context.go
+++ b/router/internal/expr/retry_context.go
@@ -84,14 +84,13 @@ func (ctx RetryContext) Is5xxError() bool {
 }
 
 // IsRetryableStatusCode returns true if the HTTP status code is generally
-// considered retryable, including 500, 502, 503, 504, and 429.
+// considered retryable, including 500, 502, 503, and 504.
 func (ctx RetryContext) IsRetryableStatusCode() bool {
 	switch ctx.StatusCode {
 	case http.StatusInternalServerError,
 		http.StatusBadGateway,
 		http.StatusServiceUnavailable,
-		http.StatusGatewayTimeout,
-		http.StatusTooManyRequests:
+		http.StatusGatewayTimeout:
 		return true
 	default:
 		return false

--- a/router/internal/expr/retry_expression.go
+++ b/router/internal/expr/retry_expression.go
@@ -1,0 +1,56 @@
+package expr
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/expr-lang/expr"
+	"github.com/expr-lang/expr/vm"
+)
+
+// RetryExpressionManager handles compilation and evaluation of retry expressions
+type RetryExpressionManager struct {
+	program *vm.Program
+}
+
+// NewRetryExpressionManager creates a new RetryExpressionManager with the given expression
+func NewRetryExpressionManager(expression string) (*RetryExpressionManager, error) {
+	if expression == "" {
+		return nil, nil
+	}
+
+	// Compile the expression with retry context
+	options := []expr.Option{
+		expr.Env(RetryContext{}),
+		expr.AsKind(reflect.Bool),
+	}
+
+	program, err := expr.Compile(expression, options...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compile retry expression: %w", handleExpressionError(err))
+	}
+
+	return &RetryExpressionManager{
+		program: program,
+	}, nil
+}
+
+// ShouldRetry evaluates the retry expression with the given context
+func (m *RetryExpressionManager) ShouldRetry(ctx RetryContext) (bool, error) {
+	if m == nil || m.program == nil {
+		// Use default behavior if no expression is configured
+		return false, nil
+	}
+
+	result, err := expr.Run(m.program, ctx)
+	if err != nil {
+		return false, fmt.Errorf("failed to evaluate retry expression: %w", handleExpressionError(err))
+	}
+
+	shouldRetry, ok := result.(bool)
+	if !ok {
+		return false, fmt.Errorf("retry expression must return a boolean, got %T", result)
+	}
+
+	return shouldRetry, nil
+}

--- a/router/internal/expr/retry_expression_test.go
+++ b/router/internal/expr/retry_expression_test.go
@@ -83,18 +83,6 @@ func TestRetryExpressionManager(t *testing.T) {
 			expected:   true,
 		},
 		{
-			name:       "is5xxError helper",
-			expression: "Is5xxError()",
-			ctx:        RetryContext{StatusCode: 503},
-			expected:   true,
-		},
-		{
-			name:       "is5xxError with non-5xx",
-			expression: "Is5xxError()",
-			ctx:        RetryContext{StatusCode: 404},
-			expected:   false,
-		},
-		{
 			name:       "isConnectionError helper",
 			expression: "IsConnectionError()",
 			ctx:        RetryContext{Error: "connection refused"},

--- a/router/internal/expr/retry_expression_test.go
+++ b/router/internal/expr/retry_expression_test.go
@@ -70,6 +70,13 @@ func TestRetryExpressionManager(t *testing.T) {
 			expected:   true,
 		},
 		{
+			name:       "IsTimeout helper function wrapped",
+			expression: "IsTimeout()",
+			ctx: LoadRetryContext(
+				fmt.Errorf("wrapped error: %w", &mockTimeoutError{msg: "net timeout", timeout: true}), nil),
+			expected: true,
+		},
+		{
 			name:       "complex expression with helpers",
 			expression: "statusCode == 500 || IsTimeout()",
 			ctx:        LoadRetryContext(&mockTimeoutError{msg: "net timeout", timeout: true}, &http.Response{StatusCode: 200}),

--- a/router/internal/expr/retry_expression_test.go
+++ b/router/internal/expr/retry_expression_test.go
@@ -98,7 +98,7 @@ func TestRetryExpressionManager(t *testing.T) {
 			name:       "isRetryableStatusCode helper",
 			expression: "IsRetryableStatusCode()",
 			ctx:        RetryContext{StatusCode: 429},
-			expected:   true,
+			expected:   false,
 		},
 		{
 			name:       "range check",

--- a/router/internal/expr/retry_expression_test.go
+++ b/router/internal/expr/retry_expression_test.go
@@ -1,0 +1,554 @@
+package expr
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRetryExpressionManager(t *testing.T) {
+	tests := []struct {
+		name       string
+		expression string
+		ctx        RetryContext
+		expected   bool
+		expectErr  bool
+	}{
+		{
+			name:       "status code exact match",
+			expression: "statusCode == 500",
+			ctx:        RetryContext{StatusCode: 500},
+			expected:   true,
+		},
+		{
+			name:       "status code no match",
+			expression: "statusCode == 500",
+			ctx:        RetryContext{StatusCode: 200},
+			expected:   false,
+		},
+		{
+			name:       "OR condition - first true",
+			expression: "statusCode == 500 || statusCode == 502",
+			ctx:        RetryContext{StatusCode: 500},
+			expected:   true,
+		},
+		{
+			name:       "OR condition - second true",
+			expression: "statusCode == 500 || statusCode == 502",
+			ctx:        RetryContext{StatusCode: 502},
+			expected:   true,
+		},
+		{
+			name:       "OR condition - both false",
+			expression: "statusCode == 500 || statusCode == 502",
+			ctx:        RetryContext{StatusCode: 200},
+			expected:   false,
+		},
+		{
+			name:       "IsHttpReadTimeout helper function",
+			expression: "IsHttpReadTimeout()",
+			ctx:        RetryContext{Error: "timeout awaiting response headers"},
+			expected:   true,
+		},
+		{
+			name:       "IsHttpReadTimeout with different error",
+			expression: "IsHttpReadTimeout()",
+			ctx:        RetryContext{Error: "connection refused"},
+			expected:   false,
+		},
+		{
+			name:       "IsTimeout helper function",
+			expression: "IsTimeout()",
+			ctx:        LoadRetryContext(&mockTimeoutError{msg: "net timeout", timeout: true}, nil),
+			expected:   true,
+		},
+		{
+			name:       "complex expression with helpers",
+			expression: "statusCode == 500 || IsTimeout()",
+			ctx:        LoadRetryContext(&mockTimeoutError{msg: "net timeout", timeout: true}, &http.Response{StatusCode: 200}),
+			expected:   true,
+		},
+		{
+			name:       "is5xxError helper",
+			expression: "Is5xxError()",
+			ctx:        RetryContext{StatusCode: 503},
+			expected:   true,
+		},
+		{
+			name:       "is5xxError with non-5xx",
+			expression: "Is5xxError()",
+			ctx:        RetryContext{StatusCode: 404},
+			expected:   false,
+		},
+		{
+			name:       "isConnectionError helper",
+			expression: "IsConnectionError()",
+			ctx:        RetryContext{Error: "connection refused"},
+			expected:   true,
+		},
+
+		{
+			name:       "isRetryableStatusCode helper",
+			expression: "IsRetryableStatusCode()",
+			ctx:        RetryContext{StatusCode: 429},
+			expected:   true,
+		},
+		{
+			name:       "range check",
+			expression: "statusCode >= 500 && statusCode < 600",
+			ctx:        RetryContext{StatusCode: 503},
+			expected:   true,
+		},
+		{
+			name:       "error string contains",
+			expression: `error contains "timeout"`,
+			ctx:        RetryContext{Error: "request timeout occurred"},
+			expected:   true,
+		},
+		{
+			name:       "error string exact match",
+			expression: `error == "connection refused"`,
+			ctx:        RetryContext{Error: "connection refused"},
+			expected:   true,
+		},
+		{
+			name:       "invalid expression",
+			expression: "invalid syntax +++",
+			expectErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager, err := NewRetryExpressionManager(tt.expression)
+			if tt.expectErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, manager)
+
+			result, err := manager.ShouldRetry(tt.ctx)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestRetryExpressionManager_EmptyExpression(t *testing.T) {
+	manager, err := NewRetryExpressionManager("")
+	assert.NoError(t, err)
+	assert.Nil(t, manager)
+}
+
+func TestLoadRetryContext(t *testing.T) {
+	t.Run("with error and response", func(t *testing.T) {
+		err := errors.New("connection timeout")
+		resp := &http.Response{StatusCode: 500}
+
+		ctx := LoadRetryContext(err, resp)
+
+		assert.Equal(t, "connection timeout", ctx.Error)
+		assert.Equal(t, 500, ctx.StatusCode)
+	})
+
+	t.Run("with only error", func(t *testing.T) {
+		err := errors.New("network error")
+
+		ctx := LoadRetryContext(err, nil)
+
+		assert.Equal(t, "network error", ctx.Error)
+		assert.Equal(t, 0, ctx.StatusCode)
+	})
+
+	t.Run("with only response", func(t *testing.T) {
+		resp := &http.Response{StatusCode: 503}
+
+		ctx := LoadRetryContext(nil, resp)
+
+		assert.Equal(t, "", ctx.Error)
+		assert.Equal(t, 503, ctx.StatusCode)
+	})
+
+	t.Run("with neither error nor response", func(t *testing.T) {
+		ctx := LoadRetryContext(nil, nil)
+
+		assert.Equal(t, "", ctx.Error)
+		assert.Equal(t, 0, ctx.StatusCode)
+	})
+}
+
+func TestRetryContext_SyscallErrorDetection(t *testing.T) {
+	t.Run("IsConnectionRefused", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			err      error
+			expected bool
+		}{
+			{
+				name:     "direct ECONNREFUSED",
+				err:      syscall.ECONNREFUSED,
+				expected: true,
+			},
+			{
+				name:     "wrapped ECONNREFUSED",
+				err:      fmt.Errorf("connection failed: %w", syscall.ECONNREFUSED),
+				expected: true,
+			},
+			{
+				name: "ECONNREFUSED in net.OpError",
+				err: &net.OpError{
+					Err: &os.SyscallError{
+						Err: syscall.ECONNREFUSED,
+					},
+				},
+				expected: true,
+			},
+			{
+				name:     "string fallback - connection refused",
+				err:      errors.New("connection refused"),
+				expected: true,
+			},
+			{
+				name:     "string fallback - mixed case",
+				err:      errors.New("Connection Refused by server"),
+				expected: true,
+			},
+			{
+				name:     "different error",
+				err:      syscall.ECONNRESET,
+				expected: false,
+			},
+			{
+				name:     "nil error",
+				err:      nil,
+				expected: false,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				ctx := LoadRetryContext(tt.err, nil)
+				result := ctx.IsConnectionRefused()
+				assert.Equal(t, tt.expected, result)
+			})
+		}
+	})
+
+	t.Run("IsConnectionReset", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			err      error
+			expected bool
+		}{
+			{
+				name:     "direct ECONNRESET",
+				err:      syscall.ECONNRESET,
+				expected: true,
+			},
+			{
+				name:     "wrapped ECONNRESET",
+				err:      fmt.Errorf("network error: %w", syscall.ECONNRESET),
+				expected: true,
+			},
+			{
+				name: "ECONNRESET in net.OpError",
+				err: &net.OpError{
+					Err: &os.SyscallError{
+						Err: syscall.ECONNRESET,
+					},
+				},
+				expected: true,
+			},
+			{
+				name:     "string fallback - connection reset",
+				err:      errors.New("connection reset by peer"),
+				expected: true,
+			},
+			{
+				name:     "string fallback - mixed case",
+				err:      errors.New("Connection Reset By Peer"),
+				expected: true,
+			},
+			{
+				name:     "different error",
+				err:      syscall.ECONNREFUSED,
+				expected: false,
+			},
+			{
+				name:     "nil error",
+				err:      nil,
+				expected: false,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				ctx := LoadRetryContext(tt.err, nil)
+				result := ctx.IsConnectionReset()
+				assert.Equal(t, tt.expected, result)
+			})
+		}
+	})
+}
+
+func TestRetryContext_ImprovedErrorDetection(t *testing.T) {
+	t.Run("IsConnectionError with syscall errors", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			err      error
+			expected bool
+		}{
+			{
+				name:     "ECONNREFUSED detected",
+				err:      syscall.ECONNREFUSED,
+				expected: true,
+			},
+			{
+				name:     "ECONNRESET detected",
+				err:      syscall.ECONNRESET,
+				expected: true,
+			},
+			{
+				name:     "wrapped ECONNREFUSED detected",
+				err:      fmt.Errorf("dial error: %w", syscall.ECONNREFUSED),
+				expected: true,
+			},
+			{
+				name:     "string fallback still works",
+				err:      errors.New("no such host"),
+				expected: true,
+			},
+			{
+				name:     "ETIMEDOUT not detected by IsConnectionError",
+				err:      syscall.ETIMEDOUT,
+				expected: false,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				ctx := LoadRetryContext(tt.err, nil)
+				result := ctx.IsConnectionError()
+				assert.Equal(t, tt.expected, result)
+			})
+		}
+	})
+
+	t.Run("IsTimeout with syscall errors", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			err      error
+			expected bool
+		}{
+			{
+				name:     "ETIMEDOUT detected",
+				err:      syscall.ETIMEDOUT,
+				expected: true,
+			},
+			{
+				name:     "wrapped ETIMEDOUT detected",
+				err:      fmt.Errorf("read error: %w", syscall.ETIMEDOUT),
+				expected: true,
+			},
+			{
+				name: "ETIMEDOUT in net.OpError detected",
+				err: &net.OpError{
+					Err: &os.SyscallError{
+						Err: syscall.ETIMEDOUT,
+					},
+				},
+				expected: true,
+			},
+			{
+				name:     "i/o timeout string not detected (no string matching)",
+				err:      errors.New("i/o timeout"),
+				expected: false,
+			},
+			{
+				name:     "operation timed out string not detected (no string matching)",
+				err:      errors.New("operation timed out"),
+				expected: false,
+			},
+			{
+				name:     "connection errors not detected by IsTimeout",
+				err:      syscall.ECONNREFUSED,
+				expected: false,
+			},
+			{
+				name:     "deadline exceeded error should be detected as timeout",
+				err:      os.ErrDeadlineExceeded,
+				expected: true,
+			},
+			{
+				name:     "HTTP read timeout detected by IsTimeout",
+				err:      errors.New("timeout awaiting response headers"),
+				expected: true,
+			},
+			{
+				name:     "non-timeout error not detected",
+				err:      errors.New("some other error"),
+				expected: false,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				ctx := LoadRetryContext(tt.err, nil)
+				result := ctx.IsTimeout()
+				assert.Equal(t, tt.expected, result)
+			})
+		}
+	})
+
+	t.Run("IsHttpReadTimeout with specific HTTP timeout", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			err      error
+			expected bool
+		}{
+			{
+				name:     "HTTP timeout awaiting response headers",
+				err:      errors.New("timeout awaiting response headers"),
+				expected: true,
+			},
+			{
+				name:     "HTTP timeout awaiting response headers mixed case",
+				err:      errors.New("Timeout Awaiting Response Headers"),
+				expected: true,
+			},
+			{
+				name:     "ETIMEDOUT not detected by IsHttpReadTimeout",
+				err:      syscall.ETIMEDOUT,
+				expected: false,
+			},
+			{
+				name:     "nil error",
+				err:      nil,
+				expected: false,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				ctx := LoadRetryContext(tt.err, nil)
+				result := ctx.IsHttpReadTimeout()
+				assert.Equal(t, tt.expected, result)
+			})
+		}
+	})
+
+	t.Run("IsTimeout with net timeout errors", func(t *testing.T) {
+		// Mock net timeout error
+		mockNetTimeoutErr := &mockTimeoutError{msg: "net timeout error", timeout: true}
+		mockNetNonTimeoutErr := &mockTimeoutError{msg: "net regular error", timeout: false}
+
+		tests := []struct {
+			name     string
+			err      error
+			expected bool
+		}{
+			{
+				name:     "net timeout error detected",
+				err:      mockNetTimeoutErr,
+				expected: true,
+			},
+			{
+				name:     "net non-timeout error not detected",
+				err:      mockNetNonTimeoutErr,
+				expected: false,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				ctx := LoadRetryContext(tt.err, nil)
+				result := ctx.IsTimeout()
+				assert.Equal(t, tt.expected, result)
+			})
+		}
+	})
+}
+
+// mockTimeoutError implements net.Error interface for testing
+type mockTimeoutError struct {
+	msg     string
+	timeout bool
+}
+
+func (e *mockTimeoutError) Error() string {
+	return e.msg
+}
+
+func (e *mockTimeoutError) Timeout() bool {
+	return e.timeout
+}
+
+func (e *mockTimeoutError) Temporary() bool {
+	return false // Not a temporary error for this test
+}
+
+func TestRetryExpressionManager_WithSyscallErrors(t *testing.T) {
+	t.Run("expression with specific syscall error helpers", func(t *testing.T) {
+		expression := "IsConnectionRefused() || IsConnectionReset() || IsTimeout()"
+		manager, err := NewRetryExpressionManager(expression)
+		require.NoError(t, err)
+		require.NotNil(t, manager)
+
+		// Test ECONNREFUSED
+		ctx := LoadRetryContext(syscall.ECONNREFUSED, nil)
+		result, err := manager.ShouldRetry(ctx)
+		assert.NoError(t, err)
+		assert.True(t, result)
+
+		// Test ECONNRESET
+		ctx = LoadRetryContext(syscall.ECONNRESET, nil)
+		result, err = manager.ShouldRetry(ctx)
+		assert.NoError(t, err)
+		assert.True(t, result)
+
+		// Test ETIMEDOUT
+		ctx = LoadRetryContext(syscall.ETIMEDOUT, nil)
+		result, err = manager.ShouldRetry(ctx)
+		assert.NoError(t, err)
+		assert.True(t, result)
+
+		// Test unrelated error
+		ctx = LoadRetryContext(errors.New("some other error"), nil)
+		result, err = manager.ShouldRetry(ctx)
+		assert.NoError(t, err)
+		assert.False(t, result)
+	})
+
+	t.Run("expression combining status and syscall errors", func(t *testing.T) {
+		expression := "statusCode == 500 || IsConnectionRefused()"
+		manager, err := NewRetryExpressionManager(expression)
+		require.NoError(t, err)
+		require.NotNil(t, manager)
+
+		// Test with status code
+		ctx := LoadRetryContext(nil, &http.Response{StatusCode: 500})
+		result, err := manager.ShouldRetry(ctx)
+		assert.NoError(t, err)
+		assert.True(t, result)
+
+		// Test with syscall error
+		ctx = LoadRetryContext(syscall.ECONNREFUSED, nil)
+		result, err = manager.ShouldRetry(ctx)
+		assert.NoError(t, err)
+		assert.True(t, result)
+
+		// Test with neither condition
+		ctx = LoadRetryContext(nil, &http.Response{StatusCode: 200})
+		result, err = manager.ShouldRetry(ctx)
+		assert.NoError(t, err)
+		assert.False(t, result)
+	})
+}

--- a/router/internal/retrytransport/retry_transport.go
+++ b/router/internal/retrytransport/retry_transport.go
@@ -23,8 +23,7 @@ type RetryOptions struct {
 	ShouldRetry   ShouldRetryFunc
 
 	// Test specific only
-	OnRetry           OnRetryFunc
-	RoundTripOverride http.RoundTripper
+	OnRetry OnRetryFunc
 }
 
 type requestLoggerGetter func(req *http.Request) *zap.Logger
@@ -138,6 +137,7 @@ func (rt *RetryHTTPTransport) RoundTrip(req *http.Request) (*http.Response, erro
 			)
 		}
 
+		// Test Specific
 		if rt.RetryOptions.OnRetry != nil {
 			rt.RetryOptions.OnRetry(retries, req, resp, sleepDuration, err)
 		}

--- a/router/internal/retrytransport/retry_transport.go
+++ b/router/internal/retrytransport/retry_transport.go
@@ -16,6 +16,7 @@ type OnRetryFunc func(count int, req *http.Request, resp *http.Response, sleepDu
 
 type RetryOptions struct {
 	Enabled       bool
+	Algorithm     string
 	MaxRetryCount int
 	Interval      time.Duration
 	MaxDuration   time.Duration

--- a/router/internal/retrytransport/retry_transport_test.go
+++ b/router/internal/retrytransport/retry_transport_test.go
@@ -503,7 +503,7 @@ func TestOnRetryCallbackInvoked(t *testing.T) {
 
 	// Verify callback parameters are correct
 	for i, callback := range retryCallbacks {
-		assert.Equal(t, i, callback.count)
+		assert.Equal(t, i+1, callback.count)
 		assert.Error(t, callback.err)
 		assert.Equal(t, "retryable error", callback.err.Error())
 		assert.Nil(t, callback.resp)

--- a/router/internal/retrytransport/retry_transport_test.go
+++ b/router/internal/retrytransport/retry_transport_test.go
@@ -29,6 +29,18 @@ func simpleShouldRetry(err error, req *http.Request, resp *http.Response) bool {
 	return false
 }
 
+// shouldRetryWith429 includes 429 responses in addition to the simple retry logic
+func shouldRetryWith429(err error, req *http.Request, resp *http.Response) bool {
+	// Include 429 responses in retryable conditions
+	if err != nil {
+		return true
+	}
+	if resp != nil && (resp.StatusCode >= 500 || resp.StatusCode == http.StatusTooManyRequests) {
+		return true
+	}
+	return false
+}
+
 type MockTransport struct {
 	handler func(req *http.Request) (*http.Response, error)
 }
@@ -502,5 +514,556 @@ func TestOnRetryCallbackInvoked(t *testing.T) {
 		assert.Error(t, callback.err)
 		assert.Equal(t, "retryable error", callback.err.Error())
 		assert.Nil(t, callback.resp)
+	}
+}
+
+func TestRetryOn429WithDelaySeconds(t *testing.T) {
+	retries := 0
+	attemptCount := 0
+	maxRetries := 2
+	retryAfterSeconds := 1 // Use 1 second to keep test fast
+
+	// Track what retry duration was requested to verify Retry-After is parsed correctly
+	var retryAfterUsed []bool
+
+	tr := RetryHTTPTransport{
+		RoundTripper: &MockTransport{
+			handler: func(req *http.Request) (*http.Response, error) {
+				attemptCount++
+				if attemptCount <= maxRetries {
+					// Return 429 with Retry-After header in seconds
+					resp := &http.Response{
+						StatusCode: http.StatusTooManyRequests,
+						Header:     make(http.Header),
+					}
+					resp.Header.Set("Retry-After", fmt.Sprintf("%d", retryAfterSeconds))
+
+					// Verify the header is parsed correctly
+					duration, useRetryAfter := shouldUseRetryAfter(resp)
+					retryAfterUsed = append(retryAfterUsed, useRetryAfter)
+					assert.True(t, useRetryAfter, "Should use Retry-After header for 429")
+					assert.Equal(t, time.Duration(retryAfterSeconds)*time.Second, duration)
+
+					return resp, nil
+				}
+				// Finally return success
+				return &http.Response{
+					StatusCode: http.StatusOK,
+				}, nil
+			},
+		},
+		getRequestLogger: func(req *http.Request) *zap.Logger {
+			return zap.NewNop()
+		},
+		RetryOptions: RetryOptions{
+			MaxRetryCount: maxRetries,
+			Interval:      100 * time.Millisecond, // This should be ignored for 429
+			MaxDuration:   10 * time.Second,
+			ShouldRetry:   shouldRetryWith429,
+			OnRetry: func(count int, req *http.Request, resp *http.Response, err error) {
+				retries++
+			},
+		},
+	}
+
+	req := httptest.NewRequest("GET", "http://localhost:3000/graphql", nil)
+	resp, err := tr.RoundTrip(req)
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, maxRetries, retries)
+	assert.Equal(t, maxRetries+1, attemptCount)
+	// Verify that Retry-After was detected and used
+	assert.Len(t, retryAfterUsed, maxRetries)
+	for i, used := range retryAfterUsed {
+		assert.True(t, used, "Retry %d should have used Retry-After header", i)
+	}
+}
+
+func TestRetryOn429WithoutRetryAfter(t *testing.T) {
+	retries := 0
+	attemptCount := 0
+	maxRetries := 2
+
+	tr := RetryHTTPTransport{
+		RoundTripper: &MockTransport{
+			handler: func(req *http.Request) (*http.Response, error) {
+				attemptCount++
+				if attemptCount <= maxRetries {
+					// Return 429 without Retry-After header
+					return &http.Response{
+						StatusCode: http.StatusTooManyRequests,
+						Header:     make(http.Header),
+					}, nil
+				}
+				// Finally return success
+				return &http.Response{
+					StatusCode: http.StatusOK,
+				}, nil
+			},
+		},
+		getRequestLogger: func(req *http.Request) *zap.Logger {
+			return zap.NewNop()
+		},
+		RetryOptions: RetryOptions{
+			MaxRetryCount: maxRetries,
+			Interval:      1 * time.Millisecond,
+			MaxDuration:   10 * time.Millisecond,
+			ShouldRetry:   shouldRetryWith429,
+			OnRetry: func(count int, req *http.Request, resp *http.Response, err error) {
+				retries++
+			},
+		},
+	}
+
+	req := httptest.NewRequest("GET", "http://localhost:3000/graphql", nil)
+	resp, err := tr.RoundTrip(req)
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	// Should have retried exactly maxRetries times
+	assert.Equal(t, maxRetries, retries)
+	assert.Equal(t, maxRetries+1, attemptCount)
+}
+
+func TestRetryOn429WithHTTPDate(t *testing.T) {
+	retries := 0
+	attemptCount := 0
+	maxRetries := 2
+
+	// Track what retry duration was requested to verify Retry-After is parsed correctly
+	var retryAfterUsed []bool
+	var expectedDuration time.Duration
+
+	tr := RetryHTTPTransport{
+		RoundTripper: &MockTransport{
+			handler: func(req *http.Request) (*http.Response, error) {
+				attemptCount++
+				if attemptCount <= maxRetries {
+					// Return 429 with Retry-After header as HTTP-date (1 second in future to keep test fast)
+					expectedDuration = 1 * time.Second
+					futureTime := time.Now().UTC().Add(expectedDuration)
+					resp := &http.Response{
+						StatusCode: http.StatusTooManyRequests,
+						Header:     make(http.Header),
+					}
+					resp.Header.Set("Retry-After", futureTime.Format(http.TimeFormat))
+
+					// Verify the header is parsed correctly
+					duration, useRetryAfter := shouldUseRetryAfter(resp)
+					retryAfterUsed = append(retryAfterUsed, useRetryAfter)
+					assert.True(t, useRetryAfter, "Should use Retry-After header for 429")
+					// Allow reasonable tolerance for execution delay between time creation and parsing
+					assert.True(t, duration > 0 && duration <= expectedDuration,
+						"Duration should be positive and <= %v, got %v", expectedDuration, duration)
+
+					return resp, nil
+				}
+				// Finally return success
+				return &http.Response{
+					StatusCode: http.StatusOK,
+				}, nil
+			},
+		},
+		getRequestLogger: func(req *http.Request) *zap.Logger {
+			return zap.NewNop()
+		},
+		RetryOptions: RetryOptions{
+			MaxRetryCount: maxRetries,
+			Interval:      100 * time.Millisecond, // This should be ignored for 429
+			MaxDuration:   10 * time.Second,
+			ShouldRetry:   shouldRetryWith429,
+			OnRetry: func(count int, req *http.Request, resp *http.Response, err error) {
+				retries++
+			},
+		},
+	}
+
+	req := httptest.NewRequest("GET", "http://localhost:3000/graphql", nil)
+	resp, err := tr.RoundTrip(req)
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, maxRetries, retries)
+	assert.Equal(t, maxRetries+1, attemptCount)
+	// Verify that Retry-After was detected and used
+	assert.Len(t, retryAfterUsed, maxRetries)
+	for i, used := range retryAfterUsed {
+		assert.True(t, used, "Retry %d should have used Retry-After header", i)
+	}
+}
+
+func TestRetryOn429WithInvalidRetryAfterHeader(t *testing.T) {
+	retries := 0
+	attemptCount := 0
+	maxRetries := 2
+
+	tr := RetryHTTPTransport{
+		RoundTripper: &MockTransport{
+			handler: func(req *http.Request) (*http.Response, error) {
+				attemptCount++
+				if attemptCount <= maxRetries {
+					// Return 429 with invalid Retry-After header
+					resp := &http.Response{
+						StatusCode: http.StatusTooManyRequests,
+						Header:     make(http.Header),
+					}
+					resp.Header.Set("Retry-After", "invalid-value")
+					return resp, nil
+				}
+				// Finally return success
+				return &http.Response{
+					StatusCode: http.StatusOK,
+				}, nil
+			},
+		},
+		getRequestLogger: func(req *http.Request) *zap.Logger {
+			return zap.NewNop()
+		},
+		RetryOptions: RetryOptions{
+			MaxRetryCount: maxRetries,
+			Interval:      1 * time.Millisecond,
+			MaxDuration:   10 * time.Millisecond,
+			ShouldRetry:   shouldRetryWith429,
+			OnRetry: func(count int, req *http.Request, resp *http.Response, err error) {
+				retries++
+			},
+		},
+	}
+
+	req := httptest.NewRequest("GET", "http://localhost:3000/graphql", nil)
+	resp, err := tr.RoundTrip(req)
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	// Should have retried exactly maxRetries times
+	assert.Equal(t, maxRetries, retries)
+	assert.Equal(t, maxRetries+1, attemptCount)
+	// Should fall back to normal backoff when Retry-After is invalid
+}
+
+func TestRetryOn429WithNegativeDelaySeconds(t *testing.T) {
+	retries := 0
+	attemptCount := 0
+	maxRetries := 2
+
+	tr := RetryHTTPTransport{
+		RoundTripper: &MockTransport{
+			handler: func(req *http.Request) (*http.Response, error) {
+				attemptCount++
+				if attemptCount <= maxRetries {
+					// Return 429 with negative Retry-After value (should fall back to normal backoff)
+					resp := &http.Response{
+						StatusCode: http.StatusTooManyRequests,
+						Header:     make(http.Header),
+					}
+					resp.Header.Set("Retry-After", "-1")
+					return resp, nil
+				}
+				// Finally return success
+				return &http.Response{
+					StatusCode: http.StatusOK,
+				}, nil
+			},
+		},
+		getRequestLogger: func(req *http.Request) *zap.Logger {
+			return zap.NewNop()
+		},
+		RetryOptions: RetryOptions{
+			MaxRetryCount: maxRetries,
+			Interval:      1 * time.Millisecond,
+			MaxDuration:   10 * time.Millisecond,
+			ShouldRetry:   shouldRetryWith429,
+			OnRetry: func(count int, req *http.Request, resp *http.Response, err error) {
+				retries++
+			},
+		},
+	}
+
+	req := httptest.NewRequest("GET", "http://localhost:3000/graphql", nil)
+	resp, err := tr.RoundTrip(req)
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	// Should have retried exactly maxRetries times
+	assert.Equal(t, maxRetries, retries)
+	assert.Equal(t, maxRetries+1, attemptCount)
+}
+
+func TestRetryMixed429AndOtherErrors(t *testing.T) {
+	retries := 0
+	attemptCount := 0
+	maxRetries := 4
+
+	// Track which responses used Retry-After vs normal backoff
+	var retryAfterUsedPerAttempt []bool
+
+	tr := RetryHTTPTransport{
+		RoundTripper: &MockTransport{
+			handler: func(req *http.Request) (*http.Response, error) {
+				attemptCount++
+				switch attemptCount {
+				case 1:
+					// First: 429 with Retry-After
+					resp := &http.Response{
+						StatusCode: http.StatusTooManyRequests,
+						Header:     make(http.Header),
+					}
+					resp.Header.Set("Retry-After", "1")
+
+					// Verify this should use Retry-After
+					_, useRetryAfter := shouldUseRetryAfter(resp)
+					retryAfterUsedPerAttempt = append(retryAfterUsedPerAttempt, useRetryAfter)
+
+					return resp, nil
+				case 2:
+					// Second: Network error (should use normal backoff)
+					retryAfterUsedPerAttempt = append(retryAfterUsedPerAttempt, false)
+					return nil, errors.New("network error")
+				case 3:
+					// Third: 500 error (should use normal backoff)
+					resp := &http.Response{
+						StatusCode: http.StatusInternalServerError,
+					}
+					_, useRetryAfter := shouldUseRetryAfter(resp)
+					retryAfterUsedPerAttempt = append(retryAfterUsedPerAttempt, useRetryAfter)
+					return resp, nil
+				case 4:
+					// Fourth: 429 without Retry-After (should use normal backoff)
+					resp := &http.Response{
+						StatusCode: http.StatusTooManyRequests,
+						Header:     make(http.Header),
+					}
+					_, useRetryAfter := shouldUseRetryAfter(resp)
+					retryAfterUsedPerAttempt = append(retryAfterUsedPerAttempt, useRetryAfter)
+					return resp, nil
+				default:
+					// Finally: Success
+					return &http.Response{
+						StatusCode: http.StatusOK,
+					}, nil
+				}
+			},
+		},
+		getRequestLogger: func(req *http.Request) *zap.Logger {
+			return zap.NewNop()
+		},
+		RetryOptions: RetryOptions{
+			MaxRetryCount: maxRetries,
+			Interval:      10 * time.Millisecond, // Should be used for non-429-with-Retry-After cases
+			MaxDuration:   10 * time.Second,
+			ShouldRetry:   shouldRetryWith429,
+			OnRetry: func(count int, req *http.Request, resp *http.Response, err error) {
+				retries++
+			},
+		},
+	}
+
+	req := httptest.NewRequest("GET", "http://localhost:3000/graphql", nil)
+	resp, err := tr.RoundTrip(req)
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, maxRetries, retries)
+	assert.Equal(t, maxRetries+1, attemptCount)
+	assert.Len(t, retryAfterUsedPerAttempt, maxRetries)
+
+	// First attempt should use Retry-After (429 with header)
+	assert.True(t, retryAfterUsedPerAttempt[0], "First retry should use Retry-After")
+
+	// Other attempts should not use Retry-After
+	assert.False(t, retryAfterUsedPerAttempt[1], "Second retry should not use Retry-After (network error)")
+	assert.False(t, retryAfterUsedPerAttempt[2], "Third retry should not use Retry-After (500 error)")
+	assert.False(t, retryAfterUsedPerAttempt[3], "Fourth retry should not use Retry-After (429 without header)")
+}
+
+func TestNoRetryOn429WhenShouldRetryReturnsFalse(t *testing.T) {
+	retries := 0
+	attemptCount := 0
+
+	// ShouldRetry function that excludes 429 responses
+	shouldNotRetry429 := func(err error, req *http.Request, resp *http.Response) bool {
+		// Only retry on errors, not on 429 responses
+		if err != nil {
+			return true
+		}
+		// Do not retry on any HTTP status codes (including 429)
+		return false
+	}
+
+	tr := RetryHTTPTransport{
+		RoundTripper: &MockTransport{
+			handler: func(req *http.Request) (*http.Response, error) {
+				attemptCount++
+				// Always return 429 with Retry-After header
+				resp := &http.Response{
+					StatusCode: http.StatusTooManyRequests,
+					Header:     make(http.Header),
+				}
+				resp.Header.Set("Retry-After", "1")
+				return resp, nil
+			},
+		},
+		getRequestLogger: func(req *http.Request) *zap.Logger {
+			return zap.NewNop()
+		},
+		RetryOptions: RetryOptions{
+			MaxRetryCount: 3,
+			Interval:      1 * time.Millisecond,
+			MaxDuration:   10 * time.Millisecond,
+			ShouldRetry:   shouldNotRetry429,
+			OnRetry: func(count int, req *http.Request, resp *http.Response, err error) {
+				retries++
+			},
+		},
+	}
+
+	req := httptest.NewRequest("GET", "http://localhost:3000/graphql", nil)
+	resp, err := tr.RoundTrip(req)
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
+	// Should not have retried at all since ShouldRetry returns false for 429
+	assert.Equal(t, 0, retries)
+	assert.Equal(t, 1, attemptCount)
+}
+
+// Test unit functions directly
+func TestParseRetryAfterHeader(t *testing.T) {
+	tests := []struct {
+		name     string
+		header   string
+		expected time.Duration
+	}{
+		{
+			name:     "valid delay seconds",
+			header:   "120",
+			expected: 120 * time.Second,
+		},
+		{
+			name:     "zero delay seconds",
+			header:   "0",
+			expected: 0,
+		},
+		{
+			name:     "negative delay seconds should return 0",
+			header:   "-1",
+			expected: 0,
+		},
+		{
+			name:     "invalid string should return 0",
+			header:   "invalid",
+			expected: 0,
+		},
+		{
+			name:     "empty string should return 0",
+			header:   "",
+			expected: 0,
+		},
+		{
+			name:     "HTTP date in future",
+			header:   time.Now().UTC().Add(3 * time.Second).Format(http.TimeFormat),
+			expected: 3 * time.Second, // approximately
+		},
+		{
+			name:     "HTTP date in past should return 0",
+			header:   time.Now().UTC().Add(-3 * time.Second).Format(http.TimeFormat),
+			expected: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseRetryAfterHeader(tt.header)
+
+			if tt.name == "HTTP date in future" {
+				// For HTTP date tests, allow reasonable tolerance for timing variations
+				assert.True(t, result >= tt.expected-1*time.Second && result <= tt.expected+1*time.Second,
+					"Expected ~%v, got %v", tt.expected, result)
+			} else {
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestShouldUseRetryAfter(t *testing.T) {
+	tests := []struct {
+		name        string
+		resp        *http.Response
+		expectedDur time.Duration
+		expectedUse bool
+	}{
+		{
+			name:        "nil response",
+			resp:        nil,
+			expectedDur: 0,
+			expectedUse: false,
+		},
+		{
+			name: "non-429 response",
+			resp: &http.Response{
+				StatusCode: http.StatusInternalServerError,
+				Header:     make(http.Header),
+			},
+			expectedDur: 0,
+			expectedUse: false,
+		},
+		{
+			name: "429 without Retry-After header",
+			resp: &http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Header:     make(http.Header),
+			},
+			expectedDur: 0,
+			expectedUse: false,
+		},
+		{
+			name: "429 with empty Retry-After header",
+			resp: func() *http.Response {
+				resp := &http.Response{
+					StatusCode: http.StatusTooManyRequests,
+					Header:     make(http.Header),
+				}
+				resp.Header.Set("Retry-After", "")
+				return resp
+			}(),
+			expectedDur: 0,
+			expectedUse: false,
+		},
+		{
+			name: "429 with valid Retry-After seconds",
+			resp: func() *http.Response {
+				resp := &http.Response{
+					StatusCode: http.StatusTooManyRequests,
+					Header:     make(http.Header),
+				}
+				resp.Header.Set("Retry-After", "30")
+				return resp
+			}(),
+			expectedDur: 30 * time.Second,
+			expectedUse: true,
+		},
+		{
+			name: "429 with invalid Retry-After",
+			resp: func() *http.Response {
+				resp := &http.Response{
+					StatusCode: http.StatusTooManyRequests,
+					Header:     make(http.Header),
+				}
+				resp.Header.Set("Retry-After", "invalid")
+				return resp
+			}(),
+			expectedDur: 0,
+			expectedUse: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dur, use := shouldUseRetryAfter(tt.resp)
+			assert.Equal(t, tt.expectedDur, dur)
+			assert.Equal(t, tt.expectedUse, use)
+		})
 	}
 }

--- a/router/internal/retrytransport/retry_transport_test.go
+++ b/router/internal/retrytransport/retry_transport_test.go
@@ -269,15 +269,6 @@ func TestShortCircuitOnSuccess(t *testing.T) {
 	resp.Body.Close()
 }
 
-// Mock round tripper for testing
-type mockRoundTripper struct {
-	roundTripFunc func(req *http.Request) (*http.Response, error)
-}
-
-func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	return m.roundTripFunc(req)
-}
-
 func TestMaxRetryCountRespected(t *testing.T) {
 	maxRetries := 2
 	retries := 0
@@ -884,11 +875,8 @@ func TestNoRetryOn429WhenShouldRetryReturnsFalse(t *testing.T) {
 	// ShouldRetry function that excludes 429 responses
 	shouldNotRetry429 := func(err error, req *http.Request, resp *http.Response) bool {
 		// Only retry on errors, not on 429 responses
-		if err != nil {
-			return true
-		}
 		// Do not retry on any HTTP status codes (including 429)
-		return false
+		return err != nil
 	}
 
 	tr := RetryHTTPTransport{

--- a/router/pkg/config/config.go
+++ b/router/pkg/config/config.go
@@ -234,6 +234,7 @@ type BackoffJitterRetry struct {
 	MaxAttempts int           `yaml:"max_attempts" envDefault:"5"`
 	MaxDuration time.Duration `yaml:"max_duration" envDefault:"10s"`
 	Interval    time.Duration `yaml:"interval" envDefault:"3s"`
+	Expression  string        `yaml:"expression,omitempty" env:"RETRY_EXPRESSION" envDefault:"IsRetryableStatusCode() || IsConnectionError() || IsTimeout()"`
 }
 
 type SubgraphCacheControlRule struct {

--- a/router/pkg/config/config.go
+++ b/router/pkg/config/config.go
@@ -230,7 +230,7 @@ type GraphqlMetrics struct {
 
 type BackoffJitterRetry struct {
 	Enabled     bool          `yaml:"enabled" envDefault:"true" env:"RETRY_ENABLED"`
-	Algorithm   string        `yaml:"algorithm" envDefault:"backoff_jitter"`
+	Algorithm   string        `yaml:"algorithm" envDefault:"backoff_jitter" env:"RETRY_ALGORITHM"`
 	MaxAttempts int           `yaml:"max_attempts" envDefault:"5" env:"RETRY_MAX_ATTEMPTS"`
 	MaxDuration time.Duration `yaml:"max_duration" envDefault:"10s" env:"RETRY_MAX_DURATION"`
 	Interval    time.Duration `yaml:"interval" envDefault:"3s" env:"RETRY_INTERVAL"`

--- a/router/pkg/config/config.go
+++ b/router/pkg/config/config.go
@@ -231,9 +231,9 @@ type GraphqlMetrics struct {
 type BackoffJitterRetry struct {
 	Enabled     bool          `yaml:"enabled" envDefault:"true" env:"RETRY_ENABLED"`
 	Algorithm   string        `yaml:"algorithm" envDefault:"backoff_jitter"`
-	MaxAttempts int           `yaml:"max_attempts" envDefault:"5"`
-	MaxDuration time.Duration `yaml:"max_duration" envDefault:"10s"`
-	Interval    time.Duration `yaml:"interval" envDefault:"3s"`
+	MaxAttempts int           `yaml:"max_attempts" envDefault:"5" env:"RETRY_MAX_ATTEMPTS"`
+	MaxDuration time.Duration `yaml:"max_duration" envDefault:"10s" env:"RETRY_MAX_DURATION"`
+	Interval    time.Duration `yaml:"interval" envDefault:"3s" env:"RETRY_INTERVAL"`
 	Expression  string        `yaml:"expression,omitempty" env:"RETRY_EXPRESSION" envDefault:"IsRetryableStatusCode() || IsConnectionError() || IsTimeout()"`
 }
 

--- a/router/pkg/config/config.schema.json
+++ b/router/pkg/config/config.schema.json
@@ -3239,6 +3239,11 @@
               "format": "go-duration",
               "default": "10s",
               "description": "The maximum allowable duration between retries (random). The period is specified as a string with a number and a unit, e.g. 10ms, 1s, 1m, 1h. The supported units are 'ms', 's', 'm', 'h'."
+            },
+            "expression": {
+              "type": "string",
+              "description": "The expression used to determine if a request should be retried. The expression can reference status codes, error messages, and helper functions like IsRetryableStatusCode(), IsConnectionError(), IsHttpReadTimeout(), IsTimeout() (includes HTTP read timeouts). See https://expr-lang.org/ for expression syntax. Note: Mutations are never retried regardless of this expression. EOF errors are always retried at the transport layer regardless of this expression.",
+              "default": "IsRetryableStatusCode() || IsConnectionError() || IsTimeout()"
             }
           }
         }

--- a/router/pkg/config/testdata/config_defaults.json
+++ b/router/pkg/config/testdata/config_defaults.json
@@ -146,7 +146,8 @@
         "Algorithm": "backoff_jitter",
         "MaxAttempts": 5,
         "MaxDuration": 10000000000,
-        "Interval": 3000000000
+        "Interval": 3000000000,
+        "Expression": "IsRetryableStatusCode() || IsConnectionError() || IsTimeout()"
       },
       "CircuitBreaker": {
         "Enabled": false,

--- a/router/pkg/config/testdata/config_full.json
+++ b/router/pkg/config/testdata/config_full.json
@@ -311,7 +311,8 @@
         "Algorithm": "backoff_jitter",
         "MaxAttempts": 5,
         "MaxDuration": 10000000000,
-        "Interval": 3000000000
+        "Interval": 3000000000,
+        "Expression": "IsRetryableStatusCode() || IsConnectionError() || IsTimeout()"
       },
       "CircuitBreaker": {
         "Enabled": false,
@@ -349,7 +350,8 @@
           "Algorithm": "",
           "MaxAttempts": 0,
           "MaxDuration": 0,
-          "Interval": 0
+          "Interval": 0,
+          "Expression": ""
         },
         "CircuitBreaker": {
           "Enabled": false,


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expression-driven, configurable retry policies for subgraph requests with sensible defaults; retries skip mutations and honor Retry-After. Transport clients now wire logging, circuit-breaker, and conditional tracing; OnRetry callbacks receive computed sleep durations.
- **Configuration**
  - Retry expression exposed in config (env/YAML) with a safe default and new algorithm/max-duration/interval env bindings.
- **Tests**
  - Extensive unit and integration coverage for retry expressions, Retry-After semantics, callbacks, and edge cases.
- **Chores**
  - Dependency upgraded to expr-lang v1.17.6.
- **Breaking Changes**
  - Public retry API expanded; call sites updated to new signature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

# Example configuration

```yaml
traffic_shaping:
  all:
    retry:
      expression: IsRetryableStatusCode() || IsConnectionError() || IsTimeout()
```

# Retry Strategy Decision Table

| Scenario              | Expression                                                          | Description                                           |
| --------------------- | ------------------------------------------------------------------- | ----------------------------------------------------- |
| **Conservative**      | `IsRetryableStatusCode()`                                           | Only retry standard HTTP errors (500,502,503,504) |
| **Balanced**          | `IsRetryableStatusCode() \|\| IsTimeout() \|\| IsConnectionError()` | Most transient errors - recommended default           |
| **Aggressive**        | `Is5xxError() \|\| IsTimeout() \|\| IsConnectionError()`            | Maximum availability, higher retry volume             |
| **Timeout Only**      | `IsTimeout()`                                                       | Only network/HTTP timeouts                            |
| **HTTP Read Timeout** | `IsHttpReadTimeout()`                                               | Only HTTP read timeouts                               |
| **Connection Only**   | `IsConnectionError()`                                               | Only network connectivity issues                      |
| **Custom Status**     | `statusCode == 503`                                                 | Specific HTTP status codes                            |
| **Error Text**        | `error contains "timeout"`                                          | Match error message text                              |

**Available Methods:** `IsTimeout()`, `IsConnectionError()`, `IsConnectionRefused()`, `IsConnectionReset()`, `Is5xxError()`, `IsRetryableStatusCode()`, `IsHttpReadTimeout()`  
**Available Fields:** `statusCode` (int), `error` (string)

**Default:** `IsRetryableStatusCode() || IsConnectionError() || IsTimeout()`

**Note:** Mutations are never retried regardless of this expression. EOF errors are always retried.


## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->