### PR TITLE
fix: cache warmer graph token validation cleanup

### DIFF
--- a/router-tests/cache_warmup_test.go
+++ b/router-tests/cache_warmup_test.go
@@ -593,6 +593,27 @@ func TestCacheWarmup(t *testing.T) {
 		featureOperationCount := int64(1)
 		invalidOperationCount := int64(1)
 
+		t.Run("fails when graph token is missing with CDN cache warmup enabled", func(t *testing.T) {
+			t.Parallel()
+			testenv.FailsOnStartup(t, &testenv.Config{
+				RouterOptions: []core.Option{
+					core.WithCacheWarmupConfig(&config.CacheWarmupConfiguration{
+						Enabled: true,
+						Source: config.CacheWarmupSource{
+							CdnSource: config.CacheWarmupCDNSource{
+								Enabled: true,
+							},
+						},
+					}),
+					// Override the default graph API token with an empty string
+					core.WithGraphApiToken(""),
+				},
+			}, func(t *testing.T, err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "graph token is required for cache warmup in order to communicate with the CDN")
+			})
+		})
+
 		t.Run("cache warmup disabled with CDN config", func(t *testing.T) {
 			t.Parallel()
 			testenv.Run(t, &testenv.Config{


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

This PR moves the graph token validation to the correct condition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed graph token validation to only require the token when CDN cache warmup is enabled, improving startup validation accuracy

* **Tests**
  * Added test coverage to verify startup fails properly when graph token is missing while CDN cache warmup is enabled
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->