### PR TITLE
fix(demo): initialize NATS adapters and add GetPubSubName function

### DIFF
--- a/demo/cmd/all/main.go
+++ b/demo/cmd/all/main.go
@@ -37,6 +37,9 @@ func main() {
 			ProductsFG:   *productsFeatureSubgraph,
 		},
 		EnableDebug: *debug,
+		GetPubSubName: func(name string) string {
+			return name
+		},
 	}
 	ctx := context.Background()
 	subgraphs, err := subgraphs.New(ctx, &config)

--- a/demo/pkg/subgraphs/subgraphs.go
+++ b/demo/pkg/subgraphs/subgraphs.go
@@ -218,6 +218,9 @@ func New(ctx context.Context, config *Config) (*Subgraphs, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create default nats adapter: %w", err)
 	}
+	if err := defaultAdapter.Startup(ctx); err != nil {
+		return nil, fmt.Errorf("failed to start default nats adapter: %w", err)
+	}
 	natsPubSubByProviderID["default"] = defaultAdapter
 
 	myNatsAdapter, err := natsPubsub.NewAdapter(ctx, zap.NewNop(), url, []nats.Option{}, "hostname", "test", datasource.ProviderOpts{
@@ -225,6 +228,9 @@ func New(ctx context.Context, config *Config) (*Subgraphs, error) {
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create my-nats adapter: %w", err)
+	}
+	if err := myNatsAdapter.Startup(ctx); err != nil {
+		return nil, fmt.Errorf("failed to start my-nats adapter: %w", err)
 	}
 	natsPubSubByProviderID["my-nats"] = myNatsAdapter
 


### PR DESCRIPTION
- Call Startup() on NATS adapters to establish connections
- Add GetPubSubName function to subgraphs config to prevent nil pointer dereference
- Fixes "nats client not initialized" error in mood and availability subgraphs

The NATS adapters were being created but not started, leaving the client field uninitialized. This caused mutations that publish to NATS to fail with "nats client not initialized" errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configuration option for customizing PubSub name resolution

* **Bug Fixes**
  * Enhanced adapter initialization with proper error handling to ensure adapters are correctly started before use

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->