### PR TITLE
feat(controlplane): add REDIS_USERNAME support for Redis 6 ACL

### DIFF
--- a/controlplane/.env.example
+++ b/controlplane/.env.example
@@ -55,6 +55,11 @@ GITHUB_APP_WEBHOOK_SECRET=
 OPENAI_API_KEY=""
 
 # Redis
+# REDIS_USERNAME is optional; set it when the Redis server mandates
+# Redis 6 ACL authentication (e.g. AWS ElastiCache RBAC, Azure Cache
+# for Redis, GCP Memorystore IAM Auth). When unset, ioredis falls back
+# to the legacy `AUTH <password>` path.
+REDIS_USERNAME=""
 REDIS_PASSWORD=""
 
 # Optional for Slack Integration

--- a/controlplane/src/bin/deactivate-org.ts
+++ b/controlplane/src/bin/deactivate-org.ts
@@ -12,6 +12,7 @@ const deactivationReason = process.env.ORGANIZATION_DEACTIVATION_REASON;
 const { redisQueue, redisWorker } = await createRedisConnections({
   host: redis.host!,
   port: Number(redis.port),
+  username: redis.username,
   password: redis.password,
   tls: redis.tls,
 });

--- a/controlplane/src/bin/delete-user.ts
+++ b/controlplane/src/bin/delete-user.ts
@@ -12,6 +12,7 @@ const userEmail = process.env.USER_EMAIL || '';
 const { redisQueue, redisWorker } = await createRedisConnections({
   host: redis.host!,
   port: Number(redis.port),
+  username: redis.username,
   password: redis.password,
   tls: redis.tls,
 });

--- a/controlplane/src/bin/get-config.ts
+++ b/controlplane/src/bin/get-config.ts
@@ -27,6 +27,7 @@ const getConfig = () => {
     redis: {
       host: process.env.REDIS_HOST || 'localhost',
       port: process.env.REDIS_PORT || 6379,
+      username: process.env.REDIS_USERNAME,
       password: process.env.REDIS_PASSWORD,
       tls:
         process.env.REDIS_TLS_CERT || process.env.REDIS_TLS_KEY || process.env.REDIS_TLS_CA

--- a/controlplane/src/bin/reactivate-org.ts
+++ b/controlplane/src/bin/reactivate-org.ts
@@ -11,6 +11,7 @@ const organizationId = process.env.ORGANIZATION_ID || '';
 const { redisQueue, redisWorker } = await createRedisConnections({
   host: redis.host!,
   port: Number(redis.port),
+  username: redis.username,
   password: redis.password,
   tls: redis.tls,
 });

--- a/controlplane/src/core/env.schema.ts
+++ b/controlplane/src/core/env.schema.ts
@@ -45,6 +45,7 @@ export const envVariables = z
       .string()
       .default('6379')
       .transform((val) => Number.parseInt(val)),
+    REDIS_USERNAME: z.string().optional(),
     REDIS_PASSWORD: z.string().optional(),
     REDIS_TLS_CERT: z.string().optional(),
     REDIS_TLS_CA: z.string().optional(),

--- a/controlplane/src/core/plugins/redis.test.ts
+++ b/controlplane/src/core/plugins/redis.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from 'vitest';
+import { envVariables } from '../env.schema.js';
+
+// The minimal set of env vars env.schema.ts requires to successfully parse.
+// Anything unrelated to Redis is filled with placeholders — the tests here
+// only care that REDIS_USERNAME is plumbed through as an optional field.
+const requiredEnv = {
+  WEB_BASE_URL: 'http://localhost:3000',
+  CDN_BASE_URL: 'http://localhost:11000',
+  ALLOWED_ORIGINS: 'http://localhost:3000',
+  AUTH_JWT_SECRET: 'fkczyomvdprgvtmvkuhvprxuggkbgwld',
+  AUTH_REDIRECT_URI: 'http://localhost:3001/v1/auth/callback',
+  DB_URL: 'postgresql://postgres:changeme@localhost:5432/controlplane',
+  KC_REALM: 'cosmo',
+  KC_CLIENT_ID: 'studio',
+  KC_ADMIN_USER: 'admin',
+  KC_ADMIN_PASSWORD: 'changeme',
+  KC_API_URL: 'http://localhost:8080',
+  KC_FRONTEND_URL: 'http://localhost:8080',
+  CLICKHOUSE_DSN: '',
+  S3_STORAGE_URL: 'http://minio:changeme@localhost:10000/cosmo',
+  AUTH_ADMISSION_JWT_SECRET: 'uXDxJLEvrw4aafPfrf3rRotCoBzRfPEW',
+};
+
+describe('env.schema REDIS_USERNAME', () => {
+  test('REDIS_USERNAME is optional and defaults to undefined', () => {
+    const parsed = envVariables.parse({ ...requiredEnv });
+    expect(parsed.REDIS_USERNAME).toBeUndefined();
+  });
+
+  test('REDIS_USERNAME is passed through when set', () => {
+    const parsed = envVariables.parse({
+      ...requiredEnv,
+      REDIS_USERNAME: 'cosmo-acl-user',
+      REDIS_PASSWORD: 'secret',
+    });
+    expect(parsed.REDIS_USERNAME).toBe('cosmo-acl-user');
+    expect(parsed.REDIS_PASSWORD).toBe('secret');
+  });
+
+  test('REDIS_USERNAME empty string is accepted (treated as empty string, not undefined)', () => {
+    // Documents current behaviour: z.string().optional() does not coerce ''
+    // to undefined, so an explicitly-empty env var reaches ioredis as ''.
+    // ioredis treats '' username identically to undefined, so this is safe.
+    const parsed = envVariables.parse({ ...requiredEnv, REDIS_USERNAME: '' });
+    expect(parsed.REDIS_USERNAME).toBe('');
+  });
+});

--- a/controlplane/src/core/plugins/redis.ts
+++ b/controlplane/src/core/plugins/redis.ts
@@ -16,6 +16,11 @@ declare module 'fastify' {
 export interface RedisPluginOptions {
   host: string;
   port: number;
+  // Optional ACL username (Redis 6+). When set, ioredis sends
+  // `AUTH <username> <password>` instead of the legacy `AUTH <password>`.
+  // Required for managed Redis offerings that mandate RBAC (e.g. AWS
+  // ElastiCache RBAC, Azure Cache for Redis, GCP Memorystore IAM Auth).
+  username?: string;
   password?: string;
   tls?: {
     // Necessary only if the server uses a self-signed certificate.
@@ -30,6 +35,7 @@ export const createRedisConnections = async (opts: RedisPluginOptions) => {
   const connectionConfig: IORedis.RedisOptions = {
     host: opts.host,
     port: opts.port,
+    username: opts.username,
     password: opts.password,
   };
 

--- a/controlplane/src/index.ts
+++ b/controlplane/src/index.ts
@@ -74,6 +74,7 @@ const {
   REDIS_TLS_CA,
   REDIS_TLS_CERT,
   REDIS_TLS_KEY,
+  REDIS_USERNAME,
   REDIS_PASSWORD,
   AUTH_ADMISSION_JWT_SECRET,
   CDN_BASE_URL,
@@ -172,6 +173,7 @@ const options: BuildConfig = {
   redis: {
     host: REDIS_HOST,
     port: REDIS_PORT,
+    username: REDIS_USERNAME,
     password: REDIS_PASSWORD,
     tls:
       REDIS_TLS_CERT || REDIS_TLS_KEY || REDIS_TLS_CA


### PR DESCRIPTION
## Summary

Adds an optional `REDIS_USERNAME` environment variable to the controlplane so ioredis sends the two-argument `AUTH <username> <password>` handshake required by managed Redis offerings that enforce Redis 6 ACL (AWS ElastiCache RBAC, Azure Cache for Redis, GCP Memorystore IAM Auth, Bitnami Helm chart with `auth.useACL: true`).

This is a **parity fix**: the router has already supported ACL since v0.171.0 via the `redis://user:pass@host` URL format (#1557). Today, attempting to self-host the controlplane against any RBAC-enforced Redis crashloops the pod at startup with `NOAUTH Authentication required.` (or `WRONGPASS` depending on server version), because `createRedisConnections` only plumbs `password` and ioredis falls back to the legacy one-argument AUTH.

## Changes

Purely additive. `REDIS_USERNAME` is optional on both the zod schema and `RedisPluginOptions`; omitting it preserves today's behaviour exactly.

| File | Change |
|---|---|
| `controlplane/src/core/env.schema.ts` | `REDIS_USERNAME: z.string().optional()` |
| `controlplane/src/core/plugins/redis.ts` | `RedisPluginOptions.username?: string`, forwarded into `IORedis.RedisOptions` |
| `controlplane/src/index.ts` | destructure + forward into `createRedisConnections` |
| `controlplane/src/bin/get-config.ts` | same for the migrate/seed entrypoint |
| `controlplane/src/bin/{delete-user,deactivate-org,reactivate-org}.ts` | pass `username` through to `createRedisConnections` |
| `controlplane/.env.example` | document `REDIS_USERNAME` |
| `controlplane/src/core/plugins/redis.test.ts` | new unit tests for schema parsing |

## Test plan

### Unit tests (committed)

```bash
cd controlplane
pnpm exec vitest run src/core/plugins/redis.test.ts
# ✓ 3 tests passed
```

### Local end-to-end repro

Start an ACL-enabled Redis with only a named user and the default user disabled (matches what AWS ElastiCache RBAC exposes):

```bash
docker run -d --name redis-acl -p 6390:6379 redis:7.2.4-alpine redis-server --save "" --appendonly no
docker exec redis-acl sh -c '
  redis-cli ACL SETUSER cosmo on ">secret-cosmo-pw" "~*" "&*" "+@all" &&
  redis-cli ACL SETUSER default off
'
```

**Before this patch** (legacy single-arg AUTH, reproduces the current crashloop):

```bash
$ docker run --rm --network host redis:7.2.4-alpine redis-cli -p 6390 -a secret-cosmo-pw PING
AUTH failed: ERR AUTH <password> called without any password configured for the default user. ...
```

**After this patch** (with `REDIS_USERNAME=cosmo` set):

```bash
$ docker run --rm --network host redis:7.2.4-alpine redis-cli -p 6390 --user cosmo -a secret-cosmo-pw PING
PONG
```

Exercising `createRedisConnections` directly (tsx throwaway against the same redis): legacy AUTH path rejects with `Connection is closed`, ACL path returns `PONG`. Log output:

```
[A: no username (legacy AUTH)] FAILED: Connection is closed.
[B: with username (ACL AUTH)] PING → PONG
OK: legacy AUTH rejected, ACL AUTH accepted. REDIS_USERNAME plumbing verified.
```

### Typecheck + lint

```bash
pnpm exec tsc -p tsconfig.test.json --noEmit  # clean
pnpm exec eslint ... src/                     # clean
pnpm exec prettier -c src/                    # clean
```

## Backward compatibility

`REDIS_USERNAME` is optional. Existing deployments that set only `REDIS_PASSWORD` continue to use the legacy one-argument AUTH path — no behaviour change.

## Out of scope (intentionally)

- TLS-on-by-default: router and controlplane today both default TLS off and opt-in via `REDIS_TLS_*`. Changing the default is a breaking change that deserves its own PR.
- `REDIS_URL` parity with the router: discrete `REDIS_HOST`/`PORT`/`USERNAME`/`PASSWORD` vars are sufficient for the ACL unblock. Happy to add a follow-up PR if maintainers prefer that form.

## Checklist

- [x] I have followed the coding standards of the project.
- [x] Tests have been added (unit coverage for the schema; a manual repro script with expected output is included above).
- [ ] Documentation has been updated at [wundergraph/docs-website](https://github.com/wundergraph/docs-website) — I can open a follow-up there once the env var name is agreed.
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Redis username-based authentication, enabling connection to Redis servers requiring ACL authentication (Redis 6+). New `REDIS_USERNAME` environment variable is now available as an optional configuration parameter.

* **Tests**
  * Added test coverage validating Redis username configuration handling and optional behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->