### PR TITLE
feat(router) Add support for per message deflate extension to websockets

### DIFF
--- a/router-tests/testenv/testenv.go
+++ b/router-tests/testenv/testenv.go
@@ -2345,6 +2345,44 @@ func (e *Environment) GraphQLWebsocketDialWithRetry(header http.Header, query ur
 	return nil, nil, err
 }
 
+// GraphQLWebsocketDialWithCompressionRetry is like GraphQLWebsocketDialWithRetry but enables
+// permessage-deflate compression negotiation on the client side.
+func (e *Environment) GraphQLWebsocketDialWithCompressionRetry(header http.Header, query url.Values) (*websocket.Conn, *http.Response, error) {
+	dialer := websocket.Dialer{
+		Subprotocols:      []string{"graphql-transport-ws"},
+		EnableCompression: true,
+	}
+
+	waitBetweenRetriesInMs := rand.Intn(10)
+	timeToSleep := time.Duration(waitBetweenRetriesInMs) * time.Millisecond
+
+	var err error
+
+	for i := 0; i <= maxSocketRetries; i++ {
+		urlStr := e.GraphQLWebSocketSubscriptionURL()
+		if query != nil {
+			urlStr += "?" + query.Encode()
+		}
+		conn, resp, err := dialer.Dial(urlStr, header)
+
+		if resp != nil && err == nil {
+			return conn, resp, err
+		}
+
+		if errors.Is(err, websocket.ErrBadHandshake) {
+			return conn, resp, err
+		}
+
+		// Make sure that on the final attempt we won't wait
+		if i != maxSocketRetries {
+			time.Sleep(timeToSleep)
+			timeToSleep *= 2
+		}
+	}
+
+	return nil, nil, err
+}
+
 func (e *Environment) InitGraphQLWebSocketConnection(header http.Header, query url.Values, initialPayload json.RawMessage) *websocket.Conn {
 	conn, _, err := e.GraphQLWebsocketDialWithRetry(header, query)
 	require.NoError(e.t, err)
@@ -2360,6 +2398,25 @@ func (e *Environment) InitGraphQLWebSocketConnection(header http.Header, query u
 	require.NoError(e.t, ReadAndCheckJSON(e.t, conn, &ack))
 	require.Equal(e.t, "connection_ack", ack.Type)
 	return conn
+}
+
+// InitGraphQLWebSocketConnectionWithCompression initializes a WebSocket connection with
+// permessage-deflate compression negotiation enabled on the client side.
+func (e *Environment) InitGraphQLWebSocketConnectionWithCompression(header http.Header, query url.Values, initialPayload json.RawMessage) (*websocket.Conn, *http.Response) {
+	conn, resp, err := e.GraphQLWebsocketDialWithCompressionRetry(header, query)
+	require.NoError(e.t, err)
+	e.t.Cleanup(func() {
+		_ = conn.Close()
+	})
+	err = conn.WriteJSON(WebSocketMessage{
+		Type:    "connection_init",
+		Payload: initialPayload,
+	})
+	require.NoError(e.t, err)
+	var ack WebSocketMessage
+	require.NoError(e.t, ReadAndCheckJSON(e.t, conn, &ack))
+	require.Equal(e.t, "connection_ack", ack.Type)
+	return conn, resp
 }
 
 func (e *Environment) GraphQLSubscriptionOverSSE(ctx context.Context, request GraphQLRequest, handler func(data string)) {

--- a/router/pkg/config/config.go
+++ b/router/pkg/config/config.go
@@ -722,6 +722,16 @@ type WebSocketConfiguration struct {
 	Authentication WebSocketAuthenticationConfiguration `yaml:"authentication,omitempty"`
 	// SetClientInfoFromInitialPayload configuration for the WebSocket Connection
 	ClientInfoFromInitialPayload WebSocketClientInfoFromInitialPayloadConfiguration `yaml:"client_info_from_initial_payload"`
+	// Compression configuration for WebSocket per-message compression (permessage-deflate)
+	Compression WebSocketCompressionConfiguration `yaml:"compression,omitempty"`
+}
+
+// WebSocketCompressionConfiguration configures permessage-deflate compression for WebSocket connections
+type WebSocketCompressionConfiguration struct {
+	// Enabled enables permessage-deflate compression for WebSocket connections
+	Enabled bool `yaml:"enabled" envDefault:"false" env:"WEBSOCKETS_COMPRESSION_ENABLED"`
+	// Level is the compression level (1-9, where 1 is fastest and 9 is best compression)
+	Level int `yaml:"level" envDefault:"6" env:"WEBSOCKETS_COMPRESSION_LEVEL"`
 }
 
 type WebSocketClientInfoFromInitialPayloadConfiguration struct {

--- a/router/pkg/config/config.schema.json
+++ b/router/pkg/config/config.schema.json
@@ -560,6 +560,25 @@
               }
             }
           }
+        },
+        "compression": {
+          "type": "object",
+          "description": "Configuration for WebSocket per-message compression (permessage-deflate extension).",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false,
+              "description": "Enable permessage-deflate compression for WebSocket connections. When enabled, the server will negotiate compression with clients that support it. The default value is false."
+            },
+            "level": {
+              "type": "integer",
+              "default": 6,
+              "minimum": 1,
+              "maximum": 9,
+              "description": "The compression level (1-9). Level 1 is fastest with least compression, level 9 provides best compression but is slowest. The default value is 6."
+            }
+          }
         }
       }
     },

--- a/router/pkg/config/fixtures/full.yaml
+++ b/router/pkg/config/fixtures/full.yaml
@@ -404,6 +404,9 @@ websocket:
       export_token:
         enabled: true
         header_key: 'Authorization'
+  compression:
+    enabled: true
+    level: 6
 
 storage_providers:
   file_system:

--- a/router/pkg/config/testdata/config_defaults.json
+++ b/router/pkg/config/testdata/config_defaults.json
@@ -438,6 +438,10 @@
         "NameTargetHeader": "graphql-client-name",
         "VersionTargetHeader": "graphql-client-version"
       }
+    },
+    "Compression": {
+      "Enabled": false,
+      "Level": 6
     }
   },
   "SubgraphErrorPropagation": {

--- a/router/pkg/config/testdata/config_full.json
+++ b/router/pkg/config/testdata/config_full.json
@@ -818,6 +818,10 @@
         "NameTargetHeader": "graphql-client-name",
         "VersionTargetHeader": "graphql-client-version"
       }
+    },
+    "Compression": {
+      "Enabled": true,
+      "Level": 6
     }
   },
   "SubgraphErrorPropagation": {


### PR DESCRIPTION

Following up on an issue I created a couple months ago. https://github.com/wundergraph/cosmo/issues/2257 We are in need of this feature to be able to use websockets through cosmo due to the volume of data we are handling. 

This adds new websocket compression options to the config and handles the negotiation of the websocket upgrade to use compression if the client requests it.

<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WebSocket per-message compression (permessage-deflate) supported with configurable enabled/disabled state and compression level (1–9, default 6).

* **Configuration**
  * Configuration schema and defaults updated to include a compression block for WebSocket settings.

* **Tests**
  * Added tests and test helpers covering negotiation and data exchange across compressed and uncompressed scenarios, including varied compression levels.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [X] I have followed the coding standards of the project.
- [X] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [X] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->