### PR TITLE
fix(studio): button style CTAs in onboarding empty state

### DIFF
--- a/studio/src/components/federatedgraphs-cards.tsx
+++ b/studio/src/components/federatedgraphs-cards.tsx
@@ -638,14 +638,22 @@ export const FederatedGraphsCards = ({ graphs, refetch }: { graphs?: FederatedGr
         icon={<BookmarkIcon />}
         title="Dive right back in"
         description="Want to finish the onboarding and create your first federated graph?"
-        actions={<Link href={`/onboarding/${currentStep}`}>Continue</Link>}
+        actions={
+          <Button asChild>
+            <Link href={`/onboarding/${currentStep}`}>Continue</Link>
+          </Button>
+        }
       />
     ) : (
       <EmptyState
         icon={<BoltIcon />}
         title="Need help?"
         description="Take a quick 5-minute tour to help you set up your first federated graph"
-        actions={<Link href={`/onboarding/1`}>Start here</Link>}
+        actions={
+          <Button asChild>
+            <Link href={`/onboarding/1`}>Start here</Link>
+          </Button>
+        }
       />
     );
   }


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the presentation of onboarding action buttons in the empty state to use consistent button styling instead of link elements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wundergraph/cosmo/pull/2864)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Linear: [ENG-9491](https://linear.app/wundergraph/issue/ENG-9491/cosmoonboarding-more-prominent-buttons-for-empty-state)

## Summary

- Wrap onboarding `Continue` / `Start here` links in `<Button asChild>` so the empty-state CTAs render as primary buttons instead of plain text links.
- Triggered when a user has zero federated graphs (e.g. onboarding was skipped or paused).

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.