### PR TITLE
feat: add @composedDirective edge case docs

### DIFF
--- a/docs-website/federation/directives/composeddirective.mdx
+++ b/docs-website/federation/directives/composeddirective.mdx
@@ -162,6 +162,55 @@ type Query {
 }
 ```
 
+#### Propagation from subgraphs that include but do not compose the directive
+
+If at least _one_ subgraph both composes and references a composed directive within that same subgraph, _all_
+declarations of that directive will (attempted to) be propagated to the router schema.
+This includes all declarations of the directive within subgraphs that _do not_ explicitly compose it.
+For example:
+
+```graphql
+# subgraph 1
+schema
+@link(
+  import: ["@myDirective"],
+  url: "https://company.org/my-feature/myDirective/v1.0"
+)
+@composeDirective(name: "@myDirective") {
+  query: Query
+}
+
+directive @myDirective on FIELD_DEFINITION
+
+type Query @shareable {
+  echo(string: String!): String! @myDirective
+}
+
+# subgraph 2
+schema {
+  query: Query
+}
+
+directive @myDirective on FIELD_DEFINITION
+
+type Query @shareable {
+  echo(string: String!): String!
+  test: ID! @myDirective
+}
+
+# router schema
+schema {
+  query: Query
+}
+
+directive @myDirective(input: String!) on FIELD_DEFINITION
+
+type Query {
+  echo(string: String!): String! @myDirective
+  test: ID! @myDirective # directive propagated from subgraph 2 despite not being explicitly composed
+}
+```
+
 ### Directive de-duplication
 
 If a composed directive is declared on the same coordinates across subgraphs, only unique declarations will be
@@ -187,7 +236,10 @@ type Query @shareable {
 
 # subgraph 2
 schema
-@link(import: ["@myDirective"], url: "https://company.org/my-feature/myDirective/v1.0")
+@link(
+  import: ["@myDirective"],
+  url: "https://company.org/my-feature/myDirective/v1.0"
+)
 @composeDirective(name: "@myDirective") {
   query: Query
 }


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Introduced a new propagation behavior section in @composeDirective documentation, providing guidance on how directives propagate when subgraphs simultaneously compose and reference the same directive, with supporting examples.
  * Refined formatting of directive examples for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

<!--
Please add any additional information or context regarding your changes here.
-->