### PR TITLE
🐞fix(router): buffer NATS ChanSubscribe channel to prevent message drops

### DIFF
--- a/router/pkg/pubsub/nats/adapter.go
+++ b/router/pkg/pubsub/nats/adapter.go
@@ -165,7 +165,7 @@ func (p *ProviderAdapter) Subscribe(ctx context.Context, cfg datasource.Subscrip
 		return nil
 	}
 
-	msgChan := make(chan *nats.Msg)
+	msgChan := make(chan *nats.Msg, 1024)
 	subscriptions := make([]*nats.Subscription, len(subConf.Subjects))
 	for i, subject := range subConf.Subjects {
 		subscription, err := p.client.ChanSubscribe(subject, msgChan)


### PR DESCRIPTION
## Description

The EDFS NATS adapter in `router/pkg/pubsub/nats/adapter.go` creates an **unbuffered channel** (`make(chan *nats.Msg)`) for `ChanSubscribe`. The NATS client performs a [non-blocking send](https://github.com/nats-io/nats.go/blob/v1.36.0/nats.go#L3323-L3328) on this channel:

```go
case sub.mch <- m:
default:
    goto slowConsumer  // message silently dropped
```

If the adapter goroutine is busy processing a previous message (metrics recording, `updater.Update()`, filter evaluation, SSE flush), the unbuffered channel has zero capacity to absorb incoming messages. Every message that arrives while the goroutine is occupied is **silently dropped** as a slow consumer event.

This is particularly impactful when using `@edfs__natsSubscribe` on wildcard subjects (e.g. `some.topic.>`) that receive high message volumes. In our testing, we observed **~60% message loss** — 8 NATS messages published, only 3-4 delivered via SSE.

## Fix

Buffer the channel with capacity 1024:

```go
// Before
msgChan := make(chan *nats.Msg)       // unbuffered — capacity 0

// After
msgChan := make(chan *nats.Msg, 1024) // buffered — absorbs processing latency
```

After this one-line change, we observed **0% message loss** in the same test scenario.

For reference, the NATS client's own `DefaultMaxChanLen` is `64 * 1024` (65,536). A buffer of 1024 is conservative but sufficient to absorb burst processing latency.

## Future Improvement Suggestion

Consider making the buffer size configurable via the events provider configuration:

```yaml
events:
  providers:
    nats:
      - id: my-nats
        url: nats://localhost:4222
        channel_buffer_size: 1024
```

The JetStream path in the same adapter (`FetchNoWait(300)` polling at line 136) does not suffer from this issue as it doesn't rely on channel-based delivery.

## Checklist

- [x] Followed the coding standards of the project
- [x] Read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md)
- [ ] Tests or benchmarks added/updated
- [ ] Documentation updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message handling reliability in the NATS pub/sub adapter to prevent potential message delivery delays under high-load conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->