### PR TITLE
fix(cli): prevent hang when displaying large composition errors

### DIFF
--- a/cli/src/commands/router/commands/compose.ts
+++ b/cli/src/commands/router/commands/compose.ts
@@ -211,19 +211,14 @@ export default (opts: BaseCommandOptions) => {
     );
 
     if (!result.success) {
-      const compositionErrorsTable = new Table({
-        head: [pc.bold(pc.white('ERROR_MESSAGE'))],
-        colWidths: [120],
-        wordWrap: true,
-      });
-
       console.log(
-        pc.red(`We found composition errors, while composing.\n${pc.bold('Please check the errors below:')}`),
+        pc.red(`We found composition errors, while composing.\n${pc.bold('Please check the errors below:')}\n`),
       );
       for (const compositionError of result.errors) {
-        compositionErrorsTable.push([compositionError.message]);
+        console.log(pc.red('─'.repeat(80)));
+        console.log(compositionError.message);
       }
-      console.log(compositionErrorsTable.toString());
+      console.log(pc.red('─'.repeat(80)));
       process.exitCode = 1;
       return;
     }
@@ -591,23 +586,18 @@ async function buildFeatureFlagsConfig(
     );
 
     if (!featureResult.success) {
-      const compositionErrorsTable = new Table({
-        head: [pc.bold(pc.white('ERROR_MESSAGE'))],
-        colWidths: [120],
-        wordWrap: true,
-      });
-
       console.log(
         pc.red(
           `We found composition errors, while composing the feature flag ${pc.italic(ff.name)}.\n${pc.bold(
             'Please check the errors below:',
-          )}`,
+          )}\n`,
         ),
       );
       for (const compositionError of featureResult.errors) {
-        compositionErrorsTable.push([compositionError.message]);
+        console.log(pc.red('─'.repeat(80)));
+        console.log(compositionError.message);
       }
-      console.log(compositionErrorsTable.toString());
+      console.log(pc.red('─'.repeat(80)));
       continue;
     }
 


### PR DESCRIPTION
The `router compose` command would hang indefinitely when composition produced errors with long messages (e.g., deeply nested unresolvable field paths that can reach 29,000+ characters).

Root cause: cli-table3's wordWrap option has O(n²) or worse performance on large strings. Error messages of ~2,000 chars took ~7 seconds to render; messages of ~29,000 chars would take minutes or longer.

Fix: Remove table formatting for composition errors and print them directly with simple line separators. Tables are still used for warnings, which are typically much shorter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved composition error display format—errors now appear individually with separator lines instead of in a table layout, providing clearer readability while maintaining the same error handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->