### PR TITLE
feat(helm): add HPA extra metrics

### DIFF
--- a/helm/cosmo/charts/router/README.md
+++ b/helm/cosmo/charts/router/README.md
@@ -13,6 +13,7 @@ This is the official Helm Chart for the WunderGraph Cosmo Router.
 | affinity | object | `{}` |  |
 | autoscaling.behavior | object | `{}` |  |
 | autoscaling.enabled | bool | `false` |  |
+| autoscaling.extraMetrics | list | `[]` |  |
 | autoscaling.maxReplicas | int | `100` |  |
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |

--- a/helm/cosmo/charts/router/templates/hpa.yaml
+++ b/helm/cosmo/charts/router/templates/hpa.yaml
@@ -29,6 +29,9 @@ spec:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
+    {{- with .Values.autoscaling.extraMetrics }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.autoscaling.behavior }}
   behavior:
     {{- toYaml . | nindent 4 }}

--- a/helm/cosmo/charts/router/values.yaml
+++ b/helm/cosmo/charts/router/values.yaml
@@ -143,6 +143,18 @@ autoscaling:
   maxReplicas: 100
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
+  extraMetrics: []
+    # Additional HPA metrics appended to the rendered HPA's `metrics:` list.
+    # Each entry must be a full `autoscaling/v2` metric object.
+    # Useful for scaling on metrics provided by an external metrics adapter on top of CPU/memory.
+    # Example of using an external metric:
+    # - type: External
+    #   external:
+    #     metric:
+    #       name: router.http.requests.in_flight
+    #     target:
+    #       type: AverageValue
+    #       averageValue: "50"
   behavior: {}
     # Configures the HPA scaling behavior. When unset, Kubernetes applies its defaults
     # (300s scale-down stabilization window, no scale-up window).


### PR DESCRIPTION
Append additional HPA metrics to the rendered HorizontalPodAutoscaler on top of the chart's existing CPU/memory Resource metrics.

This unblocks scaling the router on external/custom metrics provided by adapters such as Prometheus Adapter, KEDA, or Datadog Cluster Agent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Router autoscaling now supports injecting additional custom metrics for flexible scaling policies that extend beyond the default CPU and memory utilization metrics.

* **Documentation**
  * Updated documentation for router autoscaling configuration options and custom metrics support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

<!--
Please add any additional information or context regarding your changes here.
-->