### PR TITLE
fix: handle arrayJoin of empty arrays in clickhouse queries

### DIFF
--- a/controlplane/src/core/repositories/analytics/UsageRepository.ts
+++ b/controlplane/src/core/repositories/analytics/UsageRepository.ts
@@ -212,6 +212,10 @@ export class UsageRepository {
     rangeInHours: number;
     fields: Field[];
   }): Promise<{ name: string; typeName: string }[]> {
+    if (fields.length === 0) {
+      return [];
+    }
+
     // Escape single quotes in field names and type names
     const arrayJoinFields = fields
       .map((field) => {
@@ -301,6 +305,10 @@ export class UsageRepository {
     range: number;
     fields: Field[];
   }): Promise<{ name: string; typeName: string }[]> {
+    if (fields.length === 0) {
+      return [];
+    }
+
     // Escape single quotes in field names and type names
     const arrayJoinFields = fields
       .map((field) => {


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized analytics queries to skip unnecessary database operations when querying field usage with empty input sets, resulting in faster response times.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [x] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).
