### PR TITLE
chore(docs): fix typo in README.md for simple-router example

### DIFF
--- a/examples/router-simple/README.md
+++ b/examples/router-simple/README.md
@@ -38,7 +38,7 @@ Click on "Trace" in the right corner of the Playground to see the tracing featur
 
 ## Modifying the schema
 
-In the [graphql.yaml](graphql.yaml) file, you can see the subgraphs that make up the federated schema. We download the schemas through their introspection endpoint and compose them into a federated schema.
+In the [graph.yaml](graph.yaml) file, you can see the subgraphs that make up the federated schema. We download the schemas through their introspection endpoint and compose them into a federated schema.
 You can also reference a local schema file. For more information, see the [wgc router compose](https://cosmo-docs.wundergraph.com/cli/router/compose).
 
 For demonstration purposes, all subgraphs are running on a severless environment. The Cosmo Router is running locally and proxies the requests to the remote services. It might take a few seconds for the serverless functions to start up.


### PR DESCRIPTION
* Documentation fix:
  * Changed the reference from `graphql.yaml` to `graph.yaml` when describing the file containing subgraphs for the federated schema.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Corrected the schema filename reference from “graphql.yaml” to “graph.yaml” in the router-simple example, updating the corresponding anchor.
  - Cleaned up minor formatting by removing a stray annotation and ensuring a proper trailing newline.
  - Improves clarity for users modifying the schema and reduces confusion during setup.
  - No functional changes or behavior impacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->