### PR TITLE
fix: change failed query to debug instead of warn

### DIFF
--- a/router/internal/requestlogger/requestlogger.go
+++ b/router/internal/requestlogger/requestlogger.go
@@ -233,7 +233,7 @@ func (al *accessLogger) getRequestFields(r *http.Request, logger *zap.Logger) []
 		if err != nil {
 			// We ignore logging the err since it could leak partial sensitive data
 			// such as %pa from "%password"
-			logger.Error("Failed to parse query parameters")
+			logger.Warn("Failed to parse query parameters")
 			// Since we wanted to ignore some values but we cant parse it
 			// we default to a safer skip all
 			query = ""

--- a/router/internal/requestlogger/requestlogger.go
+++ b/router/internal/requestlogger/requestlogger.go
@@ -233,7 +233,7 @@ func (al *accessLogger) getRequestFields(r *http.Request, logger *zap.Logger) []
 		if err != nil {
 			// We ignore logging the err since it could leak partial sensitive data
 			// such as %pa from "%password"
-			logger.Warn("Failed to parse query parameters")
+			logger.Debug("Failed to parse query parameters")
 			// Since we wanted to ignore some values but we cant parse it
 			// we default to a safer skip all
 			query = ""


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted logging severity for query parameter parsing errors to reduce noise in warning logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

<!--
Please add any additional information or context regarding your changes here.
-->