### PR TITLE
feat(helm): add HPA behavior and startup probe

### DIFF
--- a/helm/cosmo/charts/router/README.md
+++ b/helm/cosmo/charts/router/README.md
@@ -15,6 +15,7 @@ This is the official Helm Chart for the WunderGraph Cosmo Router.
 | autoscaling.maxReplicas | int | `100` |  |
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
+| autoscaling.behavior | object | `{}` | Configure the [HPA scaling behavior](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#configurable-scaling-behavior) |
 | commonConfiguration | string | `"version: \"1\"\nlog_level: \"info\""` | You can use this to provide the router configuration via yaml. Values here have precedence over the configurations section. For a full list of available configuration options, see https://cosmo-docs.wundergraph.com/router/configuration This value is processed with the helm `tpl` function allowing referencing of variables and inclusion of templates |
 | commonConfigurationPath | string | `""` | Path to a configuration file to embed. If set, this takes precedence over commonConfiguration. The file path is relative to the chart directory and will be processed with the helm `tpl` function. Example: "configs/router-config.yaml" |
 | commonLabels | object | `{}` | Add labels to all deployed resources |
@@ -68,6 +69,7 @@ This is the official Helm Chart for the WunderGraph Cosmo Router.
 | priorityClassName | string | `""` | Set to existing PriorityClass name to control pod preemption by the scheduler |
 | probes.liveness | object | `{"httpGet":{"path":"/health/live","port":"http"},"initialDelaySeconds":10}` | Configure liveness probe |
 | probes.readiness | object | `{"httpGet":{"path":"/health/ready","port":"http"},"initialDelaySeconds":5}` | Configure readiness probe |
+| probes.startup | object | `{}` | Configure startup probe |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
 | securityContext | object | `{}` |  |

--- a/helm/cosmo/charts/router/README.md
+++ b/helm/cosmo/charts/router/README.md
@@ -69,7 +69,7 @@ This is the official Helm Chart for the WunderGraph Cosmo Router.
 | priorityClassName | string | `""` | Set to existing PriorityClass name to control pod preemption by the scheduler |
 | probes.liveness | object | `{"httpGet":{"path":"/health/live","port":"http"},"initialDelaySeconds":10}` | Configure liveness probe |
 | probes.readiness | object | `{"httpGet":{"path":"/health/ready","port":"http"},"initialDelaySeconds":5}` | Configure readiness probe |
-| probes.startup | object | `{}` |  |
+| probes.startup | object | `{}` | Configure startup probe |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
 | securityContext | object | `{}` |  |

--- a/helm/cosmo/charts/router/README.md
+++ b/helm/cosmo/charts/router/README.md
@@ -11,11 +11,11 @@ This is the official Helm Chart for the WunderGraph Cosmo Router.
 | additionalLabels | object | `{}` | Add labels to deployment (metadata.labels) |
 | additionalPodLabels | object | `{}` | Add labels to deployment pod template (spec.template.metadata.labels) |
 | affinity | object | `{}` |  |
+| autoscaling.behavior | object | `{}` |  |
 | autoscaling.enabled | bool | `false` |  |
 | autoscaling.maxReplicas | int | `100` |  |
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
-| autoscaling.behavior | object | `{}` | Configure the [HPA scaling behavior](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#configurable-scaling-behavior) |
 | commonConfiguration | string | `"version: \"1\"\nlog_level: \"info\""` | You can use this to provide the router configuration via yaml. Values here have precedence over the configurations section. For a full list of available configuration options, see https://cosmo-docs.wundergraph.com/router/configuration This value is processed with the helm `tpl` function allowing referencing of variables and inclusion of templates |
 | commonConfigurationPath | string | `""` | Path to a configuration file to embed. If set, this takes precedence over commonConfiguration. The file path is relative to the chart directory and will be processed with the helm `tpl` function. Example: "configs/router-config.yaml" |
 | commonLabels | object | `{}` | Add labels to all deployed resources |
@@ -69,7 +69,7 @@ This is the official Helm Chart for the WunderGraph Cosmo Router.
 | priorityClassName | string | `""` | Set to existing PriorityClass name to control pod preemption by the scheduler |
 | probes.liveness | object | `{"httpGet":{"path":"/health/live","port":"http"},"initialDelaySeconds":10}` | Configure liveness probe |
 | probes.readiness | object | `{"httpGet":{"path":"/health/ready","port":"http"},"initialDelaySeconds":5}` | Configure readiness probe |
-| probes.startup | object | `{}` | Configure startup probe |
+| probes.startup | object | `{}` |  |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
 | securityContext | object | `{}` |  |

--- a/helm/cosmo/charts/router/templates/deployment.yaml
+++ b/helm/cosmo/charts/router/templates/deployment.yaml
@@ -211,6 +211,10 @@ spec:
           readinessProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.probes.startup }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             {{- if .Values.existingConfigmap }}
             - name: router-config

--- a/helm/cosmo/charts/router/templates/hpa.yaml
+++ b/helm/cosmo/charts/router/templates/hpa.yaml
@@ -29,4 +29,8 @@ spec:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
+  {{- with .Values.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/helm/cosmo/charts/router/values.yaml
+++ b/helm/cosmo/charts/router/values.yaml
@@ -143,7 +143,7 @@ autoscaling:
   maxReplicas: 100
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
-  behavior:
+  behavior: {}
     # Configures the HPA scaling behavior. When unset, Kubernetes applies its defaults
     # (300s scale-down stabilization window, no scale-up window).
     # Example of a custom scale up and scale down behavior:

--- a/helm/cosmo/charts/router/values.yaml
+++ b/helm/cosmo/charts/router/values.yaml
@@ -25,10 +25,10 @@ deploymentStrategy: {}
 imagePullSecrets: []
 
 # -- String to partially override common.names.fullname template (will maintain the release name)
-nameOverride: ''
+nameOverride: ""
 
 # -- String to fully override common.names.fullname template
-fullnameOverride: ''
+fullnameOverride: ""
 
 # -- Allows to set additional environment / runtime variables on the container. Useful for global application non-specific settings.
 extraEnvVars: []
@@ -46,10 +46,10 @@ extraVolumes: []
 extraVolumeMounts: []
 
 # -- Name of existing ConfigMap containing extra env vars
-extraEnvVarsCM: ''
+extraEnvVarsCM: ""
 
 # -- Name of existing Secret containing extra env vars
-extraEnvVarsSecret: ''
+extraEnvVarsSecret: ""
 
 serviceAccount:
   # -- Specifies whether a service account should be created
@@ -58,7 +58,7 @@ serviceAccount:
   annotations: {}
   # -- The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
-  name: ''
+  name: ""
 
 serviceAnnotations: {}
 
@@ -80,16 +80,16 @@ service:
   port: 3002
 
 ingress:
-  #  enabled: true
-  #  className: ""
-  #  annotations: {}
-  # kubernetes.io/ingress.class: nginx
-  # kubernetes.io/tls-acme: "true"
+#  enabled: true
+#  className: ""
+#  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
   hosts:
-  #    - host: router.wundergraph.local
-  #      paths:
-  #        - path: /
-  #          pathType: ImplementationSpecific
+#    - host: router.wundergraph.local
+#      paths:
+#        - path: /
+#          pathType: ImplementationSpecific
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:
@@ -143,7 +143,7 @@ autoscaling:
   maxReplicas: 100
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
-  behavior: {}
+  behavior:
     # Configures the HPA scaling behavior. When unset, Kubernetes applies its defaults
     # (300s scale-down stabilization window, no scale-up window).
     # Example of a custom scale up and scale down behavior:
@@ -174,7 +174,7 @@ affinity: {}
 podDisruptionBudget: {}
 
 # -- Set to existing PriorityClass name to control pod preemption by the scheduler
-priorityClassName: ''
+priorityClassName: ""
 
 # -- Sets the [termination grace period](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#hook-handler-execution) for Deployment pods
 terminationGracePeriodSeconds: 30
@@ -209,10 +209,10 @@ global:
 
 # -- The name of the configmap to use for the router configuration. The key "config.yaml" is required in the configmap.
 # If this is set, the commonConfiguration section is ignored.
-existingConfigmap: ''
+existingConfigmap: ""
 
 # -- Existing secret in the same namespace containing the graphApiToken. The secret key has to match with current secret.
-existingSecret: ''
+existingSecret: ""
 
 # Use this section to pass the graphApiToken or to configure simple settings.
 # -- You can use this to provide the router configuration via yaml. Values here have precedence over the configurations section.
@@ -225,30 +225,30 @@ commonConfiguration: |-
 # -- Path to a configuration file to embed. If set, this takes precedence over commonConfiguration.
 # The file path is relative to the chart directory and will be processed with the helm `tpl` function.
 # Example: "configs/router-config.yaml"
-commonConfigurationPath: ''
+commonConfigurationPath: ""
 
 # Use this section to pass the graphApiToken or to configure simple settings.
 configuration:
   # -- The router token is used to authenticate the router against the controlplane (required)
-  graphApiToken: 'replace-me'
+  graphApiToken: "replace-me"
   # -- The execution config file to statically configure the router. If set, polling of the config is disabled.
   # If your config exceeds 1MB (Kubernetes limit), you have to mount it as a file and set the path in routerConfigPath instead
-  executionConfig: ''
+  executionConfig: ""
   # -- The log level of the router. Default to info if not set.
-  logLevel: 'info'
+  logLevel: "info"
   # -- The URL of the Cosmo Controlplane. Should be internal to the cluster. Default to cloud if not set.
-  controlplaneUrl: ''
+  controlplaneUrl: ""
   # -- The URL of the Cosmo GraphQL OTEL Collector. Should be internal to the cluster. Default to cloud if not set.
-  otelCollectorUrl: ''
+  otelCollectorUrl: ""
   # -- The URL of the Cosmo GraphQL Metrics Collector. Should be internal to the cluster. Default to cloud if not set.
-  graphqlMetricsCollectorUrl: ''
+  graphqlMetricsCollectorUrl: ""
   # -- Set to true to enable the development mode. This allows for Advanced Request Tracing (ART) in the GraphQL Playground
   devMode: false
   #-- The URL of the Cosmo CDN. Should be internal to the cluster. Default to cloud if not set.
-  cdnUrl: ''
+  cdnUrl: ""
   # -- The path to the router execution config file. Before, you have to mount the file as a volume and set the path here.
   # A possible to solution could be to use an init container to download the file from a CDN. If set, polling of the config is disabled.
-  routerConfigPath: ''
+  routerConfigPath: ""
 
   # -- The path to the router config file. This does not refer to the execution config.
   # See: https://cosmo-docs.wundergraph.com/router/configuration#config-file
@@ -260,7 +260,7 @@ configuration:
     # -- The port where metrics are exposed. Default is port 8088.
     port: 8088
     # -- The HTTP path where metrics are exposed. Default is "/metrics".
-    path: '/metrics'
+    path: "/metrics"
 
   # Use this section to configure the router's HTTP(S) proxy settings.
   # When set the proxy is enabled.
@@ -270,7 +270,7 @@ configuration:
   httpProxy: ''
   # -- NO_PROXY is a comma-separated list of hosts or domains for which the proxy should not be used.
   noProxy: ''
-
+  
   # Use this section to disable/enable and configure the MCP server.
   mcp:
     # -- Enables MCP server support. Default is false.

--- a/helm/cosmo/charts/router/values.yaml
+++ b/helm/cosmo/charts/router/values.yaml
@@ -192,6 +192,7 @@ probes:
       path: /health/live
       port: http
     initialDelaySeconds: 10
+  # -- Configure startup probe
   startup: {}
 
 global:

--- a/helm/cosmo/charts/router/values.yaml
+++ b/helm/cosmo/charts/router/values.yaml
@@ -25,10 +25,10 @@ deploymentStrategy: {}
 imagePullSecrets: []
 
 # -- String to partially override common.names.fullname template (will maintain the release name)
-nameOverride: ""
+nameOverride: ''
 
 # -- String to fully override common.names.fullname template
-fullnameOverride: ""
+fullnameOverride: ''
 
 # -- Allows to set additional environment / runtime variables on the container. Useful for global application non-specific settings.
 extraEnvVars: []
@@ -46,10 +46,10 @@ extraVolumes: []
 extraVolumeMounts: []
 
 # -- Name of existing ConfigMap containing extra env vars
-extraEnvVarsCM: ""
+extraEnvVarsCM: ''
 
 # -- Name of existing Secret containing extra env vars
-extraEnvVarsSecret: ""
+extraEnvVarsSecret: ''
 
 serviceAccount:
   # -- Specifies whether a service account should be created
@@ -58,7 +58,7 @@ serviceAccount:
   annotations: {}
   # -- The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
-  name: ""
+  name: ''
 
 serviceAnnotations: {}
 
@@ -80,16 +80,16 @@ service:
   port: 3002
 
 ingress:
-#  enabled: true
-#  className: ""
-#  annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
+  #  enabled: true
+  #  className: ""
+  #  annotations: {}
+  # kubernetes.io/ingress.class: nginx
+  # kubernetes.io/tls-acme: "true"
   hosts:
-#    - host: router.wundergraph.local
-#      paths:
-#        - path: /
-#          pathType: ImplementationSpecific
+  #    - host: router.wundergraph.local
+  #      paths:
+  #        - path: /
+  #          pathType: ImplementationSpecific
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:
@@ -144,6 +144,25 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
   behavior: {}
+    # Configures the HPA scaling behavior. When unset, Kubernetes applies its defaults
+    # (300s scale-down stabilization window, no scale-up window).
+    # Example of a custom scale up and scale down behavior:
+    # scaleUp:
+    #   stabilizationWindowSeconds: 180
+    #   selectPolicy: Min
+    #   policies:
+    #     - type: Pods
+    #       value: 2
+    #       periodSeconds: 60
+    #     - type: Percent
+    #       value: 50
+    #       periodSeconds: 60
+    # scaleDown:
+    #   stabilizationWindowSeconds: 120
+    #   policies:
+    #     - type: Percent
+    #       value: 50
+    #       periodSeconds: 60
 
 nodeSelector: {}
 
@@ -155,7 +174,7 @@ affinity: {}
 podDisruptionBudget: {}
 
 # -- Set to existing PriorityClass name to control pod preemption by the scheduler
-priorityClassName: ""
+priorityClassName: ''
 
 # -- Sets the [termination grace period](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#hook-handler-execution) for Deployment pods
 terminationGracePeriodSeconds: 30
@@ -190,10 +209,10 @@ global:
 
 # -- The name of the configmap to use for the router configuration. The key "config.yaml" is required in the configmap.
 # If this is set, the commonConfiguration section is ignored.
-existingConfigmap: ""
+existingConfigmap: ''
 
 # -- Existing secret in the same namespace containing the graphApiToken. The secret key has to match with current secret.
-existingSecret: ""
+existingSecret: ''
 
 # Use this section to pass the graphApiToken or to configure simple settings.
 # -- You can use this to provide the router configuration via yaml. Values here have precedence over the configurations section.
@@ -206,30 +225,30 @@ commonConfiguration: |-
 # -- Path to a configuration file to embed. If set, this takes precedence over commonConfiguration.
 # The file path is relative to the chart directory and will be processed with the helm `tpl` function.
 # Example: "configs/router-config.yaml"
-commonConfigurationPath: ""
+commonConfigurationPath: ''
 
 # Use this section to pass the graphApiToken or to configure simple settings.
 configuration:
   # -- The router token is used to authenticate the router against the controlplane (required)
-  graphApiToken: "replace-me"
+  graphApiToken: 'replace-me'
   # -- The execution config file to statically configure the router. If set, polling of the config is disabled.
   # If your config exceeds 1MB (Kubernetes limit), you have to mount it as a file and set the path in routerConfigPath instead
-  executionConfig: ""
+  executionConfig: ''
   # -- The log level of the router. Default to info if not set.
-  logLevel: "info"
+  logLevel: 'info'
   # -- The URL of the Cosmo Controlplane. Should be internal to the cluster. Default to cloud if not set.
-  controlplaneUrl: ""
+  controlplaneUrl: ''
   # -- The URL of the Cosmo GraphQL OTEL Collector. Should be internal to the cluster. Default to cloud if not set.
-  otelCollectorUrl: ""
+  otelCollectorUrl: ''
   # -- The URL of the Cosmo GraphQL Metrics Collector. Should be internal to the cluster. Default to cloud if not set.
-  graphqlMetricsCollectorUrl: ""
+  graphqlMetricsCollectorUrl: ''
   # -- Set to true to enable the development mode. This allows for Advanced Request Tracing (ART) in the GraphQL Playground
   devMode: false
   #-- The URL of the Cosmo CDN. Should be internal to the cluster. Default to cloud if not set.
-  cdnUrl: ""
+  cdnUrl: ''
   # -- The path to the router execution config file. Before, you have to mount the file as a volume and set the path here.
   # A possible to solution could be to use an init container to download the file from a CDN. If set, polling of the config is disabled.
-  routerConfigPath: ""
+  routerConfigPath: ''
 
   # -- The path to the router config file. This does not refer to the execution config.
   # See: https://cosmo-docs.wundergraph.com/router/configuration#config-file
@@ -241,7 +260,7 @@ configuration:
     # -- The port where metrics are exposed. Default is port 8088.
     port: 8088
     # -- The HTTP path where metrics are exposed. Default is "/metrics".
-    path: "/metrics"
+    path: '/metrics'
 
   # Use this section to configure the router's HTTP(S) proxy settings.
   # When set the proxy is enabled.
@@ -251,7 +270,7 @@ configuration:
   httpProxy: ''
   # -- NO_PROXY is a comma-separated list of hosts or domains for which the proxy should not be used.
   noProxy: ''
-  
+
   # Use this section to disable/enable and configure the MCP server.
   mcp:
     # -- Enables MCP server support. Default is false.

--- a/helm/cosmo/charts/router/values.yaml
+++ b/helm/cosmo/charts/router/values.yaml
@@ -143,6 +143,7 @@ autoscaling:
   maxReplicas: 100
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
+  behavior: {}
 
 nodeSelector: {}
 
@@ -172,6 +173,7 @@ probes:
       path: /health/live
       port: http
     initialDelaySeconds: 10
+  startup: {}
 
 global:
   helmTests: false


### PR DESCRIPTION
This adds two new options in the router's HPA Helm Chart:
- `autoscaling.behavior` to allow configuring the the [HPA scaling behavior](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#configurable-scaling-behavior)
- `probes.startup` to configure startup probe

This is useful to fine tune HPA policies and allows for a cooldown period before applying HPA policies. I need this to ignore the initial CPU/memory spike caused by the [PQL manifest cache warmup](https://cosmo-docs.wundergraph.com/router/persisted-queries/persisted-operations#cache-warmup).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable startup probe support to enable container startup health checks via chart values.
  * Added configurable autoscaling behavior to tune Horizontal Pod Autoscaler's scale-up/scale-down policies.

* **Documentation**
  * Updated chart values documentation with descriptions and examples for the new startup probe and autoscaling behavior options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

<!--
Please add any additional information or context regarding your changes here.
-->