### PR TITLE
fix(cli): handle cross device link error on plugin init

### DIFF
--- a/cli/src/commands/router/commands/plugin/commands/init.ts
+++ b/cli/src/commands/router/commands/plugin/commands/init.ts
@@ -26,15 +26,14 @@ const move = async (src: string, dest: string) => {
   try {
     await rename(src, dest);
   } catch (error: unknown) {
-    if (typeof error === 'object' && error !== null && 'code' in error) {
-      if (error.code === 'EXDEV') {
-        // fallback for cross-device moves
-        await cp(src, dest, { recursive: true });
-        await rm(src, { recursive: true, force: true });
-      } else {
-        throw error;
-      }
+    if (typeof error === 'object' && error !== null && 'code' in error && error.code === 'EXDEV') {
+      // fallback for cross-device moves
+      await cp(src, dest, { recursive: true });
+      await rm(src, { recursive: true, force: true });
+      return;
     }
+
+    throw error;
   }
 };
 


### PR DESCRIPTION
fixes #2455

During plugin init we scaffold the plugin in a tmp directory. It might be the case that this tmp director is on a different device than the destination path. As `rename` calls the underlying OS rename function, the operation will fail with a Cross Device Link error. 
To solve the issue we attempt to use the OS rename function, and if this fails with an EXDEV error, we will manually copy and remove the files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Plugin initialization now reliably moves plugin files across different filesystems by falling back to a copy-and-remove strategy when direct moves fail, preventing errors during installation or updates and ensuring smoother operations in complex storage setups.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->