### PR TITLE
feat: fix recomposition bugs and optimise recompositions

### DIFF
--- a/controlplane/src/core/repositories/FeatureFlagRepository.ts
+++ b/controlplane/src/core/repositories/FeatureFlagRepository.ts
@@ -1020,6 +1020,8 @@ export class FeatureFlagRepository {
           uniqueLabels.map((l) => joinLabel(l)),
         ),
       );
+    } else {
+      conditions.push(eq(featureFlags.labels, []));
     }
 
     const matchingFeatureFlags = await this.db

--- a/controlplane/src/core/repositories/FeatureFlagRepository.ts
+++ b/controlplane/src/core/repositories/FeatureFlagRepository.ts
@@ -997,6 +997,67 @@ export class FeatureFlagRepository {
     return featureGraphsByFlag;
   }
 
+  public async getFeatureFlagsBySubgraphLabels({
+    namespaceId,
+    labels,
+    excludeDisabled,
+  }: {
+    namespaceId: string;
+    labels: Label[];
+    excludeDisabled: boolean;
+  }) {
+    const uniqueLabels = normalizeLabels(labels);
+
+    const conditions: SQL<unknown>[] = [];
+    if (excludeDisabled) {
+      conditions.push(eq(featureFlags.isEnabled, true));
+    }
+
+    if (uniqueLabels.length > 0) {
+      conditions.push(
+        arrayOverlaps(
+          featureFlags.labels,
+          uniqueLabels.map((l) => joinLabel(l)),
+        ),
+      );
+    }
+
+    const matchingFeatureFlags = await this.db
+      .select({
+        id: featureFlags.id,
+        name: featureFlags.name,
+      })
+      .from(featureFlags)
+      .where(
+        and(
+          eq(featureFlags.namespaceId, namespaceId),
+          eq(featureFlags.organizationId, this.organizationId),
+          ...conditions,
+        ),
+      )
+      .execute();
+
+    if (matchingFeatureFlags.length === 0) {
+      return [];
+    }
+
+    const result: FeatureFlagWithFeatureSubgraphs[] = [];
+    for (const featureFlag of matchingFeatureFlags) {
+      const featureSubgraphsByFlag = await this.getFeatureSubgraphsByFeatureFlagId({
+        featureFlagId: featureFlag.id,
+        namespaceId,
+      });
+
+      result.push({
+        id: featureFlag.id,
+        name: featureFlag.name,
+        featureSubgraphs: featureSubgraphsByFlag.filter((fsg) => fsg.schemaVersionId !== ''),
+      });
+    }
+
+    return result;
+  }
+
   // evaluates all the feature flags which have fgs whose base subgraph id and fed graph label matchers are passed as input and returns the feature flags that should be composed
   public async getFeatureFlagsByBaseSubgraphIdAndLabelMatchers({
     baseSubgraphId,

--- a/controlplane/src/core/repositories/SubgraphRepository.ts
+++ b/controlplane/src/core/repositories/SubgraphRepository.ts
@@ -80,6 +80,7 @@ import { SchemaCheckRepository } from './SchemaCheckRepository.js';
 import { SchemaGraphPruningRepository } from './SchemaGraphPruningRepository.js';
 import { SchemaLintRepository } from './SchemaLintRepository.js';
 import { TargetRepository } from './TargetRepository.js';
+import { OrganizationRepository } from './OrganizationRepository.js';
 
 type SubscriptionProtocol = 'ws' | 'sse' | 'sse_post';
 
@@ -259,7 +260,8 @@ export class SubgraphRepository {
 
     // The collection of federated graphs that will be potentially re-composed
     const updatedFederatedGraphs: FederatedGraphDTO[] = [];
-    const updatedFeatureFlagIds = new Set<string>();
+    const updatedFederatedGraphsById = new Map<string, FederatedGraphDTO>();
+    const affectedFeatureFlagIds = new Set<string>();
     let subgraphChanged = false;
     let labelChanged = false;
 
@@ -268,6 +270,12 @@ export class SubgraphRepository {
       const subgraphRepo = new SubgraphRepository(this.logger, tx, this.organizationId);
       const targetRepo = new TargetRepository(tx, this.organizationId);
       const featureFlagRepo = new FeatureFlagRepository(this.logger, tx, this.organizationId);
+      const orgRepo = new OrganizationRepository(this.logger, tx);
+
+      const splitConfigFeature = await orgRepo.getFeature({
+        organizationId: this.organizationId,
+        featureId: 'split-config-loading',
+      });
 
       const subgraph = await subgraphRepo.byTargetId(data.targetId);
       if (!subgraph) {
@@ -275,7 +283,7 @@ export class SubgraphRepository {
           deploymentErrors: [],
           compositionErrors: [],
           compositionWarnings: [],
-          updatedFederatedGraphs,
+          updatedFederatedGraphs: [],
           subgraphChanged: false,
         };
       }
@@ -334,33 +342,53 @@ export class SubgraphRepository {
           .execute();
       }
 
-      if (data.labels && data.labels.length > 0) {
-        labelChanged = hasLabelsChanged(subgraph.labels, data.labels);
+      // update the readme of the subgraph
+      if (data.readme !== undefined) {
+        await targetRepo.updateReadmeOfTarget({ id: data.targetId, readme: data.readme });
       }
 
-      if (labelChanged || data.unsetLabels) {
-        const newLabels = data.unsetLabels ? [] : normalizeLabels(data.labels);
+      // Feature subgraph can't change labels
+      if (!subgraph.isFeatureSubgraph) {
+        if (data.labels && data.labels.length > 0) {
+          labelChanged = hasLabelsChanged(subgraph.labels, data.labels);
+        }
 
-        // update labels of the subgraph
-        await tx
-          .update(targets)
-          .set({
-            // labels are stored as a string array in the database
-            labels: newLabels.map((ul) => joinLabel(ul)),
-          })
-          .where(eq(targets.id, subgraph.targetId));
+        if (labelChanged || data.unsetLabels) {
+          labelChanged = true;
+          const newLabels = data.unsetLabels ? [] : normalizeLabels(data.labels);
 
-        if (!subgraph.isFeatureSubgraph) {
+          // update labels of the subgraph
+          await tx
+            .update(targets)
+            .set({
+              // labels are stored as a string array in the database
+              labels: newLabels.map((ul) => joinLabel(ul)),
+            })
+            .where(eq(targets.id, subgraph.targetId));
+
           // find all federated graphs that match with the new subgraph labels
           const newFederatedGraphs = await fedGraphRepo.bySubgraphLabels({
             labels: newLabels,
             namespaceId: data.namespaceId,
           });
 
+          const newFeatureFlags = await featureFlagRepo.getFeatureFlagsBySubgraphLabels({
+            namespaceId: data.namespaceId,
+            labels: newLabels,
+            excludeDisabled: false,
+          });
+
           // add them to the updatedFederatedGraphs array without duplicates
           for (const federatedGraph of newFederatedGraphs) {
-            if (!updatedFederatedGraphs.some((g) => g.id === federatedGraph.id)) {
-              updatedFederatedGraphs.push(federatedGraph);
+            if (!federatedGraph.contract) {
+              updatedFederatedGraphsById.set(federatedGraph.id, federatedGraph);
+            }
+          }
+
+          // add the feature flags to the updatedFeatureFlagIds set without duplicates
+          for (const featureFlag of newFeatureFlags) {
+            if (featureFlag.featureSubgraphs.every((fsg) => fsg.baseSubgraphId !== subgraph.id)) {
+              affectedFeatureFlagIds.add(featureFlag.id);
             }
           }
 
@@ -396,7 +424,17 @@ export class SubgraphRepository {
         }
       }
 
-      const updatedFeatureFlags: FeatureFlagDTO[] = [];
+      // If the labels haven't changed and the subgraph hasn't changed, there should be nothing to do
+      if (!subgraphChanged && !labelChanged) {
+        return {
+          deploymentErrors: [],
+          compositionErrors: [],
+          compositionWarnings: [],
+          updatedFederatedGraphs: [],
+          subgraphChanged: false,
+        };
+      }
+
       if (subgraph.isFeatureSubgraph) {
         // the fed graphs to be composed are to be fetched by using the base subgraph
         const baseSubgraph = await tx
@@ -432,20 +470,18 @@ export class SubgraphRepository {
             });
 
             // If an enabled feature flag includes the feature graph that has just been published, push it to the array
-            if (enabledFeatureFlags.length > 0) {
-              if (!updatedFederatedGraphs.some((g) => g.id === federatedGraphDTO.id)) {
-                updatedFederatedGraphs.push(federatedGraphDTO);
-              }
+            if (enabledFeatureFlags.length > 0 && !splitConfigFeature?.enabled) {
+              updatedFederatedGraphsById.set(federatedGraphDTO.id, federatedGraphDTO);
+            }
 
-              for (const featureFlag of enabledFeatureFlags) {
-                updatedFeatureFlagIds.add(featureFlag.id);
-              }
+            for (const featureFlag of enabledFeatureFlags) {
+              affectedFeatureFlagIds.add(featureFlag.id);
             }
           }
         }
         // Generate a new router config for non-feature graphs upon routing/subscription urls and labels changes
-      } else if (subgraphChanged || labelChanged) {
-        // find all federated graphs that use this subgraph (with old labels). We need evaluate them again.
+      } else {
+        // find all federated graphs that use this subgraph (with old labels). We need to evaluate them again.
         // When labels change, graphs which matched with old labels may no longer match with new ones
         const affectedGraphs = await fedGraphRepo.bySubgraphLabels({
           labels: subgraph.labels,
@@ -453,8 +489,15 @@ export class SubgraphRepository {
         });
 
         for (const graph of affectedGraphs) {
-          if (!updatedFederatedGraphs.some((g) => g.id === graph.id)) {
-            updatedFederatedGraphs.push(graph);
+          if (graph.contract) {
+            continue;
+          }
+
+          // If the subgraph has changed, always trigger composition
+          if (updatedFederatedGraphsById.has(graph.id) && !subgraphChanged) {
+            updatedFederatedGraphsById.delete(graph.id);
+          } else {
+            updatedFederatedGraphsById.set(graph.id, graph);
           }
         }
 
@@ -466,23 +509,19 @@ export class SubgraphRepository {
 
         for (const featureFlag of featureFlags) {
           if (featureFlag.featureSubgraphs.every((fsg) => fsg.baseSubgraphId !== subgraph.id)) {
-            updatedFeatureFlagIds.add(featureFlag.id);
+            if (affectedFeatureFlagIds.has(featureFlag.id) && !subgraphChanged) {
+              affectedFeatureFlagIds.delete(featureFlag.id);
+            } else {
+              affectedFeatureFlagIds.add(featureFlag.id);
+            }
           }
         }
       }
 
-      // update the readme of the subgraph
-      if (data.readme !== undefined) {
-        await targetRepo.updateReadmeOfTarget({ id: data.targetId, readme: data.readme });
-      }
-
-      if (updatedFederatedGraphs.length === 0 && updatedFeatureFlagIds.size === 0) {
-        return;
-      }
-
-      if (updatedFeatureFlagIds.size > 0) {
+      const affectedFeatureFlags: FeatureFlagDTO[] = [];
+      if (affectedFeatureFlagIds.size > 0) {
         const featureFlagRepo = new FeatureFlagRepository(this.logger, tx, this.organizationId);
-        for (const featureFlagId of updatedFeatureFlagIds) {
+        for (const featureFlagId of affectedFeatureFlagIds) {
           const featureFlag = await featureFlagRepo.getFeatureFlagById({
             namespaceId: data.namespaceId,
             featureFlagId,
@@ -492,14 +531,25 @@ export class SubgraphRepository {
             throw new Error(`Feature flag with ID ${featureFlagId} not found in namespace ${data.namespaceId}`);
           }
 
-          updatedFeatureFlags.push(featureFlag);
+          affectedFeatureFlags.push(featureFlag);
         }
       }
 
+      if (updatedFederatedGraphsById.size === 0 && affectedFeatureFlags.length === 0) {
+        return {
+          deploymentErrors: [],
+          compositionErrors: [],
+          compositionWarnings: [],
+          updatedFederatedGraphs: [],
+          subgraphChanged: false,
+        };
+      }
+
+      updatedFederatedGraphs.push(...updatedFederatedGraphsById.values());
       const result = await compositionService.recomposeAndDeployAffected({
         actorId: data.updatedBy,
-        affectedFederatedGraphs: updatedFederatedGraphs.filter((graph) => !graph.contract),
-        affectedFeatureFlags: updatedFeatureFlags,
+        affectedFederatedGraphs: [...updatedFederatedGraphsById.values()],
+        affectedFeatureFlags,
         isFeatureSubgraph: subgraph.isFeatureSubgraph,
       });
 
@@ -508,7 +558,7 @@ export class SubgraphRepository {
       compositionWarnings.push(...result.compositionWarnings);
 
       // Re-fetch the federated graphs to get the updated composedSchemaVersionId
-      const refreshedGraphs = await Promise.all(updatedFederatedGraphs.map((g) => fedGraphRepo.byId(g.id)));
+      const refreshedGraphs = await Promise.all(updatedFederatedGraphsById.keys().map((id) => fedGraphRepo.byId(id)));
       for (let i = 0; i < updatedFederatedGraphs.length; i++) {
         const refreshedGraph = refreshedGraphs[i];
         if (refreshedGraph) {

--- a/controlplane/src/core/repositories/SubgraphRepository.ts
+++ b/controlplane/src/core/repositories/SubgraphRepository.ts
@@ -260,7 +260,17 @@ export class SubgraphRepository {
 
     // The collection of federated graphs that will be potentially re-composed
     const updatedFederatedGraphs: FederatedGraphDTO[] = [];
-    const updatedFederatedGraphsById = new Map<string, FederatedGraphDTO>();
+    /**
+     * If only the labels of the subgraph are changed, federated graphs that match both the new and the old labels
+     * need not be recomposed.
+     * This map allows the tracking of those graphs to prevent unnecessary recompositions.
+     */
+    const affectedFederatedGraphById = new Map<string, FederatedGraphDTO>();
+    /**
+     * If only the labels of the subgraph are changed, feature flags that match both the new and the old labels
+     * need not be recomposed.
+     * This set allows the tracking of those flags to prevent unnecessary recompositions.
+     */
     const affectedFeatureFlagIds = new Set<string>();
     let subgraphChanged = false;
     let labelChanged = false;
@@ -372,20 +382,20 @@ export class SubgraphRepository {
             namespaceId: data.namespaceId,
           });
 
+          // Add federated graphs (not contracts) that match the _new_ labels to `updatedFederatedGraphsById`
+          for (const federatedGraph of newFederatedGraphs) {
+            if (!federatedGraph.contract) {
+              affectedFederatedGraphById.set(federatedGraph.id, federatedGraph);
+            }
+          }
+
           const newFeatureFlags = await featureFlagRepo.getFeatureFlagsBySubgraphLabels({
             namespaceId: data.namespaceId,
             labels: newLabels,
             excludeDisabled: false,
           });
 
-          // add them to the updatedFederatedGraphs array without duplicates
-          for (const federatedGraph of newFederatedGraphs) {
-            if (!federatedGraph.contract) {
-              updatedFederatedGraphsById.set(federatedGraph.id, federatedGraph);
-            }
-          }
-
-          // add the feature flags to the updatedFeatureFlagIds set without duplicates
+          // Add feature flags that match the _new_ labels to `updatedFederatedGraphsById`
           for (const featureFlag of newFeatureFlags) {
             if (featureFlag.featureSubgraphs.every((fsg) => fsg.baseSubgraphId !== subgraph.id)) {
               affectedFeatureFlagIds.add(featureFlag.id);
@@ -424,7 +434,7 @@ export class SubgraphRepository {
         }
       }
 
-      // If the labels haven't changed and the subgraph hasn't changed, there should be nothing to do
+      // If the labels haven't changed and the subgraph hasn't changed, there should be nothing further to do
       if (!subgraphChanged && !labelChanged) {
         return {
           deploymentErrors: [],
@@ -471,7 +481,7 @@ export class SubgraphRepository {
 
             // If an enabled feature flag includes the feature graph that has just been published, push it to the array
             if (enabledFeatureFlags.length > 0 && !splitConfigFeature?.enabled) {
-              updatedFederatedGraphsById.set(federatedGraphDTO.id, federatedGraphDTO);
+              affectedFederatedGraphById.set(federatedGraphDTO.id, federatedGraphDTO);
             }
 
             for (const featureFlag of enabledFeatureFlags) {
@@ -481,8 +491,9 @@ export class SubgraphRepository {
         }
         // Generate a new router config for non-feature graphs upon routing/subscription urls and labels changes
       } else {
-        // find all federated graphs that use this subgraph (with old labels). We need to evaluate them again.
-        // When labels change, graphs which matched with old labels may no longer match with new ones
+        /** Find all federated graphs that use the subgraph's old labels; we need to recompose them.
+         * When labels change, graphs that matched with old labels may no longer match with new ones.
+         */
         const affectedGraphs = await fedGraphRepo.bySubgraphLabels({
           labels: subgraph.labels,
           namespaceId: data.namespaceId,
@@ -494,10 +505,13 @@ export class SubgraphRepository {
           }
 
           // If the subgraph has changed, always trigger composition
-          if (updatedFederatedGraphsById.has(graph.id) && !subgraphChanged) {
-            updatedFederatedGraphsById.delete(graph.id);
+          if (affectedFederatedGraphById.has(graph.id) && !subgraphChanged) {
+            /** If the federated graph matches the old labels AND the new labels,
+             * delete the entry because it need not be recomposed.
+             */
+            affectedFederatedGraphById.delete(graph.id);
           } else {
-            updatedFederatedGraphsById.set(graph.id, graph);
+            affectedFederatedGraphById.set(graph.id, graph);
           }
         }
 
@@ -509,7 +523,11 @@ export class SubgraphRepository {
 
         for (const featureFlag of featureFlags) {
           if (featureFlag.featureSubgraphs.every((fsg) => fsg.baseSubgraphId !== subgraph.id)) {
+            // Always trigger composition if a relevant subgraph has changed.
             if (affectedFeatureFlagIds.has(featureFlag.id) && !subgraphChanged) {
+              /** If the feature flag matches the old labels AND the new labels, delete the entry because it
+               * need not be recomposed.
+               */
               affectedFeatureFlagIds.delete(featureFlag.id);
             } else {
               affectedFeatureFlagIds.add(featureFlag.id);
@@ -535,7 +553,7 @@ export class SubgraphRepository {
         }
       }
 
-      if (updatedFederatedGraphsById.size === 0 && affectedFeatureFlags.length === 0) {
+      if (affectedFederatedGraphById.size === 0 && affectedFeatureFlags.length === 0) {
         return {
           deploymentErrors: [],
           compositionErrors: [],
@@ -545,10 +563,10 @@ export class SubgraphRepository {
         };
       }
 
-      updatedFederatedGraphs.push(...updatedFederatedGraphsById.values());
+      updatedFederatedGraphs.push(...affectedFederatedGraphById.values());
       const result = await compositionService.recomposeAndDeployAffected({
         actorId: data.updatedBy,
-        affectedFederatedGraphs: [...updatedFederatedGraphsById.values()],
+        affectedFederatedGraphs: [...affectedFederatedGraphById.values()],
         affectedFeatureFlags,
         isFeatureSubgraph: subgraph.isFeatureSubgraph,
       });
@@ -558,7 +576,7 @@ export class SubgraphRepository {
       compositionWarnings.push(...result.compositionWarnings);
 
       // Re-fetch the federated graphs to get the updated composedSchemaVersionId
-      const refreshedGraphs = await Promise.all(updatedFederatedGraphsById.keys().map((id) => fedGraphRepo.byId(id)));
+      const refreshedGraphs = await Promise.all(affectedFederatedGraphById.keys().map((id) => fedGraphRepo.byId(id)));
       for (let i = 0; i < updatedFederatedGraphs.length; i++) {
         const refreshedGraph = refreshedGraphs[i];
         if (refreshedGraph) {

--- a/controlplane/src/core/repositories/SubgraphRepository.ts
+++ b/controlplane/src/core/repositories/SubgraphRepository.ts
@@ -375,7 +375,7 @@ export class SubgraphRepository {
           const newFeatureFlags = await featureFlagRepo.getFeatureFlagsBySubgraphLabels({
             namespaceId: data.namespaceId,
             labels: newLabels,
-            excludeDisabled: false,
+            excludeDisabled: true,
           });
 
           // add them to the updatedFederatedGraphs array without duplicates

--- a/controlplane/src/core/repositories/SubgraphRepository.ts
+++ b/controlplane/src/core/repositories/SubgraphRepository.ts
@@ -396,6 +396,7 @@ export class SubgraphRepository {
         }
       }
 
+      const updatedFeatureFlags: FeatureFlagDTO[] = [];
       if (subgraph.isFeatureSubgraph) {
         // the fed graphs to be composed are to be fetched by using the base subgraph
         const baseSubgraph = await tx
@@ -456,6 +457,18 @@ export class SubgraphRepository {
             updatedFederatedGraphs.push(graph);
           }
         }
+
+        const featureFlags = await featureFlagRepo.getFeatureFlagsBySubgraphLabels({
+          namespaceId: data.namespaceId,
+          labels: subgraph.labels,
+          excludeDisabled: true,
+        });
+
+        for (const featureFlag of featureFlags) {
+          if (featureFlag.featureSubgraphs.every((fsg) => fsg.baseSubgraphId !== subgraph.id)) {
+            updatedFeatureFlagIds.add(featureFlag.id);
+          }
+        }
       }
 
       // update the readme of the subgraph
@@ -467,7 +480,6 @@ export class SubgraphRepository {
         return;
       }
 
-      const updatedFeatureFlags: FeatureFlagDTO[] = [];
       if (updatedFeatureFlagIds.size > 0) {
         const featureFlagRepo = new FeatureFlagRepository(this.logger, tx, this.organizationId);
         for (const featureFlagId of updatedFeatureFlagIds) {

--- a/controlplane/test/feature-flag/feature-flag-integration.test.ts
+++ b/controlplane/test/feature-flag/feature-flag-integration.test.ts
@@ -31,7 +31,7 @@ import { ClickHouseClient } from '../../src/core/clickhouse/index.js';
 import { graphCompositions } from '../../src/db/schema.js';
 
 // Change to true to enable a longer timeout
-const isDebugMode = true;
+const isDebugMode = false;
 let dbname = '';
 
 vi.mock('../src/core/clickhouse/index.js', () => {
@@ -1514,7 +1514,7 @@ describe('Feature flag integration tests', () => {
         const ffKey = blobStorage.keys().at(-1);
         expect(ffKey).toContain(`${federatedGraphResponse.graph!.id}/manifest/feature-flags/${featureFlagName}.json`);
 
-        // The base recomposition and the feature flag composition
+        // The base composition and the feature flag composition
         await assertNumberOfCompositions(client, baseGraphName, 2);
 
         await assertFeatureFlagExecutionConfig(blobStorage, key, false);
@@ -1522,12 +1522,12 @@ describe('Feature flag integration tests', () => {
 
         expect(blobStorage.keys()).toHaveLength(2);
 
-        // Another base recomposition to remove the feature flag
+        // The feature flag is removed without further compositions
         await assertNumberOfCompositions(client, baseGraphName, 2);
         await assertFeatureFlagExecutionConfig(blobStorage, key, false);
         await toggleFeatureFlag(client, featureFlagName, true);
 
-        // Another base recomposition and the feature flag composition
+        // The feature flag is composed again
         await assertNumberOfCompositions(client, baseGraphName, 3);
         await assertFeatureFlagExecutionConfig(blobStorage, key, false);
 
@@ -1587,19 +1587,19 @@ describe('Feature flag integration tests', () => {
         const ffKey = blobStorage.keys().at(-1);
         expect(ffKey).toContain(`${federatedGraphResponse.graph!.id}/manifest/feature-flags/${featureFlagName}.json`);
 
-        // The base recomposition and the feature flag composition
+        // The base composition and the feature flag composition
         await assertNumberOfCompositions(client, baseGraphName, 2, namespace);
         await assertFeatureFlagExecutionConfig(blobStorage, key, false);
         await toggleFeatureFlag(client, featureFlagName, false, namespace);
 
         expect(blobStorage.keys()).toHaveLength(2);
 
-        // Another base recomposition to remove the feature flag
+        // The feature flag is removed without further compositions
         await assertNumberOfCompositions(client, baseGraphName, 2, namespace);
         await assertFeatureFlagExecutionConfig(blobStorage, key, false);
         await toggleFeatureFlag(client, featureFlagName, true, namespace);
 
-        // Another base recomposition and the feature flag composition
+        // The feature flag is composed again
         await assertNumberOfCompositions(client, baseGraphName, 3, namespace);
         await assertFeatureFlagExecutionConfig(blobStorage, key, false);
 
@@ -1661,7 +1661,7 @@ describe('Feature flag integration tests', () => {
         const ffKey = blobStorage.keys().at(-1);
         expect(ffKey).toContain(`${federatedGraphResponse.graph!.id}/manifest/feature-flags/${featureFlagName}.json`);
 
-        // The feature flag is disabled again and trigger a base recomposition
+        // The feature flag is disabled again but the base is not recomposed
         await toggleFeatureFlag(client, featureFlagName, false, namespace);
         await assertNumberOfCompositions(client, baseGraphName, 2, namespace);
         await assertFeatureFlagExecutionConfig(blobStorage, key, false);
@@ -1913,7 +1913,7 @@ describe('Feature flag integration tests', () => {
     );
 
     test(
-      'that a feature flag can compose when base federated graph fails',
+      'that a feature flag can compose even if the base federated graph fails',
       getDebugTestOptions(isDebugMode),
       async (testContext) => {
         const { client, server, blobStorage } = await SetupTest({
@@ -1991,7 +1991,7 @@ describe('Feature flag integration tests', () => {
     );
 
     test(
-      'that a feature flag that is enabled upon creation can be deleted with contracts (namespace without labels)',
+      'that a feature flag that is enabled upon creation can be deleted despite contracts (namespace without labels)',
       getDebugTestOptions(isDebugMode),
       async (testContext) => {
         const { client, server, blobStorage } = await SetupTest({
@@ -2103,7 +2103,7 @@ describe('Feature flag integration tests', () => {
     );
 
     test(
-      'that publishing a change to a subgraph produces new compositions for the base graph and contracts that also have feature flags',
+      'that publishing a change to a base subgraph produces new compositions for the base graph and contracts (but not for the feature flag itself)',
       getDebugTestOptions(isDebugMode),
       async (testContext) => {
         const { client, server, blobStorage } = await SetupTest({
@@ -2168,7 +2168,7 @@ describe('Feature flag integration tests', () => {
           { name: contractName, key: contractKey },
         ];
 
-        // Both graphs should still be at a single composition with feature flag config
+        // Both graphs should still be at a single composition
         for (const { name, key } of graphNamesAndKeys) {
           await assertNumberOfCompositions(client, name, 1, namespace);
           await assertFeatureFlagExecutionConfig(blobStorage, key, false);
@@ -2193,7 +2193,7 @@ describe('Feature flag integration tests', () => {
           ]),
         );
 
-        // There should be a base recomposition, a feature flag composition, and an embedded feature flag config
+        // There should be a new feature flag composition
         for (const { name, key } of graphNamesAndKeys) {
           await assertNumberOfCompositions(client, name, 2, namespace);
           await assertFeatureFlagExecutionConfig(blobStorage, key, false);
@@ -2206,7 +2206,7 @@ describe('Feature flag integration tests', () => {
         });
         expect(publishResponse.response?.code).toBe(EnumStatusCode.OK);
 
-        // There should be a base recomposition, feature flag composition, and the embedded feature flag config should remain
+        // There should be a base recomposition but no feature flag recomposition (users is overridden)
         for (const { name, key } of graphNamesAndKeys) {
           await assertNumberOfCompositions(client, name, 3, namespace);
           await assertFeatureFlagExecutionConfig(blobStorage, key, false);
@@ -2541,7 +2541,7 @@ describe('Feature flag integration tests', () => {
     );
 
     test(
-      'that feature subgraph publish recomposes the feature flag',
+      'that `feature subgraph publish` recomposes the feature flag',
       getDebugTestOptions(isDebugMode),
       async (testContext) => {
         const { client, server, blobStorage } = await SetupTest({
@@ -2802,7 +2802,7 @@ describe('Feature flag integration tests', () => {
     );
 
     test(
-      'that a feature flag whose labels are updated recompose the correct federated graphs successfully',
+      'that a feature flag whose labels are updated recomposes the feature flag successfully',
       getDebugTestOptions(isDebugMode),
       async (testContext) => {
         const { client, server, blobStorage } = await SetupTest({
@@ -2882,7 +2882,7 @@ describe('Feature flag integration tests', () => {
           ]),
         );
 
-        // The base recomposition of graph one and the feature flag composition
+        // The base composition of graph one and the new feature flag composition
         await assertNumberOfCompositions(client, baseGraphNameOne, 2, namespace);
         await assertFeatureFlagExecutionConfig(blobStorage, federatedGraphKeyOne, false);
 
@@ -2897,11 +2897,11 @@ describe('Feature flag integration tests', () => {
         });
         expect(updateFeatureFlagResponse.response?.code).toBe(EnumStatusCode.OK);
 
-        // The base recomposition of graph one
+        // The base composition of graph one and the feature flag composition (no changes)
         await assertNumberOfCompositions(client, baseGraphNameOne, 2, namespace);
         await assertFeatureFlagExecutionConfig(blobStorage, federatedGraphKeyOne, false);
 
-        // The feature flag composition
+        // The base composition of graph two and the new feature flag composition
         await assertNumberOfCompositions(client, baseGraphNameTwo, 2, namespace);
         await assertFeatureFlagExecutionConfig(blobStorage, federatedGraphKeyTwo, false);
 

--- a/controlplane/test/feature-flag/feature-flag-integration.test.ts
+++ b/controlplane/test/feature-flag/feature-flag-integration.test.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import { join } from 'node:path';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 import { EnumStatusCode } from '@wundergraph/cosmo-connect/dist/common/common_pb';
+import { eq } from 'drizzle-orm';
 import { afterAllSetup, beforeAllSetup, genID } from '../../src/core/test-util.js';
 import { Label } from '../../src/types/index.js';
 import { unsuccessfulBaseCompositionError } from '../../src/core/errors/errors.js';
@@ -14,6 +15,10 @@ import {
   createFederatedGraph,
   createNamespace,
   createThenPublishFeatureSubgraph,
+  DEFAULT_NAMESPACE,
+  DEFAULT_ROUTER_URL,
+  DEFAULT_SUBGRAPH_URL_ONE,
+  DEFAULT_SUBGRAPH_URL_THREE,
   DEFAULT_SUBGRAPH_URL_TWO,
   deleteFeatureFlag,
   featureFlagIntegrationTestSetUp,
@@ -23,9 +28,10 @@ import {
   toggleFeatureFlag,
 } from '../test-util.js';
 import { ClickHouseClient } from '../../src/core/clickhouse/index.js';
+import { graphCompositions } from '../../src/db/schema.js';
 
 // Change to true to enable a longer timeout
-const isDebugMode = false;
+const isDebugMode = true;
 let dbname = '';
 
 vi.mock('../src/core/clickhouse/index.js', () => {
@@ -2912,6 +2918,321 @@ describe('Feature flag integration tests', () => {
             ),
           ]),
         );
+      },
+    );
+
+    test(
+      'that a feature flag is not recomposed if the base subgraph of a feature subgraph is published or updated',
+      getDebugTestOptions(isDebugMode),
+      async (testContext) => {
+        const { client, server, blobStorage } = await SetupTest({
+          dbname,
+          chClient,
+          enabledFeatures: ['split-config-loading'],
+        });
+        testContext.onTestFinished(() => server.close());
+
+        const namespace = genID('namespace').toLowerCase();
+        await createNamespace(client, namespace);
+
+        const labels = [{ key: 'team', value: 'A' }];
+        const baseGraphName = genID('baseFederatedGraphName');
+        const federatedGraphResponse = await featureFlagIntegrationTestSetUp(
+          client,
+          [
+            { name: 'users', hasFeatureSubgraph: false },
+            { name: 'products', hasFeatureSubgraph: true },
+          ],
+          baseGraphName,
+          labels,
+          namespace,
+        );
+
+        expect(blobStorage.keys()).toHaveLength(2);
+        const key = blobStorage.keys()[0];
+        const mapperKey = blobStorage.keys()[1];
+        expect(key).toContain(`${federatedGraphResponse.graph!.id}/manifest/latest.json`);
+        expect(mapperKey).toContain(`${federatedGraphResponse.graph!.id}/manifest/mapper.json`);
+
+        await assertFeatureFlagExecutionConfig(blobStorage, key, false);
+
+        // The base composition
+        await assertNumberOfCompositions(client, baseGraphName, 1, namespace);
+
+        const featureFlagName = genID('flag');
+        await createFeatureFlag(client, featureFlagName, labels, ['products-feature'], namespace, true);
+
+        expect(blobStorage.keys()).toHaveLength(3);
+        const ffKey = blobStorage.keys().at(-1);
+        expect(ffKey).toContain(`${federatedGraphResponse.graph!.id}/manifest/feature-flags/${featureFlagName}.json`);
+
+        // The base composition and the feature flag composition
+        await assertNumberOfCompositions(client, baseGraphName, 2, namespace);
+
+        await assertFeatureFlagExecutionConfig(blobStorage, key, false);
+
+        expect(blobStorage.keys()).toHaveLength(3);
+
+        const updateResp = await client.updateSubgraph({
+          name: 'products',
+          namespace,
+          routingUrl: 'http://example.com',
+        });
+
+        expect(updateResp.response?.code).toBe(EnumStatusCode.OK);
+        await assertNumberOfCompositions(client, baseGraphName, 3, namespace);
+
+        const publishResp = await client.publishFederatedSubgraph({
+          name: 'products',
+          namespace,
+          schema: fs
+            .readFileSync(join(process.cwd(), `test/test-data/feature-flags/products-update.graphql`))
+            .toString(),
+        });
+
+        expect(publishResp.response?.code).toBe(EnumStatusCode.OK);
+
+        // Another base recomposition
+        await assertNumberOfCompositions(client, baseGraphName, 4, namespace);
+        await assertFeatureFlagExecutionConfig(blobStorage, key, false);
+
+        expect(blobStorage.keys()).toHaveLength(3);
+      },
+    );
+
+    test(
+      'that a feature flag is recomposed if a mutual subgraph is published or updated',
+      getDebugTestOptions(isDebugMode),
+      async (testContext) => {
+        const { client, server, blobStorage } = await SetupTest({
+          dbname,
+          chClient,
+          enabledFeatures: ['split-config-loading'],
+        });
+        testContext.onTestFinished(() => server.close());
+
+        const namespace = genID('namespace').toLowerCase();
+        await createNamespace(client, namespace);
+
+        const labels = [{ key: 'team', value: 'A' }];
+        const baseGraphName = genID('baseFederatedGraphName');
+        const federatedGraphResponse = await featureFlagIntegrationTestSetUp(
+          client,
+          [
+            { name: 'users', hasFeatureSubgraph: false },
+            { name: 'products', hasFeatureSubgraph: true },
+          ],
+          baseGraphName,
+          labels,
+          namespace,
+        );
+
+        expect(blobStorage.keys()).toHaveLength(2);
+        const key = blobStorage.keys()[0];
+        const mapperKey = blobStorage.keys()[1];
+        expect(key).toContain(`${federatedGraphResponse.graph!.id}/manifest/latest.json`);
+        expect(mapperKey).toContain(`${federatedGraphResponse.graph!.id}/manifest/mapper.json`);
+
+        await assertFeatureFlagExecutionConfig(blobStorage, key, false);
+
+        // The base composition
+        await assertNumberOfCompositions(client, baseGraphName, 1, namespace);
+
+        const featureFlagName = genID('flag');
+        await createFeatureFlag(client, featureFlagName, labels, ['products-feature'], namespace, true);
+
+        expect(blobStorage.keys()).toHaveLength(3);
+        const ffKey = blobStorage.keys().at(-1);
+        expect(ffKey).toContain(`${federatedGraphResponse.graph!.id}/manifest/feature-flags/${featureFlagName}.json`);
+
+        // The base composition and the feature flag composition
+        await assertNumberOfCompositions(client, baseGraphName, 2, namespace);
+
+        await assertFeatureFlagExecutionConfig(blobStorage, key, false);
+
+        expect(blobStorage.keys()).toHaveLength(3);
+
+        const updateResp = await client.updateSubgraph({
+          name: 'users',
+          namespace,
+          routingUrl: 'http://example.com',
+        });
+
+        expect(updateResp.response?.code).toBe(EnumStatusCode.OK);
+        await assertNumberOfCompositions(client, baseGraphName, 4, namespace);
+
+        const publishResp = await client.publishFederatedSubgraph({
+          name: 'users',
+          namespace,
+          schema: fs.readFileSync(join(process.cwd(), `test/test-data/feature-flags/users-update.graphql`)).toString(),
+        });
+
+        expect(publishResp.response?.code).toBe(EnumStatusCode.OK);
+
+        // Another base recomposition
+        await assertNumberOfCompositions(client, baseGraphName, 6, namespace);
+        await assertFeatureFlagExecutionConfig(blobStorage, key, false);
+
+        expect(blobStorage.keys()).toHaveLength(3);
+      },
+    );
+
+    // TODO: We need to decide what to do with orphaned feature flags
+    test.todo(
+      'that a feature flag need not share any mutual subgraphs',
+      getDebugTestOptions(isDebugMode),
+      async (testContext) => {
+        const { client, server, blobStorage } = await SetupTest({
+          dbname,
+          chClient,
+          enabledFeatures: ['split-config-loading'],
+        });
+        testContext.onTestFinished(() => server.close());
+
+        const namespace = genID('namespace').toLowerCase();
+        await createNamespace(client, namespace);
+
+        const labelMatcher = [
+          { key: 'team', value: 'A' },
+          { key: 'team', value: 'C' },
+        ];
+        const labels1 = [{ key: 'team', value: 'A' }];
+        const labels2 = [{ key: 'team', value: 'B' }];
+        const products = genID('products');
+        const users = genID('users');
+        const usersFeature = `${users}-feature`;
+        const baseGraphName = genID('baseFederatedGraphName');
+        const featureFlagName = genID('flag');
+
+        await createAndPublishSubgraph(
+          client,
+          products,
+          namespace,
+          fs.readFileSync(join(process.cwd(), `test/test-data/feature-flags/products-standalone.graphql`)).toString(),
+          labels1,
+          DEFAULT_SUBGRAPH_URL_ONE,
+        );
+
+        await createAndPublishSubgraph(
+          client,
+          users,
+          namespace,
+          fs.readFileSync(join(process.cwd(), `test/test-data/feature-flags/users.graphql`)).toString(),
+          labels2,
+          DEFAULT_SUBGRAPH_URL_TWO,
+        );
+
+        await createFederatedGraph(
+          client,
+          baseGraphName,
+          namespace,
+          [labelMatcher.map((l) => `${l.key}=${l.value}`).join(',')],
+          DEFAULT_ROUTER_URL,
+        );
+        const federatedGraphResponse = await client.getFederatedGraphByName({
+          name: baseGraphName,
+          namespace,
+        });
+
+        expect(federatedGraphResponse.response?.code).toBe(EnumStatusCode.OK);
+        expect(blobStorage.keys()).toHaveLength(2);
+        const key = blobStorage.keys()[0];
+        const mapperKey = blobStorage.keys()[1];
+        expect(key).toContain(`${federatedGraphResponse.graph!.id}/manifest/latest.json`);
+        expect(mapperKey).toContain(`${federatedGraphResponse.graph!.id}/manifest/mapper.json`);
+
+        await assertNumberOfCompositions(client, baseGraphName, 1, namespace);
+        await createThenPublishFeatureSubgraph(
+          client,
+          usersFeature,
+          users,
+          namespace,
+          fs.readFileSync(join(process.cwd(), `test/test-data/feature-flags/users-feature.graphql`)).toString(),
+          labels2,
+          DEFAULT_SUBGRAPH_URL_THREE,
+        );
+
+        await createFeatureFlag(client, featureFlagName, labels2, [usersFeature], namespace, true);
+
+        let featureFlagCompositions = await server.db
+          .select({ id: graphCompositions.id })
+          .from(graphCompositions)
+          .where(eq(graphCompositions.isFeatureFlagComposition, true))
+          .execute();
+
+        expect(featureFlagCompositions).toHaveLength(1);
+
+        await assertNumberOfCompositions(client, baseGraphName, 1, namespace);
+
+        const updateProductsResp = await client.updateSubgraph({
+          name: products,
+          namespace,
+          routingUrl: 'http://example.com',
+        });
+
+        expect(updateProductsResp.response?.code).toBe(EnumStatusCode.OK);
+        await assertNumberOfCompositions(client, baseGraphName, 2, namespace);
+
+        featureFlagCompositions = await server.db
+          .select({ id: graphCompositions.id })
+          .from(graphCompositions)
+          .where(eq(graphCompositions.isFeatureFlagComposition, true))
+          .execute();
+
+        expect(featureFlagCompositions).toHaveLength(1);
+
+        const publishProductsResp = await client.publishFederatedSubgraph({
+          name: products,
+          namespace,
+          schema: fs
+            .readFileSync(join(process.cwd(), `test/test-data/feature-flags/products-standalone-update.graphql`))
+            .toString(),
+        });
+
+        expect(publishProductsResp.response?.code).toBe(EnumStatusCode.OK);
+        await assertNumberOfCompositions(client, baseGraphName, 3, namespace);
+
+        featureFlagCompositions = await server.db
+          .select({ id: graphCompositions.id })
+          .from(graphCompositions)
+          .where(eq(graphCompositions.isFeatureFlagComposition, true))
+          .execute();
+
+        expect(featureFlagCompositions).toHaveLength(1);
+
+        const updateUsersResp = await client.updateSubgraph({
+          name: users,
+          namespace,
+          routingUrl: 'http://example.com',
+        });
+
+        expect(updateUsersResp.response?.code).toBe(EnumStatusCode.OK);
+        await assertNumberOfCompositions(client, baseGraphName, 3, namespace);
+
+        featureFlagCompositions = await server.db
+          .select({ id: graphCompositions.id })
+          .from(graphCompositions)
+          .where(eq(graphCompositions.isFeatureFlagComposition, true))
+          .execute();
+
+        expect(featureFlagCompositions).toHaveLength(2);
+
+        const publishUsersResp = await client.publishFederatedSubgraph({
+          name: users,
+          namespace,
+          schema: fs.readFileSync(join(process.cwd(), `test/test-data/feature-flags/users-update.graphql`)).toString(),
+        });
+
+        expect(publishUsersResp.response?.code).toBe(EnumStatusCode.OK);
+        await assertNumberOfCompositions(client, baseGraphName, 3, namespace);
+
+        featureFlagCompositions = await server.db
+          .select({ id: graphCompositions.id })
+          .from(graphCompositions)
+          .where(eq(graphCompositions.isFeatureFlagComposition, true))
+          .execute();
+
+        expect(featureFlagCompositions).toHaveLength(3);
       },
     );
   });

--- a/controlplane/test/feature-flag/feature-flag-integration.test.ts
+++ b/controlplane/test/feature-flag/feature-flag-integration.test.ts
@@ -15,7 +15,6 @@ import {
   createFederatedGraph,
   createNamespace,
   createThenPublishFeatureSubgraph,
-  DEFAULT_NAMESPACE,
   DEFAULT_ROUTER_URL,
   DEFAULT_SUBGRAPH_URL_ONE,
   DEFAULT_SUBGRAPH_URL_THREE,
@@ -1096,107 +1095,111 @@ describe('Feature flag integration tests', () => {
       },
     );
 
-    test('that feature subgraph publish recomposes the feature flag', async (testContext) => {
-      const { client, server, blobStorage } = await SetupTest({
-        dbname,
-        chClient,
-      });
-      testContext.onTestFinished(() => server.close());
+    test(
+      'that feature subgraph publish recomposes the feature flag',
+      getDebugTestOptions(isDebugMode),
+      async (testContext) => {
+        const { client, server, blobStorage } = await SetupTest({
+          dbname,
+          chClient,
+        });
+        testContext.onTestFinished(() => server.close());
 
-      const labels: Array<Label> = [];
-      const namespace = genID('namespace').toLowerCase();
-      await createNamespace(client, namespace);
-      const baseGraphName = 'baseGraphName';
-      const baseGraphResponse = await featureFlagIntegrationTestSetUp(
-        client,
-        [
-          {
-            name: 'users',
-            hasFeatureSubgraph: false,
-          },
-          {
-            name: 'products',
-            hasFeatureSubgraph: false,
-          },
-        ],
-        baseGraphName,
-        labels,
-        namespace,
-      );
+        const labels: Array<Label> = [];
+        const namespace = genID('namespace').toLowerCase();
+        await createNamespace(client, namespace);
+        const baseGraphName = 'baseGraphName';
+        const baseGraphResponse = await featureFlagIntegrationTestSetUp(
+          client,
+          [
+            {
+              name: 'users',
+              hasFeatureSubgraph: false,
+            },
+            {
+              name: 'products',
+              hasFeatureSubgraph: false,
+            },
+          ],
+          baseGraphName,
+          labels,
+          namespace,
+        );
 
-      expect(blobStorage.keys()).toHaveLength(1);
-      const baseGraphKey = blobStorage.keys()[0];
-      expect(baseGraphKey).toContain(`${baseGraphResponse.graph!.id}/routerconfigs/latest.json`);
-      await assertFeatureFlagExecutionConfig(blobStorage, baseGraphKey, false);
+        expect(blobStorage.keys()).toHaveLength(1);
+        const baseGraphKey = blobStorage.keys()[0];
+        expect(baseGraphKey).toContain(`${baseGraphResponse.graph!.id}/routerconfigs/latest.json`);
+        await assertFeatureFlagExecutionConfig(blobStorage, baseGraphKey, false);
 
-      // The successful base composition
-      await assertNumberOfCompositions(client, baseGraphName, 1, namespace);
+        // The successful base composition
+        await assertNumberOfCompositions(client, baseGraphName, 1, namespace);
 
-      await createThenPublishFeatureSubgraph(
-        client,
-        'users-feature',
-        'users',
-        namespace,
-        fs.readFileSync(join(process.cwd(), `test/test-data/feature-flags/users-feature.graphql`)).toString(),
-        labels,
-        'https://localhost:4003',
-      );
+        await createThenPublishFeatureSubgraph(
+          client,
+          'users-feature',
+          'users',
+          namespace,
+          fs.readFileSync(join(process.cwd(), `test/test-data/feature-flags/users-feature.graphql`)).toString(),
+          labels,
+          'https://localhost:4003',
+        );
 
-      const featureFlagName = genID('flag');
-      const createFeatureFlagResponse = await client.createFeatureFlag({
-        name: featureFlagName,
-        featureSubgraphNames: ['users-feature'],
-        labels,
-        namespace,
-        isEnabled: true,
-      });
-      expect(createFeatureFlagResponse.response?.code).toBe(EnumStatusCode.ERR_SUBGRAPH_COMPOSITION_FAILED);
-      expect(createFeatureFlagResponse.compositionErrors).toHaveLength(2);
+        const featureFlagName = genID('flag');
+        const createFeatureFlagResponse = await client.createFeatureFlag({
+          name: featureFlagName,
+          featureSubgraphNames: ['users-feature'],
+          labels,
+          namespace,
+          isEnabled: true,
+        });
+        expect(createFeatureFlagResponse.response?.code).toBe(EnumStatusCode.ERR_SUBGRAPH_COMPOSITION_FAILED);
+        expect(createFeatureFlagResponse.compositionErrors).toHaveLength(2);
 
-      // There will be a base recomposition and a feature flag composition, but the feature flag composition will fail
-      await assertNumberOfCompositions(client, baseGraphName, 3, namespace);
-      await assertFeatureFlagExecutionConfig(blobStorage, baseGraphKey, false);
+        // There will be a base recomposition and a feature flag composition, but the feature flag composition will fail
+        await assertNumberOfCompositions(client, baseGraphName, 3, namespace);
+        await assertFeatureFlagExecutionConfig(blobStorage, baseGraphKey, false);
 
-      await createThenPublishFeatureSubgraph(
-        client,
-        'products-feature',
-        'products',
-        namespace,
-        fs.readFileSync(join(process.cwd(), `test/test-data/feature-flags/products-feature.graphql`)).toString(),
-        labels,
-        'https://localhost:4004',
-      );
+        await createThenPublishFeatureSubgraph(
+          client,
+          'products-feature',
+          'products',
+          namespace,
+          fs.readFileSync(join(process.cwd(), `test/test-data/feature-flags/products-feature.graphql`)).toString(),
+          labels,
+          'https://localhost:4004',
+        );
 
-      /* The "products-feature" feature subgraph is not yet part of the feature flag,
-       * so the number compositions should remain the same.
-       * */
-      await assertNumberOfCompositions(client, baseGraphName, 3, namespace);
-      await assertFeatureFlagExecutionConfig(blobStorage, baseGraphKey, false);
+        /* The "products-feature" feature subgraph is not yet part of the feature flag,
+         * so the number compositions should remain the same.
+         * */
+        await assertNumberOfCompositions(client, baseGraphName, 3, namespace);
+        await assertFeatureFlagExecutionConfig(blobStorage, baseGraphKey, false);
 
-      const updateFeatureFlagResponse = await client.updateFeatureFlag({
-        featureSubgraphNames: ['users-feature', 'products-feature'],
-        name: featureFlagName,
-        namespace,
-      });
-      expect(updateFeatureFlagResponse.response?.code).toBe(EnumStatusCode.OK);
+        const updateFeatureFlagResponse = await client.updateFeatureFlag({
+          featureSubgraphNames: ['users-feature', 'products-feature'],
+          name: featureFlagName,
+          namespace,
+        });
+        expect(updateFeatureFlagResponse.response?.code).toBe(EnumStatusCode.OK);
 
-      // The base recomposition and the feature flag composition
-      await assertNumberOfCompositions(client, baseGraphName, 5, namespace);
-      await assertFeatureFlagExecutionConfig(blobStorage, baseGraphKey, true);
+        // The base recomposition and the feature flag composition
+        await assertNumberOfCompositions(client, baseGraphName, 5, namespace);
+        await assertFeatureFlagExecutionConfig(blobStorage, baseGraphKey, true);
 
-      const publishSubgraphResponse = await client.publishFederatedSubgraph({
-        name: 'products-feature',
-        namespace,
-        schema: fs
-          .readFileSync(join(process.cwd(), `test/test-data/feature-flags/products-feature-update.graphql`))
-          .toString(),
-      });
-      expect(publishSubgraphResponse.response?.code).toBe(EnumStatusCode.OK);
+        const publishSubgraphResponse = await client.publishFederatedSubgraph({
+          name: 'products-feature',
+          namespace,
+          schema: fs
+            .readFileSync(join(process.cwd(), `test/test-data/feature-flags/products-feature-update.graphql`))
+            .toString(),
+        });
+        expect(publishSubgraphResponse.response?.code).toBe(EnumStatusCode.OK);
 
-      // Another base recomposition and a feature flag composition
-      await assertNumberOfCompositions(client, baseGraphName, 7, namespace);
-      await assertFeatureFlagExecutionConfig(blobStorage, baseGraphKey, true);
-    });
+        // Another base recomposition and a feature flag composition
+        await assertNumberOfCompositions(client, baseGraphName, 7, namespace);
+        await assertFeatureFlagExecutionConfig(blobStorage, baseGraphKey, true);
+      },
+    );
 
     test(
       'that a federated graph with feature flags and feature subgraphs can be moved',
@@ -1461,6 +1464,387 @@ describe('Feature flag integration tests', () => {
         // The base recomposition of graph two and the feature flag composition
         await assertNumberOfCompositions(client, baseGraphNameTwo, 3, namespace);
         await assertFeatureFlagExecutionConfig(blobStorage, federatedGraphKeyTwo, true);
+      },
+    );
+
+    test(
+      'that when a subgraph label changes, all affected graphs and feature flags are recomposed',
+      getDebugTestOptions(isDebugMode),
+      async (testContext) => {
+        const { client, server, blobStorage } = await SetupTest({
+          dbname,
+          chClient,
+        });
+        testContext.onTestFinished(() => server.close());
+
+        const namespace = genID('namespace').toLowerCase();
+        const labels = [{ key: 'team', value: 'A' }];
+        const baseGraphName = genID('baseFederatedGraphName');
+
+        await createNamespace(client, namespace);
+
+        const federatedGraphResponse = await featureFlagIntegrationTestSetUp(
+          client,
+          [
+            { name: 'users', hasFeatureSubgraph: true },
+            { name: 'products-standalone', hasFeatureSubgraph: true },
+          ],
+          baseGraphName,
+          labels,
+          namespace,
+        );
+
+        expect(blobStorage.keys()).toHaveLength(1);
+        const key = blobStorage.keys()[0];
+        expect(key).toContain(`${federatedGraphResponse.graph!.id}/routerconfigs/latest.json`);
+
+        await assertFeatureFlagExecutionConfig(blobStorage, key, false);
+
+        // The base composition
+        await assertNumberOfCompositions(client, baseGraphName, 1, namespace);
+
+        const featureFlagName = genID('flag');
+        await createFeatureFlag(client, featureFlagName, labels, ['products-standalone-feature'], namespace, true);
+
+        expect(blobStorage.keys()).toHaveLength(1);
+
+        // The base recomposition and the feature flag composition
+        await assertNumberOfCompositions(client, baseGraphName, 3, namespace);
+        await assertFeatureFlagExecutionConfig(blobStorage, key, true);
+
+        // Update the labels of the subgraph
+        let updateSubgraphResp = await client.updateSubgraph({
+          name: 'users',
+          namespace,
+          labels: [{ key: 'team', value: 'B' }],
+        });
+
+        expect(updateSubgraphResp.response?.code).toBe(EnumStatusCode.OK);
+
+        // The base graph and feature flag should have recomposed
+        await assertNumberOfCompositions(client, baseGraphName, 5, namespace);
+        await assertFeatureFlagExecutionConfig(blobStorage, key, true);
+
+        // Update the labels of the subgraph
+        updateSubgraphResp = await client.updateSubgraph({
+          name: 'users',
+          namespace,
+          labels: [{ key: 'team', value: 'A' }],
+        });
+
+        expect(updateSubgraphResp.response?.code).toBe(EnumStatusCode.OK);
+
+        // The base graph and feature flag should have recomposed
+        await assertNumberOfCompositions(client, baseGraphName, 7, namespace);
+        await assertFeatureFlagExecutionConfig(blobStorage, key, true);
+      },
+    );
+
+    test(
+      'that setting new labels that do not affect existing label matchers does not produce unnecessary recompositions',
+      getDebugTestOptions(isDebugMode),
+      async (testContext) => {
+        const { client, server, blobStorage } = await SetupTest({
+          dbname,
+          chClient,
+        });
+        testContext.onTestFinished(() => server.close());
+
+        const namespace = genID('namespace').toLowerCase();
+        const labels = [{ key: 'team', value: 'A' }];
+        const baseGraphName = genID('baseFederatedGraphName');
+
+        await createNamespace(client, namespace);
+
+        const federatedGraphResponse = await featureFlagIntegrationTestSetUp(
+          client,
+          [
+            { name: 'users', hasFeatureSubgraph: true },
+            { name: 'products-standalone', hasFeatureSubgraph: true },
+          ],
+          baseGraphName,
+          labels,
+          namespace,
+        );
+
+        expect(blobStorage.keys()).toHaveLength(1);
+        const key = blobStorage.keys()[0];
+        expect(key).toContain(`${federatedGraphResponse.graph!.id}/routerconfigs/latest.json`);
+
+        await assertFeatureFlagExecutionConfig(blobStorage, key, false);
+
+        // The base composition
+        await assertNumberOfCompositions(client, baseGraphName, 1, namespace);
+
+        const featureFlagName = genID('flag');
+        await createFeatureFlag(client, featureFlagName, labels, ['products-standalone-feature'], namespace, true);
+
+        expect(blobStorage.keys()).toHaveLength(1);
+
+        // The base recomposition and the feature flag composition
+        await assertNumberOfCompositions(client, baseGraphName, 3, namespace);
+        await assertFeatureFlagExecutionConfig(blobStorage, key, true);
+
+        // Update the labels of the subgraph
+        const updateSubgraphResp = await client.updateSubgraph({
+          name: 'users',
+          namespace,
+          labels: [
+            { key: 'team', value: 'B' },
+            { key: 'team', value: 'A' },
+          ],
+        });
+
+        expect(updateSubgraphResp.response?.code).toBe(EnumStatusCode.OK);
+
+        // There should not be any new recomposition
+        await assertNumberOfCompositions(client, baseGraphName, 3, namespace);
+        await assertFeatureFlagExecutionConfig(blobStorage, key, true);
+      },
+    );
+
+    test(
+      'that changing the routing url triggers a recomposition when label matchers do not change',
+      getDebugTestOptions(isDebugMode),
+      async (testContext) => {
+        const { client, server, blobStorage } = await SetupTest({
+          dbname,
+          chClient,
+        });
+        testContext.onTestFinished(() => server.close());
+
+        const namespace = genID('namespace').toLowerCase();
+        const labels = [{ key: 'team', value: 'A' }];
+        const baseGraphName = genID('baseFederatedGraphName');
+
+        await createNamespace(client, namespace);
+
+        const federatedGraphResponse = await featureFlagIntegrationTestSetUp(
+          client,
+          [
+            { name: 'users', hasFeatureSubgraph: true },
+            { name: 'products-standalone', hasFeatureSubgraph: true },
+          ],
+          baseGraphName,
+          labels,
+          namespace,
+        );
+
+        expect(blobStorage.keys()).toHaveLength(1);
+        const key = blobStorage.keys()[0];
+        expect(key).toContain(`${federatedGraphResponse.graph!.id}/routerconfigs/latest.json`);
+
+        await assertFeatureFlagExecutionConfig(blobStorage, key, false);
+
+        // The base composition
+        await assertNumberOfCompositions(client, baseGraphName, 1, namespace);
+
+        const featureFlagName = genID('flag');
+        await createFeatureFlag(client, featureFlagName, labels, ['products-standalone-feature'], namespace, true);
+
+        expect(blobStorage.keys()).toHaveLength(1);
+
+        // The base recomposition and the feature flag composition
+        await assertNumberOfCompositions(client, baseGraphName, 3, namespace);
+        await assertFeatureFlagExecutionConfig(blobStorage, key, true);
+
+        // Update the labels of the subgraph
+        const updateSubgraphResp = await client.updateSubgraph({
+          name: 'users',
+          namespace,
+          labels: [
+            { key: 'team', value: 'B' },
+            { key: 'team', value: 'A' },
+          ],
+          routingUrl: DEFAULT_SUBGRAPH_URL_THREE,
+        });
+
+        expect(updateSubgraphResp.response?.code).toBe(EnumStatusCode.OK);
+
+        // There should be a recomposition for the federated graph and feature flag
+        await assertNumberOfCompositions(client, baseGraphName, 5, namespace);
+        await assertFeatureFlagExecutionConfig(blobStorage, key, true);
+      },
+    );
+
+    test(
+      'that changing the routing url and the labels of a mutual subgraph trigger composition',
+      getDebugTestOptions(isDebugMode),
+      async (testContext) => {
+        const { client, server, blobStorage } = await SetupTest({
+          dbname,
+          chClient,
+        });
+        testContext.onTestFinished(() => server.close());
+
+        const namespace = genID('namespace').toLowerCase();
+        const labels = [{ key: 'team', value: 'A' }];
+        const baseGraphName = genID('baseFederatedGraphName');
+
+        await createNamespace(client, namespace);
+
+        const federatedGraphResponse = await featureFlagIntegrationTestSetUp(
+          client,
+          [
+            { name: 'users', hasFeatureSubgraph: true },
+            { name: 'products-standalone', hasFeatureSubgraph: true },
+          ],
+          baseGraphName,
+          labels,
+          namespace,
+        );
+
+        expect(blobStorage.keys()).toHaveLength(1);
+        const key = blobStorage.keys()[0];
+        expect(key).toContain(`${federatedGraphResponse.graph!.id}/routerconfigs/latest.json`);
+
+        await assertFeatureFlagExecutionConfig(blobStorage, key, false);
+
+        // The base composition
+        await assertNumberOfCompositions(client, baseGraphName, 1, namespace);
+
+        const featureFlagName = genID('flag');
+        await createFeatureFlag(client, featureFlagName, labels, ['products-standalone-feature'], namespace, true);
+
+        expect(blobStorage.keys()).toHaveLength(1);
+
+        // The base composition and the feature flag composition
+        await assertNumberOfCompositions(client, baseGraphName, 3, namespace);
+        await assertFeatureFlagExecutionConfig(blobStorage, key, true);
+
+        // Update the labels of the subgraph
+        const updateSubgraphResp = await client.updateSubgraph({
+          name: 'users',
+          namespace,
+          labels: [{ key: 'team', value: 'B' }],
+          routingUrl: DEFAULT_SUBGRAPH_URL_THREE,
+        });
+
+        expect(updateSubgraphResp.response?.code).toBe(EnumStatusCode.OK);
+
+        // There should be a recomposition for the federated graph and feature flag
+        await assertNumberOfCompositions(client, baseGraphName, 5, namespace);
+        await assertFeatureFlagExecutionConfig(blobStorage, key, true);
+      },
+    );
+
+    test(
+      'that unsetting empty labels does not trigger composition',
+      getDebugTestOptions(isDebugMode),
+      async (testContext) => {
+        const { client, server, blobStorage } = await SetupTest({
+          dbname,
+          chClient,
+        });
+        testContext.onTestFinished(() => server.close());
+
+        const namespace = genID('namespace').toLowerCase();
+        const labels: Label[] = [];
+        const baseGraphName = genID('baseFederatedGraphName');
+
+        await createNamespace(client, namespace);
+
+        const federatedGraphResponse = await featureFlagIntegrationTestSetUp(
+          client,
+          [
+            { name: 'users', hasFeatureSubgraph: true },
+            { name: 'products-standalone', hasFeatureSubgraph: true },
+          ],
+          baseGraphName,
+          labels,
+          namespace,
+        );
+
+        expect(blobStorage.keys()).toHaveLength(1);
+        const key = blobStorage.keys()[0];
+        expect(key).toContain(`${federatedGraphResponse.graph!.id}/routerconfigs/latest.json`);
+
+        await assertFeatureFlagExecutionConfig(blobStorage, key, false);
+
+        // The base composition
+        await assertNumberOfCompositions(client, baseGraphName, 1, namespace);
+
+        const featureFlagName = genID('flag');
+        await createFeatureFlag(client, featureFlagName, labels, ['products-standalone-feature'], namespace, true);
+
+        expect(blobStorage.keys()).toHaveLength(1);
+
+        // The base composition and the feature flag composition
+        await assertNumberOfCompositions(client, baseGraphName, 3, namespace);
+        await assertFeatureFlagExecutionConfig(blobStorage, key, true);
+
+        // Update the labels of the subgraph
+        const updateSubgraphResp = await client.updateSubgraph({
+          name: 'users',
+          namespace,
+          unsetLabels: true,
+        });
+
+        expect(updateSubgraphResp.response?.code).toBe(EnumStatusCode.OK);
+
+        // There should be a recomposition for the federated graph and feature flag
+        await assertNumberOfCompositions(client, baseGraphName, 3, namespace);
+        await assertFeatureFlagExecutionConfig(blobStorage, key, true);
+      },
+    );
+
+    test(
+      'that unsetting non-empty labels triggers composition',
+      getDebugTestOptions(isDebugMode),
+      async (testContext) => {
+        const { client, server, blobStorage } = await SetupTest({
+          dbname,
+          chClient,
+        });
+        testContext.onTestFinished(() => server.close());
+
+        const namespace = genID('namespace').toLowerCase();
+        const labels: Label[] = [{ key: 'team', value: 'A' }];
+        const baseGraphName = genID('baseFederatedGraphName');
+
+        await createNamespace(client, namespace);
+
+        const federatedGraphResponse = await featureFlagIntegrationTestSetUp(
+          client,
+          [
+            { name: 'users', hasFeatureSubgraph: true },
+            { name: 'products-standalone', hasFeatureSubgraph: true },
+          ],
+          baseGraphName,
+          labels,
+          namespace,
+        );
+
+        expect(blobStorage.keys()).toHaveLength(1);
+        const key = blobStorage.keys()[0];
+        expect(key).toContain(`${federatedGraphResponse.graph!.id}/routerconfigs/latest.json`);
+
+        await assertFeatureFlagExecutionConfig(blobStorage, key, false);
+
+        // The base composition
+        await assertNumberOfCompositions(client, baseGraphName, 1, namespace);
+
+        const featureFlagName = genID('flag');
+        await createFeatureFlag(client, featureFlagName, labels, ['products-standalone-feature'], namespace, true);
+
+        expect(blobStorage.keys()).toHaveLength(1);
+
+        // The base composition and the feature flag composition
+        await assertNumberOfCompositions(client, baseGraphName, 3, namespace);
+        await assertFeatureFlagExecutionConfig(blobStorage, key, true);
+
+        // Update the labels of the subgraph
+        const updateSubgraphResp = await client.updateSubgraph({
+          name: 'users',
+          namespace,
+          unsetLabels: true,
+        });
+
+        expect(updateSubgraphResp.response?.code).toBe(EnumStatusCode.OK);
+
+        // There should be a recomposition for the federated graph and feature flag
+        await assertNumberOfCompositions(client, baseGraphName, 5, namespace);
+        await assertFeatureFlagExecutionConfig(blobStorage, key, true);
       },
     );
   });
@@ -3233,6 +3617,417 @@ describe('Feature flag integration tests', () => {
           .execute();
 
         expect(featureFlagCompositions).toHaveLength(3);
+      },
+    );
+
+    test(
+      'that when a subgraph label changes, all affected graphs and feature flags are recomposed',
+      getDebugTestOptions(isDebugMode),
+      async (testContext) => {
+        const { client, server, blobStorage } = await SetupTest({
+          dbname,
+          chClient,
+          enabledFeatures: ['split-config-loading'],
+        });
+        testContext.onTestFinished(() => server.close());
+
+        const namespace = genID('namespace').toLowerCase();
+        const labels = [{ key: 'team', value: 'A' }];
+        const baseGraphName = genID('baseFederatedGraphName');
+
+        await createNamespace(client, namespace);
+
+        const federatedGraphResponse = await featureFlagIntegrationTestSetUp(
+          client,
+          [
+            { name: 'users', hasFeatureSubgraph: true },
+            { name: 'products-standalone', hasFeatureSubgraph: true },
+          ],
+          baseGraphName,
+          labels,
+          namespace,
+        );
+
+        expect(blobStorage.keys()).toHaveLength(2);
+        const key = blobStorage.keys()[0];
+        const mapperKey = blobStorage.keys()[1];
+        expect(key).toContain(`${federatedGraphResponse.graph!.id}/manifest/latest.json`);
+        expect(mapperKey).toContain(`${federatedGraphResponse.graph!.id}/manifest/mapper.json`);
+
+        await assertFeatureFlagExecutionConfig(blobStorage, key, false);
+
+        // The base composition
+        await assertNumberOfCompositions(client, baseGraphName, 1, namespace);
+
+        const featureFlagName = genID('flag');
+        await createFeatureFlag(client, featureFlagName, labels, ['products-standalone-feature'], namespace, true);
+
+        expect(blobStorage.keys()).toHaveLength(3);
+        const ffKey = blobStorage.keys().at(-1);
+        expect(ffKey).toContain(`${federatedGraphResponse.graph!.id}/manifest/feature-flags/${featureFlagName}.json`);
+
+        // The base composition and the feature flag composition
+        await assertNumberOfCompositions(client, baseGraphName, 2, namespace);
+        await assertFeatureFlagExecutionConfig(blobStorage, key, false);
+
+        // Update the labels of the subgraph
+        let updateSubgraphResp = await client.updateSubgraph({
+          name: 'users',
+          namespace,
+          labels: [{ key: 'team', value: 'B' }],
+        });
+
+        expect(updateSubgraphResp.response?.code).toBe(EnumStatusCode.OK);
+
+        // The base graph and feature flag should have recomposed
+        await assertNumberOfCompositions(client, baseGraphName, 4, namespace);
+        await assertFeatureFlagExecutionConfig(blobStorage, key, false);
+
+        // Update the labels of the subgraph
+        updateSubgraphResp = await client.updateSubgraph({
+          name: 'users',
+          namespace,
+          labels: [{ key: 'team', value: 'A' }],
+        });
+
+        expect(updateSubgraphResp.response?.code).toBe(EnumStatusCode.OK);
+
+        // The base graph and feature flag should have recomposed
+        await assertNumberOfCompositions(client, baseGraphName, 6, namespace);
+        await assertFeatureFlagExecutionConfig(blobStorage, key, false);
+      },
+    );
+
+    test(
+      'that setting new labels that do not affect existing label matchers does not produce unnecessary recompositions',
+      getDebugTestOptions(isDebugMode),
+      async (testContext) => {
+        const { client, server, blobStorage } = await SetupTest({
+          dbname,
+          chClient,
+          enabledFeatures: ['split-config-loading'],
+        });
+        testContext.onTestFinished(() => server.close());
+
+        const namespace = genID('namespace').toLowerCase();
+        const labels = [{ key: 'team', value: 'A' }];
+        const baseGraphName = genID('baseFederatedGraphName');
+
+        await createNamespace(client, namespace);
+
+        const federatedGraphResponse = await featureFlagIntegrationTestSetUp(
+          client,
+          [
+            { name: 'users', hasFeatureSubgraph: true },
+            { name: 'products-standalone', hasFeatureSubgraph: true },
+          ],
+          baseGraphName,
+          labels,
+          namespace,
+        );
+
+        expect(blobStorage.keys()).toHaveLength(2);
+        const key = blobStorage.keys()[0];
+        const mapperKey = blobStorage.keys()[1];
+        expect(key).toContain(`${federatedGraphResponse.graph!.id}/manifest/latest.json`);
+        expect(mapperKey).toContain(`${federatedGraphResponse.graph!.id}/manifest/mapper.json`);
+
+        await assertFeatureFlagExecutionConfig(blobStorage, key, false);
+
+        // The base composition
+        await assertNumberOfCompositions(client, baseGraphName, 1, namespace);
+
+        const featureFlagName = genID('flag');
+        await createFeatureFlag(client, featureFlagName, labels, ['products-standalone-feature'], namespace, true);
+
+        expect(blobStorage.keys()).toHaveLength(3);
+        const ffKey = blobStorage.keys().at(-1);
+        expect(ffKey).toContain(`${federatedGraphResponse.graph!.id}/manifest/feature-flags/${featureFlagName}.json`);
+
+        // The base composition and the feature flag composition
+        await assertNumberOfCompositions(client, baseGraphName, 2, namespace);
+        await assertFeatureFlagExecutionConfig(blobStorage, key, false);
+
+        // Update the labels of the subgraph
+        const updateSubgraphResp = await client.updateSubgraph({
+          name: 'users',
+          namespace,
+          labels: [
+            { key: 'team', value: 'B' },
+            { key: 'team', value: 'A' },
+          ],
+        });
+
+        expect(updateSubgraphResp.response?.code).toBe(EnumStatusCode.OK);
+
+        // There should not be any new recomposition
+        await assertNumberOfCompositions(client, baseGraphName, 2, namespace);
+        await assertFeatureFlagExecutionConfig(blobStorage, key, false);
+      },
+    );
+
+    test(
+      'that changing the routing url triggers a recomposition when label matchers do not change',
+      getDebugTestOptions(isDebugMode),
+      async (testContext) => {
+        const { client, server, blobStorage } = await SetupTest({
+          dbname,
+          chClient,
+          enabledFeatures: ['split-config-loading'],
+        });
+        testContext.onTestFinished(() => server.close());
+
+        const namespace = genID('namespace').toLowerCase();
+        const labels = [{ key: 'team', value: 'A' }];
+        const baseGraphName = genID('baseFederatedGraphName');
+
+        await createNamespace(client, namespace);
+
+        const federatedGraphResponse = await featureFlagIntegrationTestSetUp(
+          client,
+          [
+            { name: 'users', hasFeatureSubgraph: true },
+            { name: 'products-standalone', hasFeatureSubgraph: true },
+          ],
+          baseGraphName,
+          labels,
+          namespace,
+        );
+
+        expect(blobStorage.keys()).toHaveLength(2);
+        const key = blobStorage.keys()[0];
+        const mapperKey = blobStorage.keys()[1];
+        expect(key).toContain(`${federatedGraphResponse.graph!.id}/manifest/latest.json`);
+        expect(mapperKey).toContain(`${federatedGraphResponse.graph!.id}/manifest/mapper.json`);
+
+        await assertFeatureFlagExecutionConfig(blobStorage, key, false);
+
+        // The base composition
+        await assertNumberOfCompositions(client, baseGraphName, 1, namespace);
+
+        const featureFlagName = genID('flag');
+        await createFeatureFlag(client, featureFlagName, labels, ['products-standalone-feature'], namespace, true);
+
+        expect(blobStorage.keys()).toHaveLength(3);
+        const ffKey = blobStorage.keys().at(-1);
+        expect(ffKey).toContain(`${federatedGraphResponse.graph!.id}/manifest/feature-flags/${featureFlagName}.json`);
+
+        // The base composition and the feature flag composition
+        await assertNumberOfCompositions(client, baseGraphName, 2, namespace);
+        await assertFeatureFlagExecutionConfig(blobStorage, key, false);
+
+        // Update the labels of the subgraph
+        const updateSubgraphResp = await client.updateSubgraph({
+          name: 'users',
+          namespace,
+          labels: [
+            { key: 'team', value: 'B' },
+            { key: 'team', value: 'A' },
+          ],
+          routingUrl: DEFAULT_SUBGRAPH_URL_THREE,
+        });
+
+        expect(updateSubgraphResp.response?.code).toBe(EnumStatusCode.OK);
+
+        // There should be a recomposition for the federated graph and feature flag
+        await assertNumberOfCompositions(client, baseGraphName, 4, namespace);
+        await assertFeatureFlagExecutionConfig(blobStorage, key, false);
+      },
+    );
+
+    test(
+      'that changing the routing url and the labels of a mutual subgraph trigger composition',
+      getDebugTestOptions(isDebugMode),
+      async (testContext) => {
+        const { client, server, blobStorage } = await SetupTest({
+          dbname,
+          chClient,
+          enabledFeatures: ['split-config-loading'],
+        });
+        testContext.onTestFinished(() => server.close());
+
+        const namespace = genID('namespace').toLowerCase();
+        const labels = [{ key: 'team', value: 'A' }];
+        const baseGraphName = genID('baseFederatedGraphName');
+
+        await createNamespace(client, namespace);
+
+        const federatedGraphResponse = await featureFlagIntegrationTestSetUp(
+          client,
+          [
+            { name: 'users', hasFeatureSubgraph: true },
+            { name: 'products-standalone', hasFeatureSubgraph: true },
+          ],
+          baseGraphName,
+          labels,
+          namespace,
+        );
+
+        expect(blobStorage.keys()).toHaveLength(2);
+        const key = blobStorage.keys()[0];
+        const mapperKey = blobStorage.keys()[1];
+        expect(key).toContain(`${federatedGraphResponse.graph!.id}/manifest/latest.json`);
+        expect(mapperKey).toContain(`${federatedGraphResponse.graph!.id}/manifest/mapper.json`);
+
+        await assertFeatureFlagExecutionConfig(blobStorage, key, false);
+
+        // The base composition
+        await assertNumberOfCompositions(client, baseGraphName, 1, namespace);
+
+        const featureFlagName = genID('flag');
+        await createFeatureFlag(client, featureFlagName, labels, ['products-standalone-feature'], namespace, true);
+
+        expect(blobStorage.keys()).toHaveLength(3);
+        const ffKey = blobStorage.keys().at(-1);
+        expect(ffKey).toContain(`${federatedGraphResponse.graph!.id}/manifest/feature-flags/${featureFlagName}.json`);
+
+        // The base composition and the feature flag composition
+        await assertNumberOfCompositions(client, baseGraphName, 2, namespace);
+        await assertFeatureFlagExecutionConfig(blobStorage, key, false);
+
+        // Update the labels of the subgraph
+        const updateSubgraphResp = await client.updateSubgraph({
+          name: 'users',
+          namespace,
+          labels: [{ key: 'team', value: 'B' }],
+          routingUrl: DEFAULT_SUBGRAPH_URL_THREE,
+        });
+
+        expect(updateSubgraphResp.response?.code).toBe(EnumStatusCode.OK);
+
+        // There should be a recomposition for the federated graph and feature flag
+        await assertNumberOfCompositions(client, baseGraphName, 4, namespace);
+        await assertFeatureFlagExecutionConfig(blobStorage, key, false);
+      },
+    );
+
+    test(
+      'that unsetting non-empty labels triggers composition',
+      getDebugTestOptions(isDebugMode),
+      async (testContext) => {
+        const { client, server, blobStorage } = await SetupTest({
+          dbname,
+          chClient,
+          enabledFeatures: ['split-config-loading'],
+        });
+        testContext.onTestFinished(() => server.close());
+
+        const namespace = genID('namespace').toLowerCase();
+        const labels: Label[] = [{ key: 'team', value: 'A' }];
+        const baseGraphName = genID('baseFederatedGraphName');
+
+        await createNamespace(client, namespace);
+
+        const federatedGraphResponse = await featureFlagIntegrationTestSetUp(
+          client,
+          [
+            { name: 'users', hasFeatureSubgraph: true },
+            { name: 'products-standalone', hasFeatureSubgraph: true },
+          ],
+          baseGraphName,
+          labels,
+          namespace,
+        );
+
+        expect(blobStorage.keys()).toHaveLength(2);
+        const key = blobStorage.keys()[0];
+        const mapperKey = blobStorage.keys()[1];
+        expect(key).toContain(`${federatedGraphResponse.graph!.id}/manifest/latest.json`);
+        expect(mapperKey).toContain(`${federatedGraphResponse.graph!.id}/manifest/mapper.json`);
+
+        await assertFeatureFlagExecutionConfig(blobStorage, key, false);
+
+        // The base composition
+        await assertNumberOfCompositions(client, baseGraphName, 1, namespace);
+
+        const featureFlagName = genID('flag');
+        await createFeatureFlag(client, featureFlagName, labels, ['products-standalone-feature'], namespace, true);
+
+        expect(blobStorage.keys()).toHaveLength(3);
+        const ffKey = blobStorage.keys().at(-1);
+        expect(ffKey).toContain(`${federatedGraphResponse.graph!.id}/manifest/feature-flags/${featureFlagName}.json`);
+
+        // The base composition and the feature flag composition
+        await assertNumberOfCompositions(client, baseGraphName, 2, namespace);
+        await assertFeatureFlagExecutionConfig(blobStorage, key, false);
+
+        // Update the labels of the subgraph
+        const updateSubgraphResp = await client.updateSubgraph({
+          name: 'users',
+          namespace,
+          unsetLabels: true,
+        });
+
+        expect(updateSubgraphResp.response?.code).toBe(EnumStatusCode.OK);
+
+        // There should be a recomposition for the federated graph and feature flag
+        await assertNumberOfCompositions(client, baseGraphName, 4, namespace);
+        await assertFeatureFlagExecutionConfig(blobStorage, key, false);
+      },
+    );
+
+    test(
+      'that unsetting empty labels does not trigger composition',
+      getDebugTestOptions(isDebugMode),
+      async (testContext) => {
+        const { client, server, blobStorage } = await SetupTest({
+          dbname,
+          chClient,
+          enabledFeatures: ['split-config-loading'],
+        });
+        testContext.onTestFinished(() => server.close());
+
+        const namespace = genID('namespace').toLowerCase();
+        const labels: Label[] = [];
+        const baseGraphName = genID('baseFederatedGraphName');
+
+        await createNamespace(client, namespace);
+
+        const federatedGraphResponse = await featureFlagIntegrationTestSetUp(
+          client,
+          [
+            { name: 'users', hasFeatureSubgraph: true },
+            { name: 'products-standalone', hasFeatureSubgraph: true },
+          ],
+          baseGraphName,
+          labels,
+          namespace,
+        );
+
+        expect(blobStorage.keys()).toHaveLength(2);
+        const key = blobStorage.keys()[0];
+        const mapperKey = blobStorage.keys()[1];
+        expect(key).toContain(`${federatedGraphResponse.graph!.id}/manifest/latest.json`);
+        expect(mapperKey).toContain(`${federatedGraphResponse.graph!.id}/manifest/mapper.json`);
+
+        await assertFeatureFlagExecutionConfig(blobStorage, key, false);
+
+        // The base composition
+        await assertNumberOfCompositions(client, baseGraphName, 1, namespace);
+
+        const featureFlagName = genID('flag');
+        await createFeatureFlag(client, featureFlagName, labels, ['products-standalone-feature'], namespace, true);
+
+        expect(blobStorage.keys()).toHaveLength(3);
+        const ffKey = blobStorage.keys().at(-1);
+        expect(ffKey).toContain(`${federatedGraphResponse.graph!.id}/manifest/feature-flags/${featureFlagName}.json`);
+
+        // The base composition and the feature flag composition
+        await assertNumberOfCompositions(client, baseGraphName, 2, namespace);
+        await assertFeatureFlagExecutionConfig(blobStorage, key, false);
+
+        // Update the labels of the subgraph
+        const updateSubgraphResp = await client.updateSubgraph({
+          name: 'users',
+          namespace,
+          unsetLabels: true,
+        });
+
+        expect(updateSubgraphResp.response?.code).toBe(EnumStatusCode.OK);
+
+        // There should be a recomposition for the federated graph and feature flag
+        await assertNumberOfCompositions(client, baseGraphName, 2, namespace);
+        await assertFeatureFlagExecutionConfig(blobStorage, key, false);
       },
     );
   });

--- a/controlplane/test/label.test.ts
+++ b/controlplane/test/label.test.ts
@@ -584,7 +584,7 @@ describe('Labels', (ctx) => {
     expect(graph2AfterSet.subgraphs.length).toBe(1);
   });
 
-  test('Updating subgraph label should result in a single composition', async (testContext) => {
+  test('that updating subgraph labels that still match should not trigger recomposition', async (testContext) => {
     const { client, server } = await SetupTest({ dbname, chClient });
     testContext.onTestFinished(() => server.close());
 
@@ -623,6 +623,68 @@ describe('Labels', (ctx) => {
       name: subgraph1Name,
       namespace: 'default',
       labels: [label2],
+    });
+
+    const updatedGraph = await client.getCompositions({
+      fedGraphName: fedGraph1Name,
+      namespace: 'default',
+      startDate: formatISO(subDays(new Date(), 1)),
+      endDate: formatISO(addSeconds(new Date(), 5)),
+    });
+    expect(updatedGraph.response?.code).toBe(EnumStatusCode.OK);
+    expect(updatedGraph.compositions.length).toBe(1);
+  });
+
+  test(`that updating a subgraph's labels to labels that do not match should trigger composition`, async (testContext) => {
+    const { client, server } = await SetupTest({ dbname, chClient });
+    testContext.onTestFinished(() => server.close());
+
+    const fedGraph1Name = genID('fedGraph1');
+    const subgraph1Name = genID('subgraph1');
+    const subgraph2Name = genID('subgraph2');
+    const label1 = genUniqueLabel('label1');
+    const label2 = genUniqueLabel('label2');
+    const label3 = genUniqueLabel('label3');
+
+    await createAndPublishSubgraph(
+      client,
+      subgraph1Name,
+      'default',
+      `type Query { name: String! }`,
+      [label1],
+      'http://localhost:8083',
+    );
+
+    await createAndPublishSubgraph(
+      client,
+      subgraph2Name,
+      'default',
+      `type Query { name: String! }`,
+      [label2],
+      'http://localhost:8083',
+    );
+
+    await createFederatedGraph(
+      client,
+      fedGraph1Name,
+      'default',
+      [`${joinLabel(label1)},${joinLabel(label2)}`],
+      'http://localhost:8081',
+    );
+
+    const graph1 = await client.getCompositions({
+      fedGraphName: fedGraph1Name,
+      namespace: 'default',
+      startDate: formatISO(subDays(new Date(), 1)),
+      endDate: formatISO(addSeconds(new Date(), 5)),
+    });
+    expect(graph1.response?.code).toBe(EnumStatusCode.OK);
+    expect(graph1.compositions.length).toBe(1);
+
+    await client.updateSubgraph({
+      name: subgraph1Name,
+      namespace: 'default',
+      labels: [label3],
     });
 
     const updatedGraph = await client.getCompositions({

--- a/controlplane/test/test-data/feature-flags/products-standalone-feature.graphql
+++ b/controlplane/test/test-data/feature-flags/products-standalone-feature.graphql
@@ -1,0 +1,11 @@
+type Product @key(fields: "upc sku") {
+  upc: Int!
+  sku: String!
+  details: String!
+  isPremium: Boolean! @tag(name: "exclude")
+  newField: String!
+}
+
+type Query {
+  products: [Product!]!
+}

--- a/controlplane/test/test-data/feature-flags/products-standalone-update.graphql
+++ b/controlplane/test/test-data/feature-flags/products-standalone-update.graphql
@@ -1,0 +1,11 @@
+type Product @key(fields: "upc sku") {
+  upc: Int!
+  sku: String!
+  details: String!
+  isPremium: Boolean! @tag(name: "exclude")
+  newField: String!
+}
+
+type Query {
+  products: [Product!]!
+}

--- a/controlplane/test/test-data/feature-flags/products-standalone.graphql
+++ b/controlplane/test/test-data/feature-flags/products-standalone.graphql
@@ -1,0 +1,10 @@
+type Product @key(fields: "upc sku") {
+  upc: Int!
+  sku: String!
+  details: String!
+  isPremium: Boolean! @tag(name: "exclude")
+}
+
+type Query {
+  products: [Product!]!
+}

--- a/controlplane/test/test-data/feature-flags/products-update.graphql
+++ b/controlplane/test/test-data/feature-flags/products-update.graphql
@@ -1,0 +1,16 @@
+type Mutation {
+  addProductToUserBasket(userID: ID!, upc: Int!, sku: String!): User
+}
+
+type Product @key(fields: "upc sku") {
+  upc: Int!
+  sku: String!
+  details: String!
+  isPremium: Boolean! @tag(name: "exclude")
+  newField: String!
+}
+
+type User @key(fields: "id") {
+  id: ID!
+  basket: [Product!]!
+}


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add label-based lookup for feature flags by subgraph labels with optional enabled-only filtering.
  * Improve tracking of affected federated graphs and feature flags during subgraph updates; recomposition now honors the split-config-loading toggle.

* **Tests**
  * Expand integration coverage for feature-flag recomposition scenarios, add split-config-loading tests, and include additional GraphQL schema fixtures for publish/update flows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wundergraph/cosmo/pull/2860)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [x] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

<!--
Please add any additional information or context regarding your changes here.
-->