### PR TITLE
fix: reject ext key fields on non extensions v2 entities

### DIFF
--- a/composition/src/errors/errors.ts
+++ b/composition/src/errors/errors.ts
@@ -1554,6 +1554,24 @@ export function invalidExternalDirectiveError(fieldCoords: string): Error {
   );
 }
 
+export function externalKeyFieldOnNonExtensionEntityError(
+  entityName: string,
+  fieldCoordinates: Array<string>,
+  subgraphName: string,
+): Error {
+  return new Error(
+    `The entity "${entityName}" defined in subgraph "${subgraphName}" has the following "@key" field` +
+      (fieldCoordinates.length > 1 ? 's' : '') +
+      ` that ` +
+      (fieldCoordinates.length > 1 ? 'are' : 'is') +
+      ` declared "@external":\n "` +
+      fieldCoordinates.join(QUOTATION_JOIN) +
+      `"\n` +
+      `In Federation V2, "@key" fields on non-extension entity types cannot be declared "@external"` +
+      ` because they must be resolvable by the subgraph in which the entity is defined.`,
+  );
+}
+
 export function configureDescriptionNoDescriptionError(typeString: string, typeName: string): Error {
   return new Error(
     `The "@openfed__configureDescription" directive defined on ${typeString} "${typeName}" is invalid` +


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Federation V2 composition now properly detects and reports an error when @key fields are declared @external on non-extension entities, providing clearer error messages for invalid federation configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

<!--
Please add any additional information or context regarding your changes here.
-->