### PR TITLE
feat(router): add introspection authentication bypass feature

### DIFF
--- a/router-tests/authentication_test.go
+++ b/router-tests/authentication_test.go
@@ -24,11 +24,13 @@ import (
 )
 
 const (
-	employeesQuery                = `{"query":"{ employees { id } }"}`
-	employeesQueryRequiringClaims = `{"query":"{ employees { id startDate } }"}`
-	employeesExpectedData         = `{"data":{"employees":[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5},{"id":7},{"id":8},{"id":10},{"id":11},{"id":12}]}}`
-	unauthorizedExpectedData      = `{"errors":[{"message":"unauthorized"}]}`
-	xAuthenticatedByHeader        = "X-Authenticated-By"
+	employeesQuery                  = `{"query":"{ employees { id } }"}`
+	employeesQueryRequiringClaims   = `{"query":"{ employees { id startDate } }"}`
+	employeesExpectedData           = `{"data":{"employees":[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5},{"id":7},{"id":8},{"id":10},{"id":11},{"id":12}]}}`
+	unauthorizedExpectedData        = `{"errors":[{"message":"unauthorized"}]}`
+	xAuthenticatedByHeader          = "X-Authenticated-By"
+	simpleIntrospectionQuery        = `{"query":"{ __type(name: \"Query\") { name } }"}`
+	simpleIntrospectionExpectedData = `{"data":{"__type":{"name":"Query"}}}`
 )
 
 func TestAuthentication(t *testing.T) {
@@ -41,7 +43,7 @@ func TestAuthentication(t *testing.T) {
 
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
-				core.WithAccessController(core.NewAccessController(authenticators, false)),
+				core.WithAccessController(core.NewAccessController(authenticators, false, false, "")),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			// Operations without token should succeed
@@ -62,7 +64,7 @@ func TestAuthentication(t *testing.T) {
 		authenticators, _ := ConfigureAuth(t)
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
-				core.WithAccessController(core.NewAccessController(authenticators, false)),
+				core.WithAccessController(core.NewAccessController(authenticators, false, false, "")),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			// Operations with an invalid token should fail
@@ -86,7 +88,7 @@ func TestAuthentication(t *testing.T) {
 		authenticators, authServer := ConfigureAuth(t)
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
-				core.WithAccessController(core.NewAccessController(authenticators, false)),
+				core.WithAccessController(core.NewAccessController(authenticators, false, false, "")),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			// Operations with a token should succeed
@@ -112,7 +114,7 @@ func TestAuthentication(t *testing.T) {
 		authenticators, _ := ConfigureAuth(t)
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
-				core.WithAccessController(core.NewAccessController(authenticators, false)),
+				core.WithAccessController(core.NewAccessController(authenticators, false, false, "")),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			res, err := xEnv.MakeRequest(http.MethodPost, "/graphql", nil, strings.NewReader(employeesQueryRequiringClaims))
@@ -130,7 +132,7 @@ func TestAuthentication(t *testing.T) {
 		authenticators, authServer := ConfigureAuth(t)
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
-				core.WithAccessController(core.NewAccessController(authenticators, false)),
+				core.WithAccessController(core.NewAccessController(authenticators, false, false, "")),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			// Operations with a token should succeed
@@ -155,7 +157,7 @@ func TestAuthentication(t *testing.T) {
 		authenticators, authServer := ConfigureAuth(t)
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
-				core.WithAccessController(core.NewAccessController(authenticators, false)),
+				core.WithAccessController(core.NewAccessController(authenticators, false, false, "")),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			// Operations with a token should succeed
@@ -182,7 +184,7 @@ func TestAuthentication(t *testing.T) {
 		authenticators, authServer := ConfigureAuth(t)
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
-				core.WithAccessController(core.NewAccessController(authenticators, false)),
+				core.WithAccessController(core.NewAccessController(authenticators, false, false, "")),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			// Operations with a token should succeed
@@ -208,7 +210,7 @@ func TestAuthentication(t *testing.T) {
 		authenticators, authServer := ConfigureAuth(t)
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
-				core.WithAccessController(core.NewAccessController(authenticators, false)),
+				core.WithAccessController(core.NewAccessController(authenticators, false, false, "")),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			// Operations with an token should succeed
@@ -235,7 +237,7 @@ func TestAuthentication(t *testing.T) {
 		authenticators, authServer := ConfigureAuth(t)
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
-				core.WithAccessController(core.NewAccessController(authenticators, false)),
+				core.WithAccessController(core.NewAccessController(authenticators, false, false, "")),
 				core.WithAuthorizationConfig(&config.AuthorizationConfiguration{
 					RejectOperationIfUnauthorized: true,
 				}),
@@ -266,7 +268,7 @@ func TestAuthentication(t *testing.T) {
 		authenticators, authServer := ConfigureAuth(t)
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
-				core.WithAccessController(core.NewAccessController(authenticators, false)),
+				core.WithAccessController(core.NewAccessController(authenticators, false, false, "")),
 				core.WithAuthorizationConfig(&config.AuthorizationConfiguration{
 					RejectOperationIfUnauthorized: true,
 				}),
@@ -295,7 +297,7 @@ func TestAuthentication(t *testing.T) {
 		authenticators, _ := ConfigureAuth(t)
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
-				core.WithAccessController(core.NewAccessController(authenticators, false)),
+				core.WithAccessController(core.NewAccessController(authenticators, false, false, "")),
 				core.WithAuthorizationConfig(&config.AuthorizationConfiguration{
 					RejectOperationIfUnauthorized: true,
 				}),
@@ -320,7 +322,7 @@ func TestAuthentication(t *testing.T) {
 		authenticators, _ := ConfigureAuth(t)
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
-				core.WithAccessController(core.NewAccessController(authenticators, false)),
+				core.WithAccessController(core.NewAccessController(authenticators, false, false, "")),
 				core.WithAuthorizationConfig(&config.AuthorizationConfiguration{
 					RejectOperationIfUnauthorized: true,
 				}),
@@ -343,7 +345,7 @@ func TestAuthentication(t *testing.T) {
 		authenticators, authServer := ConfigureAuth(t)
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
-				core.WithAccessController(core.NewAccessController(authenticators, false)),
+				core.WithAccessController(core.NewAccessController(authenticators, false, false, "")),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			// Operations with a token should succeed
@@ -370,7 +372,7 @@ func TestAuthentication(t *testing.T) {
 		authenticators, authServer := ConfigureAuth(t)
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
-				core.WithAccessController(core.NewAccessController(authenticators, false)),
+				core.WithAccessController(core.NewAccessController(authenticators, false, false, "")),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			// Operations with a token should succeed
@@ -397,7 +399,7 @@ func TestAuthentication(t *testing.T) {
 		authenticators, authServer := ConfigureAuth(t)
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
-				core.WithAccessController(core.NewAccessController(authenticators, false)),
+				core.WithAccessController(core.NewAccessController(authenticators, false, false, "")),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			// Operations with a token should succeed
@@ -426,7 +428,7 @@ func TestAuthentication(t *testing.T) {
 		authenticators, _ := ConfigureAuth(t)
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
-				core.WithAccessController(core.NewAccessController(authenticators, false)),
+				core.WithAccessController(core.NewAccessController(authenticators, false, false, "")),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			res, err := xEnv.MakeRequest(http.MethodPost, "/graphql", nil, strings.NewReader(`
@@ -446,7 +448,7 @@ func TestAuthentication(t *testing.T) {
 		authenticators, _ := ConfigureAuth(t)
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
-				core.WithAccessController(core.NewAccessController(authenticators, false)),
+				core.WithAccessController(core.NewAccessController(authenticators, false, false, "")),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			res, err := xEnv.MakeRequest(http.MethodPost, "/graphql", nil, strings.NewReader(`
@@ -466,7 +468,7 @@ func TestAuthentication(t *testing.T) {
 		authenticators, _ := ConfigureAuth(t)
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
-				core.WithAccessController(core.NewAccessController(authenticators, false)),
+				core.WithAccessController(core.NewAccessController(authenticators, false, false, "")),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			res, err := xEnv.MakeRequest(http.MethodPost, "/graphql", nil, strings.NewReader(`
@@ -486,7 +488,7 @@ func TestAuthentication(t *testing.T) {
 		authenticators, authServer := ConfigureAuth(t)
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
-				core.WithAccessController(core.NewAccessController(authenticators, false)),
+				core.WithAccessController(core.NewAccessController(authenticators, false, false, "")),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			token, err := authServer.Token(nil)
@@ -511,7 +513,7 @@ func TestAuthentication(t *testing.T) {
 		authenticators, authServer := ConfigureAuth(t)
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
-				core.WithAccessController(core.NewAccessController(authenticators, false)),
+				core.WithAccessController(core.NewAccessController(authenticators, false, false, "")),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			token, err := authServer.Token(map[string]any{
@@ -538,7 +540,7 @@ func TestAuthentication(t *testing.T) {
 		authenticators, authServer := ConfigureAuth(t)
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
-				core.WithAccessController(core.NewAccessController(authenticators, false)),
+				core.WithAccessController(core.NewAccessController(authenticators, false, false, "")),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			token, err := authServer.Token(map[string]any{
@@ -565,7 +567,7 @@ func TestAuthentication(t *testing.T) {
 		authenticators, authServer := ConfigureAuth(t)
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
-				core.WithAccessController(core.NewAccessController(authenticators, false)),
+				core.WithAccessController(core.NewAccessController(authenticators, false, false, "")),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			token, err := authServer.Token(map[string]any{
@@ -592,7 +594,7 @@ func TestAuthentication(t *testing.T) {
 		authenticators, authServer := ConfigureAuth(t)
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
-				core.WithAccessController(core.NewAccessController(authenticators, false)),
+				core.WithAccessController(core.NewAccessController(authenticators, false, false, "")),
 				core.WithAuthorizationConfig(&config.AuthorizationConfiguration{
 					RejectOperationIfUnauthorized: true,
 				}),
@@ -649,7 +651,7 @@ func TestAuthenticationWithCustomHeaders(t *testing.T) {
 	runTest := func(t *testing.T, headerValue string) {
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
-				core.WithAccessController(core.NewAccessController(authenticators, false)),
+				core.WithAccessController(core.NewAccessController(authenticators, false, false, "")),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 
@@ -710,7 +712,7 @@ func TestHttpJwksAuthorization(t *testing.T) {
 		authenticators, _ := ConfigureAuth(t)
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
-				core.WithAccessController(core.NewAccessController(authenticators, true)),
+				core.WithAccessController(core.NewAccessController(authenticators, true, false, "")),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			// Operations without token should fail
@@ -731,7 +733,7 @@ func TestHttpJwksAuthorization(t *testing.T) {
 		authenticators, _ := ConfigureAuth(t)
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
-				core.WithAccessController(core.NewAccessController(authenticators, true)),
+				core.WithAccessController(core.NewAccessController(authenticators, true, false, "")),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			// Operations with an invalid token should fail
@@ -757,7 +759,7 @@ func TestHttpJwksAuthorization(t *testing.T) {
 		require.NoError(t, err)
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
-				core.WithAccessController(core.NewAccessController(authenticators, true)),
+				core.WithAccessController(core.NewAccessController(authenticators, true, false, "")),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			// Operations with a token should succeed
@@ -810,7 +812,7 @@ func TestHttpJwksAuthorization(t *testing.T) {
 
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
-				core.WithAccessController(core.NewAccessController(authenticators, true)),
+				core.WithAccessController(core.NewAccessController(authenticators, true, false, "")),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			// Operations with a token should succeed
@@ -870,7 +872,7 @@ func TestNonHttpAuthorization(t *testing.T) {
 
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
-				core.WithAccessController(core.NewAccessController(authenticators, true)),
+				core.WithAccessController(core.NewAccessController(authenticators, true, false, "")),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			// Operations with a token should succeed
@@ -913,7 +915,7 @@ func TestNonHttpAuthorization(t *testing.T) {
 
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
-				core.WithAccessController(core.NewAccessController(authenticators, true)),
+				core.WithAccessController(core.NewAccessController(authenticators, true, false, "")),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			// Operations with a token should succeed
@@ -952,7 +954,7 @@ func TestNonHttpAuthorization(t *testing.T) {
 
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
-				core.WithAccessController(core.NewAccessController(authenticators, true)),
+				core.WithAccessController(core.NewAccessController(authenticators, true, false, "")),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			header := http.Header{
@@ -989,7 +991,7 @@ func TestAuthenticationValuePrefixes(t *testing.T) {
 	require.NoError(t, err)
 
 	authenticators := []authentication.Authenticator{authenticator1}
-	accessController := core.NewAccessController(authenticators, false)
+	accessController := core.NewAccessController(authenticators, false, false, "")
 
 	t.Run("no prefix", func(t *testing.T) {
 		t.Parallel()
@@ -1076,7 +1078,7 @@ func TestAuthenticationMultipleProviders(t *testing.T) {
 	})
 	require.NoError(t, err)
 	authenticators := []authentication.Authenticator{authenticator1, authenticator2}
-	accessController := core.NewAccessController(authenticators, false)
+	accessController := core.NewAccessController(authenticators, false, false, "")
 
 	t.Run("authenticate with first provider due to matching prefix", func(t *testing.T) {
 		t.Parallel()
@@ -1214,7 +1216,7 @@ func TestAlgorithmMismatch(t *testing.T) {
 
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
-				core.WithAccessController(core.NewAccessController(authenticators, true)),
+				core.WithAccessController(core.NewAccessController(authenticators, true, false, "")),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			// Operation with forged token should fail
@@ -1242,7 +1244,7 @@ func TestAlgorithmMismatch(t *testing.T) {
 
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
-				core.WithAccessController(core.NewAccessController(authenticators, true)),
+				core.WithAccessController(core.NewAccessController(authenticators, true, false, "")),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			header := http.Header{
@@ -1363,7 +1365,7 @@ func TestOidcDiscovery(t *testing.T) {
 
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
-				core.WithAccessController(core.NewAccessController(authenticators, true)),
+				core.WithAccessController(core.NewAccessController(authenticators, true, false, "")),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			for _, token := range tokens {
@@ -1446,7 +1448,7 @@ func TestMultipleKeys(t *testing.T) {
 
 			testenv.Run(t, &testenv.Config{
 				RouterOptions: []core.Option{
-					core.WithAccessController(core.NewAccessController(authenticators, true)),
+					core.WithAccessController(core.NewAccessController(authenticators, true, false, "")),
 				},
 			}, func(t *testing.T, xEnv *testenv.Environment) {
 				for _, token := range tokens {
@@ -1468,7 +1470,7 @@ func TestMultipleKeys(t *testing.T) {
 
 			testenv.Run(t, &testenv.Config{
 				RouterOptions: []core.Option{
-					core.WithAccessController(core.NewAccessController(authenticators, true)),
+					core.WithAccessController(core.NewAccessController(authenticators, true, false, "")),
 				},
 			}, func(t *testing.T, xEnv *testenv.Environment) {
 				for _, token := range tokens {
@@ -1490,7 +1492,7 @@ func TestMultipleKeys(t *testing.T) {
 
 			testenv.Run(t, &testenv.Config{
 				RouterOptions: []core.Option{
-					core.WithAccessController(core.NewAccessController(authenticators, true)),
+					core.WithAccessController(core.NewAccessController(authenticators, true, false, "")),
 				},
 			}, func(t *testing.T, xEnv *testenv.Environment) {
 				for _, token := range tokens {
@@ -1516,7 +1518,7 @@ func TestMultipleKeys(t *testing.T) {
 
 			testenv.Run(t, &testenv.Config{
 				RouterOptions: []core.Option{
-					core.WithAccessController(core.NewAccessController(authenticators, true)),
+					core.WithAccessController(core.NewAccessController(authenticators, true, false, "")),
 				},
 			}, func(t *testing.T, xEnv *testenv.Environment) {
 				for _, token := range tokens {
@@ -1542,7 +1544,7 @@ func TestMultipleKeys(t *testing.T) {
 
 			testenv.Run(t, &testenv.Config{
 				RouterOptions: []core.Option{
-					core.WithAccessController(core.NewAccessController(authenticators, true)),
+					core.WithAccessController(core.NewAccessController(authenticators, true, false, "")),
 				},
 			}, func(t *testing.T, xEnv *testenv.Environment) {
 				for _, token := range tokens {
@@ -1623,7 +1625,7 @@ func TestSupportedAlgorithms(t *testing.T) {
 
 			testenv.Run(t, &testenv.Config{
 				RouterOptions: []core.Option{
-					core.WithAccessController(core.NewAccessController(authenticators, true)),
+					core.WithAccessController(core.NewAccessController(authenticators, true, false, "")),
 				},
 			}, func(t *testing.T, xEnv *testenv.Environment) {
 				t.Run("Should succeed when providing token", func(t *testing.T) {
@@ -1652,7 +1654,7 @@ func TestSupportedAlgorithms(t *testing.T) {
 
 			testenv.Run(t, &testenv.Config{
 				RouterOptions: []core.Option{
-					core.WithAccessController(core.NewAccessController(authenticators, true)),
+					core.WithAccessController(core.NewAccessController(authenticators, true, false, "")),
 				},
 			}, func(t *testing.T, xEnv *testenv.Environment) {
 				t.Run("Should succeed when providing token", func(t *testing.T) {
@@ -1681,7 +1683,7 @@ func TestSupportedAlgorithms(t *testing.T) {
 
 			testenv.Run(t, &testenv.Config{
 				RouterOptions: []core.Option{
-					core.WithAccessController(core.NewAccessController(authenticators, true)),
+					core.WithAccessController(core.NewAccessController(authenticators, true, false, "")),
 				},
 			}, func(t *testing.T, xEnv *testenv.Environment) {
 				t.Run("Should succeed when providing token", func(t *testing.T) {
@@ -1710,7 +1712,7 @@ func TestSupportedAlgorithms(t *testing.T) {
 
 			testenv.Run(t, &testenv.Config{
 				RouterOptions: []core.Option{
-					core.WithAccessController(core.NewAccessController(authenticators, true)),
+					core.WithAccessController(core.NewAccessController(authenticators, true, false, "")),
 				},
 			}, func(t *testing.T, xEnv *testenv.Environment) {
 				t.Run("Should succeed when providing token", func(t *testing.T) {
@@ -1739,7 +1741,7 @@ func TestSupportedAlgorithms(t *testing.T) {
 
 			testenv.Run(t, &testenv.Config{
 				RouterOptions: []core.Option{
-					core.WithAccessController(core.NewAccessController(authenticators, true)),
+					core.WithAccessController(core.NewAccessController(authenticators, true, false, "")),
 				},
 			}, func(t *testing.T, xEnv *testenv.Environment) {
 				t.Run("Should succeed when providing token", func(t *testing.T) {
@@ -1768,7 +1770,7 @@ func TestSupportedAlgorithms(t *testing.T) {
 
 			testenv.Run(t, &testenv.Config{
 				RouterOptions: []core.Option{
-					core.WithAccessController(core.NewAccessController(authenticators, true)),
+					core.WithAccessController(core.NewAccessController(authenticators, true, false, "")),
 				},
 			}, func(t *testing.T, xEnv *testenv.Environment) {
 				t.Run("Should succeed when providing token", func(t *testing.T) {
@@ -1801,7 +1803,7 @@ func TestSupportedAlgorithms(t *testing.T) {
 
 			testenv.Run(t, &testenv.Config{
 				RouterOptions: []core.Option{
-					core.WithAccessController(core.NewAccessController(authenticators, true)),
+					core.WithAccessController(core.NewAccessController(authenticators, true, false, "")),
 				},
 			}, func(t *testing.T, xEnv *testenv.Environment) {
 				t.Run("Should succeed when providing token", func(t *testing.T) {
@@ -1830,7 +1832,7 @@ func TestSupportedAlgorithms(t *testing.T) {
 
 			testenv.Run(t, &testenv.Config{
 				RouterOptions: []core.Option{
-					core.WithAccessController(core.NewAccessController(authenticators, true)),
+					core.WithAccessController(core.NewAccessController(authenticators, true, false, "")),
 				},
 			}, func(t *testing.T, xEnv *testenv.Environment) {
 				t.Run("Should succeed when providing token", func(t *testing.T) {
@@ -1859,7 +1861,7 @@ func TestSupportedAlgorithms(t *testing.T) {
 
 			testenv.Run(t, &testenv.Config{
 				RouterOptions: []core.Option{
-					core.WithAccessController(core.NewAccessController(authenticators, true)),
+					core.WithAccessController(core.NewAccessController(authenticators, true, false, "")),
 				},
 			}, func(t *testing.T, xEnv *testenv.Environment) {
 				t.Run("Should succeed when providing token", func(t *testing.T) {
@@ -1892,7 +1894,7 @@ func TestSupportedAlgorithms(t *testing.T) {
 
 			testenv.Run(t, &testenv.Config{
 				RouterOptions: []core.Option{
-					core.WithAccessController(core.NewAccessController(authenticators, true)),
+					core.WithAccessController(core.NewAccessController(authenticators, true, false, "")),
 				},
 			}, func(t *testing.T, xEnv *testenv.Environment) {
 				t.Run("Should succeed when providing token", func(t *testing.T) {
@@ -1925,7 +1927,7 @@ func TestSupportedAlgorithms(t *testing.T) {
 
 			testenv.Run(t, &testenv.Config{
 				RouterOptions: []core.Option{
-					core.WithAccessController(core.NewAccessController(authenticators, true)),
+					core.WithAccessController(core.NewAccessController(authenticators, true, false, "")),
 				},
 			}, func(t *testing.T, xEnv *testenv.Environment) {
 				t.Run("Should succeed when providing token", func(t *testing.T) {
@@ -1954,7 +1956,7 @@ func TestSupportedAlgorithms(t *testing.T) {
 
 			testenv.Run(t, &testenv.Config{
 				RouterOptions: []core.Option{
-					core.WithAccessController(core.NewAccessController(authenticators, true)),
+					core.WithAccessController(core.NewAccessController(authenticators, true, false, "")),
 				},
 			}, func(t *testing.T, xEnv *testenv.Environment) {
 				t.Run("Should succeed when providing token", func(t *testing.T) {
@@ -1983,7 +1985,7 @@ func TestSupportedAlgorithms(t *testing.T) {
 
 			testenv.Run(t, &testenv.Config{
 				RouterOptions: []core.Option{
-					core.WithAccessController(core.NewAccessController(authenticators, true)),
+					core.WithAccessController(core.NewAccessController(authenticators, true, false, "")),
 				},
 			}, func(t *testing.T, xEnv *testenv.Environment) {
 				t.Run("Should succeed when providing token", func(t *testing.T) {
@@ -2014,7 +2016,7 @@ func TestSupportedAlgorithms(t *testing.T) {
 
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
-				core.WithAccessController(core.NewAccessController(authenticators, true)),
+				core.WithAccessController(core.NewAccessController(authenticators, true, false, "")),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			// Operations with a token should fail
@@ -2049,7 +2051,7 @@ func TestAuthenticationOverWebsocket(t *testing.T) {
 
 	testenv.Run(t, &testenv.Config{
 		RouterOptions: []core.Option{
-			core.WithAccessController(core.NewAccessController(authenticators, true)),
+			core.WithAccessController(core.NewAccessController(authenticators, true, false, "")),
 		},
 	}, func(t *testing.T, xEnv *testenv.Environment) {
 
@@ -2105,7 +2107,7 @@ func TestAudienceValidation(t *testing.T) {
 
 				testenv.Run(t, &testenv.Config{
 					RouterOptions: []core.Option{
-						core.WithAccessController(core.NewAccessController(authenticators, true)),
+						core.WithAccessController(core.NewAccessController(authenticators, true, false, "")),
 					},
 				}, func(t *testing.T, xEnv *testenv.Environment) {
 					// Operations with a token should succeed
@@ -2145,7 +2147,7 @@ func TestAudienceValidation(t *testing.T) {
 
 				testenv.Run(t, &testenv.Config{
 					RouterOptions: []core.Option{
-						core.WithAccessController(core.NewAccessController(authenticators, true)),
+						core.WithAccessController(core.NewAccessController(authenticators, true, false, "")),
 					},
 				}, func(t *testing.T, xEnv *testenv.Environment) {
 					// Operations with a token should succeed
@@ -2189,7 +2191,7 @@ func TestAudienceValidation(t *testing.T) {
 
 				testenv.Run(t, &testenv.Config{
 					RouterOptions: []core.Option{
-						core.WithAccessController(core.NewAccessController(authenticators, true)),
+						core.WithAccessController(core.NewAccessController(authenticators, true, false, "")),
 					},
 				}, func(t *testing.T, xEnv *testenv.Environment) {
 					// Operations with a token should succeed
@@ -2229,7 +2231,7 @@ func TestAudienceValidation(t *testing.T) {
 
 				testenv.Run(t, &testenv.Config{
 					RouterOptions: []core.Option{
-						core.WithAccessController(core.NewAccessController(authenticators, true)),
+						core.WithAccessController(core.NewAccessController(authenticators, true, false, "")),
 					},
 				}, func(t *testing.T, xEnv *testenv.Environment) {
 					// Operations with a token should succeed
@@ -2278,7 +2280,7 @@ func TestAudienceValidation(t *testing.T) {
 
 				testenv.Run(t, &testenv.Config{
 					RouterOptions: []core.Option{
-						core.WithAccessController(core.NewAccessController(authenticators, true)),
+						core.WithAccessController(core.NewAccessController(authenticators, true, false, "")),
 					},
 				}, func(t *testing.T, xEnv *testenv.Environment) {
 					// Operations with a token should succeed
@@ -2319,7 +2321,7 @@ func TestAudienceValidation(t *testing.T) {
 
 				testenv.Run(t, &testenv.Config{
 					RouterOptions: []core.Option{
-						core.WithAccessController(core.NewAccessController(authenticators, true)),
+						core.WithAccessController(core.NewAccessController(authenticators, true, false, "")),
 					},
 				}, func(t *testing.T, xEnv *testenv.Environment) {
 					// Operations with a token should succeed
@@ -2363,7 +2365,7 @@ func TestAudienceValidation(t *testing.T) {
 
 				testenv.Run(t, &testenv.Config{
 					RouterOptions: []core.Option{
-						core.WithAccessController(core.NewAccessController(authenticators, true)),
+						core.WithAccessController(core.NewAccessController(authenticators, true, false, "")),
 					},
 				}, func(t *testing.T, xEnv *testenv.Environment) {
 					// Operations with a token should succeed
@@ -2403,7 +2405,7 @@ func TestAudienceValidation(t *testing.T) {
 
 				testenv.Run(t, &testenv.Config{
 					RouterOptions: []core.Option{
-						core.WithAccessController(core.NewAccessController(authenticators, true)),
+						core.WithAccessController(core.NewAccessController(authenticators, true, false, "")),
 					},
 				}, func(t *testing.T, xEnv *testenv.Environment) {
 					// Operations with a token should succeed
@@ -2445,7 +2447,7 @@ func TestAudienceValidation(t *testing.T) {
 
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
-				core.WithAccessController(core.NewAccessController(authenticators, true)),
+				core.WithAccessController(core.NewAccessController(authenticators, true, false, "")),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			// Operations with a token should succeed
@@ -2485,7 +2487,7 @@ func TestAudienceValidation(t *testing.T) {
 
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
-				core.WithAccessController(core.NewAccessController(authenticators, true)),
+				core.WithAccessController(core.NewAccessController(authenticators, true, false, "")),
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			// Operations with a token should succeed
@@ -2500,6 +2502,224 @@ func TestAudienceValidation(t *testing.T) {
 			data, err := io.ReadAll(res.Body)
 			require.NoError(t, err)
 			require.Equal(t, employeesExpectedData, string(data))
+		})
+	})
+}
+
+func TestIntrospectionAuthentication(t *testing.T) {
+	t.Run("introspection query no token no auth skip", func(t *testing.T) {
+		t.Parallel()
+
+		// when introspection auth skip is not enabled,
+		// introspection queries must fail when they do not have a valid token
+
+		authenticators, _ := ConfigureAuth(t)
+		testenv.Run(t, &testenv.Config{
+			RouterOptions: []core.Option{
+				core.WithAccessController(core.NewAccessController(authenticators, true, false, "")),
+			},
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			res, err := xEnv.MakeRequest(http.MethodPost, "/graphql", http.Header{},
+				strings.NewReader(simpleIntrospectionQuery))
+			require.NoError(t, err)
+			defer res.Body.Close()
+
+			require.Equal(t, http.StatusUnauthorized, res.StatusCode)
+			require.Equal(t, "", res.Header.Get(xAuthenticatedByHeader))
+			data, err := io.ReadAll(res.Body)
+			require.NoError(t, err)
+			require.Equal(t, unauthorizedExpectedData, string(data))
+		})
+	})
+
+	t.Run("introspection query no token with auth skip", func(t *testing.T) {
+		t.Parallel()
+
+		// when introspection auth skip is enabled,
+		// introspection queries are not expected to have a valid token
+
+		authenticators, _ := ConfigureAuth(t)
+		testenv.Run(t, &testenv.Config{
+			RouterOptions: []core.Option{
+				core.WithAccessController(core.NewAccessController(authenticators, true, true, "")),
+			},
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			res, err := xEnv.MakeRequest(http.MethodPost, "/graphql", nil, strings.NewReader(simpleIntrospectionQuery))
+			require.NoError(t, err)
+			defer res.Body.Close()
+			require.Equal(t, http.StatusOK, res.StatusCode)
+			require.Equal(t, "", res.Header.Get(xAuthenticatedByHeader))
+			data, err := io.ReadAll(res.Body)
+			require.NoError(t, err)
+			require.Equal(t, simpleIntrospectionExpectedData, string(data))
+		})
+	})
+
+	t.Run("introspection query valid token with auth skip", func(t *testing.T) {
+		t.Parallel()
+
+		// even though a token is set, since introspection auth is bypassed,
+		// no authentication should be performed
+
+		authenticators, authServer := ConfigureAuth(t)
+		testenv.Run(t, &testenv.Config{
+			RouterOptions: []core.Option{
+				core.WithAccessController(core.NewAccessController(authenticators, true, true, "")),
+			},
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			token, err := authServer.Token(nil)
+			require.NoError(t, err)
+			header := http.Header{
+				"Authorization": []string{"Bearer " + token},
+			}
+			res, err := xEnv.MakeRequest(http.MethodPost, "/graphql", header, strings.NewReader(simpleIntrospectionQuery))
+			require.NoError(t, err)
+			defer res.Body.Close()
+
+			require.Equal(t, http.StatusOK, res.StatusCode)
+			require.Equal(t, "", res.Header.Get(xAuthenticatedByHeader))
+			data, err := io.ReadAll(res.Body)
+			require.NoError(t, err)
+			require.Equal(t, simpleIntrospectionExpectedData, string(data))
+		})
+	})
+
+	t.Run("introspection query invalid token with auth skip", func(t *testing.T) {
+		t.Parallel()
+
+		// since we are skipping auth for introspection and have not configured
+		// a dedicated token for introspection queries, this query must succeed
+
+		authenticators, _ := ConfigureAuth(t)
+		testenv.Run(t, &testenv.Config{
+			RouterOptions: []core.Option{
+				core.WithAccessController(core.NewAccessController(authenticators, true, true, "")),
+			},
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			header := http.Header{
+				"Authorization": []string{"Bearer invalid"},
+			}
+			res, err := xEnv.MakeRequest(http.MethodPost, "/graphql", header, strings.NewReader(simpleIntrospectionQuery))
+			require.NoError(t, err)
+			defer res.Body.Close()
+
+			require.Equal(t, http.StatusOK, res.StatusCode)
+			require.Equal(t, "", res.Header.Get(xAuthenticatedByHeader))
+			data, err := io.ReadAll(res.Body)
+			require.NoError(t, err)
+			require.Equal(t, simpleIntrospectionExpectedData, string(data))
+		})
+	})
+
+	t.Run("introspection query with auth skip and introspection token", func(t *testing.T) {
+		t.Parallel()
+
+		// since we are skipping auth for introspection and have not configured
+		// a dedicated token for introspection queries, this query must succeed
+
+		authenticators, _ := ConfigureAuth(t)
+		token := "0aG3TVhkZ2lPy8ULUPQLXZ4JFPfpxk"
+		testenv.Run(t, &testenv.Config{
+			RouterOptions: []core.Option{
+				core.WithAccessController(core.NewAccessController(authenticators, true, true, token)),
+			},
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			header := http.Header{
+				"Authorization": []string{token},
+			}
+			res, err := xEnv.MakeRequest(http.MethodPost, "/graphql", header, strings.NewReader(simpleIntrospectionQuery))
+			require.NoError(t, err)
+			defer res.Body.Close()
+
+			require.Equal(t, http.StatusOK, res.StatusCode)
+			require.Equal(t, "", res.Header.Get(xAuthenticatedByHeader))
+			data, err := io.ReadAll(res.Body)
+			require.NoError(t, err)
+			require.Equal(t, simpleIntrospectionExpectedData, string(data))
+		})
+	})
+
+	t.Run("introspection query with auth skip and invalid introspection token", func(t *testing.T) {
+		t.Parallel()
+
+		// since we are skipping auth for introspection and have not configured
+		// a dedicated token for introspection queries, this query must succeed
+
+		authenticators, _ := ConfigureAuth(t)
+		token := "0aG3TVhkZ2lPy8ULUPQLXZ4JFPfpxk"
+		testenv.Run(t, &testenv.Config{
+			RouterOptions: []core.Option{
+				core.WithAccessController(core.NewAccessController(authenticators, true, true, token)),
+			},
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			header := http.Header{
+				"Authorization": []string{"doesnotmatchtoken"},
+			}
+			res, err := xEnv.MakeRequest(http.MethodPost, "/graphql", header, strings.NewReader(simpleIntrospectionQuery))
+			require.NoError(t, err)
+			defer res.Body.Close()
+
+			require.Equal(t, http.StatusUnauthorized, res.StatusCode)
+			require.Equal(t, "", res.Header.Get(xAuthenticatedByHeader))
+			data, err := io.ReadAll(res.Body)
+			require.NoError(t, err)
+			require.Equal(t, unauthorizedExpectedData, string(data))
+		})
+	})
+
+	t.Run("normal query with auth skip and valid token", func(t *testing.T) {
+		t.Parallel()
+
+		// a normal query with valid token is expected to be authenticated
+		// with an authenticator, even when auth skip (for introspection) is enabled.
+
+		authenticators, authServer := ConfigureAuth(t)
+		testenv.Run(t, &testenv.Config{
+			RouterOptions: []core.Option{
+				core.WithAccessController(core.NewAccessController(authenticators, true, true, "")),
+			},
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			token, err := authServer.Token(nil)
+			require.NoError(t, err)
+			header := http.Header{
+				"Authorization": []string{"Bearer " + token},
+			}
+			res, err := xEnv.MakeRequest(http.MethodPost, "/graphql", header, strings.NewReader(employeesQuery))
+			require.NoError(t, err)
+			defer res.Body.Close()
+
+			require.Equal(t, http.StatusOK, res.StatusCode)
+			require.Equal(t, JwksName, res.Header.Get(xAuthenticatedByHeader))
+			data, err := io.ReadAll(res.Body)
+			require.NoError(t, err)
+			require.Equal(t, employeesExpectedData, string(data))
+		})
+	})
+
+	t.Run("normal query with auth skip and invalid token", func(t *testing.T) {
+		t.Parallel()
+
+		// a normal query with invalid token is expected to fail authentication,
+		// even when auth skip (for introspection) is enabled.
+
+		authenticators, _ := ConfigureAuth(t)
+		testenv.Run(t, &testenv.Config{
+			RouterOptions: []core.Option{
+				core.WithAccessController(core.NewAccessController(authenticators, true, true, "")),
+			},
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			header := http.Header{
+				"Authorization": []string{"Bearer invalid"},
+			}
+			res, err := xEnv.MakeRequest(http.MethodPost, "/graphql", header, strings.NewReader(employeesQuery))
+			require.NoError(t, err)
+			defer res.Body.Close()
+
+			require.Equal(t, http.StatusUnauthorized, res.StatusCode)
+			require.Equal(t, "", res.Header.Get(xAuthenticatedByHeader))
+			data, err := io.ReadAll(res.Body)
+			require.NoError(t, err)
+			require.Equal(t, unauthorizedExpectedData, string(data))
 		})
 	})
 }

--- a/router-tests/batch_test.go
+++ b/router-tests/batch_test.go
@@ -337,7 +337,7 @@ func TestBatch(t *testing.T) {
 		testenv.Run(t,
 			&testenv.Config{
 				RouterOptions: []core.Option{
-					core.WithAccessController(core.NewAccessController(authenticators, false)),
+					core.WithAccessController(core.NewAccessController(authenticators, false, false, "")),
 				},
 				BatchingConfig: config.BatchingConfig{
 					Enabled:            true,
@@ -745,7 +745,7 @@ func TestBatch(t *testing.T) {
 				MaxEntriesPerBatch: 100,
 			},
 			RouterOptions: []core.Option{
-				core.WithAccessController(core.NewAccessController(authenticators, false)),
+				core.WithAccessController(core.NewAccessController(authenticators, false, false, "")),
 				core.WithRouterTrafficConfig(&config.RouterTrafficConfiguration{
 					MaxRequestBodyBytes:  5 << 20, // 5MiB
 					DecompressionEnabled: true,

--- a/router-tests/block_operations_test.go
+++ b/router-tests/block_operations_test.go
@@ -129,7 +129,7 @@ func TestBlockOperations(t *testing.T) {
 			authenticators, authServer := ConfigureAuth(t)
 			testenv.Run(t, &testenv.Config{
 				RouterOptions: []core.Option{
-					core.WithAccessController(core.NewAccessController(authenticators, false)),
+					core.WithAccessController(core.NewAccessController(authenticators, false, false, "")),
 				},
 				ModifySecurityConfiguration: func(securityConfiguration *config.SecurityConfiguration) {
 					securityConfiguration.BlockMutations = config.BlockOperationConfiguration{
@@ -283,7 +283,7 @@ func TestBlockOperations(t *testing.T) {
 
 			testenv.Run(t, &testenv.Config{
 				RouterOptions: []core.Option{
-					core.WithAccessController(core.NewAccessController(authenticators, false)),
+					core.WithAccessController(core.NewAccessController(authenticators, false, false, "")),
 					core.WithAuthorizationConfig(&config.AuthorizationConfiguration{
 						RejectOperationIfUnauthorized: false,
 					}),
@@ -379,7 +379,7 @@ func TestBlockOperations(t *testing.T) {
 					cfg.Enabled = true
 				},
 				RouterOptions: []core.Option{
-					core.WithAccessController(core.NewAccessController(authenticators, false)),
+					core.WithAccessController(core.NewAccessController(authenticators, false, false, "")),
 					core.WithAuthorizationConfig(&config.AuthorizationConfiguration{
 						RejectOperationIfUnauthorized: false,
 					}),

--- a/router-tests/header_set_test.go
+++ b/router-tests/header_set_test.go
@@ -281,7 +281,7 @@ func TestHeaderSetWithExpression(t *testing.T) {
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: append(
 				global(customHeader, `request.auth.claims.user_id`),
-				core.WithAccessController(core.NewAccessController([]authentication.Authenticator{authenticator}, true)),
+				core.WithAccessController(core.NewAccessController([]authentication.Authenticator{authenticator}, true, false, "")),
 			),
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{

--- a/router-tests/modules/router_on_request_test.go
+++ b/router-tests/modules/router_on_request_test.go
@@ -2,10 +2,11 @@ package module_test
 
 import (
 	"encoding/json"
-	"github.com/wundergraph/cosmo/router-tests/modules/router-on-request"
-	"go.uber.org/zap/zapcore"
 	"net/http"
 	"testing"
+
+	router_on_request "github.com/wundergraph/cosmo/router-tests/modules/router-on-request"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -71,7 +72,7 @@ func TestRouterOnRequestHook(t *testing.T) {
 
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
-				core.WithAccessController(core.NewAccessController(authenticators, true)),
+				core.WithAccessController(core.NewAccessController(authenticators, true, false, "")),
 				core.WithModulesConfig(cfg.Modules),
 				core.WithCustomModules(&router_on_request.RouterOnRequestModule{}),
 			},

--- a/router-tests/modules/set_authentication_scopes_test.go
+++ b/router-tests/modules/set_authentication_scopes_test.go
@@ -34,7 +34,7 @@ func TestCustomModuleSetAuthenticationScopes(t *testing.T) {
 		authenticators, authServer := configureAuth(t)
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
-				core.WithAccessController(core.NewAccessController(authenticators, false)),
+				core.WithAccessController(core.NewAccessController(authenticators, false, false, "")),
 				core.WithModulesConfig(cfg.Modules),
 				core.WithCustomModules(&setScopesModule.SetAuthenticationScopesModule{}, &verifyScopes.VerifyScopesModule{}),
 			},
@@ -75,7 +75,7 @@ func TestCustomModuleSetAuthenticationScopes(t *testing.T) {
 		authenticators, authServer := configureAuth(t)
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
-				core.WithAccessController(core.NewAccessController(authenticators, false)),
+				core.WithAccessController(core.NewAccessController(authenticators, false, false, "")),
 				core.WithModulesConfig(cfg.Modules),
 				core.WithCustomModules(&setScopesModule.SetAuthenticationScopesModule{}, &verifyScopes.VerifyScopesModule{}),
 			},
@@ -118,7 +118,7 @@ func TestCustomModuleSetAuthenticationScopes(t *testing.T) {
 		authenticators, authServer := configureAuth(t)
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
-				core.WithAccessController(core.NewAccessController(authenticators, false)),
+				core.WithAccessController(core.NewAccessController(authenticators, false, false, "")),
 				core.WithModulesConfig(cfg.Modules),
 				core.WithCustomModules(&setScopesModule.SetAuthenticationScopesModule{}, &verifyScopes.VerifyScopesModule{}),
 			},

--- a/router-tests/modules/set_scopes_test.go
+++ b/router-tests/modules/set_scopes_test.go
@@ -63,7 +63,7 @@ func TestCustomModuleSetScopes(t *testing.T) {
 		authenticators, authServer := configureAuth(t)
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
-				core.WithAccessController(core.NewAccessController(authenticators, false)),
+				core.WithAccessController(core.NewAccessController(authenticators, false, false, "")),
 				core.WithModulesConfig(cfg.Modules),
 				core.WithCustomModules(&module.MyModule{}, &setScopesModule.SetScopesModule{}),
 			},
@@ -103,7 +103,7 @@ func TestCustomModuleSetScopes(t *testing.T) {
 		authenticators, authServer := configureAuth(t)
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
-				core.WithAccessController(core.NewAccessController(authenticators, false)),
+				core.WithAccessController(core.NewAccessController(authenticators, false, false, "")),
 				core.WithModulesConfig(cfg.Modules),
 				core.WithCustomModules(&module.MyModule{}, &setScopesModule.SetScopesModule{}),
 			},

--- a/router-tests/prometheus_test.go
+++ b/router-tests/prometheus_test.go
@@ -4128,7 +4128,7 @@ func TestPrometheus(t *testing.T) {
 			MetricReader:       metricReader,
 			PrometheusRegistry: promRegistry,
 			RouterOptions: []core.Option{
-				core.WithAccessController(core.NewAccessController(authenticators, true)),
+				core.WithAccessController(core.NewAccessController(authenticators, true, false, "")),
 			},
 			CustomMetricAttributes: []config.CustomAttribute{
 				{

--- a/router-tests/ratelimit_test.go
+++ b/router-tests/ratelimit_test.go
@@ -272,7 +272,7 @@ func TestRateLimit(t *testing.T) {
 
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
-				core.WithAccessController(core.NewAccessController(authenticators, false)),
+				core.WithAccessController(core.NewAccessController(authenticators, false, false, "")),
 				core.WithRateLimitConfig(&config.RateLimitConfiguration{
 					Enabled:  true,
 					Strategy: "simple",

--- a/router-tests/telemetry/telemetry_test.go
+++ b/router-tests/telemetry/telemetry_test.go
@@ -9041,7 +9041,7 @@ func TestFlakyTelemetry(t *testing.T) {
 					},
 				},
 				RouterOptions: []core.Option{
-					core.WithAccessController(core.NewAccessController(authenticators, false)),
+					core.WithAccessController(core.NewAccessController(authenticators, false, false, "")),
 				},
 			}, func(t *testing.T, xEnv *testenv.Environment) {
 				// Operations with a token should succeed
@@ -9090,7 +9090,7 @@ func TestFlakyTelemetry(t *testing.T) {
 					},
 				},
 				RouterOptions: []core.Option{
-					core.WithAccessController(core.NewAccessController(authenticators, false)),
+					core.WithAccessController(core.NewAccessController(authenticators, false, false, "")),
 				},
 			}, func(t *testing.T, xEnv *testenv.Environment) {
 				// Operations with a token should succeed
@@ -9137,7 +9137,7 @@ func TestFlakyTelemetry(t *testing.T) {
 					},
 				},
 				RouterOptions: []core.Option{
-					core.WithAccessController(core.NewAccessController(authenticators, false)),
+					core.WithAccessController(core.NewAccessController(authenticators, false, false, "")),
 				},
 			}, func(t *testing.T, xEnv *testenv.Environment) {
 				// Operations with a token should succeed
@@ -9221,7 +9221,7 @@ func TestFlakyTelemetry(t *testing.T) {
 					},
 				},
 				RouterOptions: []core.Option{
-					core.WithAccessController(core.NewAccessController(authenticators, false)),
+					core.WithAccessController(core.NewAccessController(authenticators, false, false, "")),
 				},
 			}, func(t *testing.T, xEnv *testenv.Environment) {
 				// Operations with a token should succeed
@@ -9288,7 +9288,7 @@ func TestFlakyTelemetry(t *testing.T) {
 					},
 				},
 				RouterOptions: []core.Option{
-					core.WithAccessController(core.NewAccessController(authenticators, false)),
+					core.WithAccessController(core.NewAccessController(authenticators, false, false, "")),
 				},
 			}, func(t *testing.T, xEnv *testenv.Environment) {
 				// Operations with a token should succeed
@@ -9344,7 +9344,7 @@ func TestFlakyTelemetry(t *testing.T) {
 					},
 				},
 				RouterOptions: []core.Option{
-					core.WithAccessController(core.NewAccessController(authenticators, false)),
+					core.WithAccessController(core.NewAccessController(authenticators, false, false, "")),
 				},
 			}, func(t *testing.T, xEnv *testenv.Environment) {
 				// Operations with a token should succeed
@@ -9551,7 +9551,7 @@ func TestFlakyTelemetry(t *testing.T) {
 					},
 				},
 				RouterOptions: []core.Option{
-					core.WithAccessController(core.NewAccessController(authenticators, false)),
+					core.WithAccessController(core.NewAccessController(authenticators, false, false, "")),
 				},
 			}, func(t *testing.T, xEnv *testenv.Environment) {
 				// Operations with a token should succeed

--- a/router-tests/websocket_test.go
+++ b/router-tests/websocket_test.go
@@ -137,7 +137,7 @@ func TestWebSockets(t *testing.T) {
 
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
-				core.WithAccessController(core.NewAccessController(authenticators, false)),
+				core.WithAccessController(core.NewAccessController(authenticators, false, false, "")),
 				core.WithAuthorizationConfig(&config.AuthorizationConfiguration{
 					RejectOperationIfUnauthorized: true,
 				}),
@@ -186,7 +186,7 @@ func TestWebSockets(t *testing.T) {
 
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
-				core.WithAccessController(core.NewAccessController(authenticators, false)),
+				core.WithAccessController(core.NewAccessController(authenticators, false, false, "")),
 				core.WithAuthorizationConfig(&config.AuthorizationConfiguration{
 					RejectOperationIfUnauthorized: false,
 				}),
@@ -237,7 +237,7 @@ func TestWebSockets(t *testing.T) {
 			RouterConfigJSONTemplate: testenv.ConfigWithEdfsNatsJSONTemplate,
 			EnableNats:               true,
 			RouterOptions: []core.Option{
-				core.WithAccessController(core.NewAccessController(authenticators, false)),
+				core.WithAccessController(core.NewAccessController(authenticators, false, false, "")),
 				core.WithAuthorizationConfig(&config.AuthorizationConfiguration{
 					RejectOperationIfUnauthorized: false,
 				}),
@@ -296,7 +296,7 @@ func TestWebSockets(t *testing.T) {
 			RouterConfigJSONTemplate: testenv.ConfigWithEdfsNatsJSONTemplate,
 			EnableNats:               true,
 			RouterOptions: []core.Option{
-				core.WithAccessController(core.NewAccessController(authenticators, false)),
+				core.WithAccessController(core.NewAccessController(authenticators, false, false, "")),
 				core.WithAuthorizationConfig(&config.AuthorizationConfiguration{
 					RejectOperationIfUnauthorized: true,
 				}),
@@ -358,7 +358,7 @@ func TestWebSockets(t *testing.T) {
 				cfg.Enabled = true
 			},
 			RouterOptions: []core.Option{
-				core.WithAccessController(core.NewAccessController(authenticators, true)),
+				core.WithAccessController(core.NewAccessController(authenticators, true, false, "")),
 				core.WithAuthorizationConfig(&config.AuthorizationConfiguration{
 					RejectOperationIfUnauthorized: true,
 				}),
@@ -418,7 +418,7 @@ func TestWebSockets(t *testing.T) {
 				cfg.Enabled = true
 			},
 			RouterOptions: []core.Option{
-				core.WithAccessController(core.NewAccessController(authenticators, true)),
+				core.WithAccessController(core.NewAccessController(authenticators, true, false, "")),
 				core.WithAuthorizationConfig(&config.AuthorizationConfiguration{
 					RejectOperationIfUnauthorized: true,
 				}),
@@ -467,7 +467,7 @@ func TestWebSockets(t *testing.T) {
 				cfg.Enabled = true
 			},
 			RouterOptions: []core.Option{
-				core.WithAccessController(core.NewAccessController(authenticators, true)),
+				core.WithAccessController(core.NewAccessController(authenticators, true, false, "")),
 				core.WithAuthorizationConfig(&config.AuthorizationConfiguration{
 					RejectOperationIfUnauthorized: false,
 				}),
@@ -882,7 +882,7 @@ func TestWebSockets(t *testing.T) {
 		testenv.Run(t, &testenv.Config{
 			RouterOptions: []core.Option{
 				core.WithHeaderRules(headerRules),
-				core.WithAccessController(core.NewAccessController(authenticators, false)),
+				core.WithAccessController(core.NewAccessController(authenticators, false, false, "")),
 			},
 			Subgraphs: testenv.SubgraphsConfig{
 				GlobalMiddleware: func(next http.Handler) http.Handler {

--- a/router/core/access_controller.go
+++ b/router/core/access_controller.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"crypto/subtle"
 	"errors"
 	"net/http"
 
@@ -16,14 +17,18 @@ var (
 
 // AccessController handles both authentication and authorization for the Router
 type AccessController struct {
-	authenticationRequired bool
-	authenticators         []authentication.Authenticator
+	authenticationRequired     bool
+	authenticators             []authentication.Authenticator
+	skipIntrospectionAuth      bool
+	introspectionAuthSkipToken string
 }
 
-func NewAccessController(authenticators []authentication.Authenticator, authenticationRequired bool) *AccessController {
+func NewAccessController(authenticators []authentication.Authenticator, authenticationRequired bool, skipIntrospectionAuth bool, introspectionAuthSkipToken string) *AccessController {
 	return &AccessController{
-		authenticationRequired: authenticationRequired,
-		authenticators:         authenticators,
+		authenticationRequired:     authenticationRequired,
+		authenticators:             authenticators,
+		skipIntrospectionAuth:      skipIntrospectionAuth,
+		introspectionAuthSkipToken: introspectionAuthSkipToken,
 	}
 }
 
@@ -43,4 +48,65 @@ func (a *AccessController) Access(w http.ResponseWriter, r *http.Request) (*http
 		return nil, ErrUnauthorized
 	}
 	return r, nil
+}
+
+// BypassAuthIfIntrospection checks if the request is an introspection query and if so,
+// bypasses the auth if configured to do so.
+// It will return false, basically fall back to authentication, in the following cases:
+// - introspection is disabled
+// - cannot parse or identify the operation as introspection
+// - the provided token does not match the configured token (authentication later on will verify the token)
+func (a *AccessController) BypassAuthIfIntrospection(r *http.Request, operationProcessor *OperationProcessor, body []byte) bool {
+	if !a.skipIntrospectionAuth {
+		return false
+	}
+
+	if operationProcessor == nil || body == nil {
+		return false
+	}
+
+	operationKit, err := operationProcessor.NewKit()
+	if err != nil {
+		return false
+	}
+	defer operationKit.Free()
+
+	err = operationKit.UnmarshalOperationFromBody(body)
+	if err != nil {
+		return false
+	}
+
+	err = operationKit.Parse()
+	if err != nil {
+		return false
+	}
+
+	isIntrospection, err := operationKit.isIntrospectionQuery()
+	if err != nil {
+		return false
+	}
+
+	if isIntrospection {
+		if a.isValidIntrospectionToken(r) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// isValidIntrospectionToken safely validates the configured introspection token
+// against the Authorization header of the request.
+func (a *AccessController) isValidIntrospectionToken(r *http.Request) bool {
+	// If no token is configured, allow introspection without authentication
+	if len(a.introspectionAuthSkipToken) == 0 {
+		return true
+	}
+
+	authHeader := r.Header.Get("Authorization")
+	if authHeader == "" {
+		return false
+	}
+
+	return subtle.ConstantTimeCompare([]byte(authHeader), []byte(a.introspectionAuthSkipToken)) == 1
 }

--- a/router/core/router.go
+++ b/router/core/router.go
@@ -222,6 +222,13 @@ func NewRouter(opts ...Option) (*Router, error) {
 		r.playgroundConfig.Path = "/"
 	}
 
+	// handle introspection config deprecation
+	// this is set via the deprecated method
+	if !r.introspection {
+		r.introspectionConfig.Enabled = r.introspection
+		r.logger.Warn("The introspection_enabled option is deprecated. Use the introspection.enabled option in the config instead.")
+	}
+
 	if r.instanceID == "" {
 		r.instanceID = nuid.Next()
 	}
@@ -1520,6 +1527,12 @@ func WithPlayground(enable bool) Option {
 func WithIntrospection(enable bool) Option {
 	return func(r *Router) {
 		r.introspection = enable
+	}
+}
+
+func WithIntrospectionConfig(config config.IntrospectionConfiguration) Option {
+	return func(r *Router) {
+		r.introspectionConfig = config
 	}
 }
 

--- a/router/core/router_config.go
+++ b/router/core/router_config.go
@@ -50,6 +50,7 @@ type Config struct {
 	graphqlPath                     string
 	playground                      bool
 	introspection                   bool
+	introspectionConfig             config.IntrospectionConfiguration
 	queryPlansEnabled               bool
 	graphApiToken                   string
 	healthCheckPath                 string

--- a/router/core/supervisor_instance.go
+++ b/router/core/supervisor_instance.go
@@ -57,7 +57,12 @@ func newRouter(ctx context.Context, params RouterResources, additionalOptions ..
 	}
 
 	if len(authenticators) > 0 {
-		options = append(options, WithAccessController(NewAccessController(authenticators, cfg.Authorization.RequireAuthentication)))
+		options = append(options, WithAccessController(NewAccessController(
+			authenticators,
+			cfg.Authorization.RequireAuthentication,
+			cfg.IntrospectionConfig.SkipAuthentication,
+			cfg.IntrospectionConfig.Token,
+		)))
 	}
 
 	// HTTP_PROXY, HTTPS_PROXY and NO_PROXY
@@ -156,6 +161,7 @@ func optionsFromResources(logger *zap.Logger, config *config.Config) []Option {
 		WithOverrides(config.Overrides),
 		WithLogger(logger),
 		WithIntrospection(config.IntrospectionEnabled),
+		WithIntrospectionConfig(config.IntrospectionConfig),
 		WithQueryPlans(config.QueryPlansEnabled),
 		WithPlayground(config.PlaygroundEnabled),
 		WithGraphApiToken(config.Graph.Token),

--- a/router/pkg/config/config.go
+++ b/router/pkg/config/config.go
@@ -982,6 +982,12 @@ type PluginRegistryConfiguration struct {
 	URL string `yaml:"url" env:"URL" envDefault:"cosmo-registry.wundergraph.com"`
 }
 
+type IntrospectionConfiguration struct {
+	Enabled            bool   `yaml:"enabled" envDefault:"true" env:"INTROSPECTION_ENABLED"`
+	SkipAuthentication bool   `yaml:"skip_authentication" envDefault:"false" env:"INTROSPECTION_SKIP_AUTHENTICATION"`
+	Token              string `yaml:"token" env:"INTROSPECTION_TOKEN"`
+}
+
 type Config struct {
 	Version string `yaml:"version,omitempty" ignored:"true"`
 
@@ -1008,7 +1014,8 @@ type Config struct {
 	ControlplaneURL               string                      `yaml:"controlplane_url" envDefault:"https://cosmo-cp.wundergraph.com" env:"CONTROLPLANE_URL"`
 	PlaygroundConfig              PlaygroundConfig            `yaml:"playground,omitempty"`
 	PlaygroundEnabled             bool                        `yaml:"playground_enabled" envDefault:"true" env:"PLAYGROUND_ENABLED"`
-	IntrospectionEnabled          bool                        `yaml:"introspection_enabled" envDefault:"true" env:"INTROSPECTION_ENABLED"`
+	IntrospectionEnabled          bool                        `yaml:"introspection_enabled" envDefault:"true" env:"INTROSPECTION_ENABLED"` // deprecated, use IntrospectionConfiguration instead
+	IntrospectionConfig           IntrospectionConfiguration  `yaml:"introspection,omitempty"`
 	QueryPlansEnabled             bool                        `yaml:"query_plans_enabled" envDefault:"true" env:"QUERY_PLANS_ENABLED"`
 	LogLevel                      zapcore.Level               `yaml:"log_level" envDefault:"info" env:"LOG_LEVEL"`
 	JSONLog                       bool                        `yaml:"json_log" envDefault:"true" env:"JSON_LOG"`

--- a/router/pkg/config/config.schema.json
+++ b/router/pkg/config/config.schema.json
@@ -1362,7 +1362,31 @@
     "introspection_enabled": {
       "type": "boolean",
       "description": "Enable the GraphQL introspection. The GraphQL introspection allows you to query the schema of the GraphQL API. The default value is true. If the value is false, the GraphQL introspection is disabled. In production, it is recommended to disable the introspection.",
-      "default": true
+      "default": true,
+      "deprecated": true,
+      "deprecationMessage": "introspection_enabled is deprecated. Please use the introspection.enabled configuration instead."
+    },
+    "introspection": {
+      "type": "object",
+      "description": "",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "",
+          "default": true
+        },
+        "skip_authentication": {
+          "type": "boolean",
+          "description": "If set to true introspection requests will skip the auth.",
+          "default": false
+        },
+        "token": {
+          "type": "string",
+          "description": "Optionally, you can set a token to authenticate the introspection requests.",
+          "minLength": 32
+        }
+      }
     },
     "query_plans_enabled": {
       "type": "boolean",

--- a/router/pkg/config/fixtures/full.yaml
+++ b/router/pkg/config/fixtures/full.yaml
@@ -20,6 +20,10 @@ playground:
   path: '/my-playground'
   concurrency_limit: 1500
 introspection_enabled: true
+introspection:
+  enabled: true
+  skip_authentication: false
+  token: 'aTLQw7rckY3N19Fo7ynYgbwaJFKMrXxI'
 json_log: true
 shutdown_delay: 15s
 grace_period: 20s

--- a/router/pkg/config/testdata/config_defaults.json
+++ b/router/pkg/config/testdata/config_defaults.json
@@ -228,6 +228,11 @@
   },
   "PlaygroundEnabled": true,
   "IntrospectionEnabled": true,
+  "IntrospectionConfig": {
+    "Enabled": true,
+    "SkipAuthentication": false,
+    "Token": ""
+  },
   "QueryPlansEnabled": true,
   "LogLevel": "info",
   "JSONLog": true,

--- a/router/pkg/config/testdata/config_full.json
+++ b/router/pkg/config/testdata/config_full.json
@@ -459,6 +459,11 @@
   },
   "PlaygroundEnabled": true,
   "IntrospectionEnabled": true,
+  "IntrospectionConfig": {
+    "Enabled": true,
+    "SkipAuthentication": false,
+    "Token": "aTLQw7rckY3N19Fo7ynYgbwaJFKMrXxI"
+  },
   "QueryPlansEnabled": true,
   "LogLevel": "info",
   "JSONLog": true,


### PR DESCRIPTION
@coderabbitai summary

## Checklist

- [x] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [x] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

Marked this PR as draft since I want to create a docs PR before this is here is ready for review. 

# Motivation and Context

Linear ticket: https://linear.app/wundergraph/issue/ENG-7980/allow-to-exclude-introspection-endpoint-from-auth

This pull requests adds the ability to configure the router to bypass authentication, if the operation is identified as an introspection query. Optionally a separate, static secret for introspection can be configured, which has to be passed via `Authorization` header instead of the usual JWT token when an introspection query is sent.

The motivation behind this feature is that it allows users to configure GraphQL client tooling without the need to acquire valid auth tokens first, which sometimes is not easy in this scenario. It's meant to be used locally. **This should not be enabled in production**.

To enable this feature I added a new section to the router configuration called `introspection`:

```yaml
introspection:
  enabled: true # deprecates the introspection_enabled config parameter
  skip_authentication: true # bypasses auth for introspection queries, if enabled (default: false)
  token: "demo" # optionally require a secret passed via Authorization header for introspection queries
```

# Changes

- Config parameter `introspection_enabled` is marked as deprecated
- New config parameter `introspection` with three child parameters, as described above, added
- `AccessController` is extended to know wether introspection auth bypass is enabled and what the secret is
- `AccessController` provides a method to check wether the incoming operation is an introspection query (using a temporary `OperationKit`) and based on it's configuration, if it should be bypassed
- `PreHandler` first checks via `AccessController` if authentication should be bypassed and skips it if true
- Modified existing auth tests in `router-tests` to disable this feature for all existing tests (to reflect the default config)
- Extended auth tests in `router-tests` to test authentication when this feature is enabled