### PR TITLE
chore: exclude buf-generated protobuf files from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,3 +28,9 @@
 /studio/ @JivusAyrus @wilsonrivera @StarpTech @thisisnithin
 # Cosmo Streams / EDFS
 /router/pkg/pubsub @alepane21 @StarpTech @jensneuse @dkorittki
+
+# generated protobuf files, sourced from /proto/
+/router/gen/
+/connect-go/gen/
+/graphqlmetrics/gen/
+/connect/src/wg/


### PR DESCRIPTION
Removes review requirements for auto-generated protobuf files in 

- `/router/gen/`
- `/connect-go/gen/`
- `/graphqlmetrics/gen/`
- `/connect/src/wg/`. 

These files are sourced from `/proto/` and shouldn't require review from the directory-specific owners.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code ownership configuration to align ownership assignments with the current project structure and team responsibilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->