### PR TITLE
fix: using browser translation causes crash in onboarding

### DIFF
--- a/studio/src/components/onboarding/onboarding-navigation.tsx
+++ b/studio/src/components/onboarding/onboarding-navigation.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeftIcon, ArrowRightIcon, InfoCircledIcon } from '@radix-ui/react-icons';
+import { ArrowLeftIcon, ArrowRightIcon, InfoCircledIcon, UpdateIcon } from '@radix-ui/react-icons';
 import { cn } from '@/lib/utils';
 import { Link } from '../ui/link';
 import { Button } from '../ui/button';
@@ -58,14 +58,16 @@ export const OnboardingNavigation = ({
             </Link>
           </Button>
         ) : (
-          <Button
-            className="group"
-            onClick={forward.onClick}
-            isLoading={forward.isLoading}
-            disabled={forward.isLoading || forward.disabled}
-          >
-            {forwardLabel}
-            <ArrowRightIcon className="ml-2 transition-transform group-hover:translate-x-1" />
+          <Button className="group relative" onClick={forward.onClick} disabled={forward.isLoading || forward.disabled}>
+            {forward.isLoading && (
+              <span className="absolute inset-0 flex items-center justify-center">
+                <UpdateIcon className="animate-spin" />
+              </span>
+            )}
+            <span className={cn('inline-flex items-center justify-center', forward.isLoading && 'opacity-0')}>
+              {forwardLabel}
+              <ArrowRightIcon className="ml-2 transition-transform group-hover:translate-x-1" />
+            </span>
           </Button>
         )}
       </div>


### PR DESCRIPTION
When using Chrome's built-in translation feature, component `<Button>` which is using
`isLoading` prop can cause runtime crash.

The issue is that the translation feature replaces text node in the button and when
loading is triggered, React is trying to remove that text node and replace it with
a loader UI. But since DOM node has different identity, React can't reconciliate with
this and crashes.

We should probably patch all instances of our `<Button>` component but that would
also change behaviour and UI, so it would be a breaking change. For now, I consider
fixing onboarding a priority as it's an important entry point to the application
and it should work flawlessly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the loading indicator in the onboarding navigation's forward button to display a custom spinner overlay while processing, enhancing user feedback during the onboarding flow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wundergraph/cosmo/pull/2862)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [X] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated. (n/a)
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website). (n/a)
- [X] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

<!--
Please add any additional information or context regarding your changes here.
-->
