### PR TITLE
docs(router): link subscriptions overhaul release

### DIFF
--- a/docs-website/router/subscriptions-migration.mdx
+++ b/docs-website/router/subscriptions-migration.mdx
@@ -4,7 +4,7 @@ description: "Migration guide for the subscriptions overhaul. Covers the three b
 icon: "arrows-turn-right"
 ---
 
-This release ships three behavioral changes alongside configuration renames. Each behavioral change is documented in its reference page; this guide links to those and summarizes what an upgrader needs to check.
+The [router@0.313.0 subscription overhaul release](https://github.com/wundergraph/cosmo/releases/tag/router%400.313.0) ships three behavioral changes alongside configuration renames. Each behavioral change is documented in its reference page; this guide links to those and summarizes what an upgrader needs to check.
 
 The router's WebSocket protocol behavior is a strict superset of the `graphql-transport-ws` and `graphql-ws` specifications. Spec-compliant clients are unaffected by the spec-fix change below. The other two changes may require adjustments.
 

--- a/docs-website/router/subscriptions.mdx
+++ b/docs-website/router/subscriptions.mdx
@@ -87,7 +87,7 @@ The router forwards each subscribe message's `extensions` to the subgraph in the
 The router does not merge subscribe-message `extensions` into `connection_init.payload`. The `connection_init.payload` carries only the downstream client's initial payload, unchanged.
 
 <Note>
-  Prior to the subscription overhaul release, the router merged subscribe-message extensions into `connection_init.payload.extensions`, overriding any `initial_payload` extensions. Subgraphs that read extensions from `connection_init` must now read them from `subscribe.payload.extensions`.
+  Prior to the [router@0.313.0 subscription overhaul release](https://github.com/wundergraph/cosmo/releases/tag/router%400.313.0), the router merged subscribe-message extensions into `connection_init.payload.extensions`, overriding any `initial_payload` extensions. Subgraphs that read extensions from `connection_init` must now read them from `subscribe.payload.extensions`.
 </Note>
 
 ### Header forwarding


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated subscription guides to reference specific router release version links for improved clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

<!--
Please add any additional information or context regarding your changes here.
-->