### PR TITLE
fix: feature flags not being reloaded

### DIFF
--- a/studio/src/lib/track.ts
+++ b/studio/src/lib/track.ts
@@ -18,7 +18,15 @@ const resetTracking = () => {
   posthog.reset();
 };
 
-const identify = ({
+const setupReo = (email: string) => {
+  // Identify with Reo
+  window.Reo?.identify({
+    username: email,
+    type: 'email',
+  });
+};
+
+const setupPosthog = ({
   email,
   id,
   organizationId,
@@ -33,10 +41,6 @@ const identify = ({
   organizationSlug: string;
   plan?: string;
 }) => {
-  if (typeof window === 'undefined' || !process.env.NEXT_PUBLIC_POSTHOG_KEY) {
-    return;
-  }
-
   // We allow PostHog tracking for any environment, if the key is provided
   // Identify with PostHog
   let distinctId = posthog.get_distinct_id();
@@ -59,29 +63,53 @@ const identify = ({
       plan: plan,
     });
     posthog.reloadFeatureFlags();
+  } else {
+    posthog.identify(email, {
+      id,
+    });
+    posthog.group('cosmo_organization', organizationId, {
+      id: organizationId,
+      slug: organizationSlug,
+      name: organizationName,
+      plan: plan,
+    });
+    posthog.reloadFeatureFlags();
+  }
+};
+
+const identify = ({
+  email,
+  id,
+  organizationId,
+  organizationName,
+  organizationSlug,
+  plan,
+}: {
+  id: string;
+  email: string;
+  organizationId: string;
+  organizationName: string;
+  organizationSlug: string;
+  plan?: string;
+}) => {
+  if (typeof window === 'undefined') {
     return;
   }
 
-  posthog.identify(email, {
-    id,
-  });
-  posthog.group('cosmo_organization', organizationId, {
-    id: organizationId,
-    slug: organizationSlug,
-    name: organizationName,
-    plan: plan,
-  });
-  posthog.reloadFeatureFlags();
-
-  if (process.env.NODE_ENV !== 'production') {
-    return;
+  if (process.env.NEXT_PUBLIC_POSTHOG_KEY) {
+    setupPosthog({
+      email,
+      id,
+      organizationId,
+      organizationName,
+      organizationSlug,
+      plan,
+    });
   }
 
-  // Identify with Reo
-  window.Reo?.identify({
-    username: email,
-    type: 'email',
-  });
+  if (process.env.NODE_ENV === 'production') {
+    setupReo(email);
+  }
 };
 
 /**

--- a/studio/src/lib/track.ts
+++ b/studio/src/lib/track.ts
@@ -50,7 +50,6 @@ const identify = ({
   } else if (distinctId === email) {
     posthog.identify(email, {
       id,
-      email,
     });
     // This session has been already identified, just keep the organization synchronized!
     posthog.group('cosmo_organization', organizationId, {
@@ -65,7 +64,6 @@ const identify = ({
 
   posthog.identify(email, {
     id,
-    email,
   });
   posthog.group('cosmo_organization', organizationId, {
     id: organizationId,

--- a/studio/src/lib/track.ts
+++ b/studio/src/lib/track.ts
@@ -48,6 +48,10 @@ const identify = ({
     // with the right data
     posthog.reset();
   } else if (distinctId === email) {
+    posthog.identify(email, {
+      id,
+      email,
+    });
     // This session has been already identified, just keep the organization synchronized!
     posthog.group('cosmo_organization', organizationId, {
       id: organizationId,
@@ -55,11 +59,13 @@ const identify = ({
       name: organizationName,
       plan: plan,
     });
+    posthog.reloadFeatureFlags();
     return;
   }
 
   posthog.identify(email, {
     id,
+    email,
   });
   posthog.group('cosmo_organization', organizationId, {
     id: organizationId,
@@ -67,6 +73,7 @@ const identify = ({
     name: organizationName,
     plan: plan,
   });
+  posthog.reloadFeatureFlags();
 
   if (process.env.NODE_ENV !== 'production') {
     return;

--- a/studio/src/lib/track.ts
+++ b/studio/src/lib/track.ts
@@ -52,9 +52,6 @@ const setupPosthog = ({
     // with the right data
     posthog.reset();
   } else if (distinctId === email) {
-    posthog.identify(email, {
-      id,
-    });
     // This session has been already identified, just keep the organization synchronized!
     posthog.group('cosmo_organization', organizationId, {
       id: organizationId,
@@ -62,7 +59,6 @@ const setupPosthog = ({
       name: organizationName,
       plan: plan,
     });
-    posthog.reloadFeatureFlags();
   } else {
     posthog.identify(email, {
       id,
@@ -73,8 +69,8 @@ const setupPosthog = ({
       name: organizationName,
       plan: plan,
     });
-    posthog.reloadFeatureFlags();
   }
+  posthog.reloadFeatureFlags();
 };
 
 const identify = ({


### PR DESCRIPTION
We need to call identify and reload the feature flags after the tracking is initialized

@coderabbit summary

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

<!--
Please add any additional information or context regarding your changes here.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved analytics identification flow so users are consistently identified and feature flags are reloaded immediately across all identification paths, yielding more reliable feature-flag behavior.
  * Analytics setup now runs only when properly configured and a secondary analytics provider is limited to production, improving telemetry consistency and avoiding accidental non-production tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->