### PR TITLE
fix: make cache warmer debug logs info logs

### DIFF
--- a/router/core/cache_warmup.go
+++ b/router/core/cache_warmup.go
@@ -62,7 +62,7 @@ func WarmupCaches(ctx context.Context, cfg *CacheWarmupConfig) (err error) {
 	if cfg.Timeout <= 0 {
 		w.timeout = time.Second * 30
 	}
-	w.log.Debug("Warmup started",
+	w.log.Info("Warmup started",
 		zap.Int("workers", cfg.Workers),
 		zap.Int("items_per_second", cfg.ItemsPerSecond),
 		zap.Duration("timeout", cfg.Timeout),
@@ -84,7 +84,7 @@ func WarmupCaches(ctx context.Context, cfg *CacheWarmupConfig) (err error) {
 		)
 		return err
 	}
-	w.log.Debug("Warmup completed",
+	w.log.Info("Warmup completed",
 		zap.Int("processed_items", completed),
 		zap.Duration("duration", time.Since(start)),
 	)
@@ -119,7 +119,7 @@ func (w *cacheWarmup) run(ctx context.Context) (int, error) {
 	}
 
 	if len(items) == 0 {
-		w.log.Debug("No items to process")
+		w.log.Info("No items to process")
 		return 0, nil
 	}
 

--- a/router/core/cache_warmup_test.go
+++ b/router/core/cache_warmup_test.go
@@ -7,8 +7,11 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	nodev1 "github.com/wundergraph/cosmo/router/gen/proto/wg/cosmo/node/v1"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 type CacheWarmupMockSource struct {
@@ -329,5 +332,108 @@ func TestCacheWarmup(t *testing.T) {
 		processor.mux.Lock()
 		assert.Len(t, processor.processedItems, 0)
 		processor.mux.Unlock()
+	})
+	t.Run("logs warmup started and completed at info level", func(t *testing.T) {
+		t.Parallel()
+		core, logs := observer.New(zapcore.InfoLevel)
+		logger := zap.New(core)
+		source := &CacheWarmupMockSource{
+			items: []*nodev1.Operation{
+				{
+					Request: &nodev1.OperationRequest{
+						Query: "query { foo }",
+					},
+				},
+			},
+		}
+		processor := &CacheWarmupMockProcessor{
+			mux: sync.Mutex{},
+		}
+		cfg := &CacheWarmupConfig{
+			Log:            logger,
+			Source:         source,
+			Processor:      processor,
+			ItemsPerSecond: 0,
+			Workers:        2,
+			Timeout:        time.Second,
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		err := WarmupCaches(ctx, cfg)
+		require.NoError(t, err)
+
+		infoLogs := logs.FilterLevelExact(zapcore.InfoLevel)
+		messages := make([]string, infoLogs.Len())
+		for i, entry := range infoLogs.All() {
+			messages[i] = entry.Message
+		}
+		require.Contains(t, messages, "Warmup started")
+		require.Contains(t, messages, "Warmup completed")
+	})
+	t.Run("logs no items to process at info level", func(t *testing.T) {
+		t.Parallel()
+		core, logs := observer.New(zapcore.InfoLevel)
+		logger := zap.New(core)
+		source := &CacheWarmupMockSource{}
+		processor := &CacheWarmupMockProcessor{
+			mux: sync.Mutex{},
+		}
+		cfg := &CacheWarmupConfig{
+			Log:            logger,
+			Source:         source,
+			Processor:      processor,
+			ItemsPerSecond: 0,
+			Workers:        2,
+			Timeout:        time.Second,
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		err := WarmupCaches(ctx, cfg)
+		require.NoError(t, err)
+
+		infoLogs := logs.FilterLevelExact(zapcore.InfoLevel)
+		messages := make([]string, infoLogs.Len())
+		for i, entry := range infoLogs.All() {
+			messages[i] = entry.Message
+		}
+		require.Contains(t, messages, "No items to process")
+	})
+	t.Run("warmup started and completed not logged at debug level", func(t *testing.T) {
+		t.Parallel()
+		// With a DebugLevel observer, Info messages are captured too,
+		// but the key assertion is that the entries themselves are at InfoLevel, not DebugLevel.
+		core, logs := observer.New(zapcore.DebugLevel)
+		logger := zap.New(core)
+		source := &CacheWarmupMockSource{
+			items: []*nodev1.Operation{
+				{
+					Request: &nodev1.OperationRequest{
+						Query: "query { foo }",
+					},
+				},
+			},
+		}
+		processor := &CacheWarmupMockProcessor{
+			mux: sync.Mutex{},
+		}
+		cfg := &CacheWarmupConfig{
+			Log:            logger,
+			Source:         source,
+			Processor:      processor,
+			ItemsPerSecond: 0,
+			Workers:        2,
+			Timeout:        time.Second,
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		err := WarmupCaches(ctx, cfg)
+		require.NoError(t, err)
+
+		// Verify that "Warmup started" and "Warmup completed" are logged at Info, not Debug
+		for _, entry := range logs.All() {
+			if entry.Message == "Warmup started" || entry.Message == "Warmup completed" || entry.Message == "No items to process" {
+				require.Equal(t, zapcore.InfoLevel, entry.Level, "expected %q to be logged at Info level", entry.Message)
+			}
+		}
 	})
 }


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

This pr makes certain debug logs as info logs, for the cache warmer. This runs only on schema reloads, so should not really add a few more logs.

@coderabbitai summary

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

<!--
Please add any additional information or context regarding your changes here.
-->