### PR TITLE
feat(mcp): 8245 header forwarding

### DIFF
--- a/router/pkg/mcpserver/server.go
+++ b/router/pkg/mcpserver/server.go
@@ -224,6 +224,11 @@ func NewGraphQLSchemaServer(routerGraphQLEndpoint string, opts ...func(*Options)
 	return gs, nil
 }
 
+// SetHTTPClient allows setting a custom HTTP client (useful for testing)
+func (s *GraphQLSchemaServer) SetHTTPClient(client *http.Client) {
+	s.httpClient = client
+}
+
 // WithGraphName sets the graph name
 func WithGraphName(graphName string) func(*Options) {
 	return func(o *Options) {


### PR DESCRIPTION
Adds header forwarding from MCP client through MCP server to the GraphQL router, enabling authentication tokens, tracing headers, and custom metadata to be propagated through the request chain.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MCP server now forwards all incoming HTTP request headers to downstream GraphQL services, preserving tracing, custom and non-standard headers while ensuring required GraphQL headers are set.
  * Added ability to configure a custom HTTP client for GraphQL requests.

* **Tests**
  * End-to-end tests validate header forwarding in stateless mode, confirming custom/non-standard headers reach subgraphs and return 200 OK.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->