### PR TITLE
feat: pod label configuration in cosmo router helm chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ docker-build-minikube: docker-build-local
 	minikube image load mk-cdn.tar
 	minikube cache reload
 
-	del mk-*.tar
+	rm -f mk-*.tar
 
 run-subgraphs-local:
 	cd demo && go run cmd/all/main.go

--- a/helm/cosmo/README.md
+++ b/helm/cosmo/README.md
@@ -240,6 +240,7 @@ This is the official Helm Chart for WunderGraph Cosmo - The Full Lifecycle Graph
 | redis.master.persistence.enabled | bool | `true` |  |
 | redis.master.persistence.size | string | `"1Gi"` |  |
 | redis.replica.replicaCount | int | `0` |  |
+| router.additionalPodLabels | object | `{}` | Add labels to pod resources |
 | router.commonLabels | object | `{}` | Add labels to all deployed resources |
 | router.configuration.cdnUrl | string | `"http://cosmo-cdn:8787"` | The URL of the Cosmo CDN. Should be internal to the cluster. |
 | router.configuration.controlplaneUrl | string | `"http://cosmo-controlplane:3001"` | The URL of the Cosmo Controlplane. Should be internal to the cluster. |

--- a/helm/cosmo/charts/router/README.md
+++ b/helm/cosmo/charts/router/README.md
@@ -8,7 +8,8 @@ This is the official Helm Chart for the WunderGraph Cosmo Router.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| additionalLabels | object | `{}` | Add labels to deployment metadata.labels |
+| additionalLabels | object | `{}` | Add labels to deployment (metadata.labels) |
+| additionalPodLabels | object | `{}` | Add labels to deployment pod template (spec.template.metadata.labels) |
 | affinity | object | `{}` |  |
 | autoscaling.enabled | bool | `false` |  |
 | autoscaling.maxReplicas | int | `100` |  |

--- a/helm/cosmo/charts/router/templates/_helpers.tpl
+++ b/helm/cosmo/charts/router/templates/_helpers.tpl
@@ -53,6 +53,15 @@ Additional Labels that are just rendered in metadata.labels
 {{- end }}
 
 {{/*
+Additional Pod Labels that are just rendered in metadata.labels
+*/}}
+{{- define "router.additionalPodLabels" -}}
+{{- range $key, $value := .Values.additionalPodLabels }}
+{{ $key }}: {{ quote $value }}
+{{- end }}
+{{- end }}
+
+{{/*
 Common labels
 */}}
 {{- define "router.labels" -}}

--- a/helm/cosmo/charts/router/templates/deployment.yaml
+++ b/helm/cosmo/charts/router/templates/deployment.yaml
@@ -30,6 +30,7 @@ spec:
       {{- end }}
       labels:
         {{- include "router.selectorLabels" . | nindent 8 }}
+        {{- include "router.additionalPodLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/helm/cosmo/charts/router/values.yaml
+++ b/helm/cosmo/charts/router/values.yaml
@@ -14,8 +14,11 @@ image:
 # -- Add labels to all deployed resources
 commonLabels: {}
 
-# -- Add labels to deployment metadata.labels
+# -- Add labels to deployment (metadata.labels)
 additionalLabels: {}
+
+# -- Add labels to deployment pod template (spec.template.metadata.labels)
+additionalPodLabels: {}
 
 deploymentStrategy: {}
 

--- a/helm/cosmo/values.yaml
+++ b/helm/cosmo/values.yaml
@@ -252,6 +252,9 @@ router:
   # -- Add labels to all deployed resources
   commonLabels: {}
 
+  # -- Add labels to pod resources
+  additionalPodLabels: {}
+
   terminationGracePeriodSeconds: 60
   deploymentStrategy:
     rollingUpdate:


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Added support for setting pod-level labels on the router via a new configuration option.
* Documentation
  * Updated charts documentation to include the new pod label option and clarified label scopes.
* Chores
  * Adjusted build cleanup command to use Unix-compatible removal for artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->