### PR TITLE
feat(router): add option to block on missing client headers

### DIFF
--- a/router/pkg/config/config.go
+++ b/router/pkg/config/config.go
@@ -927,8 +927,15 @@ type ApolloCompatibilityFlag struct {
 }
 
 type ClientHeader struct {
-	Name    string `yaml:"name,omitempty"`
-	Version string `yaml:"version,omitempty"`
+	Name    string                           `yaml:"name,omitempty"`
+	Version string                           `yaml:"version,omitempty"`
+	Enforce ClientHeaderEnforceConfiguration `yaml:"enforce,omitempty"`
+}
+
+type ClientHeaderEnforceConfiguration struct {
+	OnName       bool `yaml:"on_name"`
+	OnVersion    bool `yaml:"on_version"`
+	ResponseCode int  `yaml:"response_code" envDefault:"400"`
 }
 
 type CacheWarmupSource struct {

--- a/router/pkg/config/config.schema.json
+++ b/router/pkg/config/config.schema.json
@@ -3051,6 +3051,28 @@
         "version": {
           "type": "string",
           "description": "The custom client version header."
+        },
+        "enforce": {
+          "type": "object",
+          "description": "The configuration for enforcing client header requirements.",
+          "additionalProperties": false,
+          "properties": {
+            "on_name": {
+              "type": "boolean",
+              "description": "Whether to block requests that are missing the client name header.",
+              "default": false
+            },
+            "on_version": {
+              "type": "boolean",
+              "description": "Whether to block requests that are missing the client version header.",
+              "default": false
+            },  
+            "response_code": {
+              "type": "integer",
+              "description": "The HTTP response code to return when an expected header is missing.",
+              "default": 400
+            }
+          }
         }
       }
     },

--- a/router/pkg/config/fixtures/full.yaml
+++ b/router/pkg/config/fixtures/full.yaml
@@ -473,6 +473,10 @@ router_config_path: 'latest.json'
 client_header:
   name: 'Client-Name'
   version: 'Client_Version'
+  enforce:
+    on_name: false
+    on_version: false
+    response_code: 400
 
 apollo_compatibility_flags:
   enable_all: false

--- a/router/pkg/config/testdata/config_defaults.json
+++ b/router/pkg/config/testdata/config_defaults.json
@@ -517,7 +517,12 @@
   },
   "ClientHeader": {
     "Name": "",
-    "Version": ""
+    "Version": "",
+    "Enforce": {
+      "OnName": false,
+      "OnVersion": false,
+      "ResponseCode": 400
+    }
   },
   "Plugins": {
     "Enabled": false,

--- a/router/pkg/config/testdata/config_full.json
+++ b/router/pkg/config/testdata/config_full.json
@@ -903,7 +903,12 @@
   },
   "ClientHeader": {
     "Name": "Client-Name",
-    "Version": "Client_Version"
+    "Version": "Client_Version",
+    "Enforce": {
+      "OnName": false,
+      "OnVersion": false,
+      "ResponseCode": 400
+    }
   },
   "Plugins": {
     "Enabled": true,


### PR DESCRIPTION
@coderabbitai summary

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

# Motivation and Context

Cosmo Router supports two special http request header configuration parameters for identifying clients by their requests:
https://cosmo-docs.wundergraph.com/studio/analytics/client-identification#client-identification

Sometimes users want to reject requests, which do not add these headers. This is currently not supported and that is, what this PR will change. Right now this PR only contains the configuration changes as a basis for discussion. After discussion I will start implementing it.

The proposal is to let the user decide wether to reject requests, which do not contain the `Name`, the `Version` or both headers. The user can also decide what http response code should be used, the default being `400`.