### PR TITLE
fix(protographic): move protobufjs to dependencies

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -882,6 +882,9 @@ importers:
       lodash-es:
         specifier: 4.17.21
         version: 4.17.21
+      protobufjs:
+        specifier: ^7.5.0
+        version: 7.5.0
     devDependencies:
       '@types/lodash-es':
         specifier: 4.17.12
@@ -889,9 +892,6 @@ importers:
       '@types/node':
         specifier: ^20.11.5
         version: 20.12.12
-      protobufjs:
-        specifier: ^7.5.0
-        version: 7.5.0
       typescript:
         specifier: ^5.0.0
         version: 5.5.2

--- a/protographic/package.json
+++ b/protographic/package.json
@@ -31,7 +31,6 @@
   "devDependencies": {
     "@types/lodash-es": "4.17.12",
     "@types/node": "^20.11.5",
-    "protobufjs": "^7.5.0",
     "typescript": "^5.0.0",
     "vitest": "^3.2.4"
   },
@@ -39,6 +38,7 @@
     "@bufbuild/protobuf": "^1.8.0",
     "@wundergraph/cosmo-connect": "workspace:*",
     "graphql": "^16.9.0",
-    "lodash-es": "4.17.21"
+    "lodash-es": "4.17.21",
+    "protobufjs": "^7.5.0"
   }
 }

--- a/protographic/src/index.ts
+++ b/protographic/src/index.ts
@@ -5,7 +5,6 @@ import type { GraphQLToProtoTextVisitorOptions } from './sdl-to-proto-visitor.js
 import { GraphQLToProtoTextVisitor } from './sdl-to-proto-visitor.js';
 import type { ProtoLock } from './proto-lock.js';
 import { SDLValidationVisitor, type ValidationResult } from './sdl-validation-visitor.js';
-import protobuf from 'protobufjs';
 
 /**
  * Compiles a GraphQL schema to a mapping structure


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Moved a protobuf runtime library from dev to regular dependencies so it’s available at runtime, improving packaging reliability for protobuf-related features without changing public APIs or behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->