### PR TITLE
feat(router): enable unauthenticated request tracing

### DIFF
--- a/docs-website/router/advanced-request-tracing-art.mdx
+++ b/docs-website/router/advanced-request-tracing-art.mdx
@@ -99,10 +99,42 @@ POST http://example.com/graphql?wg_trace=exclude_output
 
 ## Development
 
-For security reasons, we don't enable Advanced Request Tracing (ART) by default but you can enable it by setting the router environment variable `DEV_MODE` to `true` and using the following header in the playground:
+For security reasons, we don't enable Advanced Request Tracing (ART) by default,
+but you can enable it by setting the router environment variable `DEV_MODE` to `true` and
+using the following header in the playground:
 
 ```bash
 {
   "X-WG-TRACE" : "true"
 }
 ```
+
+## Bypassing authentication (unsafe)
+
+The router can also accept ART headers without a signed request token and without `DEV_MODE`.
+This is controlled by `force_unauthenticated_request_tracing`
+(env `ENGINE_FORCE_UNAUTHENTICATED_REQUEST_TRACING`), default `false`.
+
+```yaml
+engine:
+  enable_request_tracing: true
+  force_unauthenticated_request_tracing: true
+```
+
+<Warning>
+  Do not enable unauthenticated request tracing on a router that is reachable by untrusted clients.
+
+  When this flag is `true`, any client that can send a request to the router can set the header
+    `X-WG-Trace` (or `?wg_trace=...`) and receive the full ART payload in the response.
+
+  That payload could expose:
+
+  - internal subgraph URLs and the router's federation topology
+  - the exact requests sent to subgraphs, including propagated headers (which may contain auth tokens, cookies, or API keys)
+  - raw subgraph responses, including fields filtered by the gateway
+  - the complete query plan and per-fetch timings
+
+  On startup the router logs a warning whenever this flag is enabled.
+  Use it only for local debugging or in trusted, isolated environments.
+  For production debugging, keep the default and let Cosmo Studio issue signed request tokens.
+</Warning>

--- a/docs-website/router/advanced-request-tracing-art.mdx
+++ b/docs-website/router/advanced-request-tracing-art.mdx
@@ -99,9 +99,10 @@ POST http://example.com/graphql?wg_trace=exclude_output
 
 ## Development
 
-For security reasons, we don't enable Advanced Request Tracing (ART) by default,
-but you can enable it by setting the router environment variable `DEV_MODE` to `true` and
-using the following header in the playground:
+In production, ART responses are gated behind a signed request token issued by Cosmo Studio
+so untrusted clients can't trigger them. For local development,
+set the router environment variable `DEV_MODE` to `true` to bypass that check,
+then send the header in the playground:
 
 ```bash
 {
@@ -109,15 +110,16 @@ using the following header in the playground:
 }
 ```
 
-## Bypassing authentication (unsafe)
+## Bypassing authentication (Dangerous and Unsafe)
 
 The router can also accept ART headers without a signed request token and without `DEV_MODE`.
-This is controlled by `force_unauthenticated_request_tracing`
-(env `ENGINE_FORCE_UNAUTHENTICATED_REQUEST_TRACING`), default `false`.
+This is controlled by the `force_unauthenticated_request_tracing` option
+(env `ENGINE_FORCE_UNAUTHENTICATED_REQUEST_TRACING`). By default, it is disabled.
+
+To enable it:
 
 ```yaml
 engine:
-  enable_request_tracing: true
   force_unauthenticated_request_tracing: true
 ```
 

--- a/router-tests/operations/request_tracing_security_test.go
+++ b/router-tests/operations/request_tracing_security_test.go
@@ -1,0 +1,105 @@
+package integration
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/wundergraph/cosmo/router-tests/testenv"
+	"github.com/wundergraph/cosmo/router/core"
+	"github.com/wundergraph/cosmo/router/pkg/config"
+)
+
+// TestRequestTracingSecurity verifies the production authorization gate around
+// Advanced Request Tracing (ART).
+func TestRequestTracingSecurity(t *testing.T) {
+	t.Parallel()
+
+	const query = `{ employees { id } }`
+	headers := http.Header{
+		"X-WG-Trace":              []string{"true"},
+		"X-WG-Include-Query-Plan": []string{"true"},
+	}
+	wantLogMsg := "Advanced Request Tracing (ART) is enabled for unauthenticated requests."
+
+	t.Run("anonymous ART is denied in production by default", func(t *testing.T) {
+		t.Parallel()
+
+		testenv.Run(t, &testenv.Config{
+			LogObservation: testenv.LogObservationConfig{
+				Enabled:  true,
+				LogLevel: zapcore.WarnLevel,
+			},
+			RouterOptions: []core.Option{
+				core.WithDevelopmentMode(false),
+			},
+			ModifyEngineExecutionConfiguration: func(cfg *config.EngineExecutionConfiguration) {
+				cfg.EnableRequestTracing = true
+				cfg.ForceUnauthenticatedRequestTracing = false
+			},
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+				Header: headers,
+				Query:  query,
+			})
+
+			var resp struct {
+				Extensions map[string]json.RawMessage `json:"extensions"`
+			}
+			require.NoError(t, json.Unmarshal([]byte(res.Body), &resp))
+			require.NotContains(t, resp.Extensions, "trace")
+			require.NotContains(t, resp.Extensions, "queryPlan")
+
+			warns := xEnv.Observer().FilterMessageSnippet(wantLogMsg).All()
+			require.Len(t, warns, 0)
+		})
+	})
+
+	t.Run("anonymous ART is allowed when force_unauthenticated_request_tracing is enabled", func(t *testing.T) {
+		t.Parallel()
+
+		testenv.Run(t, &testenv.Config{
+			LogObservation: testenv.LogObservationConfig{
+				Enabled:  true,
+				LogLevel: zapcore.WarnLevel,
+			},
+			RouterOptions: []core.Option{
+				core.WithDevelopmentMode(false),
+			},
+			ModifyEngineExecutionConfiguration: func(cfg *config.EngineExecutionConfiguration) {
+				cfg.EnableRequestTracing = true
+				cfg.ForceUnauthenticatedRequestTracing = true
+			},
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+				Header: headers,
+				Query:  query,
+			})
+
+			var resp struct {
+				Extensions map[string]json.RawMessage `json:"extensions"`
+			}
+			require.NoError(t, json.Unmarshal([]byte(res.Body), &resp))
+			require.Contains(t, resp.Extensions, "trace")
+
+			var trace struct {
+				Version string          `json:"version"`
+				Info    json.RawMessage `json:"info"`
+				Fetches json.RawMessage `json:"fetches"`
+				Request json.RawMessage `json:"request"`
+			}
+			require.NoError(t, json.Unmarshal(resp.Extensions["trace"], &trace))
+			require.NotEmpty(t, trace.Version)
+			require.NotEmpty(t, trace.Info)
+			require.NotEmpty(t, trace.Fetches)
+			require.NotEmpty(t, trace.Request)
+
+			warns := xEnv.Observer().FilterMessageSnippet(wantLogMsg).All()
+			require.Len(t, warns, 1)
+			require.Equal(t, zapcore.WarnLevel, warns[0].Level)
+		})
+	})
+}

--- a/router/core/graph_server.go
+++ b/router/core/graph_server.go
@@ -1646,6 +1646,7 @@ func (s *graphServer) buildGraphMux(
 		OperationBlocker:                       operationBlocker,
 		RouterPublicKey:                        s.publicKey,
 		EnableRequestTracing:                   s.engineExecutionConfiguration.EnableRequestTracing,
+		ForceUnauthenticatedRequestTracing:     s.engineExecutionConfiguration.ForceUnauthenticatedRequestTracing,
 		DevelopmentMode:                        s.developmentMode,
 		TracerProvider:                         s.tracerProvider,
 		FlushTelemetryAfterResponse:            s.awsLambda,

--- a/router/core/graphql_prehandler.go
+++ b/router/core/graphql_prehandler.go
@@ -56,6 +56,7 @@ type PreHandlerOptions struct {
 	FileUploadEnabled                      bool
 	TraceExportVariables                   bool
 	DevelopmentMode                        bool
+	ForceUnauthenticatedRequestTracing     bool
 	EnableRequestTracing                   bool
 	AlwaysIncludeQueryPlan                 bool
 	AlwaysSkipLoader                       bool
@@ -88,6 +89,7 @@ type PreHandler struct {
 	operationBlocker                       *OperationBlocker
 	headerPropagation                      *HeaderPropagation
 	developmentMode                        bool
+	forceUnauthenticatedRequestTracing     bool
 	alwaysIncludeQueryPlan                 bool
 	alwaysSkipLoader                       bool
 	queryPlansEnabled                      bool // queryPlansEnabled is a flag to enable query plans output in the extensions
@@ -144,19 +146,20 @@ func NewPreHandler(opts *PreHandlerOptions) *PreHandler {
 		spanNameFormatter = DefaultSpanNameFormatter
 	}
 	return &PreHandler{
-		log:                         opts.Logger,
-		executor:                    opts.Executor,
-		metrics:                     opts.Metrics,
-		operationProcessor:          opts.OperationProcessor,
-		planner:                     opts.Planner,
-		accessController:            opts.AccessController,
-		operationBlocker:            opts.OperationBlocker,
-		routerPublicKey:             opts.RouterPublicKey,
-		developmentMode:             opts.DevelopmentMode,
-		enableRequestTracing:        opts.EnableRequestTracing,
-		flushTelemetryAfterResponse: opts.FlushTelemetryAfterResponse,
-		tracerProvider:              opts.TracerProvider,
-		traceExportVariables:        opts.TraceExportVariables,
+		log:                                opts.Logger,
+		executor:                           opts.Executor,
+		metrics:                            opts.Metrics,
+		operationProcessor:                 opts.OperationProcessor,
+		planner:                            opts.Planner,
+		accessController:                   opts.AccessController,
+		operationBlocker:                   opts.OperationBlocker,
+		routerPublicKey:                    opts.RouterPublicKey,
+		developmentMode:                    opts.DevelopmentMode,
+		enableRequestTracing:               opts.EnableRequestTracing,
+		forceUnauthenticatedRequestTracing: opts.ForceUnauthenticatedRequestTracing,
+		flushTelemetryAfterResponse:        opts.FlushTelemetryAfterResponse,
+		tracerProvider:                     opts.TracerProvider,
+		traceExportVariables:               opts.TraceExportVariables,
 		tracer: opts.TracerProvider.Tracer(
 			"wundergraph/cosmo/router/pre_handler",
 			trace.WithInstrumentationVersion("0.0.1"),
@@ -1310,8 +1313,9 @@ func (h *PreHandler) parseExecutionAndTraceOptions(r *http.Request, clientInfo *
 func (h *PreHandler) internalParseRequestOptions(r *http.Request, clientInfo *ClientInfo, requestLogger *zap.Logger) (resolve.ExecutionOptions, resolve.TraceOptions, error) {
 	// Determine if we should enable request tracing / query plans at all
 	if h.enableRequestTracing {
-		// In dev mode we always allow to enable tracing / query plans
-		if h.developmentMode {
+		// In dev mode we always allow to enable tracing / query plans.
+		// force_unauthenticated_request_tracing=true allows ART without dev_mode or a controlplane token.
+		if h.developmentMode || h.forceUnauthenticatedRequestTracing {
 			return h.parseRequestExecutionOptions(r), h.parseRequestTraceOptions(r), nil
 		}
 		// If the client has a valid request token, and we have a public key from the controlplane

--- a/router/core/graphql_prehandler_request_options_test.go
+++ b/router/core/graphql_prehandler_request_options_test.go
@@ -1,0 +1,48 @@
+package core
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestPreHandlerInternalParseRequestOptions_ForceUnauthenticatedRequestTracing(t *testing.T) {
+	t.Parallel()
+
+	t.Run("allows ART options when force_unauthenticated_request_tracing is true without dev mode or token", func(t *testing.T) {
+		t.Parallel()
+
+		req := httptest.NewRequest("GET", "http://localhost/graphql?wg_include_query_plan=1&wg_trace=exclude_output", nil)
+		h := &PreHandler{
+			enableRequestTracing:               true,
+			developmentMode:                    false,
+			forceUnauthenticatedRequestTracing: true,
+		}
+
+		executionOptions, traceOptions, err := h.internalParseRequestOptions(req, &ClientInfo{}, zap.NewNop())
+		require.NoError(t, err)
+		require.True(t, executionOptions.IncludeQueryPlanInResponse)
+		require.True(t, traceOptions.Enable)
+		require.True(t, traceOptions.ExcludeOutput)
+	})
+
+	t.Run("keeps ART options disabled when force_unauthenticated_request_tracing is false without dev mode or token", func(t *testing.T) {
+		t.Parallel()
+
+		req := httptest.NewRequest("GET", "http://localhost/graphql?wg_include_query_plan=1&wg_trace=exclude_output", nil)
+		h := &PreHandler{
+			enableRequestTracing:               true,
+			developmentMode:                    false,
+			forceUnauthenticatedRequestTracing: false,
+			routerPublicKey:                    nil,
+		}
+
+		executionOptions, traceOptions, err := h.internalParseRequestOptions(req, &ClientInfo{}, zap.NewNop())
+		require.NoError(t, err)
+		require.False(t, executionOptions.IncludeQueryPlanInResponse)
+		require.False(t, traceOptions.Enable)
+		require.True(t, traceOptions.ExcludeOutput)
+	})
+}

--- a/router/core/graphql_prehandler_request_options_test.go
+++ b/router/core/graphql_prehandler_request_options_test.go
@@ -1,9 +1,13 @@
 package core
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 )
@@ -44,5 +48,37 @@ func TestPreHandlerInternalParseRequestOptions_ForceUnauthenticatedRequestTracin
 		require.False(t, executionOptions.IncludeQueryPlanInResponse)
 		require.False(t, traceOptions.Enable)
 		require.True(t, traceOptions.ExcludeOutput)
+	})
+
+	t.Run("returns error with disabled ART when force_unauthenticated_request_tracing is false and request token is invalid", func(t *testing.T) {
+		t.Parallel()
+
+		// A public key is configured but the client presents a token signed by a different key,
+		// so signature verification must fail and ART must stay disabled (fail closed).
+		routerKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err)
+		attackerKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err)
+
+		token := jwt.NewWithClaims(jwt.SigningMethodES256, jwt.MapClaims{})
+		signed, err := token.SignedString(attackerKey)
+		require.NoError(t, err)
+
+		req := httptest.NewRequest("GET", "http://localhost/graphql?wg_include_query_plan=1&wg_trace=exclude_output", nil)
+		h := &PreHandler{
+			enableRequestTracing:               true,
+			developmentMode:                    false,
+			forceUnauthenticatedRequestTracing: false,
+			routerPublicKey:                    &routerKey.PublicKey,
+		}
+
+		executionOptions, traceOptions, err := h.internalParseRequestOptions(
+			req,
+			&ClientInfo{WGRequestToken: signed},
+			zap.NewNop(),
+		)
+		require.ErrorAs(t, err, &jwt.ErrSignatureInvalid)
+		require.False(t, executionOptions.IncludeQueryPlanInResponse)
+		require.False(t, traceOptions.Enable)
 	})
 }

--- a/router/core/graphql_prehandler_request_options_test.go
+++ b/router/core/graphql_prehandler_request_options_test.go
@@ -77,7 +77,7 @@ func TestPreHandlerInternalParseRequestOptions_ForceUnauthenticatedRequestTracin
 			&ClientInfo{WGRequestToken: signed},
 			zap.NewNop(),
 		)
-		require.ErrorAs(t, err, &jwt.ErrSignatureInvalid)
+		require.ErrorIs(t, err, jwt.ErrTokenSignatureInvalid)
 		require.False(t, executionOptions.IncludeQueryPlanInResponse)
 		require.False(t, traceOptions.Enable)
 	})

--- a/router/core/router.go
+++ b/router/core/router.go
@@ -1471,6 +1471,15 @@ func (r *Router) Start(ctx context.Context) error {
 
 	r.reloadPersistentState.UpdateReloadPersistentState(&r.Config)
 
+	if r.engineExecutionConfiguration.EnableRequestTracing {
+		if r.developmentMode && r.graphApiToken == "" {
+			r.logger.Warn("Advanced Request Tracing (ART) is enabled in development mode but requires a graph token to work in production. For more information see https://cosmo-docs.wundergraph.com/router/advanced-request-tracing-art")
+		}
+		if r.engineExecutionConfiguration.ForceUnauthenticatedRequestTracing {
+			r.logger.Warn("Advanced Request Tracing (ART) is enabled for unauthenticated requests. This exposes internal subgraph URLs, request and response payloads, propagated headers, and query plans to any client that can reach the router. For more information see https://cosmo-docs.wundergraph.com/router/advanced-request-tracing-art")
+		}
+	}
+
 	// Start the server with the static config without polling
 	if r.staticExecutionConfig != nil {
 
@@ -1593,14 +1602,6 @@ func (r *Router) Start(ctx context.Context) error {
 
 	if r.localhostFallbackInsideDocker && docker.Inside() {
 		r.logger.Info("localhost fallback enabled, connections that fail to connect to localhost will be retried using host.docker.internal")
-	}
-
-	if r.developmentMode && r.engineExecutionConfiguration.EnableRequestTracing && r.graphApiToken == "" {
-		r.logger.Warn("Advanced Request Tracing (ART) is enabled in development mode but requires a graph token to work in production. For more information see https://cosmo-docs.wundergraph.com/router/advanced-request-tracing-art")
-	}
-
-	if r.engineExecutionConfiguration.EnableRequestTracing && r.engineExecutionConfiguration.ForceUnauthenticatedRequestTracing {
-		r.logger.Warn("Advanced Request Tracing (ART) is enabled for unauthenticated requests. This exposes internal subgraph URLs, request and response payloads, propagated headers, and query plans to any client that can reach the router. For more information see https://cosmo-docs.wundergraph.com/router/advanced-request-tracing-art")
 	}
 
 	if r.redisClient != nil {

--- a/router/core/router.go
+++ b/router/core/router.go
@@ -1599,6 +1599,10 @@ func (r *Router) Start(ctx context.Context) error {
 		r.logger.Warn("Advanced Request Tracing (ART) is enabled in development mode but requires a graph token to work in production. For more information see https://cosmo-docs.wundergraph.com/router/advanced-request-tracing-art")
 	}
 
+	if r.engineExecutionConfiguration.EnableRequestTracing && r.engineExecutionConfiguration.ForceUnauthenticatedRequestTracing {
+		r.logger.Warn("Advanced Request Tracing (ART) is enabled for unauthenticated requests. This exposes internal subgraph URLs, request and response payloads, propagated headers, and query plans to any client that can reach the router. For more information see https://cosmo-docs.wundergraph.com/router/advanced-request-tracing-art")
+	}
+
 	if r.redisClient != nil {
 		r.logger.Info("Rate limiting enabled",
 			zap.Int("rate", r.rateLimit.SimpleStrategy.Rate),

--- a/router/core/router_config.go
+++ b/router/core/router_config.go
@@ -273,6 +273,7 @@ func (c *Config) Usage() map[string]any {
 
 	usage["engine_execution_configuration_enable_single_flight"] = c.engineExecutionConfiguration.EnableSingleFlight
 	usage["engine_execution_configuration_enable_request_tracing"] = c.engineExecutionConfiguration.EnableRequestTracing
+	usage["engine_execution_configuration_force_unauthenticated_request_tracing"] = c.engineExecutionConfiguration.ForceUnauthenticatedRequestTracing
 	usage["engine_execution_configuration_enable_net_poll"] = c.engineExecutionConfiguration.EnableNetPoll
 	usage["engine_execution_configuration_execution_plan_cache_size"] = c.engineExecutionConfiguration.ExecutionPlanCacheSize
 	usage["engine_execution_configuration_minify_subgraph_operations"] = c.engineExecutionConfiguration.MinifySubgraphOperations

--- a/router/core/router_test.go
+++ b/router/core/router_test.go
@@ -407,3 +407,4 @@ func TestNewTransportRequestOptions(t *testing.T) {
 	assert.Equal(t, defaults.MaxIdleConns, transportCfg.MaxIdleConns)
 	assert.Equal(t, defaults.MaxIdleConnsPerHost, transportCfg.MaxIdleConnsPerHost)
 }
+

--- a/router/core/router_test.go
+++ b/router/core/router_test.go
@@ -407,4 +407,3 @@ func TestNewTransportRequestOptions(t *testing.T) {
 	assert.Equal(t, defaults.MaxIdleConns, transportCfg.MaxIdleConns)
 	assert.Equal(t, defaults.MaxIdleConnsPerHost, transportCfg.MaxIdleConnsPerHost)
 }
-

--- a/router/pkg/config/config.go
+++ b/router/pkg/config/config.go
@@ -424,7 +424,11 @@ type EngineExecutionConfiguration struct {
 	EnableInboundRequestDeduplication bool `envDefault:"true" env:"ENGINE_ENABLE_INBOUND_REQUEST_DEDUPLICATION" yaml:"enable_inbound_request_deduplication"`
 	// ForceEnableInboundRequestDeduplication forces enable inbound request deduplication, even when PreOriginHandlers are configured
 	ForceEnableInboundRequestDeduplication bool `envDefault:"false" env:"ENGINE_FORCE_ENABLE_INBOUND_REQUEST_DEDUPLICATION" yaml:"force_enable_inbound_request_deduplication"`
-	EnableRequestTracing                   bool `envDefault:"true" env:"ENGINE_ENABLE_REQUEST_TRACING" yaml:"enable_request_tracing"`
+
+	EnableRequestTracing bool `envDefault:"true" env:"ENGINE_ENABLE_REQUEST_TRACING" yaml:"enable_request_tracing"`
+	// ForceUnauthenticatedRequestTracing always enables request tracing for unauthenticated requests,
+	// even when Development Mode is not enabled. USE WITH CAUTION.
+	ForceUnauthenticatedRequestTracing bool `envDefault:"false" env:"ENGINE_FORCE_UNAUTHENTICATED_REQUEST_TRACING" yaml:"force_unauthenticated_request_tracing"`
 
 	// Deprecated: EnableExecutionPlanCacheResponseHeader is deprecated, use EngineDebugConfiguration.EnableCacheResponseHeaders instead.
 	EnableExecutionPlanCacheResponseHeader bool `envDefault:"false" env:"ENGINE_ENABLE_EXECUTION_PLAN_CACHE_RESPONSE_HEADER" yaml:"enable_execution_plan_cache_response_header"`

--- a/router/pkg/config/config.schema.json
+++ b/router/pkg/config/config.schema.json
@@ -420,7 +420,7 @@
     "dev_mode": {
       "type": "boolean",
       "default": false,
-      "description": "Enable the development mode. The development mode is used to enable the development features like ART (Advanced Request Tracing) and pretty logs."
+      "description": "Enable the development mode. Development mode enables developer-focused behavior (such as pretty logs) and allows ART request options without request-token authentication."
     },
     "tls": {
       "type": "object",
@@ -3537,7 +3537,12 @@
         "enable_request_tracing": {
           "type": "boolean",
           "default": true,
-          "description": "Enable the advanced request tracing. See https://cosmo-docs.wundergraph.com/router/advanced-request-tracing-art for more information."
+          "description": "Capability gate for Advanced Request Tracing (ART). When false, ART is disabled regardless of headers, query parameters, or authentication."
+        },
+        "force_unauthenticated_request_tracing": {
+          "type": "boolean",
+          "default": false,
+          "description": "UNSAFE — DO NOT ENABLE IN PRODUCTION. Bypasses the authorization gate for Advanced Request Tracing (ART) when dev_mode is false. If false (default), ART request options require a valid WG request token. If true, ART request options are allowed without request-token authentication; this exposes internal subgraph URLs, request and response payloads, propagated headers (which may include auth tokens or API keys), and full query plans to any client that can reach the router. See https://cosmo-docs.wundergraph.com/router/advanced-request-tracing-art."
         },
         "enable_execution_plan_cache_response_header": {
           "type": "boolean",

--- a/router/pkg/config/config_test.go
+++ b/router/pkg/config/config_test.go
@@ -124,6 +124,59 @@ poll_interval: 11s
 	require.Equal(t, time.Second*11, cfg.Config.PollInterval)
 }
 
+func TestForceUnauthenticatedRequestTracingConfigLoading(t *testing.T) {
+	t.Run("defaults to false", func(t *testing.T) {
+		t.Parallel()
+
+		f := createTempFileFromFixture(t, `
+version: "1"
+
+graph:
+  token: "token"
+`)
+
+		cfg, err := LoadConfig([]string{f})
+		require.NoError(t, err)
+		require.False(t, cfg.Config.EngineExecutionConfiguration.ForceUnauthenticatedRequestTracing)
+	})
+
+	t.Run("can be enabled from yaml", func(t *testing.T) {
+		t.Parallel()
+
+		f := createTempFileFromFixture(t, `
+version: "1"
+
+graph:
+  token: "token"
+
+engine:
+  force_unauthenticated_request_tracing: true
+`)
+
+		cfg, err := LoadConfig([]string{f})
+		require.NoError(t, err)
+		require.True(t, cfg.Config.EngineExecutionConfiguration.ForceUnauthenticatedRequestTracing)
+	})
+
+	t.Run("yaml value takes precedence over env", func(t *testing.T) {
+		t.Setenv("ENGINE_FORCE_UNAUTHENTICATED_REQUEST_TRACING", "false")
+
+		f := createTempFileFromFixture(t, `
+version: "1"
+
+graph:
+  token: "token"
+
+engine:
+  force_unauthenticated_request_tracing: true
+`)
+
+		cfg, err := LoadConfig([]string{f})
+		require.NoError(t, err)
+		require.True(t, cfg.Config.EngineExecutionConfiguration.ForceUnauthenticatedRequestTracing)
+	})
+}
+
 // Confirms https://github.com/caarlos0/env/issues/354 is fixed
 func TestConfigSlicesHaveDefaults(t *testing.T) {
 	t.Parallel()

--- a/router/pkg/config/fixtures/full.yaml
+++ b/router/pkg/config/fixtures/full.yaml
@@ -372,6 +372,7 @@ events:
 engine:
   enable_single_flight: true
   enable_request_tracing: true
+  force_unauthenticated_request_tracing: true
   enable_execution_plan_cache_response_header: false
   max_concurrent_resolvers: 32
   enable_net_poll: true

--- a/router/pkg/config/fixtures/full.yaml
+++ b/router/pkg/config/fixtures/full.yaml
@@ -372,7 +372,7 @@ events:
 engine:
   enable_single_flight: true
   enable_request_tracing: true
-  force_unauthenticated_request_tracing: true
+  force_unauthenticated_request_tracing: false
   enable_execution_plan_cache_response_header: false
   max_concurrent_resolvers: 32
   enable_net_poll: true

--- a/router/pkg/config/testdata/config_defaults.json
+++ b/router/pkg/config/testdata/config_defaults.json
@@ -441,6 +441,7 @@
     "EnableInboundRequestDeduplication": true,
     "ForceEnableInboundRequestDeduplication": false,
     "EnableRequestTracing": true,
+    "ForceUnauthenticatedRequestTracing": false,
     "EnableExecutionPlanCacheResponseHeader": false,
     "MaxConcurrentResolvers": 1024,
     "EnableNetPoll": true,

--- a/router/pkg/config/testdata/config_full.json
+++ b/router/pkg/config/testdata/config_full.json
@@ -861,7 +861,7 @@
     "EnableInboundRequestDeduplication": true,
     "ForceEnableInboundRequestDeduplication": false,
     "EnableRequestTracing": true,
-    "ForceUnauthenticatedRequestTracing": true,
+    "ForceUnauthenticatedRequestTracing": false,
     "EnableExecutionPlanCacheResponseHeader": false,
     "MaxConcurrentResolvers": 32,
     "EnableNetPoll": true,

--- a/router/pkg/config/testdata/config_full.json
+++ b/router/pkg/config/testdata/config_full.json
@@ -861,6 +861,7 @@
     "EnableInboundRequestDeduplication": true,
     "ForceEnableInboundRequestDeduplication": false,
     "EnableRequestTracing": true,
+    "ForceUnauthenticatedRequestTracing": true,
     "EnableExecutionPlanCacheResponseHeader": false,
     "MaxConcurrentResolvers": 32,
     "EnableNetPoll": true,


### PR DESCRIPTION
This PR adds the `force_unauthenticated_request_tracing` feature flag.
The router can accept ART headers without a signed request token
and without `DEV_MODE`. 
This is controlled by `force_unauthenticated_request_tracing` 
(env `ENGINE_FORCE_UNAUTHENTICATED_REQUEST_TRACING`), 
by default it has `false` value.

Fixes #2555

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `force_unauthenticated_request_tracing` configuration option to enable Advanced Request Tracing capabilities for unauthenticated GraphQL requests in production environments (disabled by default; explicit enablement required).

* **Documentation**
  * Updated Advanced Request Tracing documentation with comprehensive details on the unauthenticated tracing pathway, security implications and warnings regarding sensitive data exposure, and configuration steps.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wundergraph/cosmo/pull/2858)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->