### PR TITLE
refactor(studio): button loading state

### DIFF
--- a/studio/src/components/onboarding/onboarding-navigation.tsx
+++ b/studio/src/components/onboarding/onboarding-navigation.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeftIcon, ArrowRightIcon, InfoCircledIcon, UpdateIcon } from '@radix-ui/react-icons';
+import { ArrowLeftIcon, ArrowRightIcon, InfoCircledIcon } from '@radix-ui/react-icons';
 import { cn } from '@/lib/utils';
 import { Link } from '../ui/link';
 import { Button } from '../ui/button';
@@ -58,16 +58,14 @@ export const OnboardingNavigation = ({
             </Link>
           </Button>
         ) : (
-          <Button className="group relative" onClick={forward.onClick} disabled={forward.isLoading || forward.disabled}>
-            {forward.isLoading && (
-              <span className="absolute inset-0 flex items-center justify-center">
-                <UpdateIcon className="animate-spin" />
-              </span>
-            )}
-            <span className={cn('inline-flex items-center justify-center', forward.isLoading && 'opacity-0')}>
-              {forwardLabel}
-              <ArrowRightIcon className="ml-2 transition-transform group-hover:translate-x-1" />
-            </span>
+          <Button
+            className="group"
+            onClick={forward.onClick}
+            isLoading={forward.isLoading}
+            disabled={forward.isLoading || forward.disabled}
+          >
+            {forwardLabel}
+            <ArrowRightIcon className="ml-2 transition-transform group-hover:translate-x-1" />
           </Button>
         )}
       </div>

--- a/studio/src/components/ui/button.tsx
+++ b/studio/src/components/ui/button.tsx
@@ -53,13 +53,28 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 
     return (
       <Comp
-        className={cn(isDisabled ? 'cursor-not-allowed' : '', buttonVariants({ variant, size, className }))}
+        className={cn(
+          isDisabled ? 'cursor-not-allowed' : '',
+          buttonVariants({ variant, size, className }),
+          !asChild && isLoading && 'relative',
+        )}
         ref={ref}
         {...props}
         type={type}
         disabled={isDisabled}
       >
-        {isLoading ? <Loader /> : children}
+        {asChild ? (
+          children
+        ) : (
+          <>
+            {isLoading && (
+              <span className="absolute inset-0 flex items-center justify-center">
+                <Loader />
+              </span>
+            )}
+            <span className={cn('inline-flex items-center justify-center', isLoading && 'invisible')}>{children}</span>
+          </>
+        )}
       </Comp>
     );
   },


### PR DESCRIPTION
Modifies the base button to avoid unmounting and re-mounting the children. Doing this
previously caused issues in some edge cases, due to children being unmounted (see #2862)

My original intention was to also allow for new variant of loading state: showing a spinner
along with children (imagine spinner on left side, text on right side). I decided not to
introduce it as we don't have this use case yet.

The current approach uses the existing UI: replace contents of a button with a spinner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Refined button loading state indicator behavior to display more intuitively during async operations.
  * Enhanced onboarding navigation forward button interaction with improved loading state presentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wundergraph/cosmo/pull/2866)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [X] I have discussed my proposed changes in an issue and have received approval to proceed.
- [X] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated. (n/a)
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website). (n/a)
- [X] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

<!--
Please add any additional information or context regarding your changes here.
-->
