### PR TITLE
fix: onboarding_started tracking event not fired + default channel

### DIFF
--- a/studio/src/components/onboarding/onboarding-provider.tsx
+++ b/studio/src/components/onboarding/onboarding-provider.tsx
@@ -25,6 +25,8 @@ export interface OnboardingState {
   currentStep: number | undefined;
   setStep: (step: number | undefined) => void;
   skipped: boolean;
+  initialized: boolean;
+  setInitialized: () => void;
   setSkipped: () => void;
   resetSkipped: () => void;
 }
@@ -36,6 +38,8 @@ export const OnboardingContext = createContext<OnboardingState>({
   currentStep: undefined,
   setStep: () => undefined,
   skipped: false,
+  initialized: false,
+  setInitialized: () => undefined,
   setSkipped: () => undefined,
   resetSkipped: () => undefined,
 });
@@ -47,6 +51,7 @@ export const OnboardingProvider = ({ children }: { children: ReactNode }) => {
   const [onboarding, setOnboarding] = useState<Onboarding | undefined>(undefined);
   const [currentStep, setCurrentStep] = useSessionStorage<undefined | number>('cosmo-onboarding-v1-step', undefined);
   const [skipped, setSkippedValue] = useSessionStorage('cosmo-onboarding-v1-skipped', false);
+  const [initialized, setInitializedValue] = useSessionStorage('cosmo-onboarding-v1-initialized', false);
 
   const setSkipped = useCallback(() => {
     setSkippedValue(true);
@@ -70,6 +75,8 @@ export const OnboardingProvider = ({ children }: { children: ReactNode }) => {
     [setCurrentStep, resetSkipped],
   );
 
+  const setInitialized = useCallback(() => setInitializedValue(true), [setInitializedValue]);
+
   const value = useMemo(
     () => ({
       onboarding,
@@ -80,8 +87,21 @@ export const OnboardingProvider = ({ children }: { children: ReactNode }) => {
       setSkipped,
       resetSkipped,
       skipped,
+      initialized,
+      setInitialized,
     }),
-    [onboarding, onboardingFlag, featureFlagStatus, currentStep, setStep, setSkipped, resetSkipped, skipped],
+    [
+      onboarding,
+      onboardingFlag,
+      featureFlagStatus,
+      currentStep,
+      setStep,
+      setSkipped,
+      resetSkipped,
+      skipped,
+      initialized,
+      setInitialized,
+    ],
   );
 
   return <OnboardingContext.Provider value={value}>{children}</OnboardingContext.Provider>;

--- a/studio/src/components/onboarding/step-1.tsx
+++ b/studio/src/components/onboarding/step-1.tsx
@@ -55,7 +55,10 @@ export const Step1 = () => {
     mode: 'onChange',
     schema: onboardingSchema,
     defaultValues: {
-      channels: onboarding,
+      channels: {
+        slack: onboarding?.slack ?? true,
+        email: onboarding?.email ?? false,
+      },
     },
   });
 

--- a/studio/src/components/onboarding/step-1.tsx
+++ b/studio/src/components/onboarding/step-1.tsx
@@ -47,7 +47,7 @@ export const Step1 = () => {
   const router = useRouter();
   const posthog = usePostHog();
   const { toast } = useToast();
-  const { setStep, setSkipped, setOnboarding, onboarding } = useOnboarding();
+  const { setStep, setSkipped, setOnboarding, onboarding, initialized, setInitialized } = useOnboarding();
   // Referrer can be `wgc` when onboarding is opened via `wgc demo` command
   const referrer = normalizeReferrer(router.query.referrer || document?.referrer);
 
@@ -119,13 +119,14 @@ export const Step1 = () => {
 
   useEffect(() => {
     setStep(1);
-  }, [setStep]);
+    setInitialized();
+  }, [setStep, setInitialized]);
 
   useEffect(() => {
-    // We want to trigger the onboarding only for the first time when the onboarding record
-    // does not exist in the database yet. Users can navigate to this first step as well
-    // and in that case we want to ignore it.
-    if (onboarding) return;
+    // We only want to trigger the started event once, when user is shown the first
+    // step of the onboarding. In case the user re-visits by going back, we don't
+    // fire it again.
+    if (initialized) return;
 
     captureOnboardingEvent(posthog, {
       name: 'onboarding_started',
@@ -133,7 +134,7 @@ export const Step1 = () => {
         entry_source: referrer,
       },
     });
-  }, [onboarding, referrer, posthog]);
+  }, [initialized, referrer, posthog]);
 
   return (
     <OnboardingContainer>

--- a/studio/src/components/onboarding/step-1.tsx
+++ b/studio/src/components/onboarding/step-1.tsx
@@ -119,7 +119,7 @@ export const Step1 = () => {
 
   useEffect(() => {
     setStep(1);
-  }, [setStep, posthog, referrer]);
+  }, [setStep]);
 
   useEffect(() => {
     // We want to trigger the onboarding only for the first time when the onboarding record


### PR DESCRIPTION
We are not able to reliable see `onboarding_started` event being fired in our analytics.
I found out that relying on database record can cause the effect, which captures the
event to run multiple times, because of the asynchronous nature[^1] of the onboarding
architecture.

Since we are tracking parts of onboarding state in the browser state, I think adding one
more storage key `cosmo-onboarding-v1-initialized` is fine. The initial value is falsy
and as soon as the onboarding UI is mounted, it is set to true.

Additionally, I'm also fixing default values for the communication channel. I noticed
that in some cases the form becomes invalid and "start the tour" button becomes
inactive. This is because of failed validation, I'm adding default values now and
I believe having at least one channel (Slack) set is the sensible choice here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced onboarding initialization tracking with improved state persistence to ensure analytics events fire once and reliably
  * Improved handling of user channel preferences during onboarding setup with explicit fallback values for Slack and Email
  * Fixed onboarding state management for better completion tracking across user sessions

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wundergraph/cosmo/pull/2852)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[^1]: We have top-level component which contains `use-onboarding-navigation` hook. This hook is responsible for the initial re-direct and is the one that fetches onboarding DB record. However, we're not storing the state of that request so it means the effect in `Step1` component for capturing the event, can fire multiple times.

## Checklist

- [X] I have discussed my proposed changes in an issue and have received approval to proceed.
- [X] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated. (n/a)
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website). (n/a)
- [X] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

<!--
Please add any additional information or context regarding your changes here.
-->
