### PR TITLE
feat: add UTM parameter tracking for new user signups

### DIFF
--- a/controlplane/src/core/controllers/auth.ts
+++ b/controlplane/src/core/controllers/auth.ts
@@ -4,6 +4,7 @@ import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import { and, eq, sql } from 'drizzle-orm';
 import { lru } from 'tiny-lru';
 import { uid } from 'uid';
+import cookie from 'cookie';
 import { PlatformEventName } from '@wundergraph/cosmo-connect/dist/notifications/events_pb';
 import { cosmoIdpHintCookieName, decodeJWT, DEFAULT_SESSION_MAX_AGE_SEC, encrypt } from '../crypto/jwt.js';
 import { CustomAccessTokenClaims, UserInfoEndpointResponse, UserSession } from '../../types/index.js';
@@ -375,12 +376,25 @@ const plugin: FastifyPluginCallback<AuthControllerOptions> = function Auth(fasti
       }
 
       if (orgs === 0) {
+        // Read UTM parameters from cookies
+        const cookies = cookie.parse(req.headers.cookie || '');
+        const utmSource = cookies.utm_source;
+        const utmMedium = cookies.utm_medium;
+        const utmCampaign = cookies.utm_campaign;
+        const utmContent = cookies.utm_content;
+        const utmTerm = cookies.utm_term;
+
         // Send a notification to the platform that a new user has been created
         opts.platformWebhooks.send(PlatformEventName.USER_REGISTER_SUCCESS, {
           user_id: userId,
           user_email: userEmail,
           user_first_name: firstName,
           user_last_name: lastName,
+          utm_source: utmSource,
+          utm_medium: utmMedium,
+          utm_campaign: utmCampaign,
+          utm_content: utmContent,
+          utm_term: utmTerm,
         });
       }
 

--- a/controlplane/src/core/webhooks/PlatformWebhookService.ts
+++ b/controlplane/src/core/webhooks/PlatformWebhookService.ts
@@ -11,6 +11,11 @@ interface User {
   user_email: string;
   user_first_name?: string;
   user_last_name?: string;
+  utm_source?: string;
+  utm_medium?: string;
+  utm_campaign?: string;
+  utm_content?: string;
+  utm_term?: string;
 }
 
 interface ApolloMigrate {


### PR DESCRIPTION
- Read UTM cookies (utm_source, utm_medium, utm_campaign, utm_content, utm_term) from request headers
- Include UTM parameters in USER_REGISTER_SUCCESS webhook payload
- Update PlatformWebhookService User interface to support optional UTM fields

https://linear.app/wundergraph/issue/ENG-8867/feat-pass-utm-tags-to-ac-upon-cosmo-sign-up

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Platform webhooks now include UTM campaign attribution data (source, medium, campaign, content, and term) in user registration events. These parameters are automatically captured from cookies and forwarded with webhook payloads, enabling improved tracking of user acquisition sources, marketing channel performance, and overall campaign effectiveness across your connected systems and integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->