### PR TITLE
feat(controlplane): add support for failover s3 bucket in helm chart

### DIFF
--- a/controlplane/src/bin/get-config.ts
+++ b/controlplane/src/bin/get-config.ts
@@ -49,6 +49,20 @@ const getConfig = () => {
       password: process.env.S3_SECRET_ACCESS_KEY,
       forcePathStyle: process.env.S3_FORCE_PATH_STYLE === undefined ? true : process.env.S3_FORCE_PATH_STYLE === 'true',
     },
+
+    s3StorageFailover: process.env.S3_FAILOVER_STORAGE_URL
+      ? {
+          url: process.env.S3_FAILOVER_STORAGE_URL,
+          endpoint: process.env.S3_FAILOVER_ENDPOINT,
+          region: process.env.S3_FAILOVER_REGION || 'auto',
+          username: process.env.S3_FAILOVER_ACCESS_KEY_ID,
+          password: process.env.S3_FAILOVER_SECRET_ACCESS_KEY,
+          forcePathStyle:
+            process.env.S3_FAILOVER_FORCE_PATH_STYLE === undefined
+              ? true
+              : process.env.S3_FAILOVER_FORCE_PATH_STYLE === 'true',
+        }
+      : undefined,
   };
 };
 

--- a/helm/cosmo/charts/controlplane/README.md
+++ b/helm/cosmo/charts/controlplane/README.md
@@ -52,6 +52,12 @@ WunderGraph Cosmo Controlplane
 | configuration.redisTlsKey | string | `""` |  |
 | configuration.s3AccessKeyId | string | `""` | s3 access key id, can be used instead of [username]:[password] in the url |
 | configuration.s3Endpoint | string | `""` | The endpoint of the S3 bucket. |
+| configuration.s3FailoverAccessKeyId | string | `""` | S3 failover access key id, can be used instead of [username]:[password] in the url |
+| configuration.s3FailoverEndpoint | string | `""` | The endpoint of the S3 failover bucket. |
+| configuration.s3FailoverForcePathStyle | string | `""` | Forces usage of path style urls for the failover S3. Default is true. |
+| configuration.s3FailoverRegion | string | `""` | The region where the S3 failover bucket is located. |
+| configuration.s3FailoverSecretAccessKey | string | `""` | S3 failover secret access key, can be used instead of [username]:[password] in the url |
+| configuration.s3FailoverStorageUrl | string | `""` | The url of S3-compatible storage for backup/failover purposes. If not defined, failover is not used. |
 | configuration.s3ForcePathStyle | string | `"true"` | Forces usage of path style urls for S3. Default is true. |
 | configuration.s3Region | string | `"auto"` | The region where the S3 bucket is located. |
 | configuration.s3SecretAccessKey | string | `""` | s3 secret access key, can be used instead of [username]:[password] in the url |

--- a/helm/cosmo/charts/controlplane/templates/deployment.yaml
+++ b/helm/cosmo/charts/controlplane/templates/deployment.yaml
@@ -274,6 +274,48 @@ spec:
                   name: {{ include "controlplane.secretName" . }}
                   key: s3SecretAccessKey
             {{- end }}
+            {{- if .Values.configuration.s3FailoverStorageUrl }}
+            - name: S3_FAILOVER_STORAGE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "controlplane.secretName" . }}
+                  key: s3FailoverStorageUrl
+            {{- end }}
+            {{- if .Values.configuration.s3FailoverRegion }}
+            - name: S3_FAILOVER_REGION
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "controlplane.fullname" . }}-configmap
+                  key: s3FailoverRegion
+            {{- end }}
+            {{- if .Values.configuration.s3FailoverEndpoint }}
+            - name: S3_FAILOVER_ENDPOINT
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "controlplane.fullname" . }}-configmap
+                  key: s3FailoverEndpoint
+            {{- end }}
+            {{- if .Values.configuration.s3FailoverForcePathStyle }}
+            - name: S3_FAILOVER_FORCE_PATH_STYLE
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "controlplane.fullname" . }}-configmap
+                  key: s3FailoverForcePathStyle
+            {{- end }}
+            {{- if .Values.configuration.s3FailoverAccessKeyId }}
+            - name: S3_FAILOVER_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "controlplane.secretName" . }}
+                  key: s3FailoverAccessKeyId
+            {{- end }}
+            {{- if .Values.configuration.s3FailoverSecretAccessKey }}
+            - name: S3_FAILOVER_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "controlplane.secretName" . }}
+                  key: s3FailoverSecretAccessKey
+            {{- end }}
             - name: SMTP_ENABLED
               valueFrom:
                 configMapKeyRef:

--- a/helm/cosmo/charts/controlplane/templates/secret.yaml
+++ b/helm/cosmo/charts/controlplane/templates/secret.yaml
@@ -49,4 +49,22 @@ stringData:
   {{- if .Values.configuration.s3SecretAccessKey }}
   s3SecretAccessKey: "{{ .Values.configuration.s3SecretAccessKey }}"
   {{- end }}
+  {{- if .Values.configuration.s3FailoverStorageUrl }}
+  s3FailoverStorageUrl: "{{ .Values.configuration.s3FailoverStorageUrl }}"
+  {{- end }}
+  {{- if .Values.configuration.s3FailoverRegion }}
+  s3FailoverRegion: "{{ .Values.configuration.s3FailoverRegion }}"
+  {{- end }}
+  {{- if .Values.configuration.s3FailoverEndpoint }}
+  s3FailoverEndpoint: "{{ .Values.configuration.s3FailoverEndpoint }}"
+  {{- end }}
+  {{- if .Values.configuration.s3FailoverForcePathStyle }}
+  s3FailoverForcePathStyle: "{{ .Values.configuration.s3FailoverForcePathStyle }}"
+  {{- end }}
+  {{- if .Values.configuration.s3FailoverAccessKeyId }}
+  s3FailoverAccessKeyId: "{{ .Values.configuration.s3FailoverAccessKeyId }}"
+  {{- end }}
+  {{- if .Values.configuration.s3FailoverSecretAccessKey }}
+  s3FailoverSecretAccessKey: "{{ .Values.configuration.s3FailoverSecretAccessKey }}"
+  {{- end }}
 {{- end }}

--- a/helm/cosmo/charts/controlplane/values.yaml
+++ b/helm/cosmo/charts/controlplane/values.yaml
@@ -195,6 +195,18 @@ configuration:
   s3SecretAccessKey: ''
   # -- Forces usage of path style urls for S3. Default is true.
   s3ForcePathStyle: 'true'
+  # -- The url of S3-compatible storage for backup/failover purposes. If not defined, failover is not used.
+  s3FailoverStorageUrl: ''
+  # -- The region where the S3 failover bucket is located.
+  s3FailoverRegion: ''
+  # -- The endpoint of the S3 failover bucket.
+  s3FailoverEndpoint: ''
+  # -- S3 failover access key id, can be used instead of [username]:[password] in the url
+  s3FailoverAccessKeyId: ''
+  # -- S3 failover secret access key, can be used instead of [username]:[password] in the url
+  s3FailoverSecretAccessKey: ''
+  # -- Forces usage of path style urls for the failover S3. Default is true.
+  s3FailoverForcePathStyle: ''
   stripeSecretKey: ''
   stripeWebhookSecret: ''
   # -- The default billing plan, eg `developer@1`


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added S3-compatible failover storage support; failover activates only when a failover storage URL is provided.
  * Runtime now exposes optional failover connection details (storage URL, endpoint, region, credentials, and path-style) when configured.

* **Documentation**
  * Helm chart README and values documented with optional failover parameters and defaults.

* **Deployment**
  * Control plane injects failover environment variables and secret entries into deployments when configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

<!--
Please add any additional information or context regarding your changes here.
-->