### PR TITLE
fix: Composition fails when interface implements another interface

### DIFF
--- a/composition/src/schema-building/utils.ts
+++ b/composition/src/schema-building/utils.ts
@@ -624,15 +624,16 @@ export function isTypeValidImplementation(
   originalType: TypeNode,
   implementationType: TypeNode,
   concreteTypeNamesByAbstractTypeName: Map<TypeName, Set<TypeName>>,
+  parentDefinitionDataByTypeName?: Map<TypeName, ParentDefinitionData>,
 ): boolean {
   if (originalType.kind === Kind.NON_NULL_TYPE) {
     if (implementationType.kind !== Kind.NON_NULL_TYPE) {
       return false;
     }
-    return isTypeValidImplementation(originalType.type, implementationType.type, concreteTypeNamesByAbstractTypeName);
+    return isTypeValidImplementation(originalType.type, implementationType.type, concreteTypeNamesByAbstractTypeName, parentDefinitionDataByTypeName);
   }
   if (implementationType.kind === Kind.NON_NULL_TYPE) {
-    return isTypeValidImplementation(originalType, implementationType.type, concreteTypeNamesByAbstractTypeName);
+    return isTypeValidImplementation(originalType, implementationType.type, concreteTypeNamesByAbstractTypeName, parentDefinitionDataByTypeName);
   }
   switch (originalType.kind) {
     case Kind.NAMED_TYPE:
@@ -643,10 +644,21 @@ export function isTypeValidImplementation(
           return true;
         }
         const concreteTypes = concreteTypeNamesByAbstractTypeName.get(originalTypeName);
-        if (!concreteTypes) {
-          return false;
+        if (concreteTypes && concreteTypes.has(implementationTypeName)) {
+          return true;
         }
-        return concreteTypes.has(implementationTypeName);
+        // Check if the implementation type is an interface that implements the original interface
+        if (parentDefinitionDataByTypeName) {
+          const implementationData = parentDefinitionDataByTypeName.get(implementationTypeName);
+          if (
+            implementationData &&
+            implementationData.kind === Kind.INTERFACE_TYPE_DEFINITION &&
+            implementationData.implementedInterfaceTypeNames.has(originalTypeName)
+          ) {
+            return true;
+          }
+        }
+        return false;
       }
       return false;
     default:
@@ -655,6 +667,7 @@ export function isTypeValidImplementation(
           originalType.type,
           implementationType.type,
           concreteTypeNamesByAbstractTypeName,
+          parentDefinitionDataByTypeName,
         );
       }
       return false;

--- a/composition/src/v1/federation/federation-factory.ts
+++ b/composition/src/v1/federation/federation-factory.ts
@@ -410,6 +410,7 @@ export class FederationFactory {
             interfaceField.node.type,
             fieldData.node.type,
             this.concreteTypeNamesByAbstractTypeName,
+            this.parentDefinitionDataByTypeName,
           )
         ) {
           hasErrors = true;

--- a/composition/src/v1/normalization/normalization-factory.ts
+++ b/composition/src/v1/normalization/normalization-factory.ts
@@ -2254,6 +2254,7 @@ export class NormalizationFactory {
             interfaceField.node.type,
             fieldData.node.type,
             this.concreteTypeNamesByAbstractTypeName,
+            this.parentDefinitionDataByTypeName,
           )
         ) {
           hasErrors = true;

--- a/composition/tests/v1/types/interfaces.test.ts
+++ b/composition/tests/v1/types/interfaces.test.ts
@@ -1061,6 +1061,51 @@ describe('Interface tests', () => {
         ),
       );
     });
+
+    test('that an interface implementing another interface is a valid covariant return type', () => {
+      const { federatedGraphSchema } = federateSubgraphsSuccess(
+        [subgraphAO],
+        ROUTER_COMPATIBILITY_VERSION_ONE,
+      );
+      expect(schemaToSortedNormalizedString(federatedGraphSchema)).toBe(
+        normalizeString(
+          SCHEMA_QUERY_DEFINITION +
+            `
+          type Beagle implements Dog & Node {
+            id: ID!
+            name: String!
+          }
+
+          type Brittany implements Dog & Node {
+            id: ID!
+            name: String!
+          }
+
+          interface Dog implements Node {
+            id: ID!
+          }
+
+          interface Edge {
+            cursor: String!
+            node: Node!
+          }
+
+          interface Node {
+            id: ID!
+          }
+
+          type Pet implements Edge {
+            cursor: String!
+            node: Dog!
+          }
+
+          type Query {
+            pet: Pet!
+          }
+        `,
+        ),
+      );
+    });
   });
 });
 
@@ -1686,24 +1731,62 @@ const nbaaa: Subgraph = {
       name: String!
       sound(a: String!, b: Int, c: Float, d: Boolean): String!
     }
-      
+
     interface Pet implements Animal {
       age: Int!
       sound(a: Int, b: String!): String!
     }
-    
+
     extend interface Pet {
       price: Float
       name: String!
     }
-    
+
     type Cat implements Pet & Animal {
       isPurring: Boolean!
       sound(e: Int!): String!
     }
-    
+
     extend type Cat {
       name: String!
+    }
+  `),
+};
+
+const subgraphAO: Subgraph = {
+  name: 'subgraph-ao',
+  url: '',
+  definitions: parse(`
+    type Query {
+      pet: Pet!
+    }
+
+    interface Node {
+      id: ID!
+    }
+
+    type Pet implements Edge {
+      node: Dog!
+      cursor: String!
+    }
+
+    interface Dog implements Node {
+      id: ID!
+    }
+
+    type Beagle implements Dog & Node {
+      id: ID!
+      name: String!
+    }
+
+    type Brittany implements Dog & Node {
+      id: ID!
+      name: String!
+    }
+
+    interface Edge {
+      node: Node!
+      cursor: String!
     }
   `),
 };


### PR DESCRIPTION
We are migrating from Apollo and have a situation where we have an interface that implements an interface that is failing composition with an error like:

```
│ The Object "ConversationEventEdge" has the following Interface implementation errors:                                  │
│  The implementation of Interface "ConnectionEdge" by "ConversationEventEdge" is invalid because:                       │
│   The field "node" is invalid because:                                                                                 │
│    The implemented response type "ConversationEvent!" is not a valid subtype (equally or more restrictive) of the      │
│ response type "ConnectionNode!" for "ConnectionEdge.node".
```

I believe an interface implementing another interface is valid, and I took a pass at updating the code to support this. The test schema in `subgraphAO`, although contrived, mirrors the pattern we have. This is my first time contributing, feel free to let me know if I missed something or if this is not the correct solution/place!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interfaces can now implement other interfaces in federated schemas, enabling more flexible schema designs with covariant return types during composition.

* **Tests**
  * Added test coverage for interface-implementing-interface scenarios in schema federation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [x] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

<!--
Please add any additional information or context regarding your changes here.
-->