### PR TITLE
chore: restructure codeowners from individuals to teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-# Give everyone ownership for everything expections listed below
+# Give everyone ownership for everything exceptions listed below
 *                   @wundergraph/Cosmo @wundergraph/Router
 
 # Protect the CODEOWNERS file

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,7 @@
 /.github/scripts/   @wundergraph/Platform
 /.github/workflows/ @wundergraph/Platform
 /admission-server/  @wundergraph/Cosmo
-/cdn-server/        @wundergraph/Cosmo
+/cdn-server/        @wundergraph/Cosmo @wundergraph/Platform
 /cli/               @wundergraph/Cosmo
 /composition/       @wundergraph/Cosmo
 /connect/           @wundergraph/Router

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,7 +21,6 @@
 /otelcollector/     @wundergraph/Platform
 /playground/        @wundergraph/Cosmo
 /protographic/      @wundergraph/Router
-# Same owner for router and tests to avoid requesting too many reviewers
 /router/            @wundergraph/Router
 /router-tests/      @wundergraph/Router
 /router-plugin/     @wundergraph/Router

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,32 +1,31 @@
 # Give everyone ownership for everything expections listed below
-* @wundergraph/Cosmo @wundergraph/Router
+*                   @wundergraph/Cosmo @wundergraph/Router
 
 # Protect the CODEOWNERS file
-/.github/CODEOWNERS @StarpTech @Aenimus
+/.github/CODEOWNERS @wundergraph/Owners
 
-/admission-server/ @JivusAyrus @StarpTech @thisisnithin @wilsonrivera @Aenimus
-/cdn-server/ @JivusAyrus @StarpTech @thisisnithin @wilsonrivera @Aenimus
-/cli/ @endigma @JivusAyrus @StarpTech @jensneuse @wilsonrivera @Aenimus @thisisnithin
-/composition/ @Aenimus @JivusAyrus @StarpTech @thisisnithin @wilsonrivera
-/connect/ @Aenimus @JivusAyrus @StarpTech @jensneuse @endigma @wilsonrivera @thisisnithin
-/connect-go/ @Aenimus @JivusAyrus @StarpTech @jensneuse @endigma @wilsonrivera @thisisnithin
-/controlplane/ @JivusAyrus @wilsonrivera @StarpTech @thisisnithin @Aenimus
-/graphqlmetrics/ @Noroth @pepol @StarpTech
-/helm/ @Noroth @pepol @StarpTech
-/infrastructure/ @Noroth @pepol @StarpTech
-/keycloak/ @JivusAyrus @wilsonrivera @StarpTech @thisisnithin @Aenimus
-/otelcollector/ @Noroth @pepol @StarpTech
-/playground/ @wundergraph/Router @thisisnithin @StarpTech @Aenimus @JivusAyrus
-/proto/ @JivusAyrus @wilsonrivera @StarpTech @endigma
-/protographic/ @Noroth @StarpTech @endigma @dkorittki
+/.github/actions/   @wundergraph/Platform
+/.github/scripts/   @wundergraph/Platform
+/.github/workflows/ @wundergraph/Platform
+/admission-server/  @wundergraph/Cosmo
+/cdn-server/        @wundergraph/Cosmo
+/cli/               @wundergraph/Cosmo
+/composition/       @wundergraph/Cosmo
+/connect/           @wundergraph/Router
+/connect-go/        @wundergraph/Router
+/controlplane/      @wundergraph/Cosmo
+/graphqlmetrics/    @wundergraph/Platform
+/helm/              @wundergraph/Platform
+/infrastructure/    @wundergraph/Platform
+/keycloak/          @wundergraph/Cosmo
+/otelcollector/     @wundergraph/Platform
+/playground/        @wundergraph/Router
+/protographic/      @wundergraph/Router
 # Same owner for router and tests to avoid requesting too many reviewers
-/router/ @Noroth @devsergiy @StarpTech @jensneuse @endigma @SkArchon
-/router-tests/ @Noroth @devsergiy @StarpTech @jensneuse @endigma @SkArchon
-/router-plugin/ @Noroth @StarpTech @endigma @devsergiy @SkArchon
-/shared/ @Aenimus @JivusAyrus @StarpTech @thisisnithin @wilsonrivera
-/studio/ @JivusAyrus @wilsonrivera @StarpTech @thisisnithin @Aenimus
-# Cosmo Streams / EDFS
-/router/pkg/pubsub @alepane21 @StarpTech @jensneuse @dkorittki
+/router/            @wundergraph/Router
+/router-tests/      @wundergraph/Router
+/router-plugin/     @wundergraph/Router
+/studio/            @wundergraph/Cosmo
 
 # generated protobuf files, sourced from /proto/
 /router/gen/

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,7 +19,7 @@
 /infrastructure/    @wundergraph/Platform
 /keycloak/          @wundergraph/Cosmo
 /otelcollector/     @wundergraph/Platform
-/playground/        @wundergraph/Router
+/playground/        @wundergraph/Cosmo
 /protographic/      @wundergraph/Router
 # Same owner for router and tests to avoid requesting too many reviewers
 /router/            @wundergraph/Router

--- a/.github/workflows/codecov-post-merge.yaml
+++ b/.github/workflows/codecov-post-merge.yaml
@@ -6,6 +6,7 @@ on:
     paths-ignore:
       - 'docs-website/**'
       - '*.md'
+      - '.github/CODEOWNERS'
 
 env:
   CI: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,12 +18,14 @@ on:
     paths-ignore:
       - 'docs-website/**'
       - '*.md'
+      - '.github/CODEOWNERS'
   pull_request:
     branches:
       - main
     paths-ignore:
       - 'docs-website/**'
       - '*.md'
+      - '.github/CODEOWNERS'
   schedule:
     - cron: '27 3 * * 1'
 

--- a/.github/workflows/dummy-ci.yaml
+++ b/.github/workflows/dummy-ci.yaml
@@ -14,6 +14,7 @@ on:
       - 'SECURITY.md'
       - 'LICENSE'
       - '.github/PULL_REQUEST_TEMPLATE.md'
+      - '.github/CODEOWNERS'
 jobs:
   build_test:
     timeout-minutes: 5

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -10,6 +10,7 @@ on:
     paths-ignore:
       - 'docs-website/**'
       - '*.md'
+      - '.github/CODEOWNERS'
 
 permissions:
   contents: write

--- a/.github/workflows/release-preview.yaml
+++ b/.github/workflows/release-preview.yaml
@@ -9,6 +9,7 @@ on:
     paths-ignore:
       - 'docs*/**'
       - '*.md'
+      - '.github/CODEOWNERS'
 
 concurrency:
   group: ${{github.workflow}}-${{github.head_ref}}


### PR DESCRIPTION
- **chore: refactor codeowners**
- **chore: ignore codeowners changes in ci**

<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated repository ownership into fewer, team-based owners and simplified path mappings across top-level areas.
  * Removed many granular ownership entries while preserving the protobuf-generated-files ignore block.
  * Updated CI triggers so edits to the ownership declaration no longer run long workflows; a lightweight CI job will run for PRs that modify it.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wundergraph/cosmo/pull/2870?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

<!--
Please add any additional information or context regarding your changes here.
-->