### PR TITLE
chore(tests): fix timing issue in jitter tests

### DIFF
--- a/router/pkg/controlplane/poll_test.go
+++ b/router/pkg/controlplane/poll_test.go
@@ -67,10 +67,12 @@ func Test_Poller(t *testing.T) {
 				"execution %d: actual interval %v should be >= minimum interval %v",
 				i, actualInterval, expectedMinInterval)
 
-			// Each interval should be at most interval + maxJitter, a small delay to account for system scheduling delays
-			assert.LessOrEqual(t, actualInterval, expectedMaxInterval+20,
+			// Each interval should be at most interval + maxJitter
+			// a small delay to account for system scheduling delays
+			expectedInterval := expectedMaxInterval + 10*time.Millisecond
+			assert.LessOrEqual(t, actualInterval, expectedInterval,
 				"execution %d: actual interval %v should be <= maximum interval %v",
-				i, actualInterval, expectedMaxInterval)
+				i, actualInterval, expectedInterval)
 
 			t.Logf("execution %d: interval = %v (expected: %v to %v)",
 				i, actualInterval, expectedMinInterval, expectedMaxInterval)


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Adjusted polling interval test tolerances to account for timing variations, adding a 10ms buffer to the maximum allowed interval threshold.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->