### PR TITLE
fix(router-tests): fix connectrpc tests and add to CI

### DIFF
--- a/.github/workflows/router-ci.yaml
+++ b/.github/workflows/router-ci.yaml
@@ -200,6 +200,7 @@ jobs:
             './. ./fuzzquery ./lifecycle ./modules',
             './telemetry',
             './events',
+            './connectrpc',
           ]
     services:
       nats:

--- a/router-tests/connectrpc/connectrpc_client_test.go
+++ b/router-tests/connectrpc/connectrpc_client_test.go
@@ -196,11 +196,11 @@ func TestConnectRPC_ClientErrorHandling(t *testing.T) {
 		assert.Contains(t, connectErr.Message(), "GraphQL partial success with errors")
 	})
 
-	t.Run("HTTP 404 maps to CodeNotFound", func(t *testing.T) {
+	t.Run("HTTP 404 maps to CodeUnimplemented", func(t *testing.T) {
 		ts := NewTestConnectRPCServer(t, ConnectRPCServerOptions{
 			GraphQLHandler: HTTPErrorHandler(http.StatusNotFound, "Not Found"),
 		})
-		
+
 		err := ts.Start()
 		require.NoError(t, err)
 
@@ -218,7 +218,7 @@ func TestConnectRPC_ClientErrorHandling(t *testing.T) {
 
 		var connectErr *connect.Error
 		require.ErrorAs(t, err, &connectErr)
-		assert.Equal(t, connect.CodeNotFound, connectErr.Code())
+		assert.Equal(t, connect.CodeUnimplemented, connectErr.Code())
 	})
 
 	t.Run("HTTP 500 maps to CodeInternal", func(t *testing.T) {

--- a/router-tests/connectrpc/connectrpc_server_lifecycle_test.go
+++ b/router-tests/connectrpc/connectrpc_server_lifecycle_test.go
@@ -37,7 +37,7 @@ func TestConnectRPC_ServerLifecycle_StartStopReload(t *testing.T) {
 
 	t.Run("stop without start returns error", func(t *testing.T) {
 		server, err := connectrpc.NewServer(connectrpc.ServerConfig{
-			ServicesDir:     "../../router/pkg/connectrpc/samples/services",
+			ServicesDir:     "../../router/pkg/connectrpc/testdata/services",
 			GraphQLEndpoint: "http://localhost:4000/graphql",
 			Logger:          zap.NewNop(),
 		})

--- a/router-tests/connectrpc/connectrpc_test_helpers.go
+++ b/router-tests/connectrpc/connectrpc_test_helpers.go
@@ -95,7 +95,7 @@ func NewTestConnectRPCServer(t *testing.T, opts ConnectRPCServerOptions) *TestCo
 
 	// Set defaults
 	if opts.ServicesDir == "" {
-		opts.ServicesDir = "../../router/pkg/connectrpc/samples/services"
+		opts.ServicesDir = "../../router/pkg/connectrpc/testdata/services"
 	}
 	if opts.ListenAddr == "" {
 		opts.ListenAddr = "localhost:0"


### PR DESCRIPTION
## Summary
- Fix test service directory paths from `samples/services` → `testdata/services` (directory was renamed)
- Fix HTTP 404 mapping assertion: `CodeUnimplemented` not `CodeNotFound` per [Connect RPC spec](https://connectrpc.com/docs/protocol/)
- Add `./connectrpc` to the CI integration test matrix so these tests run on every PR

Fixes ENG-8984

## Test plan
- [x] All 21 connectrpc tests pass locally with race detector enabled
- [ ] CI pipeline runs the new `./connectrpc` matrix entry successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded the CI test matrix to include additional RPC protocol test targets for broader coverage
  * Refined test assertions around HTTP error-code mapping to ensure correct error classification
  * Reorganized test data layout for improved maintainability and clearer test organization
<!-- end of auto-generated comment: release notes by coderabbit.ai -->