### PR TITLE
fix: fix corruption of persisted operation cache key

### DIFF
--- a/router-tests/operations/persisted_skip_include_concurrency_test.go
+++ b/router-tests/operations/persisted_skip_include_concurrency_test.go
@@ -1,0 +1,196 @@
+package integration
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wundergraph/cosmo/router-tests/testenv"
+	"github.com/wundergraph/cosmo/router/core"
+	"github.com/wundergraph/cosmo/router/pkg/config"
+)
+
+// TestPersistedOperationSkipIncludeConcurrency reproduces the wrong-response bug
+// caused by unsafe string aliasing in skipIncludeVariableNames.
+//
+// Root cause:
+//
+//   - OperationKit.skipIncludeVariableNames() returned strings produced via
+//     unsafebytes.BytesToString — they aliased kit.doc.Input.RawBytes.
+//   - savePersistedOperationToCache() stored those strings in the long-lived
+//     persistedOperationVariableNames map without strings.Clone().
+//   - Parse kits are pooled. When a kit is freed and reused, doc.Reset() keeps
+//     the underlying buffer and the new request overwrites it.
+//   - writeSkipIncludeCacheKeyToKeyGen then looks up the wrong variable names,
+//     mapping variant A's request to variant B's normalization-cache entry and
+//     vice versa — returning the wrong response body.
+//
+// Why single-letter variable names:
+//
+//	Both $a and $b are exactly 1 byte.  polluterQuery is identical to query
+//	except $a and $b are swapped in the two @include directive arguments.
+//	The queries have the same byte length, so parsing polluterQuery overwrites
+//	the kit buffer at byte 130 (where "a" lives in query's first @include arg)
+//	with 'b', and byte 160 (where "b" lives) with 'a'.
+//
+//	skipIncludeVariableNames returns a sorted slice, so aliases[0]→"a" (byte 130)
+//	and aliases[1]→"b" (byte 160).  After one polluter parse they read "b" and "a".
+//	writeSkipIncludeCacheKeyToKeyGen then:
+//	  - for variant {a:true,  b:false}: Get("b")=false, Get("a")=true  → key "ft" (B's key)
+//	  - for variant {a:false, b:true}:  Get("b")=true,  Get("a")=false → key "tf" (A's key)
+//
+//	Each variant hits the other's normalization entry.  Because the normalizer
+//	evaluates @include at plan time, variant A receives a plan that omits
+//	AlligatorFields — returning empty pets instead of Snappy — and variant B
+//	receives a plan that includes AlligatorFields — returning Snappy instead of
+//	empty pets.
+//
+// See also TestSkipIncludeVariableNamesStableAfterKitReuse in router/core for
+// the targeted unit test that directly demonstrates the aliasing.
+func TestPersistedOperationSkipIncludeConcurrency(t *testing.T) {
+	t.Parallel()
+
+	// $a controls AlligatorFields, $b controls CatFields.
+	// Variable names are single bytes so polluterQuery causes a clean byte-swap.
+	const query = `query Employee($id: Int! = 3, $a: Boolean!, $b: Boolean!) { employee(id: $id) { details { pets { ...AlligatorFields @include(if: $a) ...CatFields @include(if: $b) } } } } fragment AlligatorFields on Alligator { __typename class dangerous gender name } fragment CatFields on Cat { __typename class gender name type }`
+
+	// Same byte length as query; $a and $b are swapped in the @include args.
+	// Parsing this writes 'b' at byte 130 and 'a' at byte 160 of the kit buffer,
+	// reversing the aliases stored for the Employee query sha.
+	const polluterQuery = `query Employee($id: Int! = 3, $a: Boolean!, $b: Boolean!) { employee(id: $id) { details { pets { ...AlligatorFields @include(if: $b) ...CatFields @include(if: $a) } } } } fragment AlligatorFields on Alligator { __typename class dangerous gender name } fragment CatFields on Cat { __typename class gender name type }`
+
+	sum := sha256.Sum256([]byte(query))
+	sha := hex.EncodeToString(sum[:])
+
+	type variant struct {
+		name      string
+		variables string
+		expected  string
+	}
+
+	variants := []variant{
+		{
+			name:      "a=true b=false",
+			variables: `{"a":true,"b":false}`,
+			// AlligatorFields included → Snappy; CatFields excluded.
+			expected: `{"data":{"employee":{"details":{"pets":[{"__typename":"Alligator","class":"REPTILE","dangerous":"yes","gender":"UNKNOWN","name":"Snappy"}]}}}}`,
+		},
+		{
+			name:      "a=false b=true",
+			variables: `{"a":false,"b":true}`,
+			// AlligatorFields excluded; CatFields included but pet is Alligator → no Cat match.
+			expected: `{"data":{"employee":{"details":{"pets":[{}]}}}}`,
+		},
+	}
+
+	testenv.Run(t, &testenv.Config{
+		ModifyEngineExecutionConfiguration: func(c *config.EngineExecutionConfiguration) {
+			// Single kit slot forces every request to share the same buffer.
+			c.ParseKitPoolSize = 1
+		},
+		ApqConfig: config.AutomaticPersistedQueriesConfig{
+			Enabled: true,
+			Cache: config.AutomaticPersistedQueriesCacheConfig{
+				Size: 1024 * 1024,
+			},
+		},
+		RouterOptions: []core.Option{
+			core.WithGraphApiToken(""),
+		},
+	}, func(t *testing.T, xEnv *testenv.Environment) {
+		header := func() http.Header {
+			h := make(http.Header)
+			h.Add("graphql-client-name", "concurrency-client")
+			return h
+		}
+
+		extensions := fmt.Sprintf(`{"persistedQuery": {"version": 1, "sha256Hash": %q}}`, sha)
+
+		// 1) Register both variants with the full query body so the APQ store and
+		//    normalization cache are pre-populated with separate entries.
+		for _, v := range variants {
+			res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+				Query:         query,
+				OperationName: []byte(`"Employee"`),
+				Variables:     []byte(v.variables),
+				Extensions:    []byte(extensions),
+				Header:        header(),
+			})
+			assert.Equalf(t, v.expected, res.Body, "registration mismatch for %s", v.name)
+		}
+
+		// 2) Hammer both variants concurrently (hash-only, no query body).
+		//    Polluter goroutines parse polluterQuery through the same single-slot
+		//    kit, swapping bytes 130 and 160 in the buffer.  Without strings.Clone
+		//    the stored aliases are reversed: each variant looks up the other's
+		//    normalization entry and receives the wrong response body.
+		const iterations = 200
+		const parallelism = 32
+		const polluterParallelism = 8
+
+		var wg sync.WaitGroup
+		errCh := make(chan error, parallelism*iterations)
+
+		for w := 0; w < parallelism; w++ {
+			wg.Add(1)
+			go func(workerID int) {
+				defer wg.Done()
+				for i := 0; i < iterations; i++ {
+					v := variants[(workerID+i)%len(variants)]
+					res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+						OperationName: []byte(`"Employee"`),
+						Variables:     []byte(v.variables),
+						Extensions:    []byte(extensions),
+						Header:        header(),
+					})
+					if res.Body != v.expected {
+						errCh <- fmt.Errorf(
+							"variant %q (vars=%s) returned wrong body:\n  got:  %s\n  want: %s",
+							v.name, v.variables, res.Body, v.expected,
+						)
+					}
+				}
+			}(w)
+		}
+
+		// Polluters parse polluterQuery (same length as query, $a/$b swapped) to
+		// overwrite the alias bytes in the shared kit buffer.
+		for p := 0; p < polluterParallelism; p++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for i := 0; i < iterations; i++ {
+					_, _ = xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
+						Query:     polluterQuery,
+						Variables: []byte(`{"a":true,"b":true}`),
+						Header:    header(),
+					})
+				}
+			}()
+		}
+
+		wg.Wait()
+		close(errCh)
+
+		var mismatches []error
+		for e := range errCh {
+			mismatches = append(mismatches, e)
+		}
+		require.Emptyf(t, mismatches,
+			"%d/%d responses crossed variants (sample: %v)",
+			len(mismatches), parallelism*iterations, firstN(mismatches, 3))
+	})
+}
+
+func firstN[T any](s []T, n int) []T {
+	if len(s) < n {
+		return s
+	}
+	return s[:n]
+}

--- a/router/core/operation_processor.go
+++ b/router/core/operation_processor.go
@@ -24,6 +24,7 @@ import (
 	"github.com/tidwall/sjson"
 
 	fastjson "github.com/wundergraph/astjson"
+
 	"github.com/wundergraph/cosmo/router/internal/persistedoperation"
 	"github.com/wundergraph/cosmo/router/internal/unsafebytes"
 	"github.com/wundergraph/cosmo/router/pkg/config"
@@ -1469,7 +1470,8 @@ func (o *OperationKit) skipIncludeVariableNames() []string {
 				if value.Kind != ast.ValueKindVariable {
 					continue
 				}
-				variableName := o.kit.doc.VariableValueNameString(value.Ref)
+				// explicitly convert to string to not store unsafe reference in a map
+				variableName := string(o.kit.doc.VariableValueNameBytes(value.Ref))
 				variableNames[variableName] = struct{}{}
 			}
 		}

--- a/router/core/operation_processor_test.go
+++ b/router/core/operation_processor_test.go
@@ -651,3 +651,61 @@ func TestOperationProcessorIntrospectionQuery(t *testing.T) {
 		})
 	}
 }
+
+// TestSkipIncludeVariableNamesStableAfterKitReuse verifies that skipIncludeVariableNames
+// returns owned strings (not unsafe aliases into kit.doc.Input.RawBytes) so that the slice
+// stored in persistedOperationVariableNames remains valid after the kit is returned to the
+// pool and reused for a different query. Without explicit string creation the aliased strings would
+// silently read garbage, causing cache-key corruption for every subsequent APQ request.
+func TestSkipIncludeVariableNamesStableAfterKitReuse(t *testing.T) {
+	executor := &Executor{
+		PlanConfig:      plan.Configuration{},
+		RouterSchema:    nil,
+		Resolver:        nil,
+		RenameTypeNames: nil,
+	}
+	// Pool of exactly one kit so that kit2 is guaranteed to reuse kit1's buffer.
+	processor := NewOperationProcessor(OperationProcessorOptions{
+		Executor:                executor,
+		MaxOperationSizeInBytes: 10 << 20,
+		ParseKitPoolSize:        1,
+	})
+
+	// A query whose @include directives bind two variables.  The variable names
+	// "withAligators" and "withCats" live at well-known byte offsets inside the
+	// raw query bytes written to kit.doc.Input.RawBytes by Parse().
+	const skipIncludeQuery = `query Employee($withAligators: Boolean!, $withCats: Boolean!) { employee(id: 1) { details { pets { ... on Alligator @include(if: $withAligators) { name } ... on Cat @include(if: $withCats) { name } } } } }`
+
+	kit1, err := processor.NewKit()
+	require.NoError(t, err)
+
+	kit1.parsedOperation.Request.Query = skipIncludeQuery
+	require.NoError(t, kit1.Parse())
+
+	names := kit1.skipIncludeVariableNames()
+	require.Equal(t, []string{"withAligators", "withCats"}, names,
+		"skipIncludeVariableNames should return sorted variable names")
+
+	kit1.Free() // returns kit to pool; RawBytes are zeroed in length but NOT zeroed in content
+
+	// Acquire the same kit slot and parse a different query with reversed order of fragments and variables,
+	// whose bytes overwrite the positions where "withAligators" and "withCats" used to live.
+	const polluterQuery = `query Employee($withCats: Boolean! $withAligators: Boolean!) { employee(id: 1) { details { pets { ... on Cat @include(if: $withCats) { name } ... on Alligator @include(if: $withAligators) { name } } } } }`
+
+	kit2, err := processor.NewKit()
+	require.NoError(t, err)
+	defer kit2.Free()
+
+	kit2.parsedOperation.Request.Query = polluterQuery
+	require.NoError(t, kit2.Parse())
+
+	// Without strings.Clone in skipIncludeVariableNames, names[0] and names[1]
+	// are unsafe aliases into the now-overwritten RawBytes — they will read the
+	// polluter query's bytes and no longer equal the original variable names.
+	require.Equal(t, "withAligators", names[0],
+		"skipIncludeVariableNames must return cloned (not aliased) strings: "+
+			"'withAligators' was corrupted after kit reuse")
+	require.Equal(t, "withCats", names[1],
+		"skipIncludeVariableNames must return cloned (not aliased) strings: "+
+			"'withCats' was corrupted after kit reuse")
+}


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where automatic persisted queries could return incorrect GraphQL responses when handling concurrent requests with variable combinations.

* **Tests**
  * Added integration test to detect response mismatches in automatic persisted queries under concurrent conditions.
  * Added unit test to verify variable name stability after internal cache reuse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

<!--
Please add any additional information or context regarding your changes here.
-->