### PR TITLE
fix(router): guard against nil context in getResponseHeaderPropagation

### DIFF
--- a/router/core/header_rule_engine.go
+++ b/router/core/header_rule_engine.go
@@ -76,6 +76,9 @@ func WithResponseHeaderPropagation(ctx *resolve.Context) *resolve.Context {
 }
 
 func getResponseHeaderPropagation(ctx context.Context) *responseHeaderPropagation {
+	if ctx == nil {
+		return nil
+	}
 	v := ctx.Value(responseHeaderPropagationKey{})
 	if v == nil {
 		return nil

--- a/router/core/header_rule_engine_test.go
+++ b/router/core/header_rule_engine_test.go
@@ -336,6 +336,16 @@ func TestPropagatedHeaders(t *testing.T) {
 	})
 }
 
+func TestGetResponseHeaderPropagation_NilContext(t *testing.T) {
+	t.Parallel()
+
+	// Ensure nil context does not panic (regression test for #2530)
+	assert.NotPanics(t, func() {
+		result := getResponseHeaderPropagation(nil)
+		assert.Nil(t, result)
+	})
+}
+
 func TestNewHeaderPropagation(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Fixes #2530

The router panics with `runtime error: invalid memory address or nil pointer dereference` in `getResponseHeaderPropagation` when a fetch path completes with a nil `context.Context`. This happens because `ctx.Value()` is called without checking if `ctx` is nil first.

## Changes

**`router/core/header_rule_engine.go`**
- Added nil guard for `ctx` parameter in `getResponseHeaderPropagation()`
- When `ctx` is nil, returns `nil` (no-op), which causes `ApplyResponseHeaderRules` to return early — matching the expected behavior

**`router/core/header_rule_engine_test.go`**
- Added regression test `TestGetResponseHeaderPropagation_NilContext` to verify nil context does not panic

## Root Cause

As described in the issue, certain query plan variants can result in a fetch path completing with a nil context. The `OnFinished` hook in `engine_loader_hooks.go` then calls `ApplyResponseHeaderRules` which calls `getResponseHeaderPropagation(ctx)`, and `ctx.Value()` panics on nil receiver.

## Before / After

**Before:** Router panics → 500 error → recovery middleware catches it
**After:** Nil context treated as no-op → response returned normally (no header propagation applied)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved header processing stability by adding a defensive check to safely handle missing context.

* **Tests**
  * Added a regression test to ensure header handling does not fail when context is absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->