### PR TITLE
fix: pin NodeJS version explicitly & use consistently in CI

### DIFF
--- a/.github/actions/node/action.yaml
+++ b/.github/actions/node/action.yaml
@@ -1,66 +1,71 @@
-name: 'Setup Node'
-description: 'This action install node and cache modules. It uses pnpm as package manager.'
+name: "Setup Node"
+description: "This action install node and cache modules. It uses pnpm as package manager."
 inputs:
   node-version:
-    description: 'The node version to install'
+    description: "The node version to install"
     required: false
 
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - name: Use default versions
       id: runtime-versions
       env:
         nodeVersionOverride: ${{ inputs.node-version }}
-      shell: node
+      shell: bash
       run: |
-        // Runtime versions are defined once for the monorepo at the root.
-        const pkgPath = path.join(process.env.GITHUB_WORKSPACE, 'package.json');
-        const re = /^[>=<]+/;
-        const nodeVersionOverride = process.env.nodeVersionOverride;
-        let nodeVersion = "";
-        let pnpmVersion = "";
-        let pkg = {};
+        set -euo pipefail
 
-        try {
-          const pkgFile = await fs.readFile(pkgPath, "utf-8");
-          pkg = JSON.parse(pkgFile);
-        } catch (err) {
-          console.error(`Failed to read 'package.json' at path ${pkgPath}`);
-          throw err
+        strip_range_prefix() {
+          local version="$1"
+          while [[ "$version" == [\<\=\>]* ]]; do
+            version="${version:1}"
+          done
+          printf '%s' "$version"
         }
 
-        const { engines: { node } = {}, packageManager } = pkg;
+        # Runtime versions are defined once for the monorepo at the root.
+        pkgPath="${GITHUB_WORKSPACE}/package.json"
+        nodeVersion="${nodeVersionOverride:-}"
 
-        if (!nodeVersionOverride) {
-          if (!node) {
-            throw new Error(`Missing field 'engines.node' in ${pkgPath}`)
-          }
+        if [[ ! -f "$pkgPath" ]]; then
+          echo "Failed to read 'package.json' at path ${pkgPath}" >&2
+          exit 1
+        fi
 
-          let hasUnsupportedPrefix = re.test(node);
-          nodeVersion = hasUnsupportedPrefix ? node.replace(re, "") : node;
+        if [[ -z "$nodeVersion" ]]; then
+          nodeVersion=$(jq -r '.engines.node // empty' "$pkgPath")
 
-          if (nodeVersion !== node) {
-            console.info(`Normalizing NodeJS to version ${nodeVersion}.`);
-          }
-        } else {
-          nodeVersion = nodeVersionOverride;
-        }
+          if [[ -z "$nodeVersion" ]]; then
+            echo "Missing field 'engines.node' in ${pkgPath}" >&2
+            exit 1
+          fi
 
-        if (!packageManager) {
-          throw new Error(`Missing field 'packageManager' in ${pkgPath}`)
-        }
+          normalizedNodeVersion=$(strip_range_prefix "$nodeVersion")
 
-        const normalizedPnpmVersion = packageManager.replace(/^pnpm@/, "");
-        const hasUnsupportedPnpmPrefix = re.test(normalizedPnpmVersion);
-        pnpmVersion = hasUnsupportedPnpmPrefix ? normalizedPnpmVersion.replace(re, "") : normalizedPnpmVersion ;
+          if [[ "$normalizedNodeVersion" != "$nodeVersion" ]]; then
+            echo "Normalizing NodeJS to version ${normalizedNodeVersion}."
+          fi
 
-        if (pnpmVersion !== normalizedPnpmVersion) {
-          console.info(`Normalizing pnpm to version ${pnpmVersion}.`);
-        }
+          nodeVersion="$normalizedNodeVersion"
+        fi
 
-        await fs.appendFile(process.env.GITHUB_OUTPUT, `node-version=${nodeVersion}\n`);
-        await fs.appendFile(process.env.GITHUB_OUTPUT, `pnpm-version=${pnpmVersion}\n`);
+        packageManager=$(jq -r '.packageManager // empty' "$pkgPath")
+
+        if [[ -z "$packageManager" ]]; then
+          echo "Missing field 'packageManager' in ${pkgPath}" >&2
+          exit 1
+        fi
+
+        normalizedPnpmVersion="${packageManager#pnpm@}"
+        pnpmVersion=$(strip_range_prefix "$normalizedPnpmVersion")
+
+        if [[ "$pnpmVersion" != "$normalizedPnpmVersion" ]]; then
+          echo "Normalizing pnpm to version ${pnpmVersion}."
+        fi
+
+        printf 'node-version=%s\n' "$nodeVersion" >> "$GITHUB_OUTPUT"
+        printf 'pnpm-version=%s\n' "$pnpmVersion" >> "$GITHUB_OUTPUT"
 
     - uses: actions/setup-node@v4
       with:

--- a/.github/actions/node/action.yaml
+++ b/.github/actions/node/action.yaml
@@ -1,80 +1,23 @@
-name: "Setup Node"
-description: "This action install node and cache modules. It uses pnpm as package manager."
+name: 'Setup Node'
+description: 'This action install node and cache modules. It uses pnpm as package manager.'
 inputs:
   node-version:
-    description: "The node version to install"
+    description: 'The node version to install'
     required: false
 
 runs:
-  using: "composite"
+  using: 'composite'
   steps:
-    - name: Use default versions
-      id: runtime-versions
-      env:
-        nodeVersionOverride: ${{ inputs.node-version }}
-      shell: bash
-      run: |
-        set -euo pipefail
-
-        strip_range_prefix() {
-          local version="$1"
-          while [[ "$version" == [\<\=\>]* ]]; do
-            version="${version:1}"
-          done
-          printf '%s' "$version"
-        }
-
-        # Runtime versions are defined once for the monorepo at the root.
-        pkgPath="${GITHUB_WORKSPACE}/package.json"
-        nodeVersion="${nodeVersionOverride:-}"
-
-        if [[ ! -f "$pkgPath" ]]; then
-          echo "Failed to read 'package.json' at path ${pkgPath}" >&2
-          exit 1
-        fi
-
-        if [[ -z "$nodeVersion" ]]; then
-          nodeVersion=$(jq -r '.engines.node // empty' "$pkgPath")
-
-          if [[ -z "$nodeVersion" ]]; then
-            echo "Missing field 'engines.node' in ${pkgPath}" >&2
-            exit 1
-          fi
-
-          normalizedNodeVersion=$(strip_range_prefix "$nodeVersion")
-
-          if [[ "$normalizedNodeVersion" != "$nodeVersion" ]]; then
-            echo "Normalizing NodeJS to version ${normalizedNodeVersion}."
-          fi
-
-          nodeVersion="$normalizedNodeVersion"
-        fi
-
-        packageManager=$(jq -r '.packageManager // empty' "$pkgPath")
-
-        if [[ -z "$packageManager" ]]; then
-          echo "Missing field 'packageManager' in ${pkgPath}" >&2
-          exit 1
-        fi
-
-        normalizedPnpmVersion="${packageManager#pnpm@}"
-        pnpmVersion=$(strip_range_prefix "$normalizedPnpmVersion")
-
-        if [[ "$pnpmVersion" != "$normalizedPnpmVersion" ]]; then
-          echo "Normalizing pnpm to version ${pnpmVersion}."
-        fi
-
-        printf 'node-version=%s\n' "$nodeVersion" >> "$GITHUB_OUTPUT"
-        printf 'pnpm-version=%s\n' "$pnpmVersion" >> "$GITHUB_OUTPUT"
-
-    - uses: actions/setup-node@v4
+    # `node-version` takes priority if not empty, otherwise fallback to root `package.json`
+    - uses: actions/setup-node@v6.4.0
       with:
-        node-version: ${{ steps.runtime-versions.outputs.node-version }}
+        node-version: ${{ inputs.node-version }}
+        node-version-file: './package.json'
 
-    - uses: pnpm/action-setup@v4.0.0
+    # Using version from `package.json` field
+    - uses: pnpm/action-setup@v5.0.0
       id: pnpm-install
       with:
-        version: ${{ steps.runtime-versions.outputs.pnpm-version }}
         run_install: false
 
     - name: Get pnpm store directory

--- a/.github/actions/node/action.yaml
+++ b/.github/actions/node/action.yaml
@@ -4,10 +4,6 @@ inputs:
   node-version:
     description: 'The node version to install'
     required: false
-  working-directory:
-    description: 'The working directory of your node package'
-    default: '.'
-    required: false
 
 runs:
   using: 'composite'

--- a/.github/actions/node/action.yaml
+++ b/.github/actions/node/action.yaml
@@ -1,27 +1,79 @@
-name: "Setup Node"
-description: "This action install node and cache modules. It uses pnpm as package manager."
+name: 'Setup Node'
+description: 'This action install node and cache modules. It uses pnpm as package manager.'
 inputs:
   node-version:
-    description: "The node version to install (Default: lts)"
-    # TODO: revert to lts/* after 20 is EOL
-    default: "22.x"
+    description: 'The node version to install'
     required: false
   working-directory:
-    description: "The working directory of your node package"
-    default: "."
+    description: 'The working directory of your node package'
+    default: '.'
     required: false
 
 runs:
-  using: "composite"
+  using: 'composite'
   steps:
+    - name: Use default versions
+      id: runtime-versions
+      env:
+        nodeVersionOverride: ${{ inputs.node-version }}
+      shell: node
+      run: |
+        // Runtime versions are defined once for the monorepo at the root.
+        const pkgPath = path.join(process.env.GITHUB_WORKSPACE, 'package.json');
+        const re = /^[>=<]+/;
+        const nodeVersionOverride = process.env.nodeVersionOverride;
+        let nodeVersion = "";
+        let pnpmVersion = "";
+        let pkg = {};
+
+        try {
+          const pkgFile = await fs.readFile(pkgPath, "utf-8");
+          pkg = JSON.parse(pkgFile);
+        } catch (err) {
+          console.error(`Failed to read 'package.json' at path ${pkgPath}`);
+          throw err
+        }
+
+        const { engines: { node } = {}, packageManager } = pkg;
+
+        if (!nodeVersionOverride) {
+          if (!node) {
+            throw new Error(`Missing field 'engines.node' in ${pkgPath}`)
+          }
+
+          let hasUnsupportedPrefix = re.test(node);
+          nodeVersion = hasUnsupportedPrefix ? node.replace(re, "") : node;
+
+          if (nodeVersion !== node) {
+            console.info(`Normalizing NodeJS to version ${nodeVersion}.`);
+          }
+        } else {
+          nodeVersion = nodeVersionOverride;
+        }
+
+        if (!packageManager) {
+          throw new Error(`Missing field 'packageManager' in ${pkgPath}`)
+        }
+
+        const normalizedPnpmVersion = packageManager.replace(/^pnpm@/, "");
+        const hasUnsupportedPnpmPrefix = re.test(normalizedPnpmVersion);
+        pnpmVersion = hasUnsupportedPnpmPrefix ? normalizedPnpmVersion.replace(re, "") : normalizedPnpmVersion ;
+
+        if (pnpmVersion !== normalizedPnpmVersion) {
+          console.info(`Normalizing pnpm to version ${pnpmVersion}.`);
+        }
+
+        await fs.appendFile(process.env.GITHUB_OUTPUT, `node-version=${nodeVersion}\n`);
+        await fs.appendFile(process.env.GITHUB_OUTPUT, `pnpm-version=${pnpmVersion}\n`);
+
     - uses: actions/setup-node@v4
       with:
-        node-version: ${{ inputs.node-version }}
+        node-version: ${{ steps.runtime-versions.outputs.node-version }}
 
     - uses: pnpm/action-setup@v4.0.0
       id: pnpm-install
       with:
-        version: 9.12.3
+        version: ${{ steps.runtime-versions.outputs.pnpm-version }}
         run_install: false
 
     - name: Get pnpm store directory

--- a/.github/workflows/release-preview.yaml
+++ b/.github/workflows/release-preview.yaml
@@ -29,8 +29,6 @@ jobs:
           token: ${{ secrets.GH_TOKEN_WORKFLOW_PUBLISH }}
 
       - uses: ./.github/actions/node
-        with:
-          working-directory: ${{ env.WORKING_DIRECTORY }}
 
       - run: npm config set //registry.npmjs.org/:_authToken $NPM_TOKEN
         shell: bash

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,8 +29,6 @@ jobs:
           token: ${{ secrets.GH_TOKEN_WORKFLOW_PUBLISH }}
 
       - uses: ./.github/actions/node
-        with:
-          working-directory: ${{ env.WORKING_DIRECTORY }}
 
       - run: npm config set //registry.npmjs.org/:_authToken $NPM_TOKEN
         shell: bash

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "dist"
   ],
   "engines": {
-    "node": ">=22.11.0",
+    "node": "22.22.2",
     "pnpm": "9"
   },
   "lint-staged": {


### PR DESCRIPTION
> [!CAUTION]
> Our previous semver for NodeJS specified anything `22.11.0` and above, but the
> actual version `22.11.00` would **fail** to compile. That's why I opted for explicit
> version

This PR modifies CI action for setting NodeJS + `pnpm` versions to use `package.json`
as the source of truth, instead of hard-coding different values in CI scripts. On top of this, I removed `working-directory` input which was unused and does not completely make sense in monorepo setup I think.

The consequence of this change is for local development, you **must** have explicit 22.22.2 installed.

This change was tested by manually modifying `pnpm-lock.yaml` (appending a comment) which triggered all CI pipelines related to TS packages, see [here](https://github.com/wundergraph/cosmo/pull/2818/checks?sha=a6057e2e65994464ed2fca065dd646ee5cdc17ad). _That commit was removed to not pollute the file_ as it was only intended for testing.

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [X] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated. (n/a)
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website). (n/a)
- [X] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

<!--
Please add any additional information or context regarding your changes here.
-->
