### PR TITLE
fix: expose GraphQL error details to MCP clients

### DIFF
--- a/router-tests/protocol/mcp_test.go
+++ b/router-tests/protocol/mcp_test.go
@@ -350,6 +350,131 @@ func TestMCP(t *testing.T) {
 						assert.Equal(t, content.Text, "Input validation Error: validation error: at '/criteria': got null, want object")
 					})
 				})
+
+				t.Run("GraphQL error from subgraph is passed through to the MCP client", func(t *testing.T) {
+					testenv.Run(t, &testenv.Config{
+						MCP: config.MCPConfiguration{
+							Enabled: true,
+						},
+						Subgraphs: testenv.SubgraphsConfig{
+							Family: testenv.SubgraphConfig{
+								Middleware: func(handler http.Handler) http.Handler {
+									return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+										w.Header().Set("Content-Type", "application/json")
+										w.WriteHeader(http.StatusForbidden)
+										_, _ = w.Write([]byte(`{"errors":[{"message":"not authorized","extensions":{"code":"FORBIDDEN"}}]}`))
+									})
+								},
+							},
+						},
+					}, func(t *testing.T, xEnv *testenv.Environment) {
+
+						req := mcp.CallToolRequest{}
+						req.Params.Name = "execute_operation_my_employees"
+						req.Params.Arguments = map[string]interface{}{
+							"criteria": map[string]interface{}{},
+						}
+
+						resp, err := xEnv.MCPClient.CallTool(xEnv.Context, req)
+						require.NoError(t, err)
+						require.NotNil(t, resp)
+						require.True(t, resp.IsError)
+						require.Len(t, resp.Content, 1)
+
+						content, ok := resp.Content[0].(mcp.TextContent)
+						require.True(t, ok)
+						require.Equal(t, "text", content.Type)
+						// The actual GraphQL error message from the router must be surfaced to
+						// the MCP client, not masked by a generic "Response Error" placeholder.
+						require.Equal(t, "Response Error: Failed to fetch from Subgraph 'family'.", content.Text)
+					})
+				})
+
+				t.Run("GraphQL error from subgraph is forwarded in pass-through mode", func(t *testing.T) {
+					testenv.Run(t, &testenv.Config{
+						MCP: config.MCPConfiguration{
+							Enabled: true,
+						},
+						RouterOptions: []core.Option{
+							core.WithSubgraphErrorPropagation(config.SubgraphErrorPropagationConfiguration{
+								Enabled: true,
+								Mode:    config.SubgraphErrorPropagationModePassthrough,
+							}),
+						},
+						Subgraphs: testenv.SubgraphsConfig{
+							Family: testenv.SubgraphConfig{
+								Middleware: func(handler http.Handler) http.Handler {
+									return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+										w.Header().Set("Content-Type", "application/json")
+										w.WriteHeader(http.StatusForbidden)
+										_, _ = w.Write([]byte(`{"errors":[{"message":"not authorized","extensions":{"code":"FORBIDDEN"}}]}`))
+									})
+								},
+							},
+						},
+					}, func(t *testing.T, xEnv *testenv.Environment) {
+
+						req := mcp.CallToolRequest{}
+						req.Params.Name = "execute_operation_my_employees"
+						req.Params.Arguments = map[string]interface{}{
+							"criteria": map[string]interface{}{},
+						}
+
+						resp, err := xEnv.MCPClient.CallTool(xEnv.Context, req)
+						require.NoError(t, err)
+						require.NotNil(t, resp)
+						require.True(t, resp.IsError)
+						require.Len(t, resp.Content, 1)
+
+						content, ok := resp.Content[0].(mcp.TextContent)
+						require.True(t, ok)
+						require.Equal(t, "text", content.Type)
+						// When pass-through is enabled the original subgraph error message must
+						// reach the MCP client (the motivating scenario for this bug fix).
+						require.Contains(t, content.Text, "Response Error: not authorized")
+					})
+				})
+
+				t.Run("GraphQL partial success with errors includes both data and error details", func(t *testing.T) {
+					testenv.Run(t, &testenv.Config{
+						MCP: config.MCPConfiguration{
+							Enabled: true,
+						},
+						Subgraphs: testenv.SubgraphsConfig{
+							Family: testenv.SubgraphConfig{
+								Middleware: func(handler http.Handler) http.Handler {
+									return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+										w.Header().Set("Content-Type", "application/json")
+										w.WriteHeader(http.StatusOK)
+										_, _ = w.Write([]byte(`{"data":{"findEmployees":[{"id":1,"isAvailable":false,"currentMood":"HAPPY","products":["COSMO"],"details":{"forename":"Jens","nationality":"GERMAN"}}]},"errors":[{"message":"partial failure"}]}`))
+									})
+								},
+							},
+						},
+					}, func(t *testing.T, xEnv *testenv.Environment) {
+
+						req := mcp.CallToolRequest{}
+						req.Params.Name = "execute_operation_my_employees"
+						req.Params.Arguments = map[string]interface{}{
+							"criteria": map[string]interface{}{},
+						}
+
+						resp, err := xEnv.MCPClient.CallTool(xEnv.Context, req)
+						require.NoError(t, err)
+						require.NotNil(t, resp)
+						require.True(t, resp.IsError)
+						require.Len(t, resp.Content, 1)
+
+						content, ok := resp.Content[0].(mcp.TextContent)
+						require.True(t, ok)
+						require.Equal(t, "text", content.Type)
+						require.Contains(t, content.Text, "Response error with partial success")
+						// Error message from the router is included in the combined payload.
+						require.Contains(t, content.Text, "Failed to fetch from Subgraph 'family'")
+						// Partial data from the upstream response is also preserved.
+						require.Contains(t, content.Text, `"findEmployees"`)
+					})
+				})
 			})
 
 			t.Run("Execute Mutation", func(t *testing.T) {

--- a/router/pkg/mcpserver/server.go
+++ b/router/pkg/mcpserver/server.go
@@ -769,7 +769,7 @@ func (s *GraphQLSchemaServer) executeGraphQLQuery(ctx context.Context, query str
 
 		// If we have both errors and data, include data in the error message
 		dataString := string(graphqlResponse.Data)
-		combinedErrorMsg := fmt.Sprintf("Response error with partial success, Error: %s, Data: %s)", errorMessage, dataString)
+		combinedErrorMsg := fmt.Sprintf("Response error with partial success, Error: %s, Data: %s", errorMessage, dataString)
 		return mcp.NewToolResultError(combinedErrorMsg), nil
 	}
 

--- a/router/pkg/mcpserver/server.go
+++ b/router/pkg/mcpserver/server.go
@@ -764,13 +764,13 @@ func (s *GraphQLSchemaServer) executeGraphQLQuery(ctx context.Context, query str
 
 		// If there are errors but no data, return only the errors
 		if len(graphqlResponse.Data) == 0 || string(graphqlResponse.Data) == "null" {
-			return mcp.NewToolResultErrorFromErr("Response Error", err), nil
+			return mcp.NewToolResultError("Response Error: " + errorMessage), nil
 		}
 
 		// If we have both errors and data, include data in the error message
 		dataString := string(graphqlResponse.Data)
 		combinedErrorMsg := fmt.Sprintf("Response error with partial success, Error: %s, Data: %s)", errorMessage, dataString)
-		return mcp.NewToolResultErrorFromErr(combinedErrorMsg, err), nil
+		return mcp.NewToolResultError(combinedErrorMsg), nil
 	}
 
 	return mcp.NewToolResultText(string(body)), nil


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

MCP server should expose GraphQL error details, to allow clients to take decisions based on it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Error messages now surface the actual backend/subgraph error text instead of generic placeholders, and partial query results are preserved when errors occur.

* **New Features / Tests**
  * Added integration tests covering error payloads from subgraphs, including passthrough mode that forwards original subgraph error text and mixed data+errors scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

<!--
Please add any additional information or context regarding your changes here.
-->