### PR TITLE
fix: create the config directory only after checking for DISABLE_UPDATE_CHECK

### DIFF
--- a/cli/src/commands/index.ts
+++ b/cli/src/commands/index.ts
@@ -1,7 +1,6 @@
-import { mkdirSync } from 'node:fs';
 import { Command } from 'commander';
 import { CreateClient } from '../core/client/client.js';
-import { config, configDir } from '../core/config.js';
+import { config } from '../core/config.js';
 import { checkForUpdates } from '../utils.js';
 import { capture } from '../core/telemetry.js';
 import AuthCommands from './auth/index.js';
@@ -116,7 +115,6 @@ program.addCommand(
 );
 
 program.hook('preAction', async () => {
-  mkdirSync(configDir, { recursive: true });
   await checkForUpdates();
 });
 

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -1,5 +1,5 @@
 /* eslint-disable import/named */
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import {
   CompositionOptions,
   federateSubgraphs,
@@ -19,7 +19,7 @@ import {
   WebsocketSubprotocol,
 } from '@wundergraph/cosmo-shared';
 import { SubgraphPublishStats } from '@wundergraph/cosmo-connect/dist/platform/v1/platform_pb';
-import { config, configFile } from './core/config.js';
+import { config, configDir, configFile } from './core/config.js';
 import { KeycloakToken } from './commands/auth/utils.js';
 
 export interface Header {
@@ -209,10 +209,12 @@ export const updateConfigFile = (newData: ConfigData) => {
 };
 
 export const checkForUpdates = async () => {
+  if (config.disableUpdateCheck === 'true') {
+    return;
+  }
+
   try {
-    if (config.disableUpdateCheck === 'true') {
-      return;
-    }
+    mkdirSync(configDir, { recursive: true });
 
     const currentTime = Date.now();
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized configuration directory creation logic in CLI initialization.
  * Optimized update check function with early exit when updates are disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [x] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).
