### PR TITLE
fix: use float64 for intermediate cost calculations

### DIFF
--- a/router-tests/go.mod
+++ b/router-tests/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/wundergraph/cosmo/router v0.0.0-20260330183556-dc4388d100a4
 	github.com/wundergraph/cosmo/router-plugin v0.0.0-20250808194725-de123ba1c65e
 	github.com/wundergraph/cosmo/speedtrap v0.0.0-00010101000000-000000000000
-	github.com/wundergraph/graphql-go-tools/v2 v2.4.0
+	github.com/wundergraph/graphql-go-tools/v2 v2.4.1-0.20260522152022-e2d6da4c8e50
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0

--- a/router-tests/go.mod
+++ b/router-tests/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/wundergraph/cosmo/router v0.0.0-20260330183556-dc4388d100a4
 	github.com/wundergraph/cosmo/router-plugin v0.0.0-20250808194725-de123ba1c65e
 	github.com/wundergraph/cosmo/speedtrap v0.0.0-00010101000000-000000000000
-	github.com/wundergraph/graphql-go-tools/v2 v2.4.1-0.20260522152022-e2d6da4c8e50
+	github.com/wundergraph/graphql-go-tools/v2 v2.4.1
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0

--- a/router-tests/go.sum
+++ b/router-tests/go.sum
@@ -379,8 +379,8 @@ github.com/wundergraph/astjson v1.1.0 h1:xORDosrZ87zQFJwNGe/HIHXqzpdHOFmqWgykCLV
 github.com/wundergraph/astjson v1.1.0/go.mod h1:h12D/dxxnedtLzsKyBLK7/Oe4TAoGpRVC9nDpDrZSWw=
 github.com/wundergraph/go-arena v1.1.0 h1:9+wSRkJAkA2vbYHp6s8tEGhPViRGQNGXqPHT0QzhdIc=
 github.com/wundergraph/go-arena v1.1.0/go.mod h1:ROOysEHWJjLQ8FSfNxZCziagb7Qw2nXY3/vgKRh7eWw=
-github.com/wundergraph/graphql-go-tools/v2 v2.4.1-0.20260522152022-e2d6da4c8e50 h1:rgx1/2wNfT/ZTnW/QfDzn1zOUoNQCDGTK/oePlEIkNM=
-github.com/wundergraph/graphql-go-tools/v2 v2.4.1-0.20260522152022-e2d6da4c8e50/go.mod h1:xH7XBGtKJkNTi6w6TnCDLRa7Jo2gyBBRUipIYwC5vLI=
+github.com/wundergraph/graphql-go-tools/v2 v2.4.1 h1:zkqqyojT4feX65E+4i+1FKidpzhoeU/5NzNxs6z6a9I=
+github.com/wundergraph/graphql-go-tools/v2 v2.4.1/go.mod h1:xH7XBGtKJkNTi6w6TnCDLRa7Jo2gyBBRUipIYwC5vLI=
 github.com/xrash/smetrics v0.0.0-20250705151800-55b8f293f342 h1:FnBeRrxr7OU4VvAzt5X7s6266i6cSVkkFPS0TuXWbIg=
 github.com/xrash/smetrics v0.0.0-20250705151800-55b8f293f342/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=

--- a/router-tests/go.sum
+++ b/router-tests/go.sum
@@ -379,8 +379,8 @@ github.com/wundergraph/astjson v1.1.0 h1:xORDosrZ87zQFJwNGe/HIHXqzpdHOFmqWgykCLV
 github.com/wundergraph/astjson v1.1.0/go.mod h1:h12D/dxxnedtLzsKyBLK7/Oe4TAoGpRVC9nDpDrZSWw=
 github.com/wundergraph/go-arena v1.1.0 h1:9+wSRkJAkA2vbYHp6s8tEGhPViRGQNGXqPHT0QzhdIc=
 github.com/wundergraph/go-arena v1.1.0/go.mod h1:ROOysEHWJjLQ8FSfNxZCziagb7Qw2nXY3/vgKRh7eWw=
-github.com/wundergraph/graphql-go-tools/v2 v2.4.0 h1:Vdv6GmApSE5I0YxDDOOxev26tefEZXerP2HpzKkLU9c=
-github.com/wundergraph/graphql-go-tools/v2 v2.4.0/go.mod h1:xH7XBGtKJkNTi6w6TnCDLRa7Jo2gyBBRUipIYwC5vLI=
+github.com/wundergraph/graphql-go-tools/v2 v2.4.1-0.20260522152022-e2d6da4c8e50 h1:rgx1/2wNfT/ZTnW/QfDzn1zOUoNQCDGTK/oePlEIkNM=
+github.com/wundergraph/graphql-go-tools/v2 v2.4.1-0.20260522152022-e2d6da4c8e50/go.mod h1:xH7XBGtKJkNTi6w6TnCDLRa7Jo2gyBBRUipIYwC5vLI=
 github.com/xrash/smetrics v0.0.0-20250705151800-55b8f293f342 h1:FnBeRrxr7OU4VvAzt5X7s6266i6cSVkkFPS0TuXWbIg=
 github.com/xrash/smetrics v0.0.0-20250705151800-55b8f293f342/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=

--- a/router-tests/security/costs_test.go
+++ b/router-tests/security/costs_test.go
@@ -224,7 +224,7 @@ func TestOperationCost(t *testing.T) {
 				// 50 * (employees(1) + id(0) + 1 * (role(1) + 3 * departments(1) + 5 * title(1)))
 				require.Equal(t, "500", res.Response.Header.Get(core.CostEstimatedHeader))
 				// 10 * (employees(1) + id(0) + 1 * (role(1) + 1.2 * departments(1) + 1.4 * title(1)))
-				require.Equal(t, "40", res.Response.Header.Get(core.CostActualHeader))
+				require.Equal(t, "46", res.Response.Header.Get(core.CostActualHeader))
 			})
 		})
 
@@ -280,14 +280,14 @@ func TestOperationCost(t *testing.T) {
 				// (not merged) because resolving from two subgraphs means more work for the router.
 				//
 				// products field (abstract, both DSes): fieldCost = 5 + 8 = 13
-				// engineers (list, EstimatedListSize=10): (0 + 1) × 10 = 10
+				// engineers (list, EstimatedListSize=10): (0 + 1) * 10 = 10
 				// upc, repositoryURL, id: 0 (scalars)
-				// total: (10 + 13) × 10 = 230
+				// total: (10 + 13) * 10 = 230
 				estimated := res.Response.Header.Get(core.CostEstimatedHeader)
 				require.Equal(t, "230", estimated)
 
 				actual := res.Response.Header.Get(core.CostActualHeader)
-				require.Equal(t, "45", actual)
+				require.Equal(t, "46", actual) // (7/3 + 13) * 3
 
 				// Query 2: only employees-subgraph fields — Cosmo @cost(weight: 5) from employees applies
 				res2 := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
@@ -300,7 +300,7 @@ func TestOperationCost(t *testing.T) {
 				require.Equal(t, "150", estimated2)
 
 				actual2 := res2.Response.Header.Get(core.CostActualHeader)
-				require.Equal(t, "21", actual2)
+				require.Equal(t, "22", actual2)
 			})
 		})
 
@@ -1132,7 +1132,7 @@ func TestOperationCost(t *testing.T) {
 				require.Equal(t, uint64(3), totalCount, "should have 3 cost recordings (1 miss + 2 hits)")
 
 				// employee(id:1) cost = 8 per request.  3 requests = 24.
-				require.Equal(t, int64(24), totalSum, "total estimated cost sum should be 3×8=24")
+				require.Equal(t, int64(24), totalSum, "total estimated cost sum should be 3*8=24")
 			})
 		})
 

--- a/router/go.mod
+++ b/router/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/tidwall/gjson v1.18.0
 	github.com/tidwall/sjson v1.2.5
 	github.com/twmb/franz-go v1.16.1
-	github.com/wundergraph/graphql-go-tools/v2 v2.4.1-0.20260522152022-e2d6da4c8e50
+	github.com/wundergraph/graphql-go-tools/v2 v2.4.1
 	// Do not upgrade, it renames attributes we rely on
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0
 	go.opentelemetry.io/contrib/propagators/b3 v1.43.0

--- a/router/go.mod
+++ b/router/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/tidwall/gjson v1.18.0
 	github.com/tidwall/sjson v1.2.5
 	github.com/twmb/franz-go v1.16.1
-	github.com/wundergraph/graphql-go-tools/v2 v2.4.0
+	github.com/wundergraph/graphql-go-tools/v2 v2.4.1-0.20260522152022-e2d6da4c8e50
 	// Do not upgrade, it renames attributes we rely on
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0
 	go.opentelemetry.io/contrib/propagators/b3 v1.43.0

--- a/router/go.sum
+++ b/router/go.sum
@@ -331,8 +331,8 @@ github.com/wundergraph/astjson v1.1.0 h1:xORDosrZ87zQFJwNGe/HIHXqzpdHOFmqWgykCLV
 github.com/wundergraph/astjson v1.1.0/go.mod h1:h12D/dxxnedtLzsKyBLK7/Oe4TAoGpRVC9nDpDrZSWw=
 github.com/wundergraph/go-arena v1.1.0 h1:9+wSRkJAkA2vbYHp6s8tEGhPViRGQNGXqPHT0QzhdIc=
 github.com/wundergraph/go-arena v1.1.0/go.mod h1:ROOysEHWJjLQ8FSfNxZCziagb7Qw2nXY3/vgKRh7eWw=
-github.com/wundergraph/graphql-go-tools/v2 v2.4.0 h1:Vdv6GmApSE5I0YxDDOOxev26tefEZXerP2HpzKkLU9c=
-github.com/wundergraph/graphql-go-tools/v2 v2.4.0/go.mod h1:xH7XBGtKJkNTi6w6TnCDLRa7Jo2gyBBRUipIYwC5vLI=
+github.com/wundergraph/graphql-go-tools/v2 v2.4.1-0.20260522152022-e2d6da4c8e50 h1:rgx1/2wNfT/ZTnW/QfDzn1zOUoNQCDGTK/oePlEIkNM=
+github.com/wundergraph/graphql-go-tools/v2 v2.4.1-0.20260522152022-e2d6da4c8e50/go.mod h1:xH7XBGtKJkNTi6w6TnCDLRa7Jo2gyBBRUipIYwC5vLI=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=

--- a/router/go.sum
+++ b/router/go.sum
@@ -331,8 +331,8 @@ github.com/wundergraph/astjson v1.1.0 h1:xORDosrZ87zQFJwNGe/HIHXqzpdHOFmqWgykCLV
 github.com/wundergraph/astjson v1.1.0/go.mod h1:h12D/dxxnedtLzsKyBLK7/Oe4TAoGpRVC9nDpDrZSWw=
 github.com/wundergraph/go-arena v1.1.0 h1:9+wSRkJAkA2vbYHp6s8tEGhPViRGQNGXqPHT0QzhdIc=
 github.com/wundergraph/go-arena v1.1.0/go.mod h1:ROOysEHWJjLQ8FSfNxZCziagb7Qw2nXY3/vgKRh7eWw=
-github.com/wundergraph/graphql-go-tools/v2 v2.4.1-0.20260522152022-e2d6da4c8e50 h1:rgx1/2wNfT/ZTnW/QfDzn1zOUoNQCDGTK/oePlEIkNM=
-github.com/wundergraph/graphql-go-tools/v2 v2.4.1-0.20260522152022-e2d6da4c8e50/go.mod h1:xH7XBGtKJkNTi6w6TnCDLRa7Jo2gyBBRUipIYwC5vLI=
+github.com/wundergraph/graphql-go-tools/v2 v2.4.1 h1:zkqqyojT4feX65E+4i+1FKidpzhoeU/5NzNxs6z6a9I=
+github.com/wundergraph/graphql-go-tools/v2 v2.4.1/go.mod h1:xH7XBGtKJkNTi6w6TnCDLRa7Jo2gyBBRUipIYwC5vLI=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=


### PR DESCRIPTION
Previously we were rounding cost at every level of cost calculation.
That lead to accumulated drift, especially on the deeply nested
queries.

Round the cost on the return (final node) instead of intermediate nodes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated GraphQL tools dependency to a newer release across router modules.

* **Tests**
  * Adjusted operation cost calculation test assertions to reflect updated expected values and multi-query scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wundergraph/cosmo/pull/2887?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->