### PR TITLE
docs: update CONTRIBUTING.md with merge strategy preference and AI manifesto link

### DIFF
--- a/.github/workflows/dummy-ci.yaml
+++ b/.github/workflows/dummy-ci.yaml
@@ -8,6 +8,12 @@ on:
       - '.github/workflows/image-release.yml'
       - '.github/actions/**'
       - 'docs-website/**'
+      - 'CLAUDE.md'
+      - 'CONTRIBUTING.md'
+      - 'README.md'
+      - 'SECURITY.md'
+      - 'LICENSE'
+      - '.github/PULL_REQUEST_TEMPLATE.md'
 jobs:
   build_test:
     timeout-minutes: 5

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,8 @@
 Before contributing to the WunderGraph Cosmo repository, please open an issue to discuss the changes you would like to make. Alternatively, you can also open a discussion in the [WunderGraph Discussions](https://github.com/wundergraph/cosmo/discussions).
 We are open to all kinds of contributions, including bug fixes, new features, and documentation improvements.
 
+This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contributions align with its principles.
+
 The following sections provide a guide on how to contribute to the WunderGraph Cosmo repository.
 
 ## Prerequisites
@@ -84,6 +86,8 @@ export PATH="$PATH:$(go env GOPATH)/bin"
 ### Pull Requests Conventions
 
 We merge all pull requests in `squash merge` mode. You're not enforced to use [conventional commit standard](https://www.conventionalcommits.org/en/v1.0.0-beta.2/#why-use-conventional-commits) across all your commits, but it's a good practice and increase transparency. At the end it's important that the squashed commit message follow the standard.
+
+When updating your branch after a review has been requested, prefer using a merge strategy (e.g. `git merge main`) rather than rebasing. This preserves the review context and avoids force-pushes that can disrupt the review process.
 
 ## Local Development
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added two contribution guidelines: align contributions with the Open Source AI Manifesto and prefer merging (to preserve review history) over rebasing after review requests.
* **Chores**
  * Expanded PR trigger to run the build/test workflow when repository metadata or documentation files are modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Add a note to CONTRIBUTING.md preferring merge strategy over rebase after review has been requested. Add a link to the Open Source AI Manifesto, consistent with README.md and the PR template.

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.