### PR TITLE
feat(cli): support env var interpolation in wgc router compose input YAML

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -59,6 +59,7 @@
     "date-fns": "3.6.0",
     "decompress": "4.2.1",
     "dotenv": "16.6.0",
+    "dotenv-expand": "^12.0.1",
     "env-ci": "11.1.0",
     "env-paths": "3.0.0",
     "execa": "9.5.2",

--- a/cli/src/commands/router/commands/compose.ts
+++ b/cli/src/commands/router/commands/compose.ts
@@ -30,6 +30,16 @@ import { composeSubgraphs, introspectSubgraph } from '../../../utils.js';
 
 const STATIC_SCHEMA_VERSION_ID = '00000000-0000-0000-0000-000000000000';
 
+/**
+ * Expands environment variables in a string using ${VAR_NAME} syntax.
+ * Consistent with Go's os.ExpandEnv() used in router config.yaml.
+ */
+export function expandEnvVars(content: string): string {
+  return content.replace(/\${([^}]+)}/g, (_, varName) => {
+    return process.env[varName] ?? '';
+  });
+}
+
 type ConfigSubgraph = StandardSubgraphConfig | SubgraphPluginConfig | GRPCSubgraphConfig;
 
 type StandardSubgraphConfig = {
@@ -183,7 +193,8 @@ export default (opts: BaseCommandOptions) => {
     }
 
     const fileContent = (await readFile(inputFile)).toString();
-    const config = yaml.load(fileContent) as Config;
+    const expandedContent = expandEnvVars(fileContent);
+    const config = yaml.load(expandedContent) as Config;
 
     const subgraphs: SubgraphMetadata[] = [];
 

--- a/cli/src/commands/router/commands/compose.ts
+++ b/cli/src/commands/router/commands/compose.ts
@@ -32,7 +32,8 @@ const STATIC_SCHEMA_VERSION_ID = '00000000-0000-0000-0000-000000000000';
 
 /**
  * Expands environment variables in a string using ${VAR_NAME} syntax.
- * Consistent with Go's os.ExpandEnv() used in router config.yaml.
+ * Only the curly-brace form is supported; bare $VAR references are not expanded.
+ * Undefined variables are replaced with an empty string.
  */
 export function expandEnvVars(content: string): string {
   return content.replace(/\${([^}]+)}/g, (_, varName) => {
@@ -172,7 +173,8 @@ function constructRouterSubgraph(result: FederationSuccess, s: SubgraphMetadata,
 export default (opts: BaseCommandOptions) => {
   const command = new Command('compose');
   command.description(
-    'Generates a router config from a local composition file. This makes it easy to test your router without a control-plane connection. For production, please use the "router fetch" command',
+    // eslint-disable-next-line no-template-curly-in-string
+    'Generates a router config from a local composition file. Environment variables can be referenced in the input YAML using ${VAR_NAME} syntax. This makes it easy to test your router without a control-plane connection. For production, please use the "router fetch" command',
   );
   command.requiredOption('-i, --input <path-to-input>', 'The yaml file with data about graph and subgraphs.');
   command.option('-o, --out [string]', 'Destination file for the router config.');

--- a/cli/src/commands/router/commands/compose.ts
+++ b/cli/src/commands/router/commands/compose.ts
@@ -25,20 +25,21 @@ import {
 } from '@wundergraph/cosmo-connect/dist/node/v1/node_pb';
 import Table from 'cli-table3';
 import { FederationSuccess, ROUTER_COMPATIBILITY_VERSION_ONE } from '@wundergraph/composition';
+import { expand } from 'dotenv-expand';
 import { BaseCommandOptions } from '../../../core/types/types.js';
 import { composeSubgraphs, introspectSubgraph } from '../../../utils.js';
 
 const STATIC_SCHEMA_VERSION_ID = '00000000-0000-0000-0000-000000000000';
 
 /**
- * Expands environment variables in a string using ${VAR_NAME} syntax.
- * Only the curly-brace form is supported; bare $VAR references are not expanded.
- * Undefined variables are replaced with an empty string.
+ * Expands environment variables in a string using dotenv-expand.
+ * Supports ${VAR_NAME}, $VAR_NAME, and ${VAR:-default} syntax.
+ * Undefined variables without defaults are replaced with an empty string.
  */
 export function expandEnvVars(content: string): string {
-  return content.replace(/\${([^}]+)}/g, (_, varName) => {
-    return process.env[varName] ?? '';
-  });
+  const key = '__YAML_CONTENT__';
+  const result = expand({ parsed: { [key]: content }, processEnv: process.env as Record<string, string> });
+  return result.parsed?.[key] ?? content;
 }
 
 type ConfigSubgraph = StandardSubgraphConfig | SubgraphPluginConfig | GRPCSubgraphConfig;

--- a/cli/src/commands/router/commands/compose.ts
+++ b/cli/src/commands/router/commands/compose.ts
@@ -38,7 +38,7 @@ const STATIC_SCHEMA_VERSION_ID = '00000000-0000-0000-0000-000000000000';
  */
 export function expandEnvVars(content: string): string {
   const key = '__YAML_CONTENT__';
-  const result = expand({ parsed: { [key]: content }, processEnv: process.env as Record<string, string> });
+  const result = expand({ parsed: { [key]: content }, processEnv: { ...process.env } as Record<string, string> });
   return result.parsed?.[key] ?? content;
 }
 

--- a/cli/test/compose-env-vars.test.ts
+++ b/cli/test/compose-env-vars.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-template-curly-in-string */
-import { existsSync, mkdirSync, readFileSync, rmdirSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { Command } from 'commander';
@@ -34,7 +34,7 @@ describe('router compose with env var interpolation', () => {
     mkdirSync(tmpDir, { recursive: true });
 
     testContext.onTestFinished(() => {
-      rmdirSync(tmpDir, { recursive: true });
+      rmSync(tmpDir, { recursive: true, force: true });
     });
 
     writeFileSync(join(tmpDir, 'subgraph.graphql'), 'type Query { hello: String }');

--- a/cli/test/compose-env-vars.test.ts
+++ b/cli/test/compose-env-vars.test.ts
@@ -1,0 +1,68 @@
+/* eslint-disable no-template-curly-in-string */
+import { existsSync, mkdirSync, readFileSync, rmdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { Command } from 'commander';
+import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+import { createPromiseClient, createRouterTransport } from '@connectrpc/connect';
+import { PlatformService } from '@wundergraph/cosmo-connect/dist/platform/v1/platform_connect';
+import ComposeRouterConfig from '../src/commands/router/commands/compose.js';
+import { Client } from '../src/core/client/client.js';
+
+const mockPlatformTransport = () =>
+  createRouterTransport(({ service }) => {
+    service(PlatformService, {});
+  });
+
+describe('router compose with env var interpolation', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  test('expands env vars in routing_url', async (testContext) => {
+    const client: Client = {
+      platform: createPromiseClient(PlatformService, mockPlatformTransport()),
+    };
+
+    const tmpDir = join(tmpdir(), `compose-env-test-${Date.now()}`);
+    mkdirSync(tmpDir, { recursive: true });
+
+    testContext.onTestFinished(() => {
+      rmdirSync(tmpDir, { recursive: true });
+    });
+
+    writeFileSync(join(tmpDir, 'subgraph.graphql'), 'type Query { hello: String }');
+
+    writeFileSync(
+      join(tmpDir, 'graph.yaml'),
+      `version: 1
+subgraphs:
+  - name: myservice
+    routing_url: http://\${HOST}:\${PORT}/graphql
+    schema:
+      file: ./subgraph.graphql
+`,
+    );
+
+    process.env.HOST = 'localhost';
+    process.env.PORT = '4001';
+
+    const outFile = join(tmpDir, 'router.json');
+    const program = new Command();
+    program.addCommand(ComposeRouterConfig({ client }));
+
+    await program.parseAsync(['compose', '-i', join(tmpDir, 'graph.yaml'), '-o', outFile], { from: 'user' });
+
+    expect(existsSync(outFile)).toBe(true);
+
+    const config = JSON.parse(readFileSync(outFile, 'utf8'));
+    const subgraph = config.subgraphs[0];
+    expect(subgraph.routingUrl).toBe('http://localhost:4001/graphql');
+  });
+});

--- a/cli/test/expand-env-vars.test.ts
+++ b/cli/test/expand-env-vars.test.ts
@@ -44,9 +44,31 @@ describe('expandEnvVars', () => {
     expect(expandEnvVars('$FOO')).toBe('bar');
   });
 
-  test('supports default value syntax ${VAR:-default}', () => {
+  test('supports default value syntax ${VAR:-default} when unset', () => {
     delete process.env.MISSING;
     expect(expandEnvVars('${MISSING:-fallback}')).toBe('fallback');
+  });
+
+  test('ignores default when variable is set', () => {
+    process.env.EXISTING = 'real';
+    expect(expandEnvVars('${EXISTING:-fallback}')).toBe('real');
+  });
+
+  test('uses default when variable is empty string', () => {
+    process.env.EMPTY = '';
+    expect(expandEnvVars('${EMPTY:-fallback}')).toBe('fallback');
+  });
+
+  test('supports alternate value syntax ${VAR:+alt}', () => {
+    process.env.PRESENT = 'something';
+    expect(expandEnvVars('${PRESENT:+override}')).toBe('override');
+    delete process.env.ABSENT;
+    expect(expandEnvVars('${ABSENT:+override}')).toBe('');
+  });
+
+  test('escaped \\$ is not expanded', () => {
+    process.env.FOO = 'bar';
+    expect(expandEnvVars('\\$FOO')).toBe('$FOO');
   });
 
   test('handles variable in Authorization header context', () => {

--- a/cli/test/expand-env-vars.test.ts
+++ b/cli/test/expand-env-vars.test.ts
@@ -39,6 +39,17 @@ describe('expandEnvVars', () => {
     expect(expandEnvVars('no variables here')).toBe('no variables here');
   });
 
+  test('does not expand bare $VAR without braces', () => {
+    process.env.FOO = 'bar';
+    expect(expandEnvVars('$FOO')).toBe('$FOO');
+  });
+
+  test('does not expand nested ${FOO${BAR}}', () => {
+    process.env.BAR = 'baz';
+    // Matches ${FOO${BAR} (up to first }), looks up "FOO${BAR" which is undefined
+    expect(expandEnvVars('${FOO${BAR}}')).toBe('}');
+  });
+
   test('handles variable in Authorization header context', () => {
     process.env.API_TOKEN = 'secret123';
     const input = `headers:

--- a/cli/test/expand-env-vars.test.ts
+++ b/cli/test/expand-env-vars.test.ts
@@ -1,0 +1,50 @@
+/* eslint-disable no-template-curly-in-string */
+import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+import { expandEnvVars } from '../src/commands/router/commands/compose.js';
+
+describe('expandEnvVars', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  test('replaces ${VAR} with environment variable value', () => {
+    process.env.TEST_VAR = 'hello';
+    expect(expandEnvVars('${TEST_VAR}')).toBe('hello');
+  });
+
+  test('replaces missing variable with empty string', () => {
+    delete process.env.NONEXISTENT_VAR;
+    expect(expandEnvVars('${NONEXISTENT_VAR}')).toBe('');
+  });
+
+  test('handles multiple variables in one string', () => {
+    process.env.VAR1 = 'foo';
+    process.env.VAR2 = 'bar';
+    expect(expandEnvVars('${VAR1} and ${VAR2}')).toBe('foo and bar');
+  });
+
+  test('handles adjacent variables', () => {
+    process.env.A = 'hello';
+    process.env.B = 'world';
+    expect(expandEnvVars('${A}${B}')).toBe('helloworld');
+  });
+
+  test('preserves text without variables', () => {
+    expect(expandEnvVars('no variables here')).toBe('no variables here');
+  });
+
+  test('handles variable in Authorization header context', () => {
+    process.env.API_TOKEN = 'secret123';
+    const input = `headers:
+  Authorization: "Bearer \${API_TOKEN}"`;
+    const expected = `headers:
+  Authorization: "Bearer secret123"`;
+    expect(expandEnvVars(input)).toBe(expected);
+  });
+});

--- a/cli/test/expand-env-vars.test.ts
+++ b/cli/test/expand-env-vars.test.ts
@@ -39,15 +39,14 @@ describe('expandEnvVars', () => {
     expect(expandEnvVars('no variables here')).toBe('no variables here');
   });
 
-  test('does not expand bare $VAR without braces', () => {
+  test('expands bare $VAR without braces', () => {
     process.env.FOO = 'bar';
-    expect(expandEnvVars('$FOO')).toBe('$FOO');
+    expect(expandEnvVars('$FOO')).toBe('bar');
   });
 
-  test('does not expand nested ${FOO${BAR}}', () => {
-    process.env.BAR = 'baz';
-    // Matches ${FOO${BAR} (up to first }), looks up "FOO${BAR" which is undefined
-    expect(expandEnvVars('${FOO${BAR}}')).toBe('}');
+  test('supports default value syntax ${VAR:-default}', () => {
+    delete process.env.MISSING;
+    expect(expandEnvVars('${MISSING:-fallback}')).toBe('fallback');
   });
 
   test('handles variable in Authorization header context', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,6 +234,9 @@ importers:
       dotenv:
         specifier: 16.6.0
         version: 16.6.0
+      dotenv-expand:
+        specifier: ^12.0.1
+        version: 12.0.3
       env-ci:
         specifier: 11.1.0
         version: 11.1.0
@@ -9543,6 +9546,10 @@ packages:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
     engines: {node: '>=8'}
 
+  dotenv-expand@12.0.3:
+    resolution: {integrity: sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA==}
+    engines: {node: '>=12'}
+
   dotenv-expand@8.0.3:
     resolution: {integrity: sha512-SErOMvge0ZUyWd5B0NXMQlDkN+8r+HhVUsxgOO7IoPDOdDRD2JjExpN6y3KnFR66jsJMwSn1pqIivhU5rcJiNg==}
     engines: {node: '>=12'}
@@ -14834,6 +14841,7 @@ packages:
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
@@ -25061,6 +25069,10 @@ snapshots:
   dot-prop@5.3.0:
     dependencies:
       is-obj: 2.0.0
+
+  dotenv-expand@12.0.3:
+    dependencies:
+      dotenv: 16.6.0
 
   dotenv-expand@8.0.3: {}
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Router compose command now supports environment variable substitution in YAML configuration files. Use `${VAR}`, `$VAR`, or `${VAR:-default}` syntax to dynamically set values in your configuration.

* **Tests**
  * Added comprehensive test coverage for environment variable expansion scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Adds environment variable interpolation to `wgc router compose`, allowing users to reference env vars using `${VAR_NAME}`, `$VAR_NAME`, and `${VAR:-default}` syntax in the compose input YAML file. This is consistent with the Router's `config.yaml` behavior and avoids the need to hard-code secrets such as auth headers for subgraph introspection. Interpolation is implemented via the `dotenv-expand` library and applied to the raw file content before YAML parsing. Closes #2002.

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [x] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).