### PR TITLE
fix: getGraphMetrics by using Float64 for multipliers in clickhouse queries

### DIFF
--- a/controlplane/src/core/repositories/analytics/MetricsRepository.ts
+++ b/controlplane/src/core/repositories/analytics/MetricsRepository.ts
@@ -85,7 +85,7 @@ export class MetricsRepository {
       };
       return this.client.queryPromise<{ value: number | null }>(
         `
-        SELECT round(sum(total) / {multiplier:UInt32}, 4) AS value FROM (
+        SELECT round(sum(total) / {multiplier:Float64}, 4) AS value FROM (
         SELECT
           toDateTime({startDate:UInt32}) AS startDate,
           toDateTime({endDate:UInt32}) AS endDate,
@@ -119,7 +119,7 @@ export class MetricsRepository {
       WITH
         toDateTime({startDate:UInt32}) AS startDate,
         toDateTime({endDate:UInt32}) AS endDate
-      SELECT hash, name, isPersisted, round(sum(total) / {multiplier:UInt32}, 4) AS value FROM (
+      SELECT hash, name, isPersisted, round(sum(total) / {multiplier:Float64}, 4) AS value FROM (
         SELECT
           Timestamp as timestamp,
           OperationHash as hash,

--- a/controlplane/src/core/repositories/analytics/SubgraphMetricsRepository.ts
+++ b/controlplane/src/core/repositories/analytics/SubgraphMetricsRepository.ts
@@ -97,7 +97,7 @@ export class SubgraphMetricsRepository {
       };
       return this.client.queryPromise<{ value: number | null }>(
         `
-        SELECT round(sum(total) / {multiplier:UInt32}, 4) AS value FROM (
+        SELECT round(sum(total) / {multiplier:Float64}, 4) AS value FROM (
         SELECT
           toDateTime({startDate:UInt32}) AS startDate,
           toDateTime({endDate:UInt32}) AS endDate,
@@ -131,7 +131,7 @@ export class SubgraphMetricsRepository {
       WITH
         toDateTime({startDate:UInt32}) AS startDate,
         toDateTime({endDate:UInt32}) AS endDate
-      SELECT hash, name, isPersisted, round(sum(total) / {multiplier:UInt32}, 4) AS value FROM (
+      SELECT hash, name, isPersisted, round(sum(total) / {multiplier:Float64}, 4) AS value FROM (
         SELECT
           Timestamp as timestamp,
           OperationHash as hash,


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Improved numeric precision in analytics metrics calculations to provide more accurate data representation for request rate and subgraph metrics reporting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [x] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).
