### PR TITLE
fix: re-enable linting in CI (studio)

### DIFF
--- a/.github/workflows/studio-ci.yaml
+++ b/.github/workflows/studio-ci.yaml
@@ -43,8 +43,8 @@ jobs:
       - name: Generate code
         run: pnpm buf generate --template buf.ts.gen.yaml
 
-      # - name: Lint
-      #   run: pnpm run --filter studio lint:fix
+      - name: Lint
+        run: pnpm run --filter studio lint:fix
 
       - uses: ./.github/actions/git-dirty-check
         with:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled automated linting checks in the CI/CD pipeline to enforce code quality standards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [X] I have discussed my proposed changes in an issue and have received approval to proceed.
- [X] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated. (n/a)
- [ ] Documentation has been updated on [https://github.com/wundergraph/cosmo-docs](https://github.com/wundergraph/cosmo-docs). (n/a)
- [X] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

Re-enables linting in CI for studio to avoid formatting drift
