### PR TITLE
fix(controlplane): populate userEmail in whoAmI response

### DIFF
--- a/controlplane/src/core/bufservices/organization/whoAmI.ts
+++ b/controlplane/src/core/bufservices/organization/whoAmI.ts
@@ -38,6 +38,7 @@ export function whoAmI(
         code: EnumStatusCode.OK,
       },
       organizationId: organization.id,
+      userEmail: authContext.userDisplayName,
       organizationName: organization.name,
       organizationSlug: organization.slug,
     };


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User identity endpoints now include the user's email address in successful responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Populates the `userEmail` field in the `whoAmI` response using the authenticated user's display name (which is the email). The proto schema already declared this as an optional field, but the handler was never setting it, so clients had no way to read the current user's email from this endpoint.

Closes [ENG-9393](https://linear.app/wundergraph/issue/ENG-9393/studio-whoami-response-missing-useremail-field).

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.