### PR TITLE
feat: claude skill for monorepo dev commands

### DIFF
--- a/.claude/skills/cosmo-dev-commands/SKILL.md
+++ b/.claude/skills/cosmo-dev-commands/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: cosmo-dev-commands
+description: Use when running lint, format, build, or test commands in the wundergraph/cosmo monorepo. Triggers when user asks to lint, format, check, build, test, or verify any workspace or file in the cosmo repo. Always use this skill before suggesting any dev command in cosmo — picking the wrong filter or tool wastes time.
+---
+
+# Cosmo Dev Commands
+
+The cosmo monorepo mixes TypeScript workspaces (pnpm) and Go workspaces (make/go). Always pick the right tool based on which workspace is involved.
+
+## TypeScript Workspaces
+
+Use `pnpm --filter <package-name> <script>`.
+
+| Directory           | Package name                 | lint | lint:fix | format | build | test |
+| ------------------- | ---------------------------- | ---- | -------- | ------ | ----- | ---- |
+| `controlplane/`     | `controlplane`               | ✓    | ✓        | ✓      | ✓     | ✓    |
+| `studio/`           | `studio`                     | ✓    | ✓        | ✓      | ✓     | ✓    |
+| `cli/`              | `wgc`                        | ✓    | ✓        | ✓      | ✓     | ✓    |
+| `composition/`      | `@wundergraph/composition`   | ✓    | ✓        | ✓      | ✓     | ✓    |
+| `shared/`           | `@wundergraph/cosmo-shared`  | ✓    | ✓        | ✓      | ✓     | ✓    |
+| `connect/`          | `@wundergraph/cosmo-connect` | —    | —        | —      | ✓     | —    |
+| `playground/`       | `@wundergraph/playground`    | —    | —        | ✓      | ✓     | —    |
+| `cdn-server/`       | `cdn`                        | ✓    | —        | ✓      | ✓     | —    |
+| `admission-server/` | `admission-server`           | —    | —        | ✓      | ✓     | —    |
+
+**Examples:**
+
+```bash
+# lint
+pnpm --filter controlplane lint
+pnpm --filter studio lint
+pnpm --filter @wundergraph/composition lint
+pnpm --filter wgc lint
+
+# format (Prettier)
+pnpm --filter controlplane format
+pnpm --filter studio format
+pnpm --filter @wundergraph/composition format
+
+# build
+pnpm --filter controlplane build
+pnpm --filter studio build
+
+# test
+pnpm --filter controlplane test
+pnpm --filter @wundergraph/composition test
+```
+
+Use `lint:fix` to auto-fix lint errors. Use `test:coverage` where available.
+
+## Go Workspaces
+
+Run commands from inside the workspace directory.
+
+| Directory            | lint           | format         | build            | test                                                                  |
+| -------------------- | -------------- | -------------- | ---------------- | --------------------------------------------------------------------- |
+| `router/`            | `make lint`    | `go fmt ./...` | `make build`     | `make test` / `make test-fresh` (clears cache) / `make test-coverage` |
+| `graphqlmetrics/`    | `go vet ./...` | `go fmt ./...` | `go build ./...` | `go test ./...`                                                       |
+| `aws-lambda-router/` | `go vet ./...` | `go fmt ./...` | `go build ./...` | `go test ./...`                                                       |
+| `router-plugin/`     | `go vet ./...` | `go fmt ./...` | `go build ./...` | `go test ./...`                                                       |
+
+## Root-level (all workspaces at once)
+
+```bash
+pnpm run build                      # build all TS workspaces
+pnpm run -r --parallel test         # test all TS workspaces
+pnpm run -r --parallel lint:fix     # lint:fix all TS workspaces
+pnpm run -r --parallel format       # format all TS workspaces
+```
+
+Prefer `--filter` over root-level commands when working on a single workspace — it's faster and avoids noise.

--- a/.claude/skills/cosmo-dev-commands/evals/evals.json
+++ b/.claude/skills/cosmo-dev-commands/evals/evals.json
@@ -1,0 +1,23 @@
+{
+  "skill_name": "cosmo-dev-commands",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "I just edited controlplane/src/controllers/organization.ts. Can you lint the controlplane workspace?",
+      "expected_output": "Suggests: pnpm --filter controlplane lint",
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "I changed some code in router/pkg/engine/datasource/. How do I run the tests for the router?",
+      "expected_output": "Suggests: make test (run from router/ directory)",
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "I'm about to commit changes to composition/src/. I want to format the code and then build it.",
+      "expected_output": "Suggests: pnpm --filter @wundergraph/composition format, then pnpm --filter @wundergraph/composition build",
+      "files": []
+    }
+  ]
+}


### PR DESCRIPTION
Adds skill that can tell claude how to run build,format,lint. I ran the evals and it saves a bit
of time as Claude does not need to look through the codebase.

<img width="1264" height="513" alt="Screenshot 2026-03-14 at 18 02 18" src="https://github.com/user-attachments/assets/6ec5fd56-c75e-4592-a9ca-b996e5008e38" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for the Cosmo Dev Commands skill, including instructions for running lint, format, build, and test commands across TypeScript and Go workspaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [X] I have discussed my proposed changes in an issue and have received approval to proceed.
- [X] I have followed the coding standards of the project.
- [X] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website). (n/a)
- [X] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).
