### PR TITLE
fix(composition): reject @override on @key fields

### DIFF
--- a/composition/src/errors/errors.ts
+++ b/composition/src/errors/errors.ts
@@ -843,6 +843,29 @@ export function duplicateOverriddenFieldsError(errorMessages: string[]): Error {
   );
 }
 
+export function overrideOnKeyFieldErrorMessage(
+  fieldPath: string,
+  sourceSubgraphName: string,
+  targetSubgraphName: string,
+): string {
+  return (
+    ` The field "${fieldPath}" in subgraph "${sourceSubgraphName}" declares an @override directive targeting subgraph "${targetSubgraphName}",` +
+    ` but "${fieldPath}" is part of an @key directive.`
+  );
+}
+
+export function overrideOnKeyFieldsError(errorMessages: string[]): Error {
+  return new Error(
+    `The "@override" directive cannot be used on fields that are part of an "@key" directive.` +
+      ` Overriding a key field causes query planner failures when the field is used in entity resolution.` +
+      ` The following field` +
+      (errorMessages.length > 1 ? 's violate' : ' violates') +
+      ` this constraint: "` +
+      errorMessages.join(QUOTATION_JOIN) +
+      `".\n`,
+  );
+}
+
 export function noFieldDefinitionsError(typeString: string, typeName: string): Error {
   return new Error(`The ${typeString} "${typeName}" is invalid because it does not define any fields.`);
 }

--- a/composition/src/v1/normalization/normalization-factory.ts
+++ b/composition/src/v1/normalization/normalization-factory.ts
@@ -98,6 +98,8 @@ import {
   invalidDirectiveDefinitionLocationErrorMessage,
   invalidDirectiveError,
   invalidDirectiveLocationErrorMessage,
+  overrideOnKeyFieldErrorMessage,
+  overrideOnKeyFieldsError,
   invalidEdfsPublishResultObjectErrorMessage,
   invalidEventDirectiveError,
   invalidEventDrivenGraphError,
@@ -4047,6 +4049,42 @@ export function batchNormalize({ options, subgraphs }: BatchNormalizeParams): Ba
       duplicateOverriddenFieldErrorMessages.push(duplicateOverriddenFieldErrorMessage(fieldPath, sourceSubgraphNames));
     }
     allErrors.push(duplicateOverriddenFieldsError(duplicateOverriddenFieldErrorMessages));
+  }
+  // Check for @override on @key fields
+  const overrideOnKeyFieldErrorMessages: string[] = [];
+  for (const [sourceSubgraphName, internalSubgraph] of internalSubgraphBySubgraphName) {
+    const normalizationResult = internalSubgraph;
+    if (!normalizationResult.keyFieldNamesByParentTypeName) {
+      continue;
+    }
+    // Iterate through all types that have key fields in this subgraph
+    for (const [parentTypeName, keyFieldNames] of normalizationResult.keyFieldNamesByParentTypeName) {
+      // Check if any of these key fields are being overridden
+      for (const [targetSubgraphName, overridesData] of allOverridesByTargetSubgraphName) {
+        const overriddenFieldNames = overridesData.get(parentTypeName);
+        if (!overriddenFieldNames) {
+          continue;
+        }
+        // Check for intersection between key fields and overridden fields
+        for (const fieldName of keyFieldNames) {
+          if (overriddenFieldNames.has(fieldName)) {
+            const fieldPath = `${parentTypeName}.${fieldName}`;
+            // Find which subgraph is doing the override
+            const sourceSubgraphs = overrideSourceSubgraphNamesByFieldPath.get(fieldPath);
+            if (sourceSubgraphs) {
+              for (const overrideSourceSubgraph of sourceSubgraphs) {
+                overrideOnKeyFieldErrorMessages.push(
+                  overrideOnKeyFieldErrorMessage(fieldPath, overrideSourceSubgraph, targetSubgraphName),
+                );
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  if (overrideOnKeyFieldErrorMessages.length > 0) {
+    allErrors.push(overrideOnKeyFieldsError(overrideOnKeyFieldErrorMessages));
   }
   allErrors.push(...validationErrors);
   if (allErrors.length > 0) {

--- a/composition/tests/v1/directives/override.test.ts
+++ b/composition/tests/v1/directives/override.test.ts
@@ -784,6 +784,44 @@ describe('@override directive tests', () => {
         ]),
       );
     });
+test('that an error is returned if @override is used on a @key field', () => {
+      const subgraphMonolith: Subgraph = {
+        name: 'monolith',
+        url: '',
+        definitions: parse(`
+          type Repository @key(fields: "databaseId") {
+            databaseId: Int!
+            name: String!
+          }
+          
+          type Query {
+            repository: Repository!
+          }
+        `),
+      };
+
+      const subgraphIssues: Subgraph = {
+        name: 'issues',
+        url: '',
+        definitions: parse(`
+          type Repository @key(fields: "databaseId") {
+            databaseId: Int! @override(from: "monolith")
+            issues: [Issue!]!
+          }
+          
+          type Issue {
+            id: ID!
+          }
+        `),
+      };
+
+      const { errors } = federateSubgraphsFailure([subgraphMonolith, subgraphIssues], ROUTER_COMPATIBILITY_VERSION_ONE);
+      expect(errors).toHaveLength(1);
+      expect(errors).toBeDefined();
+      expect(errors[0].message).toContain('@override');
+      expect(errors[0].message).toContain('@key');
+      expect(errors[0].message).toContain('Repository.databaseId');
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

Prevents federation composition when a field annotated with `@override` is also part of an `@key` directive. This combination causes query planner failures during entity resolution.

## Problem

When a subgraph overrides a field that is used as an entity key in another subgraph, the query planner can fail with errors like:
```
Cannot query field "databaseId" on type "Query"
```

This occurs because the overridden key field creates an inconsistency in the federation metadata where:
- The field remains in the target subgraph's `keys` configuration
- But disappears from the target subgraph's `RootNodes` 
- This forces a cross-subgraph self-key fetch that breaks entity resolution

## Solution

This PR adds composition-time validation that:
1. Detects when any `@override` directive targets a field that is part of a `@key` directive
2. Reports all violations with clear error messages
3. Blocks composition to prevent runtime failures

## Changes

- Added `overrideOnKeyFieldsError` and `overrideOnKeyFieldErrorMessage` to composition errors
- Implemented validation logic in `batchNormalize` function
- Added test coverage for the new validation

## Testing

- New test: `that an error is returned if @override is used on a @key field`
- All existing override tests continue to pass (30/30)

## Related

- Discovered while investigating planner failures in internal federation graphs
- Alternative mitigation: generic real-schema guard (internal tooling)
- Upstream fix pending in query planner (separate PR in graph-hopper)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced composition validation to detect and report errors when @override is applied to fields declared with @key. New validation identifies conflicts across subgraphs and provides detailed error messages with affected fields and source subgraph information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->