### PR TITLE
fix: pass the right path to the playground (closes #2821)

### DIFF
--- a/router-tests/protocol/integration_test.go
+++ b/router-tests/protocol/integration_test.go
@@ -285,6 +285,38 @@ func TestPlayground(t *testing.T) {
 	})
 }
 
+// TestPlaygroundWithCustomPath verifies that when the playground is mounted at a
+// non-root path via the new playground.path config, the embedded JS receives the
+// actual playground path so itcan correctly strip it from window.location.href
+// when constructing the GraphQL URL.
+func TestPlaygroundWithCustomPath(t *testing.T) {
+	t.Parallel()
+
+	testenv.Run(t, &testenv.Config{
+		RouterOptions: []core.Option{
+			core.WithPlaygroundConfig(config.PlaygroundConfig{
+				Enabled: true,
+				Path:    "/playgroundTestPath",
+			}),
+		},
+	}, func(t *testing.T, xEnv *testenv.Environment) {
+		res, err := xEnv.MakeRequest(http.MethodGet, "/playgroundTestPath", http.Header{
+			"Accept": []string{"text/html"},
+		}, nil)
+		require.NoError(t, err)
+		defer res.Body.Close()
+		require.Equal(t, http.StatusOK, res.StatusCode)
+		body, err := io.ReadAll(res.Body)
+		require.NoError(t, err)
+		require.Contains(t, string(body), `WunderGraph Playground`)
+		// The embedded JS calls constructGraphQLURL(window.location.href, "<graphqlURL>", "<playgroundPath>").
+		// Both placeholders must be replaced with their actual values so the playground
+		// strips its own path from the location and points requests at /graphql, not
+		// /playground/graphql.
+		require.Contains(t, string(body), `(window.location.href,"/graphql","/playgroundTestPath")`)
+	})
+}
+
 func TestExecutionPlanCache(t *testing.T) {
 	t.Parallel()
 

--- a/router/core/router.go
+++ b/router/core/router.go
@@ -1032,7 +1032,7 @@ func (r *Router) bootstrap(ctx context.Context) error {
 		r.playgroundHandler = graphiql.NewPlayground(&graphiql.PlaygroundOptions{
 			Html:             graphiql.PlaygroundHTML(),
 			GraphqlURL:       r.graphqlWebURL,
-			PlaygroundPath:   r.playgroundPath,
+			PlaygroundPath:   r.playgroundConfig.Path,
 			ConcurrencyLimit: int64(r.playgroundConfig.ConcurrencyLimit),
 		})
 	}


### PR DESCRIPTION
As reported in issue #2821, when configuring a custom playground path on the router, the GraphQL requests are sent to the incorrect path. This occurs because we used the old playground path inside the playground HTML template, even when the new one was available.
So the playground was mounted on the correct path, but it thought it was on another one.

With this fix, we now exclusively use the new configuration path within the router, with the old path serving as a fallback, as intended.

<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added integration test for GraphQL Playground custom path configuration to verify correct behavior with non-root mount paths.

* **Bug Fixes**
  * Fixed GraphQL Playground path configuration to properly apply custom path settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

<!--
Please add any additional information or context regarding your changes here.
-->