### PR TITLE
fix: zod errors when sentry is imported before dotenv

### DIFF
--- a/controlplane/src/index.ts
+++ b/controlplane/src/index.ts
@@ -1,9 +1,8 @@
+import 'dotenv/config';
 import './core/sentry.config.js';
 import * as process from 'node:process';
 import * as Sentry from '@sentry/node';
 import pino from 'pino';
-
-import 'dotenv/config';
 
 import build, { BuildConfig } from './core/build-server.js';
 import { envVariables } from './core/env.schema.js';


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Environment configuration now initializes at the very start of the process, ensuring settings are available to all modules during startup. Improves consistency and reduces timing edge cases without changing features or APIs. No downtime or configuration changes required.
* **Chores**
  * Removed redundant configuration loading to streamline startup and reduce overhead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [x] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).
