### PR TITLE
Add support for per message deflate to websocket connectinos

### DIFF
--- a/router/pkg/config/config.go
+++ b/router/pkg/config/config.go
@@ -744,6 +744,16 @@ type WebSocketConfiguration struct {
 	Authentication WebSocketAuthenticationConfiguration `yaml:"authentication,omitempty"`
 	// SetClientInfoFromInitialPayload configuration for the WebSocket Connection
 	ClientInfoFromInitialPayload WebSocketClientInfoFromInitialPayloadConfiguration `yaml:"client_info_from_initial_payload"`
+	// Compression configuration for WebSocket per-message compression (permessage-deflate)
+	Compression WebSocketCompressionConfiguration `yaml:"compression,omitempty"`
+}
+
+// WebSocketCompressionConfiguration configures permessage-deflate compression for WebSocket connections
+type WebSocketCompressionConfiguration struct {
+	// Enabled enables permessage-deflate compression for WebSocket connections
+	Enabled bool `yaml:"enabled" envDefault:"false" env:"WEBSOCKETS_COMPRESSION_ENABLED"`
+	// Level is the compression level (1-9, where 1 is fastest and 9 is best compression)
+	Level int `yaml:"level" envDefault:"6" env:"WEBSOCKETS_COMPRESSION_LEVEL"`
 }
 
 type WebSocketClientInfoFromInitialPayloadConfiguration struct {

--- a/router/pkg/config/config.schema.json
+++ b/router/pkg/config/config.schema.json
@@ -599,6 +599,25 @@
               }
             }
           }
+        },
+        "compression": {
+          "type": "object",
+          "description": "Configuration for WebSocket per-message compression (permessage-deflate extension).",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false,
+              "description": "Enable permessage-deflate compression for WebSocket connections. When enabled, the server will negotiate compression with clients that support it. The default value is false."
+            },
+            "level": {
+              "type": "integer",
+              "default": 6,
+              "minimum": 1,
+              "maximum": 9,
+              "description": "The compression level (1-9). Level 1 is fastest with least compression, level 9 provides best compression but is slowest. The default value is 6."
+            }
+          }
         }
       }
     },

--- a/router/pkg/config/fixtures/full.yaml
+++ b/router/pkg/config/fixtures/full.yaml
@@ -411,6 +411,9 @@ websocket:
       export_token:
         enabled: true
         header_key: 'Authorization'
+  compression:
+    enabled: true
+    level: 6
 
 storage_providers:
   file_system:

--- a/router/pkg/config/testdata/config_defaults.json
+++ b/router/pkg/config/testdata/config_defaults.json
@@ -461,6 +461,10 @@
         "NameTargetHeader": "graphql-client-name",
         "VersionTargetHeader": "graphql-client-version"
       }
+    },
+    "Compression": {
+      "Enabled": false,
+      "Level": 6
     }
   },
   "SubgraphErrorPropagation": {

--- a/router/pkg/config/testdata/config_full.json
+++ b/router/pkg/config/testdata/config_full.json
@@ -853,6 +853,10 @@
         "NameTargetHeader": "graphql-client-name",
         "VersionTargetHeader": "graphql-client-version"
       }
+    },
+    "Compression": {
+      "Enabled": true,
+      "Level": 6
     }
   },
   "SubgraphErrorPropagation": {


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-message deflate compression support for WebSocket connections, reducing bandwidth usage.
  * New configuration options: `WEBSOCKETS_COMPRESSION_ENABLED` and `WEBSOCKETS_COMPRESSION_LEVEL` (1-9) for tuning compression behavior.

* **Tests**
  * Added comprehensive test coverage for compression negotiation and operation across various configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [X] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [X] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->

This is reopening PR https://github.com/wundergraph/cosmo/pull/2424 to add support for per-message-deflate to websockets. This is a requirement for us to be using websockets though cosmo-router