### PR TITLE
fix: perform auth for all the commands of grpc which requires controlplane

### DIFF
--- a/cli/src/commands/grpc-service/index.ts
+++ b/cli/src/commands/grpc-service/index.ts
@@ -19,6 +19,9 @@ export default (opts: BaseCommandOptions) => {
   command.addCommand(deleteCommand(opts));
 
   command.hook('preAction', async (thisCmd) => {
+    if (['generate', 'init', 'list-templates'].includes(thisCmd.args[0])) {
+      return;
+    }
     await checkAuth();
   });
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Implemented authentication validation for the gRPC service CLI. Authentication is now required for most commands, except generate, init, and list-templates which remain publicly accessible.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [x] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).
