### PR TITLE
fix: don't log graceful watcher shutdown as error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -188,7 +188,7 @@ services:
     environment:
       PORT: 11000
       NODE_ENV: development
-      AUTH_JWT_SECRET: fkczyomvdprgvtmvkuhvprxuggkbgwld
+      AUTH_JWT_SECRET: ${CDN_AUTH_JWT_SECRET:-fkczyomvdprgvtmvkuhvprxuggkbgwld}
       AUTH_ADMISSION_JWT_SECRET: uXDxJLEvrw4aafPfrf3rRotCoBzRfPEW
       S3_STORAGE_URL: ${S3_STORAGE_URL:-http://${MINIO_ROOT_USER:-minio}:${MINIO_ROOT_PASSWORD:-changeme}@minio:9000/cosmo}
       S3_REGION: ${S3_REGION_CDN:-${S3_REGION:-auto}}

--- a/router/cmd/main.go
+++ b/router/cmd/main.go
@@ -183,7 +183,7 @@ func Main() {
 			)
 		}
 
-		watchFunc, err := watcher.New(watcher.Options{
+		w, err := watcher.New(watcher.Options{
 			Interval: result.Config.WatchConfig.Interval,
 			Logger:   ll,
 			Paths:    *configPathFlag,
@@ -203,9 +203,9 @@ func Main() {
 			// different instances of the router
 			time.Sleep(startupDelay)
 
-			if err := watchFunc(rootCtx); err != nil {
+			if err := w(rootCtx); err != nil {
 				if !errors.Is(err, context.Canceled) {
-					ll.Error("Error watching execution config", zap.Error(err))
+					ll.Error("Error watching router config", zap.Error(err))
 				} else {
 					ll.Debug("Watcher context cancelled, shutting down")
 				}

--- a/router/core/router.go
+++ b/router/core/router.go
@@ -1201,8 +1201,11 @@ func (r *Router) Start(ctx context.Context) error {
 
 			go func() {
 				if err := w(ctx); err != nil {
-					r.logger.Error("Error watching execution config", zap.Error(err))
-					return
+					if !errors.Is(err, context.Canceled) {
+						ll.Error("Error watching execution config", zap.Error(err))
+					} else {
+						ll.Debug("Watcher context cancelled, shutting down")
+					}
 				}
 			}()
 

--- a/router/debug.config.yaml
+++ b/router/debug.config.yaml
@@ -5,9 +5,10 @@
 
 version: '1'
 
-# execution_config:
-#   file:
-#     path: './__schemas/config.json'
+execution_config:
+  file:
+    path: './__schemas/config.json'
+    watch: true
 
 log_level: debug
 


### PR DESCRIPTION
- **fix: don't log errors when execution config watcher shuts down gracefully**
- **chore: allow using .env for CDN JWT secret**
- **chore: uncomment local execution config for debug JSON**

<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - CDN JWT secret is now configurable via environment variable, with a safe default fallback.
  - Router supports watching and auto-reloading the execution config file in debug mode.

- Bug Fixes
  - Eliminated misleading error logs when config watching is canceled during shutdown; logs are clearer and reflect normal shutdown behavior.

- Chores
  - Minor log message polish for router configuration events to improve clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->