### PR TITLE
fix: use remapped variables in cost calculation

### DIFF
--- a/router-tests/go.mod
+++ b/router-tests/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/wundergraph/cosmo/router v0.0.0-20260330183556-dc4388d100a4
 	github.com/wundergraph/cosmo/router-plugin v0.0.0-20250808194725-de123ba1c65e
 	github.com/wundergraph/cosmo/speedtrap v0.0.0-00010101000000-000000000000
-	github.com/wundergraph/graphql-go-tools/v2 v2.3.1
+	github.com/wundergraph/graphql-go-tools/v2 v2.3.2-0.20260521124255-6bdf5cc7e187
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0

--- a/router-tests/go.mod
+++ b/router-tests/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/wundergraph/cosmo/router v0.0.0-20260330183556-dc4388d100a4
 	github.com/wundergraph/cosmo/router-plugin v0.0.0-20250808194725-de123ba1c65e
 	github.com/wundergraph/cosmo/speedtrap v0.0.0-00010101000000-000000000000
-	github.com/wundergraph/graphql-go-tools/v2 v2.3.2-0.20260521145953-a59d00e15285
+	github.com/wundergraph/graphql-go-tools/v2 v2.4.0
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0

--- a/router-tests/go.mod
+++ b/router-tests/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/wundergraph/cosmo/router v0.0.0-20260330183556-dc4388d100a4
 	github.com/wundergraph/cosmo/router-plugin v0.0.0-20250808194725-de123ba1c65e
 	github.com/wundergraph/cosmo/speedtrap v0.0.0-00010101000000-000000000000
-	github.com/wundergraph/graphql-go-tools/v2 v2.3.2-0.20260521124255-6bdf5cc7e187
+	github.com/wundergraph/graphql-go-tools/v2 v2.3.2-0.20260521145953-a59d00e15285
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0

--- a/router-tests/go.sum
+++ b/router-tests/go.sum
@@ -379,8 +379,8 @@ github.com/wundergraph/astjson v1.1.0 h1:xORDosrZ87zQFJwNGe/HIHXqzpdHOFmqWgykCLV
 github.com/wundergraph/astjson v1.1.0/go.mod h1:h12D/dxxnedtLzsKyBLK7/Oe4TAoGpRVC9nDpDrZSWw=
 github.com/wundergraph/go-arena v1.1.0 h1:9+wSRkJAkA2vbYHp6s8tEGhPViRGQNGXqPHT0QzhdIc=
 github.com/wundergraph/go-arena v1.1.0/go.mod h1:ROOysEHWJjLQ8FSfNxZCziagb7Qw2nXY3/vgKRh7eWw=
-github.com/wundergraph/graphql-go-tools/v2 v2.3.2-0.20260521124255-6bdf5cc7e187 h1:2licX2B00fU8PwRCYYBVfwUadER657hoGJNX7sUJEcI=
-github.com/wundergraph/graphql-go-tools/v2 v2.3.2-0.20260521124255-6bdf5cc7e187/go.mod h1:xH7XBGtKJkNTi6w6TnCDLRa7Jo2gyBBRUipIYwC5vLI=
+github.com/wundergraph/graphql-go-tools/v2 v2.3.2-0.20260521145953-a59d00e15285 h1:wRgqJAMEtCBAkVbRVKxhVvVqqnOC1bv/5YnBVivdoPk=
+github.com/wundergraph/graphql-go-tools/v2 v2.3.2-0.20260521145953-a59d00e15285/go.mod h1:xH7XBGtKJkNTi6w6TnCDLRa7Jo2gyBBRUipIYwC5vLI=
 github.com/xrash/smetrics v0.0.0-20250705151800-55b8f293f342 h1:FnBeRrxr7OU4VvAzt5X7s6266i6cSVkkFPS0TuXWbIg=
 github.com/xrash/smetrics v0.0.0-20250705151800-55b8f293f342/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=

--- a/router-tests/go.sum
+++ b/router-tests/go.sum
@@ -379,8 +379,8 @@ github.com/wundergraph/astjson v1.1.0 h1:xORDosrZ87zQFJwNGe/HIHXqzpdHOFmqWgykCLV
 github.com/wundergraph/astjson v1.1.0/go.mod h1:h12D/dxxnedtLzsKyBLK7/Oe4TAoGpRVC9nDpDrZSWw=
 github.com/wundergraph/go-arena v1.1.0 h1:9+wSRkJAkA2vbYHp6s8tEGhPViRGQNGXqPHT0QzhdIc=
 github.com/wundergraph/go-arena v1.1.0/go.mod h1:ROOysEHWJjLQ8FSfNxZCziagb7Qw2nXY3/vgKRh7eWw=
-github.com/wundergraph/graphql-go-tools/v2 v2.3.2-0.20260521145953-a59d00e15285 h1:wRgqJAMEtCBAkVbRVKxhVvVqqnOC1bv/5YnBVivdoPk=
-github.com/wundergraph/graphql-go-tools/v2 v2.3.2-0.20260521145953-a59d00e15285/go.mod h1:xH7XBGtKJkNTi6w6TnCDLRa7Jo2gyBBRUipIYwC5vLI=
+github.com/wundergraph/graphql-go-tools/v2 v2.4.0 h1:Vdv6GmApSE5I0YxDDOOxev26tefEZXerP2HpzKkLU9c=
+github.com/wundergraph/graphql-go-tools/v2 v2.4.0/go.mod h1:xH7XBGtKJkNTi6w6TnCDLRa7Jo2gyBBRUipIYwC5vLI=
 github.com/xrash/smetrics v0.0.0-20250705151800-55b8f293f342 h1:FnBeRrxr7OU4VvAzt5X7s6266i6cSVkkFPS0TuXWbIg=
 github.com/xrash/smetrics v0.0.0-20250705151800-55b8f293f342/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=

--- a/router-tests/go.sum
+++ b/router-tests/go.sum
@@ -379,8 +379,8 @@ github.com/wundergraph/astjson v1.1.0 h1:xORDosrZ87zQFJwNGe/HIHXqzpdHOFmqWgykCLV
 github.com/wundergraph/astjson v1.1.0/go.mod h1:h12D/dxxnedtLzsKyBLK7/Oe4TAoGpRVC9nDpDrZSWw=
 github.com/wundergraph/go-arena v1.1.0 h1:9+wSRkJAkA2vbYHp6s8tEGhPViRGQNGXqPHT0QzhdIc=
 github.com/wundergraph/go-arena v1.1.0/go.mod h1:ROOysEHWJjLQ8FSfNxZCziagb7Qw2nXY3/vgKRh7eWw=
-github.com/wundergraph/graphql-go-tools/v2 v2.3.1 h1:LMrFSpTMeAMOBjWzFt/e4C1/xAz4BpxaUl8mmlOCcyw=
-github.com/wundergraph/graphql-go-tools/v2 v2.3.1/go.mod h1:xH7XBGtKJkNTi6w6TnCDLRa7Jo2gyBBRUipIYwC5vLI=
+github.com/wundergraph/graphql-go-tools/v2 v2.3.2-0.20260521124255-6bdf5cc7e187 h1:2licX2B00fU8PwRCYYBVfwUadER657hoGJNX7sUJEcI=
+github.com/wundergraph/graphql-go-tools/v2 v2.3.2-0.20260521124255-6bdf5cc7e187/go.mod h1:xH7XBGtKJkNTi6w6TnCDLRa7Jo2gyBBRUipIYwC5vLI=
 github.com/xrash/smetrics v0.0.0-20250705151800-55b8f293f342 h1:FnBeRrxr7OU4VvAzt5X7s6266i6cSVkkFPS0TuXWbIg=
 github.com/xrash/smetrics v0.0.0-20250705151800-55b8f293f342/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=

--- a/router-tests/security/costs_test.go
+++ b/router-tests/security/costs_test.go
@@ -602,7 +602,7 @@ func TestOperationCost(t *testing.T) {
 			}, func(t *testing.T, xEnv *testenv.Environment) {
 				res, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
 					Query:     `query($some: Int) { slicedThings(first: $some) { a } }`,
-					Variables: []byte(`{"$some": null}`),
+					Variables: []byte(`{"some": null}`),
 				})
 				require.NoError(t, err)
 				require.Equal(t, http.StatusBadRequest, res.Response.StatusCode)

--- a/router-tests/security/costs_test.go
+++ b/router-tests/security/costs_test.go
@@ -510,6 +510,53 @@ func TestOperationCost(t *testing.T) {
 			})
 		})
 
+		t.Run("explicit null in remapped dot-path variable does not fall back to schema default", func(t *testing.T) {
+			t.Parallel()
+			testenv.Run(t, &testenv.Config{
+				ModifySecurityConfiguration: func(securityConfiguration *config.SecurityConfiguration) {
+					securityConfiguration.CostControl = &config.CostControl{
+						Enabled: true,
+						Mode:    config.CostControlModeMeasure,
+					}
+				},
+			}, func(t *testing.T, xEnv *testenv.Environment) {
+				// Explicit null at pagination.first must be preserved through the remap
+				// (it overrides any schema default), so requireOneSlicingArgument sees
+				// "no slicing argument provided" rather than a defaulted value.
+				res, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
+					Query:     `query S($searchInput: ProductSearchInput!) { searchThings(input: $searchInput) { a } }`,
+					Variables: []byte(`{"searchInput": {"pagination": {"first": null}}}`),
+				})
+				require.NoError(t, err)
+				require.Equal(t, http.StatusBadRequest, res.Response.StatusCode)
+				require.Contains(t, res.Body, `"errors"`)
+				require.Contains(t, res.Body, `requires exactly one slicing argument, but none was provided`)
+				require.NotContains(t, res.Body, `"data":`)
+			})
+		})
+
+		t.Run("requireOneSlicingArgument validation across two remapped variables", func(t *testing.T) {
+			t.Parallel()
+			testenv.Run(t, &testenv.Config{
+				ModifySecurityConfiguration: func(securityConfiguration *config.SecurityConfiguration) {
+					securityConfiguration.CostControl = &config.CostControl{
+						Enabled: true,
+						Mode:    config.CostControlModeMeasure,
+					}
+				},
+			}, func(t *testing.T, xEnv *testenv.Environment) {
+				res, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
+					Query:     `query S($firstCount: Int, $lastCount: Int) { slicedThings(first: $firstCount, last: $lastCount) { a } }`,
+					Variables: []byte(`{"firstCount": 5, "lastCount": 3}`),
+				})
+				require.NoError(t, err)
+				require.Equal(t, http.StatusBadRequest, res.Response.StatusCode)
+				require.Contains(t, res.Body, `"errors"`)
+				require.Contains(t, res.Body, `requires exactly one slicing argument, but 2 were provided`)
+				require.NotContains(t, res.Body, `"data":`)
+			})
+		})
+
 		t.Run("disabled variable remapping still computes cost correctly", func(t *testing.T) {
 			t.Parallel()
 			testenv.Run(t, &testenv.Config{

--- a/router-tests/security/costs_test.go
+++ b/router-tests/security/costs_test.go
@@ -457,6 +457,88 @@ func TestOperationCost(t *testing.T) {
 		})
 	})
 
+	t.Run("variables remap", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("dot-path slicingArgument via input-object variable", func(t *testing.T) {
+			t.Parallel()
+			testenv.Run(t, &testenv.Config{
+				ModifySecurityConfiguration: func(securityConfiguration *config.SecurityConfiguration) {
+					securityConfiguration.CostControl = &config.CostControl{
+						Enabled:           true,
+						Mode:              config.CostControlModeEnforce,
+						MaxEstimatedLimit: 10000,
+						EstimatedListSize: 100,
+						ExposeHeaders:     true,
+					}
+				},
+			}, func(t *testing.T, xEnv *testenv.Environment) {
+				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+					Query:     `query S($searchInput: ProductSearchInput!) { searchThings(input: $searchInput) { a } }`,
+					Variables: []byte(`{"searchInput": {"pagination": {"first": 7}}}`),
+				})
+				require.Contains(t, res.Body, `"data":`)
+				require.NotContains(t, res.Body, `"errors":`)
+
+				// pagination.first=7 must drive the estimated cost, not EstimatedListSize(100).
+				require.Equal(t, "7", res.Response.Header.Get(core.CostEstimatedHeader))
+				require.Equal(t, "7", res.Response.Header.Get(core.CostActualHeader))
+			})
+		})
+
+		t.Run("multiple remapped variables", func(t *testing.T) {
+			t.Parallel()
+			testenv.Run(t, &testenv.Config{
+				ModifySecurityConfiguration: func(securityConfiguration *config.SecurityConfiguration) {
+					securityConfiguration.CostControl = &config.CostControl{
+						Enabled:           true,
+						Mode:              config.CostControlModeEnforce,
+						MaxEstimatedLimit: 10000,
+						EstimatedListSize: 100,
+						ExposeHeaders:     true,
+					}
+				},
+			}, func(t *testing.T, xEnv *testenv.Environment) {
+				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+					Query:     `query S($firstCount: Int!, $secondCount: Int!) { sharedThings(numOfA: $firstCount, numOfB: $secondCount) { a } }`,
+					Variables: []byte(`{"firstCount": 13, "secondCount": 99}`),
+				})
+				require.Contains(t, res.Body, `"data":`)
+				require.NotContains(t, res.Body, `"errors":`)
+				require.Equal(t, "13", res.Response.Header.Get(core.CostEstimatedHeader))
+				require.Equal(t, "13", res.Response.Header.Get(core.CostActualHeader))
+			})
+		})
+
+		t.Run("disabled variable remapping still computes cost correctly", func(t *testing.T) {
+			t.Parallel()
+			testenv.Run(t, &testenv.Config{
+				ModifyEngineExecutionConfiguration: func(engineExecutionConfiguration *config.EngineExecutionConfiguration) {
+					// With remapping disabled, cost calc must read variables by their original names directly.
+					engineExecutionConfiguration.DisableVariablesRemapping = true
+				},
+				ModifySecurityConfiguration: func(securityConfiguration *config.SecurityConfiguration) {
+					securityConfiguration.CostControl = &config.CostControl{
+						Enabled:           true,
+						Mode:              config.CostControlModeEnforce,
+						MaxEstimatedLimit: 10000,
+						EstimatedListSize: 100,
+						ExposeHeaders:     true,
+					}
+				},
+			}, func(t *testing.T, xEnv *testenv.Environment) {
+				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+					Query:     `query S($firstCount: Int!, $secondCount: Int!) { sharedThings(numOfA: $firstCount, numOfB: $secondCount) { a } }`,
+					Variables: []byte(`{"firstCount": 13, "secondCount": 99}`),
+				})
+				require.Contains(t, res.Body, `"data":`)
+				require.NotContains(t, res.Body, `"errors":`)
+				require.Equal(t, "13", res.Response.Header.Get(core.CostEstimatedHeader))
+				require.Equal(t, "13", res.Response.Header.Get(core.CostActualHeader))
+			})
+		})
+	})
+
 	t.Run("requireOneSlicingArgument validation", func(t *testing.T) {
 		t.Parallel()
 
@@ -519,8 +601,8 @@ func TestOperationCost(t *testing.T) {
 				ModifySecurityConfiguration: measureCostControl,
 			}, func(t *testing.T, xEnv *testenv.Environment) {
 				res, err := xEnv.MakeGraphQLRequest(testenv.GraphQLRequest{
-					Query:     `query($f: Int) { slicedThings(first: $f) { a } }`,
-					Variables: []byte(`{"f": null}`),
+					Query:     `query($some: Int) { slicedThings(first: $some) { a } }`,
+					Variables: []byte(`{"$some": null}`),
 				})
 				require.NoError(t, err)
 				require.Equal(t, http.StatusBadRequest, res.Response.StatusCode)

--- a/router/core/context.go
+++ b/router/core/context.go
@@ -13,11 +13,11 @@ import (
 	"time"
 
 	"github.com/cespare/xxhash/v2"
-	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/variables"
 	"go.opentelemetry.io/otel/attribute"
 	"go.uber.org/zap"
 
 	"github.com/wundergraph/astjson"
+
 	graphqlmetrics "github.com/wundergraph/cosmo/router/gen/proto/wg/cosmo/graphqlmetrics/v1"
 	rcontext "github.com/wundergraph/cosmo/router/internal/context"
 	"github.com/wundergraph/cosmo/router/internal/expr"
@@ -658,8 +658,8 @@ func (o *operationContext) Variables() *astjson.Value {
 	return o.variables
 }
 
-func (c *operationContext) VariableSet() variables.Set {
-	return variables.NewSet(c.variables, c.remapVariables)
+func (c *operationContext) VariablesView() resolve.VariablesView {
+	return resolve.NewVariablesView(c.variables, c.remapVariables)
 }
 
 func (o *operationContext) Files() []*httpclient.FileUpload {

--- a/router/core/context.go
+++ b/router/core/context.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/cespare/xxhash/v2"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/variables"
 	"go.opentelemetry.io/otel/attribute"
 	"go.uber.org/zap"
 
@@ -655,6 +656,10 @@ type operationContext struct {
 
 func (o *operationContext) Variables() *astjson.Value {
 	return o.variables
+}
+
+func (c *operationContext) VariableSet() variables.Set {
+	return variables.NewSet(c.variables, c.remapVariables)
 }
 
 func (o *operationContext) Files() []*httpclient.FileUpload {

--- a/router/core/graphql_handler.go
+++ b/router/core/graphql_handler.go
@@ -233,7 +233,7 @@ func (h *GraphQLHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					pw.writer.Header().Set(CostEstimatedHeader, strconv.Itoa(reqCtx.operation.costEstimated))
 					if actualListSizes != nil {
 						if costCalc := reqCtx.operation.preparedPlan.preparedPlan.GetCostCalculator(); costCalc != nil {
-							actual := costCalc.ActualCost(resolveCtx.VariableSet(), actualListSizes)
+							actual := costCalc.ActualCost(resolveCtx.VariablesView(), actualListSizes)
 							reqCtx.operation.costActual = actual
 							reqCtx.operation.costActualSet = true
 							pw.writer.Header().Set(CostActualHeader, strconv.Itoa(actual))
@@ -255,7 +255,7 @@ func (h *GraphQLHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if !reqCtx.operation.costActualSet && resolveCtx.ActualListSizes != nil &&
 			reqCtx.operation.preparedPlan != nil && reqCtx.operation.preparedPlan.preparedPlan != nil {
 			if costCalc := reqCtx.operation.preparedPlan.preparedPlan.GetCostCalculator(); costCalc != nil {
-				reqCtx.operation.costActual = costCalc.ActualCost(resolveCtx.VariableSet(), resolveCtx.ActualListSizes)
+				reqCtx.operation.costActual = costCalc.ActualCost(resolveCtx.VariablesView(), resolveCtx.ActualListSizes)
 				reqCtx.operation.costActualSet = true
 			}
 		}

--- a/router/core/graphql_handler.go
+++ b/router/core/graphql_handler.go
@@ -233,7 +233,7 @@ func (h *GraphQLHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					pw.writer.Header().Set(CostEstimatedHeader, strconv.Itoa(reqCtx.operation.costEstimated))
 					if actualListSizes != nil {
 						if costCalc := reqCtx.operation.preparedPlan.preparedPlan.GetCostCalculator(); costCalc != nil {
-							actual := costCalc.ActualCost(resolveCtx.Variables, actualListSizes)
+							actual := costCalc.ActualCost(resolveCtx.VariableSet(), actualListSizes)
 							reqCtx.operation.costActual = actual
 							reqCtx.operation.costActualSet = true
 							pw.writer.Header().Set(CostActualHeader, strconv.Itoa(actual))
@@ -255,7 +255,7 @@ func (h *GraphQLHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if !reqCtx.operation.costActualSet && resolveCtx.ActualListSizes != nil &&
 			reqCtx.operation.preparedPlan != nil && reqCtx.operation.preparedPlan.preparedPlan != nil {
 			if costCalc := reqCtx.operation.preparedPlan.preparedPlan.GetCostCalculator(); costCalc != nil {
-				reqCtx.operation.costActual = costCalc.ActualCost(resolveCtx.Variables, resolveCtx.ActualListSizes)
+				reqCtx.operation.costActual = costCalc.ActualCost(resolveCtx.VariableSet(), resolveCtx.ActualListSizes)
 				reqCtx.operation.costActualSet = true
 			}
 		}

--- a/router/core/operation_processor.go
+++ b/router/core/operation_processor.go
@@ -1418,14 +1418,14 @@ func (o *OperationKit) ValidateStaticCost(opCtx *operationContext) error {
 	// Compute and cache estimated cost once after planning
 	if opCtx.preparedPlan != nil && opCtx.preparedPlan.preparedPlan != nil {
 		if costCalc := opCtx.preparedPlan.preparedPlan.GetCostCalculator(); costCalc != nil {
-
 			// Validate that variables/arguments are correct for the requirements in listSize
 			var sliceReport operationreport.Report
-			costCalc.ValidateSliceArguments(opCtx.variables, &sliceReport)
+			vs := opCtx.VariableSet()
+			costCalc.ValidateSliceArguments(vs, &sliceReport)
 			if sliceReport.HasErrors() {
 				return &reportError{report: &sliceReport}
 			}
-			opCtx.costEstimated = costCalc.EstimateCost(opCtx.variables)
+			opCtx.costEstimated = costCalc.EstimateCost(vs)
 			opCtx.costEstimatedSet = true
 		}
 	}

--- a/router/core/operation_processor.go
+++ b/router/core/operation_processor.go
@@ -1420,7 +1420,7 @@ func (o *OperationKit) ValidateStaticCost(opCtx *operationContext) error {
 		if costCalc := opCtx.preparedPlan.preparedPlan.GetCostCalculator(); costCalc != nil {
 			// Validate that variables/arguments are correct for the requirements in listSize
 			var sliceReport operationreport.Report
-			vs := opCtx.VariableSet()
+			vs := opCtx.VariablesView()
 			costCalc.ValidateSliceArguments(vs, &sliceReport)
 			if sliceReport.HasErrors() {
 				return &reportError{report: &sliceReport}

--- a/router/go.mod
+++ b/router/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/tidwall/gjson v1.18.0
 	github.com/tidwall/sjson v1.2.5
 	github.com/twmb/franz-go v1.16.1
-	github.com/wundergraph/graphql-go-tools/v2 v2.3.2-0.20260521124255-6bdf5cc7e187
+	github.com/wundergraph/graphql-go-tools/v2 v2.3.2-0.20260521145953-a59d00e15285
 	// Do not upgrade, it renames attributes we rely on
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0
 	go.opentelemetry.io/contrib/propagators/b3 v1.43.0

--- a/router/go.mod
+++ b/router/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/tidwall/gjson v1.18.0
 	github.com/tidwall/sjson v1.2.5
 	github.com/twmb/franz-go v1.16.1
-	github.com/wundergraph/graphql-go-tools/v2 v2.3.1
+	github.com/wundergraph/graphql-go-tools/v2 v2.3.2-0.20260521124255-6bdf5cc7e187
 	// Do not upgrade, it renames attributes we rely on
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0
 	go.opentelemetry.io/contrib/propagators/b3 v1.43.0

--- a/router/go.mod
+++ b/router/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/tidwall/gjson v1.18.0
 	github.com/tidwall/sjson v1.2.5
 	github.com/twmb/franz-go v1.16.1
-	github.com/wundergraph/graphql-go-tools/v2 v2.3.2-0.20260521145953-a59d00e15285
+	github.com/wundergraph/graphql-go-tools/v2 v2.4.0
 	// Do not upgrade, it renames attributes we rely on
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0
 	go.opentelemetry.io/contrib/propagators/b3 v1.43.0

--- a/router/go.sum
+++ b/router/go.sum
@@ -331,8 +331,8 @@ github.com/wundergraph/astjson v1.1.0 h1:xORDosrZ87zQFJwNGe/HIHXqzpdHOFmqWgykCLV
 github.com/wundergraph/astjson v1.1.0/go.mod h1:h12D/dxxnedtLzsKyBLK7/Oe4TAoGpRVC9nDpDrZSWw=
 github.com/wundergraph/go-arena v1.1.0 h1:9+wSRkJAkA2vbYHp6s8tEGhPViRGQNGXqPHT0QzhdIc=
 github.com/wundergraph/go-arena v1.1.0/go.mod h1:ROOysEHWJjLQ8FSfNxZCziagb7Qw2nXY3/vgKRh7eWw=
-github.com/wundergraph/graphql-go-tools/v2 v2.3.2-0.20260521124255-6bdf5cc7e187 h1:2licX2B00fU8PwRCYYBVfwUadER657hoGJNX7sUJEcI=
-github.com/wundergraph/graphql-go-tools/v2 v2.3.2-0.20260521124255-6bdf5cc7e187/go.mod h1:xH7XBGtKJkNTi6w6TnCDLRa7Jo2gyBBRUipIYwC5vLI=
+github.com/wundergraph/graphql-go-tools/v2 v2.3.2-0.20260521145953-a59d00e15285 h1:wRgqJAMEtCBAkVbRVKxhVvVqqnOC1bv/5YnBVivdoPk=
+github.com/wundergraph/graphql-go-tools/v2 v2.3.2-0.20260521145953-a59d00e15285/go.mod h1:xH7XBGtKJkNTi6w6TnCDLRa7Jo2gyBBRUipIYwC5vLI=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=

--- a/router/go.sum
+++ b/router/go.sum
@@ -331,8 +331,8 @@ github.com/wundergraph/astjson v1.1.0 h1:xORDosrZ87zQFJwNGe/HIHXqzpdHOFmqWgykCLV
 github.com/wundergraph/astjson v1.1.0/go.mod h1:h12D/dxxnedtLzsKyBLK7/Oe4TAoGpRVC9nDpDrZSWw=
 github.com/wundergraph/go-arena v1.1.0 h1:9+wSRkJAkA2vbYHp6s8tEGhPViRGQNGXqPHT0QzhdIc=
 github.com/wundergraph/go-arena v1.1.0/go.mod h1:ROOysEHWJjLQ8FSfNxZCziagb7Qw2nXY3/vgKRh7eWw=
-github.com/wundergraph/graphql-go-tools/v2 v2.3.1 h1:LMrFSpTMeAMOBjWzFt/e4C1/xAz4BpxaUl8mmlOCcyw=
-github.com/wundergraph/graphql-go-tools/v2 v2.3.1/go.mod h1:xH7XBGtKJkNTi6w6TnCDLRa7Jo2gyBBRUipIYwC5vLI=
+github.com/wundergraph/graphql-go-tools/v2 v2.3.2-0.20260521124255-6bdf5cc7e187 h1:2licX2B00fU8PwRCYYBVfwUadER657hoGJNX7sUJEcI=
+github.com/wundergraph/graphql-go-tools/v2 v2.3.2-0.20260521124255-6bdf5cc7e187/go.mod h1:xH7XBGtKJkNTi6w6TnCDLRa7Jo2gyBBRUipIYwC5vLI=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=

--- a/router/go.sum
+++ b/router/go.sum
@@ -331,8 +331,8 @@ github.com/wundergraph/astjson v1.1.0 h1:xORDosrZ87zQFJwNGe/HIHXqzpdHOFmqWgykCLV
 github.com/wundergraph/astjson v1.1.0/go.mod h1:h12D/dxxnedtLzsKyBLK7/Oe4TAoGpRVC9nDpDrZSWw=
 github.com/wundergraph/go-arena v1.1.0 h1:9+wSRkJAkA2vbYHp6s8tEGhPViRGQNGXqPHT0QzhdIc=
 github.com/wundergraph/go-arena v1.1.0/go.mod h1:ROOysEHWJjLQ8FSfNxZCziagb7Qw2nXY3/vgKRh7eWw=
-github.com/wundergraph/graphql-go-tools/v2 v2.3.2-0.20260521145953-a59d00e15285 h1:wRgqJAMEtCBAkVbRVKxhVvVqqnOC1bv/5YnBVivdoPk=
-github.com/wundergraph/graphql-go-tools/v2 v2.3.2-0.20260521145953-a59d00e15285/go.mod h1:xH7XBGtKJkNTi6w6TnCDLRa7Jo2gyBBRUipIYwC5vLI=
+github.com/wundergraph/graphql-go-tools/v2 v2.4.0 h1:Vdv6GmApSE5I0YxDDOOxev26tefEZXerP2HpzKkLU9c=
+github.com/wundergraph/graphql-go-tools/v2 v2.4.0/go.mod h1:xH7XBGtKJkNTi6w6TnCDLRa7Jo2gyBBRUipIYwC5vLI=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=


### PR DESCRIPTION
Simple PR to verify that remapped variables are handled correctly in the fixed engine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped a core GraphQL tooling dependency to v2.4.0.

* **Tests**
  * Expanded cost-control tests to cover variable remapping, input-object slicing, scalar multipliers, explicit null handling, and related validation edge cases.

* **Improvements**
  * Cost estimation, validation, and response cost reporting now honor remapped GraphQL variables.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wundergraph/cosmo/pull/2882?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->