### PR TITLE
fix: pin axios to 1.13.5 across all packages

### DIFF
--- a/controlplane/package.json
+++ b/controlplane/package.json
@@ -62,7 +62,7 @@
     "@wundergraph/cosmo-connect": "workspace:*",
     "@wundergraph/cosmo-shared": "workspace:*",
     "@wundergraph/protographic": "workspace:*",
-    "axios": "^1.13.5",
+    "axios": "1.13.5",
     "axios-retry": "^4.5.0",
     "bullmq": "^5.10.0",
     "cookie": "^0.7.2",

--- a/playground/package.json
+++ b/playground/package.json
@@ -49,7 +49,7 @@
     "@radix-ui/react-slot": "1.0.2",
     "@radix-ui/react-tabs": "^1.0.4",
     "@radix-ui/react-tooltip": "^1.0.7",
-    "axios": "^1.12.2",
+    "axios": "1.13.5",
     "change-case": "^5.2.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -518,7 +518,7 @@ importers:
         specifier: workspace:*
         version: link:../protographic
       axios:
-        specifier: ^1.13.5
+        specifier: 1.13.5
         version: 1.13.5
       axios-retry:
         specifier: ^4.5.0
@@ -757,8 +757,8 @@ importers:
         specifier: ^1.0.7
         version: 1.1.2(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       axios:
-        specifier: ^1.12.2
-        version: 1.12.2
+        specifier: 1.13.5
+        version: 1.13.5
       change-case:
         specifier: ^5.2.0
         version: 5.4.4
@@ -1106,8 +1106,8 @@ importers:
         specifier: workspace:*
         version: link:../connect
       axios:
-        specifier: ^1.12.2
-        version: 1.12.2
+        specifier: 1.13.5
+        version: 1.13.5
       bowser:
         specifier: ^2.11.0
         version: 2.11.0
@@ -8278,9 +8278,6 @@ packages:
     peerDependencies:
       axios: 0.x || 1.x
 
-  axios@1.12.2:
-    resolution: {integrity: sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==}
-
   axios@1.13.5:
     resolution: {integrity: sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==}
 
@@ -10093,15 +10090,6 @@ packages:
 
   follow-redirects@1.15.11:
     resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-
-  follow-redirects@1.15.9:
-    resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -23171,14 +23159,6 @@ snapshots:
       axios: 1.13.5
       is-retry-allowed: 2.2.0
 
-  axios@1.12.2:
-    dependencies:
-      follow-redirects: 1.15.9
-      form-data: 4.0.4
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
   axios@1.13.5:
     dependencies:
       follow-redirects: 1.15.11
@@ -25386,8 +25366,6 @@ snapshots:
       tslib: 2.8.1
 
   follow-redirects@1.15.11: {}
-
-  follow-redirects@1.15.9: {}
 
   for-each@0.3.3:
     dependencies:

--- a/studio/package.json
+++ b/studio/package.json
@@ -72,7 +72,7 @@
     "@tiptap/starter-kit": "2.1.13",
     "@wundergraph/composition": "workspace:*",
     "@wundergraph/cosmo-connect": "workspace:*",
-    "axios": "^1.12.2",
+    "axios": "1.13.5",
     "bowser": "^2.11.0",
     "canvas-confetti": "^1.6.0",
     "change-case": "^4.1.2",


### PR DESCRIPTION
## Summary

- Pins axios to exact version `1.13.5` in controlplane, playground, and studio (cli was already pinned)
- Removes caret (`^`) ranges to prevent automatic upgrades to unvetted versions
- Upgrades playground and studio from `1.12.2` to `1.13.5` for consistency

Closes #2711

## Test plan

- [x] `pnpm install` completes successfully
- [ ] Verify no regressions in API calls across controlplane, playground, and studio

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned axios dependency to version 1.13.5 across multiple packages for consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->