### PR TITLE
fix: provide easy way to recover UI when graph is not found

### DIFF
--- a/studio/src/components/layout/graph-layout.tsx
+++ b/studio/src/components/layout/graph-layout.tsx
@@ -5,6 +5,7 @@ import {
   ClipboardIcon,
   CommandLineIcon,
   ExclamationTriangleIcon,
+  NoSymbolIcon,
   ServerStackIcon,
 } from '@heroicons/react/24/outline';
 import { CheckCircledIcon, Component2Icon, FileTextIcon, HomeIcon, PlayIcon } from '@radix-ui/react-icons';
@@ -23,6 +24,7 @@ import { MdOutlineFeaturedPlayList } from 'react-icons/md';
 import { PiBracketsCurlyBold, PiCubeFocus, PiDevices, PiGitBranch, PiToggleRight } from 'react-icons/pi';
 import { EmptyState } from '../empty-state';
 import { Button } from '../ui/button';
+import { Link } from '../ui/link';
 import { Loader } from '../ui/loader';
 import { PageHeader } from './head';
 import { LayoutProps } from './layout';
@@ -171,6 +173,22 @@ export const GraphLayout = ({ children }: LayoutProps) => {
 
   if (isLoading) {
     render = <Loader fullscreen />;
+  } else if (data?.response?.code === EnumStatusCode.ERR_NOT_FOUND) {
+    const message = data?.response?.details || 'Click "Go back" button to recover.';
+    render = (
+      <div className="my-auto">
+        <EmptyState
+          icon={<NoSymbolIcon />}
+          title="Not found"
+          description={`${message}.\nClick the button to go back.`}
+          actions={
+            <Button asChild>
+              <Link href="/">Go home</Link>
+            </Button>
+          }
+        />
+      </div>
+    );
   } else if (error || data?.response?.code !== EnumStatusCode.OK) {
     render = (
       <div className="my-auto">

--- a/studio/src/components/layout/graph-layout.tsx
+++ b/studio/src/components/layout/graph-layout.tsx
@@ -182,7 +182,7 @@ export const GraphLayout = ({ children }: LayoutProps) => {
           description={`${data?.response?.details}.\nClick the button to go back.`}
           actions={
             <Button asChild>
-              <Link href="/">Go home</Link>
+              <Link href={`/${organizationSlug}`}>Go home</Link>
             </Button>
           }
         />

--- a/studio/src/components/layout/graph-layout.tsx
+++ b/studio/src/components/layout/graph-layout.tsx
@@ -179,7 +179,7 @@ export const GraphLayout = ({ children }: LayoutProps) => {
         <EmptyState
           icon={<NoSymbolIcon />}
           title="Not found"
-          description={data?.response?.details}
+          description={data?.response?.details || 'Graph not found'}
           actions={
             <Button asChild>
               <Link href={`/${organizationSlug}`}>Go home</Link>

--- a/studio/src/components/layout/graph-layout.tsx
+++ b/studio/src/components/layout/graph-layout.tsx
@@ -174,13 +174,12 @@ export const GraphLayout = ({ children }: LayoutProps) => {
   if (isLoading) {
     render = <Loader fullscreen />;
   } else if (data?.response?.code === EnumStatusCode.ERR_NOT_FOUND) {
-    const message = data?.response?.details || 'Click "Go back" button to recover.';
     render = (
       <div className="my-auto">
         <EmptyState
           icon={<NoSymbolIcon />}
           title="Not found"
-          description={`${message}.\nClick the button to go back.`}
+          description={`${data?.response?.details}.\nClick the button to go back.`}
           actions={
             <Button asChild>
               <Link href="/">Go home</Link>

--- a/studio/src/components/layout/graph-layout.tsx
+++ b/studio/src/components/layout/graph-layout.tsx
@@ -179,7 +179,7 @@ export const GraphLayout = ({ children }: LayoutProps) => {
         <EmptyState
           icon={<NoSymbolIcon />}
           title="Not found"
-          description={`${data?.response?.details}.\nClick the button to go back.`}
+          description={data?.response?.details}
           actions={
             <Button asChild>
               <Link href={`/${organizationSlug}`}>Go home</Link>


### PR DESCRIPTION
I am changing how we handle "not found" errors in Studio when user is on a route that deals
with graphs and subgraphs.

Up until now, we only detected whether any kind of error is received when fetching the
graph metadata. If it failed for any reason, we'd just provide generic retry button.

During manual  testing of new onboarding flow, @jensneuse hit an issue which is not strictly
related to onboarding. Whenever user has any graph-related UI opened in Studio and is looking
at specific graph view, and that specific graph gets removed (either via `wgc` or by other
user), re-focusing the browser window will re-fetch the data (standard React Query behaviour).

This causes UI to become somewhat broken. The retry button might be useful in some cases,
but when the graph is removed, it won't help you. The nav links become broken as well as a 
consequence of this behaviour.

My proposed solution does one simple thing: it detects error kind of `ERR_NOT_FOUND` and in
that case it renders different error UI with a button "Go home" which navigates user away from
the broken view. I believe it's a pragmatic approach, I wanted to avoid any automatic re-directs
or propagation of the error elsewhere. 
For all other cases, the old UI with retry button will be used.

Alternatively, we can allow N-amount of retries and in case that fails, we can show different
error UI but I think this is good enough.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling for missing graphs: users now see a clear "Not found" screen with a distinctive icon and a "Go home" button to return to the main page. This replaces the previous generic error view with technical details and a retry option, making recovery from not-found responses more straightforward and user-friendly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [X] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated. (n/a)
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website). (n/a)
- [X] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

<!--
Please add any additional information or context regarding your changes here.
-->
