### PR TITLE
fix: feature flag for onboarding not working

### DIFF
--- a/studio/src/hooks/use-onboarding-navigation.ts
+++ b/studio/src/hooks/use-onboarding-navigation.ts
@@ -38,6 +38,10 @@ export const useOnboardingNavigation = () => {
 
   useEffect(
     function handleNavigationToOnboarding() {
+      // Do not redirect if feature flag is off
+      if (!enabled) {
+        return;
+      }
       // Wait for the onboarding metadata query to resolve
       // Do not initiate redirect if we fail to fetch onboarding metadata. Fail silently in background.
       if (initialLoadSuccess === null || !initialLoadSuccess) {


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed onboarding navigation to respect disabled feature flags, preventing unnecessary redirects when the feature is turned off.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [X] I have discussed my proposed changes in an issue and have received approval to proceed.
- [X] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated. (n/a)
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website). (n/a)
- [X] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

<!--
Please add any additional information or context regarding your changes here.
-->
