### PR TITLE
fix(mcp): deduplicate scopes in insufficient_scope challenge response

### DIFF
--- a/router/pkg/mcpserver/auth_middleware.go
+++ b/router/pkg/mcpserver/auth_middleware.go
@@ -219,18 +219,22 @@ func (m *MCPAuthMiddleware) sendInsufficientScopeResponse(w http.ResponseWriter,
 	challengeScopes := operationScopes
 
 	if m.scopeChallengeIncludeTokenScopes {
-		// Union of token's existing scopes + operation's required scopes
+		// Union of token's existing scopes + operation's required scopes.
+		// Existing scopes come first so the client retains them on re-auth.
 		existing := extractScopes(claims)
-		seen := make(map[string]struct{})
+		seen := make(map[string]struct{}, len(existing)+len(operationScopes))
+		combined := make([]string, 0, len(existing)+len(operationScopes))
 		for _, s := range existing {
 			seen[s] = struct{}{}
-			challengeScopes = append(challengeScopes, s)
+			combined = append(combined, s)
 		}
 		for _, s := range operationScopes {
 			if _, ok := seen[s]; !ok {
-				challengeScopes = append(challengeScopes, s)
+				seen[s] = struct{}{}
+				combined = append(combined, s)
 			}
 		}
+		challengeScopes = combined
 	}
 
 	scopeList := strings.Join(challengeScopes, " ")


### PR DESCRIPTION
## Summary
- Fixes a bug where `sendInsufficientScopeResponse` duplicated operation scopes in the `WWW-Authenticate` header when `scopeChallengeIncludeTokenScopes` was enabled
- Root cause: `challengeScopes := operationScopes` aliased the slice, then `append` added existing scopes onto it, and the subsequent loop re-added operationScopes (already present)
- Fix: build a fresh `combined` slice — existing token scopes first, then operation scopes deduplicated

## Test plan
- [x] `TestMCPAuthMiddleware_HTTPMiddleware/insufficient_init_scopes_-_403_with_include_token_scopes_enabled` — was failing, now passes
- [x] `TestMCPAuthMiddleware_MethodLevelScopes/tools/list_with_insufficient_scopes_-_include_token_scopes` — was failing, now passes
- [x] `TestMCPAuthMiddleware_MethodLevelScopes/tools/call_with_insufficient_scopes_-_include_token_scopes` — was failing, now passes