### PR TITLE
feat(router): use `telemetry.service_name` config value as the `service` property of log messages

### DIFF
--- a/router/cmd/main.go
+++ b/router/cmd/main.go
@@ -92,7 +92,7 @@ func Main() {
 
 	baseLogger := logging.New(!result.Config.JSONLog, result.Config.DevelopmentMode, result.Config.AccessLogs.AddStacktrace, logLevelAtomic).
 		With(
-			zap.String("service", "@wundergraph/router"),
+			zap.String("service", result.Config.Telemetry.ServiceName),
 			zap.String("service_version", core.Version),
 		)
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated service name logging to be dynamically sourced from configuration settings rather than using a static value. This ensures telemetry metadata accurately reflects the configured service name at runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [x] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [x] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

Resolves https://github.com/wundergraph/cosmo/issues/2277

**Breaking Change:** Default value of the `service` property in logs is no `cosmo-router`, not `@wundergraph/router`. Filters in observability tools may need to be updated.

