### PR TITLE
feat: new post-signup screen for accepting & joining an org

### DIFF
--- a/studio/src/components/app-provider.tsx
+++ b/studio/src/components/app-provider.tsx
@@ -1,4 +1,5 @@
 import { identify, resetTracking } from '@/lib/track';
+import type { NextRouter } from 'next/router';
 import { PlainMessage } from '@bufbuild/protobuf';
 import { Transport } from '@connectrpc/connect';
 import { TransportProvider } from '@connectrpc/connect-query';
@@ -11,6 +12,8 @@ import { useCookieOrganization } from '@/hooks/use-cookie-organization';
 import { setUser as setSentryUser } from '@sentry/nextjs';
 import { OrganizationRole } from '@/lib/constants';
 import { WorkspaceProvider } from '@/components/dashboard/workspace-provider';
+import JoinInvitationsPage from '@/pages/account/join';
+import { Loader } from './ui/loader';
 
 const sessionQueryClient = new QueryClient();
 
@@ -36,6 +39,7 @@ export interface InvitedOrgs {
   id: string;
   name: string;
   slug: string;
+  invitedBy: string;
 }
 
 export interface Organization {
@@ -116,9 +120,18 @@ const fetchSession = async () => {
   }
 };
 
+const shouldSeeInvitationsJoinPage = ({
+  router,
+  invitations,
+}: {
+  router: NextRouter;
+  invitations?: User['invitations'];
+}) => router.query.onboarding === 'true' && invitations && invitations.length > 0;
+
 export const AppProvider = ({ children }: { children: ReactNode }) => {
   const router = useRouter();
   const currentOrgSlug = router.query.organizationSlug;
+  const isNewUser = router.query.onboarding === 'true';
 
   // we store the current org slug in a cookie, so that we can redirect to the correct org after login
   // as well as being able to access the cookie on the server.
@@ -216,14 +229,15 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
         (router.pathname === '/' || router.pathname === '/login' || !currentOrg) &&
         router.pathname !== '/account/invitations' &&
         // match onboarding URL `/onboarding/1` etc
-        !/^\/onboarding(?:\/\d+)?(?:\/|$)/.test(router.pathname)
+        !/^\/onboarding(?:\/\d+)?(?:\/|$)/.test(router.pathname) &&
+        !shouldSeeInvitationsJoinPage({ router, invitations: data.invitations })
       ) {
         const url = new URL(window.location.origin + router.basePath + router.asPath);
         const params = new URLSearchParams(url.search);
         router.replace(params.size !== 0 ? `/${organization.slug}?${params}` : `/${organization.slug}`);
       }
     }
-  }, [router, data, isFetching, error, cookieOrgSlug]);
+  }, [router, data, isFetching, error, cookieOrgSlug, isNewUser]);
 
   useEffect(() => {
     if (!verifiedOrganizationSlug) {
@@ -268,6 +282,23 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
           <WorkspaceProvider>{children}</WorkspaceProvider>
         </SessionClientContext.Provider>
       </UserContext.Provider>
+    );
+  }
+
+  // TODO: add skeleton
+  if (isFetching) {
+    return <Loader />;
+  }
+
+  if (shouldSeeInvitationsJoinPage({ router, invitations: data?.invitations })) {
+    return (
+      <TransportProvider transport={transport}>
+        <UserContext.Provider value={user}>
+          <SessionClientContext.Provider value={sessionQueryClient}>
+            <JoinInvitationsPage invitations={data?.invitations ?? []} isLoading={isFetching} />
+          </SessionClientContext.Provider>
+        </UserContext.Provider>
+      </TransportProvider>
     );
   }
 

--- a/studio/src/components/app-provider.tsx
+++ b/studio/src/components/app-provider.tsx
@@ -285,11 +285,6 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
     );
   }
 
-  // TODO: add skeleton
-  if (isFetching) {
-    return <Loader />;
-  }
-
   if (shouldSeeInvitationsJoinPage({ router, invitations: data?.invitations })) {
     return (
       <TransportProvider transport={transport}>

--- a/studio/src/components/empty-state.tsx
+++ b/studio/src/components/empty-state.tsx
@@ -14,9 +14,13 @@ export const EmptyState: React.FC<EmptyStateProps> = (props) => {
   return (
     <div className={cn('flex h-[520px] w-full items-center justify-center rounded-md', className)}>
       <div className="mx-auto flex w-full flex-col items-center justify-center px-6 text-center md:max-w-2xl">
-        <span className="m-auto flex h-12 w-12 items-center justify-center text-6xl text-muted-foreground">{icon}</span>
-        <h3 className="mt-4 text-lg font-semibold">{title}</h3>
-        <p className="mb-4 mt-2 break-words text-sm text-muted-foreground">{description}</p>
+        {icon && (
+          <span className="m-auto flex h-12 w-12 items-center justify-center text-6xl text-muted-foreground">
+            {icon}
+          </span>
+        )}
+        {title && <h3 className="mt-4 text-lg font-semibold">{title}</h3>}
+        {description && <p className="mb-4 mt-2 break-words text-sm text-muted-foreground">{description}</p>}
         <div className="mb-4 flex w-full justify-center">{actions}</div>
       </div>
     </div>

--- a/studio/src/components/empty-state.tsx
+++ b/studio/src/components/empty-state.tsx
@@ -2,7 +2,7 @@ import { cn } from '@/lib/utils';
 
 export interface EmptyStateProps {
   icon?: React.ReactNode;
-  title: React.ReactNode;
+  title?: React.ReactNode;
   description?: React.ReactNode;
   actions?: React.ReactNode;
   className?: string;

--- a/studio/src/components/federatedgraphs-cards.tsx
+++ b/studio/src/components/federatedgraphs-cards.tsx
@@ -491,7 +491,7 @@ export const Empty = ({
             {checkUserAccess({ rolesToBe: ['organization-admin', 'organization-developer'] }) && (
               <>
                 {displayOnboardingEmptyState ? (
-                  <OnboardingOrSeparator />
+                  <OnboardingOrSeparator className="my-4" />
                 ) : (
                   <span className="text-sm font-bold">OR</span>
                 )}
@@ -678,9 +678,9 @@ function OnboardingBoltIcon() {
   return <LightningBoltIcon className="size-10 text-primary" />;
 }
 
-function OnboardingOrSeparator() {
+function OnboardingOrSeparator({ className }: { className?: string }) {
   return (
-    <div className="mt-7 flex w-full items-center gap-4">
+    <div className={cn('mt-7 flex w-full items-center gap-4', className)}>
       <span className="h-px flex-1 bg-border" />
       <span className="text-xs font-bold text-muted-foreground">OR</span>
       <span className="h-px flex-1 bg-border" />
@@ -692,7 +692,7 @@ function OnboardingEmptyState({ step, isFinished }: { step?: number; isFinished:
   const shouldContinue = step !== undefined && !isFinished;
 
   return (
-    <div className="flex w-full max-w-2xl flex-col items-center px-4 text-center">
+    <div className="flex w-full max-w-2xl flex-col items-center px-6 text-center">
       <OnboardingBoltIcon />
       <h3 className="mt-7 text-2xl font-bold tracking-tight">Create your first graph</h3>
       <p className="mt-4 text-sm text-muted-foreground">

--- a/studio/src/components/federatedgraphs-cards.tsx
+++ b/studio/src/components/federatedgraphs-cards.tsx
@@ -6,14 +6,12 @@ import { formatMetric } from '@/lib/format-metric';
 import { useChartData } from '@/lib/insights-helpers';
 import { cn } from '@/lib/utils';
 import {
-  BoltIcon,
-  BookmarkIcon,
   ChevronDoubleRightIcon,
   CommandLineIcon,
   DocumentArrowDownIcon,
   ExclamationTriangleIcon,
 } from '@heroicons/react/24/outline';
-import { Component2Icon } from '@radix-ui/react-icons';
+import { ArrowRightIcon, Component2Icon, LightningBoltIcon, PlayIcon } from '@radix-ui/react-icons';
 import { EnumStatusCode } from '@wundergraph/cosmo-connect/dist/common/common_pb';
 import { migrateFromApollo } from '@wundergraph/cosmo-connect/dist/platform/v1/platform-PlatformService_connectquery';
 import { FederatedGraph } from '@wundergraph/cosmo-connect/dist/platform/v1/platform_pb';
@@ -413,65 +411,73 @@ export const Empty = ({
     namespace: { name: namespace },
   } = useWorkspace();
 
+  const { onboarding, enabled, currentStep } = useOnboarding();
+  const displayOnboardingEmptyState = enabled && onboarding && onboarding.federatedGraphsCount === 0;
+
   let labels = 'team=A';
   return (
-    <EmptyState
-      className="h-auto"
-      icon={<CommandLineIcon />}
-      title="No graphs found"
-      description={
-        <>
-          Use the CLI tool to create either a federated graph ({' '}
-          <a
-            target="_blank"
-            rel="noreferrer"
-            href={docsBaseURL + '/cli/federated-graph/create'}
-            className="text-primary"
-          >
-            docs
-          </a>{' '}
-          ) or a monograph ({' '}
-          <a target="_blank" rel="noreferrer" href={docsBaseURL + '/cli/monograph/create'} className="text-primary">
-            docs
-          </a>{' '}
-          ).
-        </>
-      }
-      actions={
-        <div className="flex flex-col gap-y-6">
-          <Tabs defaultValue="federated" className="mt-8 w-full">
-            <TabsList className="grid w-full grid-cols-2">
-              <TabsTrigger value="federated">Federated Graph</TabsTrigger>
-              <TabsTrigger value="monograph">Monograph</TabsTrigger>
-            </TabsList>
-            <TabsContent value="federated">
-              <CLI
-                command={`npx wgc federated-graph create production --namespace ${namespace} --label-matcher ${labels} --routing-url http://localhost:3002/graphql`}
-              />
-            </TabsContent>
-            <TabsContent value="monograph">
-              <CLI
-                command={`npx wgc monograph create production --namespace ${namespace} --routing-url http://localhost:3002/graphql  --graph-url http://localhost:4000/graphql`}
-              />
-            </TabsContent>
-          </Tabs>
+    <>
+      {displayOnboardingEmptyState && (
+        <OnboardingEmptyState step={currentStep} isFinished={Boolean(onboarding.finishedAt)} />
+      )}
+      <EmptyState
+        className="h-auto"
+        icon={<CommandLineIcon />}
+        title="No graphs found"
+        description={
+          <>
+            Use the CLI tool to create either a federated graph ({' '}
+            <a
+              target="_blank"
+              rel="noreferrer"
+              href={docsBaseURL + '/cli/federated-graph/create'}
+              className="text-primary"
+            >
+              docs
+            </a>{' '}
+            ) or a monograph ({' '}
+            <a target="_blank" rel="noreferrer" href={docsBaseURL + '/cli/monograph/create'} className="text-primary">
+              docs
+            </a>{' '}
+            ).
+          </>
+        }
+        actions={
+          <div className="flex flex-col gap-y-6">
+            <Tabs defaultValue="federated" className="mt-8 w-full">
+              <TabsList className="grid w-full grid-cols-2">
+                <TabsTrigger value="federated">Federated Graph</TabsTrigger>
+                <TabsTrigger value="monograph">Monograph</TabsTrigger>
+              </TabsList>
+              <TabsContent value="federated">
+                <CLI
+                  command={`npx wgc federated-graph create production --namespace ${namespace} --label-matcher ${labels} --routing-url http://localhost:3002/graphql`}
+                />
+              </TabsContent>
+              <TabsContent value="monograph">
+                <CLI
+                  command={`npx wgc monograph create production --namespace ${namespace} --routing-url http://localhost:3002/graphql  --graph-url http://localhost:4000/graphql`}
+                />
+              </TabsContent>
+            </Tabs>
 
-          {checkUserAccess({ rolesToBe: ['organization-admin', 'organization-developer'] }) && (
-            <>
-              <span className="text-sm font-bold">OR</span>
-              <MigrationDialog
-                refetch={refetch}
-                setIsMigrationSuccess={setIsMigrationSuccess}
-                isEmptyState={true}
-                setToken={setToken}
-                isMigrating={isMigrating}
-                setIsMigrating={setIsMigrating}
-              />
-            </>
-          )}
-        </div>
-      }
-    />
+            {checkUserAccess({ rolesToBe: ['organization-admin', 'organization-developer'] }) && (
+              <>
+                <span className="text-sm font-bold">OR</span>
+                <MigrationDialog
+                  refetch={refetch}
+                  setIsMigrationSuccess={setIsMigrationSuccess}
+                  isEmptyState={true}
+                  setToken={setToken}
+                  isMigrating={isMigrating}
+                  setIsMigrating={setIsMigrating}
+                />
+              </>
+            )}
+          </div>
+        }
+      />
+    </>
   );
 };
 
@@ -636,45 +642,41 @@ const GraphCard = ({ graph, hasStaleMetrics }: { graph: FederatedGraph; hasStale
   );
 };
 
-function OnboardingEmptyState() {
-  const { onboarding, enabled, currentStep } = useOnboarding();
+function OnboardingBoltIcon() {
+  return <LightningBoltIcon className="size-10 text-primary" />;
+}
 
-  if (!enabled || !onboarding || onboarding.federatedGraphsCount !== 0) {
-    return null;
-  }
-
-  const emptyState =
-    currentStep !== undefined && !onboarding.finishedAt ? (
-      <EmptyState
-        className="h-auto"
-        icon={<BookmarkIcon />}
-        title="Dive right back in"
-        description="Want to finish the onboarding and create your first federated graph?"
-        actions={
-          <Button asChild>
-            <Link href={`/onboarding/${currentStep}`}>Continue</Link>
-          </Button>
-        }
-      />
-    ) : (
-      <EmptyState
-        className="h-auto"
-        icon={<BoltIcon />}
-        title="Need help?"
-        description="Take a quick 5-minute tour to help you set up your first federated graph"
-        actions={
-          <Button asChild>
-            <Link href={`/onboarding/1`}>Start here</Link>
-          </Button>
-        }
-      />
-    );
+function OnboardingEmptyState({ step, isFinished }: { step?: number; isFinished: boolean }) {
+  const shouldContinue = step !== undefined && !isFinished;
 
   return (
-    <>
-      {emptyState}
-      <span className="text-sm font-bold">OR</span>
-    </>
+    <div className="flex w-full max-w-xl flex-col items-center px-4 text-center">
+      <OnboardingBoltIcon />
+      <h3 className="mt-7 text-2xl font-bold tracking-tight">Create your first graph</h3>
+      <p className="mt-4 text-sm text-muted-foreground">
+        No graphs yet. Take the guided tour, or set one up from the CLI.
+      </p>
+      <Link
+        href={`/onboarding/${shouldContinue ? step : 1}`}
+        className="mt-5 flex w-full items-center rounded-xl bg-pink-600 px-5 py-4 text-left text-white transition-colors hover:bg-pink-700"
+      >
+        <span className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-white/20">
+          <PlayIcon className="size-5" />
+        </span>
+        <span className="ml-4 min-w-0 flex-1">
+          <span className="block text-base font-bold leading-5">
+            {shouldContinue ? 'Continue the 5-minute tour' : 'Start the 5-minute tour'}
+          </span>
+          <span className="block text-sm leading-5 text-white/85">Set up your first federated graph step by step</span>
+        </span>
+        <ArrowRightIcon className="ml-4 size-5 shrink-0" />
+      </Link>
+      <div className="mt-7 flex w-full items-center gap-4">
+        <span className="h-px flex-1 bg-border" />
+        <span className="text-xs font-bold text-muted-foreground">OR</span>
+        <span className="h-px flex-1 bg-border" />
+      </div>
+    </div>
   );
 }
 
@@ -702,7 +704,6 @@ export const FederatedGraphsCards = ({
   if (!graphs || graphs.length === 0)
     return (
       <div className="flex flex-col items-center gap-y-8">
-        <OnboardingEmptyState />
         <Empty
           refetch={refetch}
           setIsMigrationSuccess={setIsMigrationSuccess}

--- a/studio/src/components/federatedgraphs-cards.tsx
+++ b/studio/src/components/federatedgraphs-cards.tsx
@@ -1,48 +1,33 @@
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useFireworks } from '@/hooks/use-fireworks';
-import { SubmitHandler, useZodForm } from '@/hooks/use-form';
 import { docsBaseURL } from '@/lib/constants';
 import { formatMetric } from '@/lib/format-metric';
 import { useChartData } from '@/lib/insights-helpers';
 import { cn } from '@/lib/utils';
-import {
-  ChevronDoubleRightIcon,
-  CommandLineIcon,
-  DocumentArrowDownIcon,
-  ExclamationTriangleIcon,
-} from '@heroicons/react/24/outline';
+import { CommandLineIcon, DocumentArrowDownIcon, ExclamationTriangleIcon } from '@heroicons/react/24/outline';
 import { ArrowRightIcon, Component2Icon, LightningBoltIcon, PlayIcon } from '@radix-ui/react-icons';
-import { EnumStatusCode } from '@wundergraph/cosmo-connect/dist/common/common_pb';
-import { migrateFromApollo } from '@wundergraph/cosmo-connect/dist/platform/v1/platform-PlatformService_connectquery';
 import { FederatedGraph } from '@wundergraph/cosmo-connect/dist/platform/v1/platform_pb';
 import copy from 'copy-to-clipboard';
 import { getTime, parseISO, subDays } from 'date-fns';
 import Link from 'next/link';
-import { useRouter } from 'next/router';
 import { Dispatch, SetStateAction, useContext, useEffect, useState } from 'react';
 import { FiCheck, FiCopy } from 'react-icons/fi';
 import { LuSquareDot } from 'react-icons/lu';
 import { MdNearbyError } from 'react-icons/md';
-import { SiApollographql } from 'react-icons/si';
 import { Line, LineChart, ResponsiveContainer, XAxis } from 'recharts';
-import { z } from 'zod';
 import { UserContext } from './app-provider';
 import { ComposeStatusMessage } from './compose-status';
 import { ComposeStatusBulb } from './compose-status-bulb';
 import { EmptyState } from './empty-state';
-import { Logo } from './logo';
 import { TimeAgo } from './time-ago';
 import { Button } from './ui/button';
 import { Card } from './ui/card';
 import { CLI } from './ui/cli';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from './ui/dialog';
-import { Input } from './ui/input';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './ui/tooltip';
-import { useToast } from './ui/use-toast';
-import { useMutation } from '@connectrpc/connect-query';
+import { MigrationDialog } from './migration-dialog';
 import { useCheckUserAccess } from '@/hooks/use-check-user-access';
 import { useWorkspace } from '@/hooks/use-workspace';
-import { useCurrentOrganization } from '@/hooks/use-current-organization';
 import { useOnboarding } from '@/hooks/use-onboarding';
 
 // this is required to render a blank line with LineChart
@@ -56,194 +41,6 @@ const fallbackData = [
     totalRequests: 0,
   },
 ];
-
-const MigrationDialog = ({
-  refetch,
-  isMigrating,
-  setIsMigrating,
-  setIsMigrationSuccess,
-  setToken,
-  isEmptyState,
-  compact,
-}: {
-  refetch: () => void;
-  isMigrating: boolean;
-  setIsMigrating: Dispatch<SetStateAction<boolean>>;
-  setIsMigrationSuccess: Dispatch<SetStateAction<boolean>>;
-  setToken: Dispatch<SetStateAction<string | undefined>>;
-  isEmptyState?: boolean;
-  compact?: boolean;
-}) => {
-  const router = useRouter();
-  const {
-    namespace: { name: namespace },
-  } = useWorkspace();
-  const organizationSlug = useCurrentOrganization()?.slug;
-  const migrate = !!router.query.migrate;
-
-  const migrateInputSchema = z.object({
-    apiKey: z.string().min(1, { message: 'API Key must contain at least 1 character.' }),
-    variantName: z.string().min(1, { message: 'Variant name must contain at least 1 character.' }),
-  });
-
-  type MigrateInput = z.infer<typeof migrateInputSchema>;
-
-  const {
-    register,
-    formState: { isValid, errors },
-    handleSubmit,
-    reset,
-  } = useZodForm<MigrateInput>({
-    mode: 'onBlur',
-    schema: migrateInputSchema,
-  });
-
-  const { toast } = useToast();
-
-  const { mutate } = useMutation(migrateFromApollo);
-
-  const [open, setOpen] = useState(migrate || false);
-
-  const trigger = compact ? (
-    <Card className="flex w-full items-center rounded-xl border-primary/70 bg-primary/10 px-5 py-4 text-left transition-colors hover:bg-primary/15">
-      <div className="flex shrink-0 items-center gap-x-2 text-foreground">
-        <SiApollographql className="size-5" />
-        <ChevronDoubleRightIcon className="size-4 text-muted-foreground" />
-        <Logo width={22} height={22} />
-      </div>
-      <div className="ml-5 min-w-0 flex-1">
-        <p className="text-base font-semibold leading-5 text-primary">Migrate from Apollo</p>
-        <p className="text-sm leading-5 text-muted-foreground">Bring your existing supergraph over</p>
-      </div>
-      <ArrowRightIcon className="ml-4 size-5 shrink-0 text-muted-foreground" />
-    </Card>
-  ) : (
-    <Card className="flex h-full flex-col justify-center gap-y-2 bg-transparent p-4 group-hover:border-ring dark:hover:border-input-active ">
-      <div className="flex items-center justify-center gap-x-5">
-        <SiApollographql className="h-10 w-10" />
-        <ChevronDoubleRightIcon className="animation h-8 w-8" />
-        <Logo width={50} height={50} />
-      </div>
-      <p className="bg-gradient-to-r from-purple-500 to-pink-500 bg-clip-text text-xl font-semibold text-transparent">
-        Migrate from Apollo
-      </p>
-    </Card>
-  );
-
-  const onSubmit: SubmitHandler<MigrateInput> = (data) => {
-    setIsMigrating(true);
-    mutate(
-      {
-        apiKey: data.apiKey,
-        variantName: data.variantName,
-        namespace,
-      },
-      {
-        onSuccess: (d) => {
-          setOpen(false);
-          if (
-            d.response?.code === EnumStatusCode.OK ||
-            d.response?.code === EnumStatusCode.ERR_SUBGRAPH_COMPOSITION_FAILED
-          ) {
-            toast({
-              description: 'Successfully migrated the graph.',
-              duration: 2000,
-            });
-            refetch();
-            setIsMigrationSuccess(true);
-            setToken(d.token);
-          } else if (d.response?.details) {
-            setIsMigrating(false);
-            toast({ description: d.response.details, duration: 3000 });
-          }
-          router.replace(`/${organizationSlug}/graphs`);
-        },
-        onError: (_) => {
-          toast({
-            description: 'Could not migrate the graph. Please try again.',
-            duration: 3000,
-          });
-          setOpen(false);
-          setIsMigrating(false);
-          router.replace(`/${organizationSlug}/graphs`);
-        },
-      },
-    );
-    reset();
-  };
-
-  return (
-    <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger
-        className={cn('w-full', {
-          'min-h-[254px]': !isEmptyState,
-          'text-left': compact,
-        })}
-      >
-        {trigger}
-      </DialogTrigger>
-      <DialogContent>
-        {!isMigrating ? (
-          <>
-            <DialogHeader>
-              <DialogTitle>Migrate from Apollo</DialogTitle>
-            </DialogHeader>
-            <div className="flex flex-col gap-y-2">
-              <p className="text-sm">
-                The Graph API Key is the api key associated to the graph which has to be migrated and it should be
-                obtained from Apollo Studio.
-              </p>
-              <p className="text-sm">
-                Click{' '}
-                <Link
-                  href={docsBaseURL + '/studio/migrate-from-apollo'}
-                  className="text-primary"
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  here
-                </Link>{' '}
-                to find the steps to obtain the key.
-              </p>
-              <p className="text-sm text-teal-400">
-                Note: This key is not stored and only used to fetch the subgraphs.
-              </p>
-            </div>
-            <form className="mt-2 flex flex-col gap-y-3" onSubmit={handleSubmit(onSubmit)}>
-              <div className="flex flex-col gap-y-2">
-                <span className="text-sm font-semibold">Graph API Key</span>
-                <Input className="w-full" type="text" {...register('apiKey')} />
-                {errors.apiKey && <span className="px-2 text-xs text-destructive">{errors.apiKey.message}</span>}
-              </div>
-              <div className="flex flex-col gap-y-2">
-                <span className="text-sm font-semibold">Graph Variant Name</span>
-                <Input className="w-full" type="text" {...register('variantName')} />
-                {errors.variantName && (
-                  <span className="px-2 text-xs text-destructive">{errors.variantName.message}</span>
-                )}
-              </div>
-
-              <Button className="mt-2" type="submit" disabled={!isValid} variant="default">
-                Migrate
-              </Button>
-            </form>
-          </>
-        ) : (
-          <div className="flex flex-col items-center justify-center gap-y-4 py-4">
-            <div className="flex items-center justify-center gap-x-5">
-              <SiApollographql className="h-10 w-10" />
-              <ChevronDoubleRightIcon className="animation h-8 w-8" />
-              <Logo width={50} height={50} />
-            </div>
-            <p className="bg-gradient-to-r from-purple-500 to-pink-500 bg-clip-text text-xl font-semibold text-transparent">
-              Migrating...
-            </p>
-          </div>
-        )}
-      </DialogContent>
-    </Dialog>
-  );
-};
 
 const MigrationSuccess = () => {
   useFireworks(true);

--- a/studio/src/components/federatedgraphs-cards.tsx
+++ b/studio/src/components/federatedgraphs-cards.tsx
@@ -422,29 +422,36 @@ export const Empty = ({
       )}
       <EmptyState
         className="h-auto"
-        icon={<CommandLineIcon />}
-        title="No graphs found"
+        icon={displayOnboardingEmptyState ? undefined : <CommandLineIcon />}
+        title={displayOnboardingEmptyState ? undefined : 'No graphs found'}
         description={
-          <>
-            Use the CLI tool to create either a federated graph ({' '}
-            <a
-              target="_blank"
-              rel="noreferrer"
-              href={docsBaseURL + '/cli/federated-graph/create'}
-              className="text-primary"
-            >
-              docs
-            </a>{' '}
-            ) or a monograph ({' '}
-            <a target="_blank" rel="noreferrer" href={docsBaseURL + '/cli/monograph/create'} className="text-primary">
-              docs
-            </a>{' '}
-            ).
-          </>
+          displayOnboardingEmptyState ? undefined : (
+            <>
+              Use the CLI tool to create either a federated graph ({' '}
+              <a
+                target="_blank"
+                rel="noreferrer"
+                href={docsBaseURL + '/cli/federated-graph/create'}
+                className="text-primary"
+              >
+                docs
+              </a>{' '}
+              ) or a monograph ({' '}
+              <a target="_blank" rel="noreferrer" href={docsBaseURL + '/cli/monograph/create'} className="text-primary">
+                docs
+              </a>{' '}
+              ).
+            </>
+          )
         }
         actions={
           <div className="flex flex-col gap-y-6">
-            <Tabs defaultValue="federated" className="mt-8 w-full">
+            <Tabs
+              defaultValue="federated"
+              className={cn('w-full', {
+                'mt-8': !displayOnboardingEmptyState,
+              })}
+            >
               <TabsList className="grid w-full grid-cols-2">
                 <TabsTrigger value="federated">Federated Graph</TabsTrigger>
                 <TabsTrigger value="monograph">Monograph</TabsTrigger>

--- a/studio/src/components/federatedgraphs-cards.tsx
+++ b/studio/src/components/federatedgraphs-cards.tsx
@@ -490,7 +490,11 @@ export const Empty = ({
 
             {checkUserAccess({ rolesToBe: ['organization-admin', 'organization-developer'] }) && (
               <>
-                <span className="text-sm font-bold">OR</span>
+                {displayOnboardingEmptyState ? (
+                  <OnboardingOrSeparator />
+                ) : (
+                  <span className="text-sm font-bold">OR</span>
+                )}
                 <MigrationDialog
                   refetch={refetch}
                   setIsMigrationSuccess={setIsMigrationSuccess}
@@ -674,11 +678,21 @@ function OnboardingBoltIcon() {
   return <LightningBoltIcon className="size-10 text-primary" />;
 }
 
+function OnboardingOrSeparator() {
+  return (
+    <div className="mt-7 flex w-full items-center gap-4">
+      <span className="h-px flex-1 bg-border" />
+      <span className="text-xs font-bold text-muted-foreground">OR</span>
+      <span className="h-px flex-1 bg-border" />
+    </div>
+  );
+}
+
 function OnboardingEmptyState({ step, isFinished }: { step?: number; isFinished: boolean }) {
   const shouldContinue = step !== undefined && !isFinished;
 
   return (
-    <div className="flex w-full max-w-xl flex-col items-center px-4 text-center">
+    <div className="flex w-full max-w-2xl flex-col items-center px-4 text-center">
       <OnboardingBoltIcon />
       <h3 className="mt-7 text-2xl font-bold tracking-tight">Create your first graph</h3>
       <p className="mt-4 text-sm text-muted-foreground">
@@ -699,11 +713,7 @@ function OnboardingEmptyState({ step, isFinished }: { step?: number; isFinished:
         </span>
         <ArrowRightIcon className="ml-4 size-5 shrink-0" />
       </Link>
-      <div className="mt-7 flex w-full items-center gap-4">
-        <span className="h-px flex-1 bg-border" />
-        <span className="text-xs font-bold text-muted-foreground">OR</span>
-        <span className="h-px flex-1 bg-border" />
-      </div>
+      <OnboardingOrSeparator />
     </div>
   );
 }

--- a/studio/src/components/federatedgraphs-cards.tsx
+++ b/studio/src/components/federatedgraphs-cards.tsx
@@ -64,6 +64,7 @@ const MigrationDialog = ({
   setIsMigrationSuccess,
   setToken,
   isEmptyState,
+  compact,
 }: {
   refetch: () => void;
   isMigrating: boolean;
@@ -71,6 +72,7 @@ const MigrationDialog = ({
   setIsMigrationSuccess: Dispatch<SetStateAction<boolean>>;
   setToken: Dispatch<SetStateAction<string | undefined>>;
   isEmptyState?: boolean;
+  compact?: boolean;
 }) => {
   const router = useRouter();
   const {
@@ -101,6 +103,32 @@ const MigrationDialog = ({
   const { mutate } = useMutation(migrateFromApollo);
 
   const [open, setOpen] = useState(migrate || false);
+
+  const trigger = compact ? (
+    <Card className="flex w-full items-center rounded-xl border-primary/70 bg-primary/10 px-5 py-4 text-left transition-colors hover:bg-primary/15">
+      <div className="flex shrink-0 items-center gap-x-2 text-foreground">
+        <SiApollographql className="size-5" />
+        <ChevronDoubleRightIcon className="size-4 text-muted-foreground" />
+        <Logo width={22} height={22} />
+      </div>
+      <div className="ml-5 min-w-0 flex-1">
+        <p className="text-base font-semibold leading-5 text-primary">Migrate from Apollo</p>
+        <p className="text-sm leading-5 text-muted-foreground">Bring your existing supergraph over</p>
+      </div>
+      <ArrowRightIcon className="ml-4 size-5 shrink-0 text-muted-foreground" />
+    </Card>
+  ) : (
+    <Card className="flex h-full flex-col justify-center gap-y-2 bg-transparent p-4 group-hover:border-ring dark:hover:border-input-active ">
+      <div className="flex items-center justify-center gap-x-5">
+        <SiApollographql className="h-10 w-10" />
+        <ChevronDoubleRightIcon className="animation h-8 w-8" />
+        <Logo width={50} height={50} />
+      </div>
+      <p className="bg-gradient-to-r from-purple-500 to-pink-500 bg-clip-text text-xl font-semibold text-transparent">
+        Migrate from Apollo
+      </p>
+    </Card>
+  );
 
   const onSubmit: SubmitHandler<MigrateInput> = (data) => {
     setIsMigrating(true);
@@ -147,20 +175,12 @@ const MigrationDialog = ({
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger
-        className={cn({
+        className={cn('w-full', {
           'min-h-[254px]': !isEmptyState,
+          'text-left': compact,
         })}
       >
-        <Card className="flex h-full flex-col justify-center gap-y-2 bg-transparent p-4 group-hover:border-ring dark:hover:border-input-active ">
-          <div className="flex items-center justify-center gap-x-5">
-            <SiApollographql className="h-10 w-10" />
-            <ChevronDoubleRightIcon className="animation h-8 w-8" />
-            <Logo width={50} height={50} />
-          </div>
-          <p className="bg-gradient-to-r from-purple-500 to-pink-500 bg-clip-text text-xl font-semibold text-transparent">
-            Migrate from Apollo
-          </p>
-        </Card>
+        {trigger}
       </DialogTrigger>
       <DialogContent>
         {!isMigrating ? (
@@ -475,6 +495,7 @@ export const Empty = ({
                   refetch={refetch}
                   setIsMigrationSuccess={setIsMigrationSuccess}
                   isEmptyState={true}
+                  compact={displayOnboardingEmptyState}
                   setToken={setToken}
                   isMigrating={isMigrating}
                   setIsMigrating={setIsMigrating}

--- a/studio/src/components/invitations/invitation-card.tsx
+++ b/studio/src/components/invitations/invitation-card.tsx
@@ -35,14 +35,15 @@ export const InvitationCard = ({ id, name, slug, invitedBy, onAcceptSuccess }: I
             description: accept ? 'Accepted the invite successfully.' : 'Declined the invite successfully. ',
             duration: 3000,
           });
+          if (accept && onAcceptSuccess) {
+            onAcceptSuccess(slug);
+            return;
+          }
           refetch();
           sessionQueryClient.invalidateQueries({
             queryKey: ['user', router.asPath],
           });
           setAccepted(undefined);
-          if (accept) {
-            onAcceptSuccess?.(slug);
-          }
         },
         onError: () => {
           setAccepted(undefined);

--- a/studio/src/components/invitations/invitation-card.tsx
+++ b/studio/src/components/invitations/invitation-card.tsx
@@ -1,0 +1,100 @@
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { useToast } from '@/components/ui/use-toast';
+import { useMutation, useQuery } from '@connectrpc/connect-query';
+import {
+  acceptOrDeclineInvitation,
+  getInvitations,
+} from '@wundergraph/cosmo-connect/dist/platform/v1/platform-PlatformService_connectquery';
+import { useRouter } from 'next/router';
+import { useContext, useState } from 'react';
+import { SessionClientContext } from '@/components/app-provider';
+
+export interface InvitationCardProps {
+  id: string;
+  name: string;
+  slug: string;
+  invitedBy?: string;
+  onAcceptSuccess?: (slug: string) => void;
+}
+
+export const InvitationCard = ({ id, name, slug, invitedBy, onAcceptSuccess }: InvitationCardProps) => {
+  const router = useRouter();
+  const { mutate, isPending } = useMutation(acceptOrDeclineInvitation);
+  const { refetch } = useQuery(getInvitations);
+  const { toast } = useToast();
+  const sessionQueryClient = useContext(SessionClientContext);
+  const [accepted, setAccepted] = useState<boolean | undefined>();
+
+  const onSubmit = (accept: boolean) => {
+    mutate(
+      { organizationId: id, accept },
+      {
+        onSuccess: () => {
+          toast({
+            description: accept ? 'Accepted the invite successfully.' : 'Declined the invite successfully. ',
+            duration: 3000,
+          });
+          refetch();
+          sessionQueryClient.invalidateQueries({
+            queryKey: ['user', router.asPath],
+          });
+          setAccepted(undefined);
+          if (accept) {
+            onAcceptSuccess?.(slug);
+          }
+        },
+        onError: () => {
+          setAccepted(undefined);
+          toast({
+            description: accept
+              ? 'Could not accept the invite. Please try again.'
+              : 'Could not decline the invite. Please try again.',
+            duration: 3000,
+          });
+        },
+      },
+    );
+  };
+
+  return (
+    <Card className="flex items-center justify-between p-4">
+      {invitedBy ? (
+        <span>
+          <span className="font-semibold">{invitedBy}</span> invites you to the{' '}
+          <span className="font-semibold">{name}</span> organization.
+        </span>
+      ) : (
+        <span>
+          You have been invited to the <span className="font-semibold capitalize">{name}</span> organization.
+        </span>
+      )}
+      <div className="flex gap-x-3">
+        <Button
+          type="submit"
+          variant="default"
+          onClick={() => {
+            setAccepted(true);
+            onSubmit(true);
+          }}
+          disabled={isPending}
+          isLoading={accepted === true && isPending}
+        >
+          Accept
+        </Button>
+        <Button
+          type="submit"
+          variant="outline"
+          onClick={() => {
+            setAccepted(false);
+            onSubmit(false);
+          }}
+          disabled={isPending}
+          isLoading={accepted === false && isPending}
+        >
+          Decline
+        </Button>
+      </div>
+    </Card>
+  );
+};

--- a/studio/src/components/invitations/invitation-card.tsx
+++ b/studio/src/components/invitations/invitation-card.tsx
@@ -58,18 +58,18 @@ export const InvitationCard = ({ id, name, slug, invitedBy, onAcceptSuccess }: I
   };
 
   return (
-    <Card className="flex items-center justify-between p-4">
+    <Card className="flex flex-col gap-4 p-4 sm:flex-row sm:items-center sm:justify-between">
       {invitedBy ? (
-        <span>
+        <span className="min-w-0 break-words">
           <span className="font-semibold">{invitedBy}</span> invites you to the{' '}
           <span className="font-semibold">{name}</span> organization.
         </span>
       ) : (
-        <span>
+        <span className="min-w-0 break-words">
           You have been invited to the <span className="font-semibold capitalize">{name}</span> organization.
         </span>
       )}
-      <div className="flex gap-x-3">
+      <div className="flex shrink-0 justify-end gap-x-3 self-end sm:self-auto">
         <Button
           type="submit"
           variant="default"

--- a/studio/src/components/migration-dialog.tsx
+++ b/studio/src/components/migration-dialog.tsx
@@ -42,6 +42,7 @@ export const MigrationDialog = ({
     namespace: { name: namespace },
   } = useWorkspace();
   const organizationSlug = useCurrentOrganization()?.slug;
+  const graphsPath = organizationSlug ? `/${organizationSlug}/graphs` : '/graphs';
   const migrate = !!router.query.migrate;
 
   const migrateInputSchema = z.object({
@@ -119,7 +120,7 @@ export const MigrationDialog = ({
             setIsMigrating(false);
             toast({ description: d.response.details, duration: 3000 });
           }
-          router.replace(`/${organizationSlug}/graphs`);
+          router.replace(graphsPath);
         },
         onError: (_) => {
           toast({
@@ -128,7 +129,7 @@ export const MigrationDialog = ({
           });
           setOpen(false);
           setIsMigrating(false);
-          router.replace(`/${organizationSlug}/graphs`);
+          router.replace(graphsPath);
         },
       },
     );

--- a/studio/src/components/migration-dialog.tsx
+++ b/studio/src/components/migration-dialog.tsx
@@ -1,0 +1,209 @@
+import { Dispatch, SetStateAction, useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { z } from 'zod';
+import { SiApollographql } from 'react-icons/si';
+import { useMutation } from '@connectrpc/connect-query';
+import { ChevronDoubleRightIcon } from '@heroicons/react/24/outline';
+import { ArrowRightIcon } from '@radix-ui/react-icons';
+import { EnumStatusCode } from '@wundergraph/cosmo-connect/dist/common/common_pb';
+import { migrateFromApollo } from '@wundergraph/cosmo-connect/dist/platform/v1/platform-PlatformService_connectquery';
+import { Logo } from './logo';
+import { Button } from './ui/button';
+import { Card } from './ui/card';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from './ui/dialog';
+import { Input } from './ui/input';
+import { useToast } from './ui/use-toast';
+import { docsBaseURL } from '@/lib/constants';
+import { cn } from '@/lib/utils';
+import { SubmitHandler, useZodForm } from '@/hooks/use-form';
+import { useWorkspace } from '@/hooks/use-workspace';
+import { useCurrentOrganization } from '@/hooks/use-current-organization';
+
+export const MigrationDialog = ({
+  refetch,
+  isMigrating,
+  setIsMigrating,
+  setIsMigrationSuccess,
+  setToken,
+  isEmptyState,
+  compact,
+}: {
+  refetch: () => void;
+  isMigrating: boolean;
+  setIsMigrating: Dispatch<SetStateAction<boolean>>;
+  setIsMigrationSuccess: Dispatch<SetStateAction<boolean>>;
+  setToken: Dispatch<SetStateAction<string | undefined>>;
+  isEmptyState?: boolean;
+  compact?: boolean;
+}) => {
+  const router = useRouter();
+  const {
+    namespace: { name: namespace },
+  } = useWorkspace();
+  const organizationSlug = useCurrentOrganization()?.slug;
+  const migrate = !!router.query.migrate;
+
+  const migrateInputSchema = z.object({
+    apiKey: z.string().min(1, { message: 'API Key must contain at least 1 character.' }),
+    variantName: z.string().min(1, { message: 'Variant name must contain at least 1 character.' }),
+  });
+
+  type MigrateInput = z.infer<typeof migrateInputSchema>;
+
+  const {
+    register,
+    formState: { isValid, errors },
+    handleSubmit,
+    reset,
+  } = useZodForm<MigrateInput>({
+    mode: 'onBlur',
+    schema: migrateInputSchema,
+  });
+
+  const { toast } = useToast();
+
+  const { mutate } = useMutation(migrateFromApollo);
+
+  const [open, setOpen] = useState(migrate || false);
+
+  const trigger = compact ? (
+    <Card className="flex w-full items-center rounded-xl border-primary/70 bg-primary/10 px-5 py-4 text-left transition-colors hover:bg-primary/15">
+      <div className="flex shrink-0 items-center gap-x-2 text-foreground">
+        <SiApollographql className="size-5" />
+        <ChevronDoubleRightIcon className="size-4 text-muted-foreground" />
+        <Logo width={22} height={22} />
+      </div>
+      <div className="ml-5 min-w-0 flex-1">
+        <p className="text-base font-semibold leading-5 text-primary">Migrate from Apollo</p>
+        <p className="text-sm leading-5 text-muted-foreground">Bring your existing supergraph over</p>
+      </div>
+      <ArrowRightIcon className="ml-4 size-5 shrink-0 text-muted-foreground" />
+    </Card>
+  ) : (
+    <Card className="flex h-full flex-col justify-center gap-y-2 bg-transparent p-4 group-hover:border-ring dark:hover:border-input-active ">
+      <div className="flex items-center justify-center gap-x-5">
+        <SiApollographql className="h-10 w-10" />
+        <ChevronDoubleRightIcon className="animation h-8 w-8" />
+        <Logo width={50} height={50} />
+      </div>
+      <p className="bg-gradient-to-r from-purple-500 to-pink-500 bg-clip-text text-xl font-semibold text-transparent">
+        Migrate from Apollo
+      </p>
+    </Card>
+  );
+
+  const onSubmit: SubmitHandler<MigrateInput> = (data) => {
+    setIsMigrating(true);
+    mutate(
+      {
+        apiKey: data.apiKey,
+        variantName: data.variantName,
+        namespace,
+      },
+      {
+        onSuccess: (d) => {
+          setOpen(false);
+          if (
+            d.response?.code === EnumStatusCode.OK ||
+            d.response?.code === EnumStatusCode.ERR_SUBGRAPH_COMPOSITION_FAILED
+          ) {
+            toast({
+              description: 'Successfully migrated the graph.',
+              duration: 2000,
+            });
+            refetch();
+            setIsMigrationSuccess(true);
+            setToken(d.token);
+          } else if (d.response?.details) {
+            setIsMigrating(false);
+            toast({ description: d.response.details, duration: 3000 });
+          }
+          router.replace(`/${organizationSlug}/graphs`);
+        },
+        onError: (_) => {
+          toast({
+            description: 'Could not migrate the graph. Please try again.',
+            duration: 3000,
+          });
+          setOpen(false);
+          setIsMigrating(false);
+          router.replace(`/${organizationSlug}/graphs`);
+        },
+      },
+    );
+    reset();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger
+        className={cn('w-full', {
+          'min-h-[254px]': !isEmptyState,
+          'text-left': compact,
+        })}
+      >
+        {trigger}
+      </DialogTrigger>
+      <DialogContent>
+        {!isMigrating ? (
+          <>
+            <DialogHeader>
+              <DialogTitle>Migrate from Apollo</DialogTitle>
+            </DialogHeader>
+            <div className="flex flex-col gap-y-2">
+              <p className="text-sm">
+                The Graph API Key is the api key associated to the graph which has to be migrated and it should be
+                obtained from Apollo Studio.
+              </p>
+              <p className="text-sm">
+                Click{' '}
+                <Link
+                  href={docsBaseURL + '/studio/migrate-from-apollo'}
+                  className="text-primary"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  here
+                </Link>{' '}
+                to find the steps to obtain the key.
+              </p>
+              <p className="text-sm text-teal-400">
+                Note: This key is not stored and only used to fetch the subgraphs.
+              </p>
+            </div>
+            <form className="mt-2 flex flex-col gap-y-3" onSubmit={handleSubmit(onSubmit)}>
+              <div className="flex flex-col gap-y-2">
+                <span className="text-sm font-semibold">Graph API Key</span>
+                <Input className="w-full" type="text" {...register('apiKey')} />
+                {errors.apiKey && <span className="px-2 text-xs text-destructive">{errors.apiKey.message}</span>}
+              </div>
+              <div className="flex flex-col gap-y-2">
+                <span className="text-sm font-semibold">Graph Variant Name</span>
+                <Input className="w-full" type="text" {...register('variantName')} />
+                {errors.variantName && (
+                  <span className="px-2 text-xs text-destructive">{errors.variantName.message}</span>
+                )}
+              </div>
+
+              <Button className="mt-2" type="submit" disabled={!isValid} variant="default">
+                Migrate
+              </Button>
+            </form>
+          </>
+        ) : (
+          <div className="flex flex-col items-center justify-center gap-y-4 py-4">
+            <div className="flex items-center justify-center gap-x-5">
+              <SiApollographql className="h-10 w-10" />
+              <ChevronDoubleRightIcon className="animation h-8 w-8" />
+              <Logo width={50} height={50} />
+            </div>
+            <p className="bg-gradient-to-r from-purple-500 to-pink-500 bg-clip-text text-xl font-semibold text-transparent">
+              Migrating...
+            </p>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/studio/src/hooks/use-onboarding-navigation.ts
+++ b/studio/src/hooks/use-onboarding-navigation.ts
@@ -40,6 +40,12 @@ export const useOnboardingNavigation = () => {
       if (!enabled) {
         return;
       }
+      // Do not redirect if user initiated invitation accept from the initial
+      // screen. In this case, the user is being re-directed to target organization
+      if (Router.query['redirected-to-invited-org'] === 'true') {
+        return;
+      }
+
       // Wait for the onboarding metadata query to resolve
       // Do not initiate redirect if we fail to fetch onboarding metadata. Fail silently in background.
       if (initialLoadSuccess === null || !initialLoadSuccess) {

--- a/studio/src/pages/account/invitations.tsx
+++ b/studio/src/pages/account/invitations.tsx
@@ -1,99 +1,13 @@
 import { EmptyState } from '@/components/empty-state';
+import { InvitationCard } from '@/components/invitations/invitation-card';
 import { getDashboardLayout } from '@/components/layout/dashboard-layout';
 import { Button } from '@/components/ui/button';
-import { Card } from '@/components/ui/card';
 import { Loader } from '@/components/ui/loader';
-import { useToast } from '@/components/ui/use-toast';
 import { NextPageWithLayout } from '@/lib/page';
 import { ExclamationTriangleIcon, InformationCircleIcon } from '@heroicons/react/24/outline';
-import { useQueryClient } from '@tanstack/react-query';
-import { useQuery, useMutation } from '@connectrpc/connect-query';
+import { useQuery } from '@connectrpc/connect-query';
 import { EnumStatusCode } from '@wundergraph/cosmo-connect/dist/common/common_pb';
-import {
-  acceptOrDeclineInvitation,
-  getInvitations,
-} from '@wundergraph/cosmo-connect/dist/platform/v1/platform-PlatformService_connectquery';
-import { useRouter } from 'next/router';
-import { useContext, useState } from 'react';
-import { SessionClientContext } from '@/components/app-provider';
-
-const InvitationCard = ({ id, name, invitedBy }: { id: string; name: string; invitedBy?: string }) => {
-  const router = useRouter();
-  const { mutate, isPending } = useMutation(acceptOrDeclineInvitation);
-  const { refetch } = useQuery(getInvitations);
-  const { toast } = useToast();
-  const sessionQueryClient = useContext(SessionClientContext);
-  const [accepted, setAccepted] = useState<boolean | undefined>();
-
-  const onSubmit = (accept: boolean) => {
-    mutate(
-      { organizationId: id, accept },
-      {
-        onSuccess: () => {
-          toast({
-            description: accept ? 'Accepted the invite successfully.' : 'Declined the invite successfully. ',
-            duration: 3000,
-          });
-          refetch();
-          sessionQueryClient.invalidateQueries({
-            queryKey: ['user', router.asPath],
-          });
-          setAccepted(undefined);
-        },
-        onError: () => {
-          setAccepted(undefined);
-          toast({
-            description: accept
-              ? 'Could not accept the invite. Please try again.'
-              : 'Could not decline the invite. Please try again.',
-            duration: 3000,
-          });
-        },
-      },
-    );
-  };
-
-  return (
-    <Card className="flex items-center justify-between p-4">
-      {invitedBy ? (
-        <span>
-          <span className="font-semibold">{invitedBy}</span> invites you to the{' '}
-          <span className="font-semibold">{name}</span> organization.
-        </span>
-      ) : (
-        <span>
-          You have been invited to the <span className="font-semibold capitalize">{name}</span> organization.
-        </span>
-      )}
-      <div className="flex gap-x-3">
-        <Button
-          type="submit"
-          variant="default"
-          onClick={() => {
-            setAccepted(true);
-            onSubmit(true);
-          }}
-          disabled={isPending}
-          isLoading={accepted === true && isPending}
-        >
-          Accept
-        </Button>
-        <Button
-          type="submit"
-          variant="outline"
-          onClick={() => {
-            setAccepted(false);
-            onSubmit(false);
-          }}
-          disabled={isPending}
-          isLoading={accepted === false && isPending}
-        >
-          Decline
-        </Button>
-      </div>
-    </Card>
-  );
-};
+import { getInvitations } from '@wundergraph/cosmo-connect/dist/platform/v1/platform-PlatformService_connectquery';
 
 const InvitationsPage: NextPageWithLayout = () => {
   const { data, isLoading, error, refetch } = useQuery(getInvitations);
@@ -124,8 +38,8 @@ const InvitationsPage: NextPageWithLayout = () => {
 
   return (
     <div className="flex flex-col gap-y-4 pt-2">
-      {data.invitations.map(({ id, name, invitedBy }) => {
-        return <InvitationCard key={id} name={name} id={id} invitedBy={invitedBy} />;
+      {data.invitations.map(({ id, name, slug, invitedBy }) => {
+        return <InvitationCard key={id} name={name} id={id} slug={slug} invitedBy={invitedBy} />;
       })}
     </div>
   );

--- a/studio/src/pages/account/join.tsx
+++ b/studio/src/pages/account/join.tsx
@@ -1,84 +1,94 @@
+import { InfoCircledIcon } from '@radix-ui/react-icons';
+import { useRouter } from 'next/router';
 import { InvitationCard } from '@/components/invitations/invitation-card';
 import { FullscreenLayout } from '@/components/layout/fullscreen-layout';
+import { Logo } from '@/components/logo';
 import { Button } from '@/components/ui/button';
 import { Loader } from '@/components/ui/loader';
 import { useUser } from '@/hooks/use-user';
 import { NextPageWithLayout } from '@/lib/page';
-import { ExclamationTriangleIcon } from '@heroicons/react/24/outline';
-import { useQuery } from '@connectrpc/connect-query';
-import { EnumStatusCode } from '@wundergraph/cosmo-connect/dist/common/common_pb';
-import { getInvitations } from '@wundergraph/cosmo-connect/dist/platform/v1/platform-PlatformService_connectquery';
-import { useRouter } from 'next/router';
-import { useEffect } from 'react';
-import { EmptyState } from '@/components/empty-state';
 
-const JoinInvitationsPage: NextPageWithLayout = () => {
+type Invitation = {
+  id: string;
+  name: string;
+  slug: string;
+  invitedBy: string;
+};
+
+const InvitationList = ({
+  invitations,
+  onAcceptButtonClick,
+}: {
+  invitations: Invitation[];
+  onAcceptButtonClick: (slug: string) => void;
+}) => (
+  <>
+    {invitations.map(({ id, name, slug, invitedBy }) => (
+      <InvitationCard
+        key={id}
+        id={id}
+        name={name}
+        slug={slug}
+        invitedBy={invitedBy}
+        onAcceptSuccess={onAcceptButtonClick}
+      />
+    ))}
+  </>
+);
+
+const JoinInvitationsPage: NextPageWithLayout<{
+  invitations: Invitation[];
+  isLoading: boolean;
+}> = ({ invitations, isLoading }) => {
   const router = useRouter();
   const user = useUser();
-  const { data, isLoading, error, refetch } = useQuery(getInvitations);
 
   const personalOrgSlug = user?.currentOrganization?.slug;
-  const invitationCount = data?.invitations?.length ?? 0;
-  const invitationsResolved = !isLoading && !error && data?.response?.code === EnumStatusCode.OK;
-
-  useEffect(() => {
-    if (invitationsResolved && invitationCount === 0 && personalOrgSlug) {
-      router.replace(`/${personalOrgSlug}`);
-    }
-  }, [invitationsResolved, invitationCount, personalOrgSlug, router]);
+  const invitationCount = invitations?.length ?? 0;
 
   if (isLoading || !user) {
     return <Loader fullscreen />;
   }
 
-  if (error || data?.response?.code !== EnumStatusCode.OK) {
-    return (
-      <div className="mx-auto max-w-screen-md px-4 py-16">
-        <EmptyState
-          icon={<ExclamationTriangleIcon />}
-          title="Could not retrieve invitations"
-          description={data?.response?.details || error?.message || 'Please try again'}
-          actions={<Button onClick={() => refetch()}>Retry</Button>}
-        />
-      </div>
-    );
-  }
-
-  if (invitationCount === 0 && isLoading) {
-    return <Loader fullscreen />;
-  }
+  const handleInvitationAcceptButtonClick = (slug: string) => router.push(`/${slug}`);
+  const handleSkipButtonClick = () => router.push(`/${personalOrgSlug}`);
 
   return (
-    <div className="mx-auto max-w-screen-md px-4 py-16">
-      <div className="mb-8 space-y-2">
-        <h1 className="text-2xl font-semibold">You have pending invitations</h1>
-        <p className="text-sm text-muted-foreground">
-          Accept an invitation to join an existing organization, or skip to continue to your own.
-        </p>
+    <div className="relative min-h-screen px-4 py-16">
+      <div className="absolute left-6 top-6">
+        <Logo />
       </div>
-      <div className="flex flex-col gap-y-4">
-        {data.invitations.map(({ id, name, slug, invitedBy }) => (
-          <InvitationCard
-            key={id}
-            id={id}
-            name={name}
-            slug={slug}
-            invitedBy={invitedBy}
-            onAcceptSuccess={(acceptedSlug) => router.push(`/${acceptedSlug}`)}
-          />
-        ))}
-      </div>
-      <div className="mt-8 flex justify-end">
-        <Button
-          variant="ghost"
-          onClick={() => {
-            if (personalOrgSlug) {
-              router.push(`/${personalOrgSlug}`);
-            }
-          }}
-        >
-          Skip for now
-        </Button>
+      <div className="mx-auto max-w-screen-md">
+        <div className="mb-8 space-y-2 pb-8">
+          <h1 className="mb-4 text-2xl font-semibold">You&apos;ve been invited to collaborate</h1>
+          {invitationCount > 0 && (
+            <p className="text-sm text-muted-foreground">
+              You&apos;ve been invited to join an organization. Select an invitation below:
+            </p>
+          )}
+        </div>
+        <div className="flex flex-col gap-y-4">
+          {invitationCount < 1 ? (
+            <p className="text-sm text-muted-foreground">No invitations found. Continue to your account.</p>
+          ) : (
+            <InvitationList invitations={invitations} onAcceptButtonClick={handleInvitationAcceptButtonClick} />
+          )}
+        </div>
+        <div className="mt-10 flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:justify-end">
+          <div className="flex min-w-0 sm:mr-2">
+            <InfoCircledIcon className="mr-1 shrink-0" />
+            <span className="text-xs text-muted-foreground">
+              You can manage these invitations from your account page.
+            </span>
+          </div>
+          <Button
+            className="self-end sm:self-auto"
+            variant="ghost"
+            onClick={personalOrgSlug ? handleSkipButtonClick : undefined}
+          >
+            Skip for now
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/studio/src/pages/account/join.tsx
+++ b/studio/src/pages/account/join.tsx
@@ -46,12 +46,17 @@ const JoinInvitationsPage: NextPageWithLayout<{
   const personalOrgSlug = user?.currentOrganization?.slug;
   const invitationCount = invitations?.length ?? 0;
 
+  const handleInvitationAcceptButtonClick = (slug: string) => {
+    const queryParams = new URLSearchParams();
+    queryParams.append('redirected-to-invited-org', 'true');
+
+    router.push(`/${slug}?${queryParams.toString()}`);
+  };
+  const handleSkipButtonClick = () => router.push(`/${personalOrgSlug}`);
+
   if (isLoading || !user) {
     return <Loader fullscreen />;
   }
-
-  const handleInvitationAcceptButtonClick = (slug: string) => router.push(`/${slug}`);
-  const handleSkipButtonClick = () => router.push(`/${personalOrgSlug}`);
 
   return (
     <div className="relative min-h-screen px-4 py-16">

--- a/studio/src/pages/account/join.tsx
+++ b/studio/src/pages/account/join.tsx
@@ -1,0 +1,91 @@
+import { InvitationCard } from '@/components/invitations/invitation-card';
+import { FullscreenLayout } from '@/components/layout/fullscreen-layout';
+import { Button } from '@/components/ui/button';
+import { Loader } from '@/components/ui/loader';
+import { useUser } from '@/hooks/use-user';
+import { NextPageWithLayout } from '@/lib/page';
+import { ExclamationTriangleIcon } from '@heroicons/react/24/outline';
+import { useQuery } from '@connectrpc/connect-query';
+import { EnumStatusCode } from '@wundergraph/cosmo-connect/dist/common/common_pb';
+import { getInvitations } from '@wundergraph/cosmo-connect/dist/platform/v1/platform-PlatformService_connectquery';
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
+import { EmptyState } from '@/components/empty-state';
+
+const JoinInvitationsPage: NextPageWithLayout = () => {
+  const router = useRouter();
+  const user = useUser();
+  const { data, isLoading, error, refetch } = useQuery(getInvitations);
+
+  const personalOrgSlug = user?.currentOrganization?.slug;
+  const invitationCount = data?.invitations?.length ?? 0;
+  const invitationsResolved = !isLoading && !error && data?.response?.code === EnumStatusCode.OK;
+
+  useEffect(() => {
+    if (invitationsResolved && invitationCount === 0 && personalOrgSlug) {
+      router.replace(`/${personalOrgSlug}`);
+    }
+  }, [invitationsResolved, invitationCount, personalOrgSlug, router]);
+
+  if (isLoading || !user) {
+    return <Loader fullscreen />;
+  }
+
+  if (error || data?.response?.code !== EnumStatusCode.OK) {
+    return (
+      <div className="mx-auto max-w-screen-md px-4 py-16">
+        <EmptyState
+          icon={<ExclamationTriangleIcon />}
+          title="Could not retrieve invitations"
+          description={data?.response?.details || error?.message || 'Please try again'}
+          actions={<Button onClick={() => refetch()}>Retry</Button>}
+        />
+      </div>
+    );
+  }
+
+  if (invitationCount === 0 && isLoading) {
+    return <Loader fullscreen />;
+  }
+
+  return (
+    <div className="mx-auto max-w-screen-md px-4 py-16">
+      <div className="mb-8 space-y-2">
+        <h1 className="text-2xl font-semibold">You have pending invitations</h1>
+        <p className="text-sm text-muted-foreground">
+          Accept an invitation to join an existing organization, or skip to continue to your own.
+        </p>
+      </div>
+      <div className="flex flex-col gap-y-4">
+        {data.invitations.map(({ id, name, slug, invitedBy }) => (
+          <InvitationCard
+            key={id}
+            id={id}
+            name={name}
+            slug={slug}
+            invitedBy={invitedBy}
+            onAcceptSuccess={(acceptedSlug) => router.push(`/${acceptedSlug}`)}
+          />
+        ))}
+      </div>
+      <div className="mt-8 flex justify-end">
+        <Button
+          variant="ghost"
+          onClick={() => {
+            if (personalOrgSlug) {
+              router.push(`/${personalOrgSlug}`);
+            }
+          }}
+        >
+          Skip for now
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+JoinInvitationsPage.getLayout = (page) => {
+  return <FullscreenLayout>{page}</FullscreenLayout>;
+};
+
+export default JoinInvitationsPage;


### PR DESCRIPTION
This change comes from observing how people behave after signup. In a lot of cases, people get invited to their organizations but there are two issues:

1. After signing up, some users might get full-screen onboarding experience. Even though their goal was to just join the org, they get immediately redirected to their personal org and the onboarding is triggered. Often the onboarding is completely skipped because it's not relevant at that point in time.
2. Even if they don't get the onboarding experience, users who are not familiar with the interface start looking how to join an org. This can result in confusion and the time spent exploring the app is unnecessary.

This PR aims to fix this by doing the following:

* when user signs up, a query param `onboarding=true` is used for the initial re-direct to the main application
* we detect this param and also check whether there are any pending invitations, if this is true we completely block rendering the whole component tree in order to avoid running the hook responsible for redirecting to onboarding experience
* user can choose to accept an invitation or skip it

When users accept an invitation, they get immediately redirected to the organization that invited them. In this situation, we are adding another query param `redirected-to-invited-org` because at this point the component tree is rendered, which means `use-onboarding-navigation` hook runs. This can result in race condition with routing.

If user skips invitation, they land in their personal organization and in case they are eligible for onboarding experience, they get one.

Example of user being onboarded __(note: the empty state looks different in the latest iteration, see the paragraph & image below)__:


https://github.com/user-attachments/assets/47a81780-346f-4409-a10f-b26ff59472c6

Additional refactoring of UI: the empty state in the graphs page has been refactored. It is now in a more compact form to make it more convenient for people to use. This is the new look when the user can onboard but has not finished onboarding yet:

<img width="800" height="auto" alt="Screenshot 2026-06-09 at 10 45 35" src="https://github.com/user-attachments/assets/85e16799-c1d4-4236-b613-32783e9eb829" />

This is backwards compatible, so the old look is still present if onboarding is not there. I also moved the dialog for apollo migration to a separate component as it was becoming harder to navigate the larger source file.

## How to test?

1. Have an organization setup up as an organization creator with admin rights (parent organization)
2. Mailpit must be running and configured
3. Invite user e.g. `user+test@wundergraph.com` (`wundergraph.com` domain is important as it can trigger the onboarding via feature flag)
4. Check the invite e-mail in Mailpit, copy the link
5. Open containerized tab/incognito tab and paste the link
6. Set up password during the signup, then login as `user+test@wundergraph.com`
7. You should now land on the new screen with the ability to accept an invite
8. Click accept
9. You should now be inside the parent organization
10. Try switching back to your personal organization. You should see CTA to finish the onboarding on the graph (index) view

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated onboarding "join invitations" page for users with pending org invitations.
  * New invitation card UI with accept/decline actions, toasts, and loading states.
  * Added a "Migrate from Apollo" dialog to guide graph migration flows.
  * Onboarding-aware empty states with guided CTAs for federated graphs.

* **Bug Fixes**
  * Improved redirect logic to avoid conflicting redirects when arriving via an invite.
  * Invitation listings now surface inviter information when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [X] I have discussed my proposed changes in an issue and have received approval to proceed.
- [X] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [X] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

<!--
Please add any additional information or context regarding your changes here.
-->