### PR TITLE
fix: display document titles during onboarding

### DIFF
--- a/studio/src/components/layout/onboarding-layout.tsx
+++ b/studio/src/components/layout/onboarding-layout.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent } from '../ui/card';
 import { Stepper } from '../onboarding/stepper';
 import { ONBOARDING_STEPS } from '../onboarding/onboarding-steps';
 import { useOnboarding } from '@/hooks/use-onboarding';
+import { PageHeader } from './head';
 
 export const OnboardingLayout = ({
   children,
@@ -14,23 +15,26 @@ export const OnboardingLayout = ({
   bare?: boolean;
 }) => {
   const { currentStep } = useOnboarding();
+  const pageTitle = title ? `Onboarding | ${title}` : 'Onboarding';
 
   return (
-    <div className="flex min-h-screen w-full flex-col bg-background font-sans antialiased">
-      <header className="mx-auto flex w-full max-w-2xl items-center gap-3 py-6">
-        <Logo width={32} height={32} />
-        {title && <h1 className="text-lg font-semibold tracking-tight">{title}</h1>}
-        <Stepper steps={ONBOARDING_STEPS} currentStep={(currentStep ?? 1) - 1} className="ml-auto" />
-      </header>
-      <main className="w-full flex-1 px-6 pb-4 pt-12">
-        {bare ? (
-          <div className="mx-auto w-full max-w-2xl">{children}</div>
-        ) : (
-          <Card className="mx-auto w-full max-w-2xl">
-            <CardContent className="flex min-h-[788px] flex-col p-6">{children}</CardContent>
-          </Card>
-        )}
-      </main>
-    </div>
+    <PageHeader title={pageTitle}>
+      <div className="flex min-h-screen w-full flex-col bg-background font-sans antialiased">
+        <header className="mx-auto flex w-full max-w-2xl items-center gap-3 py-6">
+          <Logo width={32} height={32} />
+          {title && <h1 className="text-lg font-semibold tracking-tight">{title}</h1>}
+          <Stepper steps={ONBOARDING_STEPS} currentStep={(currentStep ?? 1) - 1} className="ml-auto" />
+        </header>
+        <main className="w-full flex-1 px-6 pb-4 pt-12">
+          {bare ? (
+            <div className="mx-auto w-full max-w-2xl">{children}</div>
+          ) : (
+            <Card className="mx-auto w-full max-w-2xl">
+              <CardContent className="flex min-h-[788px] flex-col p-6">{children}</CardContent>
+            </Card>
+          )}
+        </main>
+      </div>
+    </PageHeader>
   );
 };


### PR DESCRIPTION
Adds missing title property to onboarding pages. Without these, the browser tab would
display:

"onboarding/1" etc which is not very nice. I'm adding the `PageHeader` component in
the onboarding layout and re-using the step titles. We don't really have convention
for the title format but dashboard is already using `Dashboard | <title>` so using
similar format for onboarding seemed appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Enhanced onboarding page layout with improved page header display and dynamic page titling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [X] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [X] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

<!--
Please add any additional information or context regarding your changes here.
-->
