### PR TITLE
fix(router): Use proper OTEL span type for `Authenticate` middleware step

### DIFF
--- a/router/core/graphql_prehandler.go
+++ b/router/core/graphql_prehandler.go
@@ -356,7 +356,7 @@ func (h *PreHandler) Handler(next http.Handler) http.Handler {
 		// If we have authenticators, we try to authenticate the request
 		if h.accessController != nil {
 			_, authenticateSpan := h.tracer.Start(r.Context(), "Authenticate",
-				trace.WithSpanKind(trace.SpanKindServer),
+				trace.WithSpanKind(trace.SpanKindClient),
 				trace.WithAttributes(requestContext.telemetry.traceAttrs...),
 			)
 


### PR DESCRIPTION
@coderabbitai summary

## Checklist

- [x] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

Follow up to https://github.com/wundergraph/cosmo/pull/456#discussion_r2389253235. It was unexpected for the `Authenticate` middleware step to have a [span type](https://opentelemetry.io/docs/concepts/signals/traces/#client) of `server` due to this step not representing an incoming remote call. In fact since authentication results in an outgoing HTTP request, it should in fact be `client`. It cannot be `internal` because it's crossing a process boundary (the HTTP request).