### PR TITLE
fix(docs): correct broken link to span error status page

### DIFF
--- a/docs-website/router/metrics-and-monitoring.mdx
+++ b/docs-website/router/metrics-and-monitoring.mdx
@@ -180,7 +180,7 @@ You can use the `router.http.requests.error` metric to track errors across route
 You have two ways to query for errors. Both metrics can be quite useful depending on the query scenario. In general, we recommend to use the `router.http.requests.error` metric.
 
 <Info>
-  For a detailed breakdown of which scenarios mark spans as ERROR and increment error metrics, see [Span Error Status & Error Metrics](/router/open-telemetry/span-error-status).
+  For a detailed breakdown of which scenarios mark spans as ERROR and increment error metrics, see [Span Error Status & Error Metrics](/router/metrics-and-monitoring/span-error-status).
 </Info>
 
 #### Subgraph specific


### PR DESCRIPTION
## Summary

- Fix broken link in `router/metrics-and-monitoring.mdx` pointing to `/router/open-telemetry/span-error-status`
- Correct path is `/router/metrics-and-monitoring/span-error-status`

## Test plan
- [ ] Mintlify broken link checker passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated hyperlink reference in the "Error identification" section to point to the correct documentation path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->