### PR TITLE
fix(router): return correct error when creating event config fails (Cosmo Streams)

### DIFF
--- a/router/pkg/pubsub/datasource/subscription_datasource.go
+++ b/router/pkg/pubsub/datasource/subscription_datasource.go
@@ -74,8 +74,8 @@ func (s *PubSubSubscriptionDataSource[C]) SubscriptionOnStart(ctx resolve.Startu
 	}()
 
 	for _, fn := range s.hooks.SubscriptionOnStart.Handlers {
-		conf, errConf := s.SubscriptionEventConfiguration(input)
-		if errConf != nil {
+		conf, err := s.SubscriptionEventConfiguration(input)
+		if err != nil {
 			return err
 		}
 		err = fn(ctx, conf, s.eventBuilder)


### PR DESCRIPTION
@coderabbitai summary

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [x] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

During `OnSubscriptionStart`, when handlers are executed, we create event configurations. This can return errors. We unfortunately returned the wrong  error variable in that case, which is always nil at that point. This has been fixed by returning the correct error. A new test case verifies this.