### PR TITLE
feat: restrict proposal matching to approved and draft states

### DIFF
--- a/controlplane/src/core/bufservices/subgraph/deleteFederatedSubgraph.ts
+++ b/controlplane/src/core/bufservices/subgraph/deleteFederatedSubgraph.ts
@@ -103,6 +103,7 @@ export function deleteFederatedSubgraph(
           schemaSDL: '',
           routerCompatibilityVersion: getFederatedGraphRouterCompatibilityVersion(federatedGraphs),
           isDeleted: true,
+          approvedOnly: true,
         });
         if (matches.length === 0) {
           if (proposalConfig.publishSeverityLevel === 'warn') {

--- a/controlplane/src/core/bufservices/subgraph/publishFederatedSubgraph.ts
+++ b/controlplane/src/core/bufservices/subgraph/publishFederatedSubgraph.ts
@@ -149,6 +149,7 @@ export function publishFederatedSubgraph(
           schemaSDL: subgraphSchemaSDL,
           routerCompatibilityVersion,
           isDeleted: false,
+          approvedOnly: true,
         });
         if (matches.length === 0) {
           const message = `The subgraph ${req.name}'s schema does not match to this subgraph's schema in any approved proposal.`;

--- a/controlplane/src/core/repositories/ProposalRepository.ts
+++ b/controlplane/src/core/repositories/ProposalRepository.ts
@@ -1,4 +1,4 @@
-import { and, count, desc, eq, gt, lt, SQL } from 'drizzle-orm';
+import { and, count, desc, eq, gt, inArray, lt, SQL } from 'drizzle-orm';
 import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import { joinLabel, splitLabel } from '@wundergraph/cosmo-shared';
 import { ProposalState, ProposalOrigin } from '../../db/models.js';
@@ -455,9 +455,11 @@ export class ProposalRepository {
   public async getProposalSubgraphsBySubgraph({
     subgraphName,
     namespaceId,
+    approvedOnly = false,
   }: {
     subgraphName: string;
     namespaceId: string;
+    approvedOnly?: boolean;
   }) {
     const proposalSubgraphs = await this.db
       .select({
@@ -476,6 +478,9 @@ export class ProposalRepository {
           eq(schema.proposalSubgraphs.subgraphName, subgraphName),
           eq(schema.targets.namespaceId, namespaceId),
           eq(schema.targets.organizationId, this.organizationId),
+          approvedOnly
+            ? eq(schema.proposals.state, 'APPROVED')
+            : inArray(schema.proposals.state, ['DRAFT', 'APPROVED']),
         ),
       );
 
@@ -489,6 +494,7 @@ export class ProposalRepository {
     schemaSDL,
     routerCompatibilityVersion,
     isDeleted,
+    approvedOnly = false,
   }: {
     subgraphName: string;
     namespaceId: string;
@@ -496,11 +502,9 @@ export class ProposalRepository {
     schemaSDL: string;
     routerCompatibilityVersion: string;
     isDeleted: boolean;
+    approvedOnly?: boolean;
   }): Promise<{ proposalId: string; proposalSubgraphId: string }[]> {
-    const proposalSubgraphs = await this.getProposalSubgraphsBySubgraph({
-      subgraphName,
-      namespaceId,
-    });
+    const proposalSubgraphs = await this.getProposalSubgraphsBySubgraph({ subgraphName, namespaceId, approvedOnly });
 
     const matches: { proposalId: string; proposalSubgraphId: string }[] = [];
 

--- a/controlplane/src/core/repositories/SchemaCheckRepository.ts
+++ b/controlplane/src/core/repositories/SchemaCheckRepository.ts
@@ -959,7 +959,7 @@ export class SchemaCheckRepository {
       });
     }
 
-    let proposalMatchMessage: string | undefined;
+    let proposalMatchMessage = '';
     for (const [subgraphName, checkSubgraph] of checkSubgraphs.entries()) {
       const {
         subgraph,
@@ -1482,7 +1482,7 @@ export class SchemaCheckRepository {
       graphPruneErrors,
       compositionWarnings,
       operationUsageStats: collectOperationUsageStats(inspectedOperations),
-      proposalMatchMessage,
+      proposalMatchMessage: proposalMatchMessage || undefined,
       isLinkedTrafficCheckFailed,
       isLinkedPruningCheckFailed,
     };

--- a/controlplane/src/core/repositories/SchemaCheckRepository.ts
+++ b/controlplane/src/core/repositories/SchemaCheckRepository.ts
@@ -990,7 +990,7 @@ export class SchemaCheckRepository {
 
           if (matches.length === 0) {
             if (proposalConfig.checkSeverityLevel === 'warn') {
-              proposalMatchMessage += `The subgraph ${subgraphName}'s schema does not match to this subgraph's schema in any approved proposal.\n`;
+              proposalMatchMessage += `The subgraph ${subgraphName}'s schema does not match to this subgraph's schema in any approved or draft proposals.\n`;
             } else {
               await this.update({
                 schemaCheckID,
@@ -1004,7 +1004,7 @@ export class SchemaCheckRepository {
               return {
                 response: {
                   code: EnumStatusCode.ERR_SCHEMA_MISMATCH_WITH_APPROVED_PROPOSAL,
-                  details: `The subgraph ${subgraphName}'s schema does not match to this subgraph's schema in any approved proposal.`,
+                  details: `The subgraph ${subgraphName}'s schema does not match to this subgraph's schema in any approved or draft proposals.`,
                 },
                 breakingChanges: [],
                 nonBreakingChanges: [],
@@ -1016,7 +1016,7 @@ export class SchemaCheckRepository {
                 graphPruneWarnings: [],
                 graphPruneErrors: [],
                 compositionWarnings: [],
-                proposalMatchMessage: `The subgraph ${subgraphName}'s schema does not match to this subgraph's schema in any approved proposal.`,
+                proposalMatchMessage: `The subgraph ${subgraphName}'s schema does not match to this subgraph's schema in any approved or draft proposals.`,
               };
             }
           }

--- a/controlplane/src/core/repositories/SubgraphRepository.ts
+++ b/controlplane/src/core/repositories/SubgraphRepository.ts
@@ -2152,8 +2152,8 @@ export class SubgraphRepository {
         });
         if (matches.length === 0) {
           const message = isDeleted
-            ? `The subgraph ${subgraphName} is not proposed to be deleted in any of the approved proposals.`
-            : `The subgraph ${subgraphName}'s schema does not match to this subgraph's schema in any approved proposal.`;
+            ? `The subgraph ${subgraphName} is not proposed to be deleted in any of the approved or draft proposals.`
+            : `The subgraph ${subgraphName}'s schema does not match to this subgraph's schema in any approved or draft proposals.`;
           if (proposalConfig.checkSeverityLevel === 'warn') {
             proposalMatchMessage = message;
           } else {

--- a/controlplane/test/proposal/proposal-schema-match.test.ts
+++ b/controlplane/test/proposal/proposal-schema-match.test.ts
@@ -229,7 +229,7 @@ describe('Proposal schema matching tests', () => {
     expect(checkResponse2.response?.code).toBe(EnumStatusCode.OK);
     expect(checkResponse2.proposalMatchMessage).toBeDefined();
     expect(checkResponse2.proposalMatchMessage).toContain(
-      `The subgraph ${subgraphName}'s schema does not match to this subgraph's schema in any approved proposal.`,
+      `The subgraph ${subgraphName}'s schema does not match to this subgraph's schema in any approved or draft proposals.`,
     );
   });
 
@@ -319,7 +319,7 @@ describe('Proposal schema matching tests', () => {
 
     expect(checkResponse.response?.code).toBe(EnumStatusCode.ERR_SCHEMA_MISMATCH_WITH_APPROVED_PROPOSAL);
     expect(checkResponse.response?.details).toBe(
-      `The subgraph ${subgraphName}'s schema does not match to this subgraph's schema in any approved proposal.`,
+      `The subgraph ${subgraphName}'s schema does not match to this subgraph's schema in any approved or draft proposals.`,
     );
 
     // Check with matching schema - should succeed
@@ -662,7 +662,7 @@ describe('Proposal schema matching tests', () => {
     expect(checkResponse3.response?.code).toBe(EnumStatusCode.ERR_SCHEMA_MISMATCH_WITH_APPROVED_PROPOSAL);
     expect(checkResponse3.proposalMatchMessage).toBeDefined();
     expect(checkResponse3.proposalMatchMessage).toBe(
-      `The subgraph ${subgraphName}'s schema does not match to this subgraph's schema in any approved proposal.`,
+      `The subgraph ${subgraphName}'s schema does not match to this subgraph's schema in any approved or draft proposals.`,
     );
   });
 
@@ -1034,7 +1034,7 @@ describe('Proposal schema matching tests', () => {
 
     expect(checkResponse.response?.code).toBe(EnumStatusCode.ERR_SCHEMA_MISMATCH_WITH_APPROVED_PROPOSAL);
     expect(checkResponse.response?.details).toBe(
-      `The subgraph ${subgraphName}'s schema does not match to this subgraph's schema in any approved proposal.`,
+      `The subgraph ${subgraphName}'s schema does not match to this subgraph's schema in any approved or draft proposals.`,
     );
 
     const checkResponse2 = await client.checkSubgraphSchema({
@@ -1098,7 +1098,7 @@ describe('Proposal schema matching tests', () => {
     expect(checkResponse.response?.code).toBe(EnumStatusCode.OK);
     expect(checkResponse.proposalMatchMessage).toBeDefined();
     expect(checkResponse.proposalMatchMessage).toBe(
-      `The subgraph ${subgraphName} is not proposed to be deleted in any of the approved proposals.`,
+      `The subgraph ${subgraphName} is not proposed to be deleted in any of the approved or draft proposals.`,
     );
 
     // Now set check severity to 'error' and test again
@@ -1116,7 +1116,7 @@ describe('Proposal schema matching tests', () => {
     // Should fail with an error
     expect(checkResponseError.response?.code).toBe(EnumStatusCode.ERR_SCHEMA_MISMATCH_WITH_APPROVED_PROPOSAL);
     expect(checkResponseError.response?.details).toBe(
-      `The subgraph ${subgraphName} is not proposed to be deleted in any of the approved proposals.`,
+      `The subgraph ${subgraphName} is not proposed to be deleted in any of the approved or draft proposals.`,
     );
 
     // Add a test for a case with proposal for schema modification but not deletion
@@ -1163,7 +1163,7 @@ describe('Proposal schema matching tests', () => {
     // Should still fail as there's no proposal for deletion
     expect(checkResponse3.response?.code).toBe(EnumStatusCode.ERR_SCHEMA_MISMATCH_WITH_APPROVED_PROPOSAL);
     expect(checkResponse3.response?.details).toBe(
-      `The subgraph ${subgraphName} is not proposed to be deleted in any of the approved proposals.`,
+      `The subgraph ${subgraphName} is not proposed to be deleted in any of the approved or draft proposals.`,
     );
   });
 
@@ -1302,7 +1302,7 @@ describe('Proposal schema matching tests', () => {
     });
     expect(checkResponse2.response?.code).toBe(EnumStatusCode.ERR_SCHEMA_MISMATCH_WITH_APPROVED_PROPOSAL);
     expect(checkResponse2.response?.details).toBe(
-      `The subgraph ${subgraphName}'s schema does not match to this subgraph's schema in any approved proposal.`,
+      `The subgraph ${subgraphName}'s schema does not match to this subgraph's schema in any approved or draft proposals.`,
     );
 
     // Check in namespace 2 with schema from namespace 2 - should succeed
@@ -1322,7 +1322,7 @@ describe('Proposal schema matching tests', () => {
     });
     expect(checkResponse4.response?.code).toBe(EnumStatusCode.ERR_SCHEMA_MISMATCH_WITH_APPROVED_PROPOSAL);
     expect(checkResponse4.response?.details).toBe(
-      `The subgraph ${subgraphName}'s schema does not match to this subgraph's schema in any approved proposal.`,
+      `The subgraph ${subgraphName}'s schema does not match to this subgraph's schema in any approved or draft proposals.`,
     );
 
     // Similar test with publish operation
@@ -1510,6 +1510,466 @@ describe('Proposal schema matching tests', () => {
     expect(publishResponse3.response?.code).toBe(EnumStatusCode.ERR_SCHEMA_MISMATCH_WITH_APPROVED_PROPOSAL);
     expect(publishResponse3.response?.details).toBe(
       `The subgraph ${newSubgraphName2}'s schema does not match to this subgraph's schema in any approved proposal.`,
+    );
+  });
+
+  test('check matches a DRAFT proposal (checks consider both draft and approved)', async (testContext) => {
+    const { client, server } = await SetupTest({
+      dbname,
+      chClient,
+      setupBilling: { plan: 'enterprise' },
+      enabledFeatures: ['proposals'],
+    });
+    testContext.onTestFinished(() => server.close());
+
+    const subgraphName = genID('subgraph1');
+    const fedGraphName = genID('fedGraph');
+    const label = genUniqueLabel('label');
+    const proposalName = genID('proposal');
+
+    const subgraphSchemaSDL = `
+      type Query {
+        hello: String!
+      }
+    `;
+
+    await createThenPublishSubgraph(
+      client,
+      subgraphName,
+      DEFAULT_NAMESPACE,
+      subgraphSchemaSDL,
+      [label],
+      DEFAULT_SUBGRAPH_URL_ONE,
+    );
+
+    await createFederatedGraph(client, fedGraphName, DEFAULT_NAMESPACE, [joinLabel(label)], DEFAULT_ROUTER_URL);
+
+    const enableResponse = await enableProposalsForNamespace(client);
+    expect(enableResponse.response?.code).toBe(EnumStatusCode.OK);
+
+    // Check severity error so a mismatch would fail loudly.
+    const { response } = await setProposalSeverity(client, DEFAULT_NAMESPACE, 'error', 'error');
+    expect(response.response?.code).toBe(EnumStatusCode.OK);
+
+    const updatedSubgraphSDL = `
+      type Query {
+        hello: String!
+        newField: Int!
+      }
+    `;
+
+    // Create the proposal but leave it in DRAFT (do NOT approve it).
+    const createProposalResponse = await createTestProposal(client, {
+      federatedGraphName: fedGraphName,
+      proposalName,
+      subgraphName,
+      updatedSubgraphSDL,
+    });
+    expect(createProposalResponse.response?.code).toBe(EnumStatusCode.OK);
+
+    // A check whose schema matches the DRAFT proposal must pass: checks consider
+    // draft proposals, not only approved ones.
+    const checkResponse = await client.checkSubgraphSchema({
+      subgraphName,
+      namespace: DEFAULT_NAMESPACE,
+      schema: Uint8Array.from(Buffer.from(updatedSubgraphSDL)),
+    });
+    expect(checkResponse.response?.code).toBe(EnumStatusCode.OK);
+    expect(checkResponse.proposalMatchMessage).toBeUndefined();
+  });
+
+  test('publish does not match a DRAFT proposal (writes require an approved proposal)', async (testContext) => {
+    const { client, server } = await SetupTest({
+      dbname,
+      chClient,
+      setupBilling: { plan: 'enterprise' },
+      enabledFeatures: ['proposals'],
+    });
+    testContext.onTestFinished(() => server.close());
+
+    const subgraphName = genID('subgraph1');
+    const fedGraphName = genID('fedGraph');
+    const label = genUniqueLabel('label');
+    const proposalName = genID('proposal');
+
+    const subgraphSchemaSDL = `
+      type Query {
+        hello: String!
+      }
+    `;
+
+    await createThenPublishSubgraph(
+      client,
+      subgraphName,
+      DEFAULT_NAMESPACE,
+      subgraphSchemaSDL,
+      [label],
+      DEFAULT_SUBGRAPH_URL_ONE,
+    );
+
+    await createFederatedGraph(client, fedGraphName, DEFAULT_NAMESPACE, [joinLabel(label)], DEFAULT_ROUTER_URL);
+
+    const enableResponse = await enableProposalsForNamespace(client);
+    expect(enableResponse.response?.code).toBe(EnumStatusCode.OK);
+
+    // Publish severity error so an unmatched publish fails.
+    const { response } = await setProposalSeverity(client, DEFAULT_NAMESPACE, 'warn', 'error');
+    expect(response.response?.code).toBe(EnumStatusCode.OK);
+
+    const updatedSubgraphSDL = `
+      type Query {
+        hello: String!
+        newField: Int!
+      }
+    `;
+
+    // Create the proposal but leave it in DRAFT (do NOT approve it).
+    const createProposalResponse = await createTestProposal(client, {
+      federatedGraphName: fedGraphName,
+      proposalName,
+      subgraphName,
+      updatedSubgraphSDL,
+    });
+    expect(createProposalResponse.response?.code).toBe(EnumStatusCode.OK);
+
+    // Publishing a schema that only matches a DRAFT proposal must fail: write
+    // operations require an APPROVED proposal.
+    const publishResponse = await client.publishFederatedSubgraph({
+      name: subgraphName,
+      namespace: DEFAULT_NAMESPACE,
+      schema: updatedSubgraphSDL,
+    });
+    expect(publishResponse.response?.code).toBe(EnumStatusCode.ERR_SCHEMA_MISMATCH_WITH_APPROVED_PROPOSAL);
+    expect(publishResponse.response?.details).toBe(
+      `The subgraph ${subgraphName}'s schema does not match to this subgraph's schema in any approved proposal.`,
+    );
+
+    // Once the proposal is approved, the same publish succeeds.
+    const approveResponse = await client.updateProposal({
+      proposalName: createProposalResponse.proposalName,
+      federatedGraphName: fedGraphName,
+      namespace: DEFAULT_NAMESPACE,
+      updateAction: {
+        case: 'state',
+        value: 'APPROVED',
+      },
+    });
+    expect(approveResponse.response?.code).toBe(EnumStatusCode.OK);
+
+    const publishResponse2 = await client.publishFederatedSubgraph({
+      name: subgraphName,
+      namespace: DEFAULT_NAMESPACE,
+      schema: updatedSubgraphSDL,
+    });
+    expect(publishResponse2.response?.code).toBe(EnumStatusCode.OK);
+    expect(publishResponse2.proposalMatchMessage).toBeUndefined();
+  });
+
+  test('check does not match a CLOSED proposal (checks only consider draft and approved)', async (testContext) => {
+    const { client, server } = await SetupTest({
+      dbname,
+      chClient,
+      setupBilling: { plan: 'enterprise' },
+      enabledFeatures: ['proposals'],
+    });
+    testContext.onTestFinished(() => server.close());
+
+    const subgraphName = genID('subgraph1');
+    const fedGraphName = genID('fedGraph');
+    const label = genUniqueLabel('label');
+    const proposalName = genID('proposal');
+
+    const subgraphSchemaSDL = `
+      type Query {
+        hello: String!
+      }
+    `;
+
+    await createThenPublishSubgraph(
+      client,
+      subgraphName,
+      DEFAULT_NAMESPACE,
+      subgraphSchemaSDL,
+      [label],
+      DEFAULT_SUBGRAPH_URL_ONE,
+    );
+
+    await createFederatedGraph(client, fedGraphName, DEFAULT_NAMESPACE, [joinLabel(label)], DEFAULT_ROUTER_URL);
+
+    const enableResponse = await enableProposalsForNamespace(client);
+    expect(enableResponse.response?.code).toBe(EnumStatusCode.OK);
+
+    // Check severity error so an unmatched check fails.
+    const { response } = await setProposalSeverity(client, DEFAULT_NAMESPACE, 'error', 'error');
+    expect(response.response?.code).toBe(EnumStatusCode.OK);
+
+    const updatedSubgraphSDL = `
+      type Query {
+        hello: String!
+        newField: Int!
+      }
+    `;
+
+    const createProposalResponse = await createTestProposal(client, {
+      federatedGraphName: fedGraphName,
+      proposalName,
+      subgraphName,
+      updatedSubgraphSDL,
+    });
+    expect(createProposalResponse.response?.code).toBe(EnumStatusCode.OK);
+
+    // Close the proposal — CLOSED (and PUBLISHED) proposals must never be matched.
+    const closeResponse = await client.updateProposal({
+      proposalName: createProposalResponse.proposalName,
+      federatedGraphName: fedGraphName,
+      namespace: DEFAULT_NAMESPACE,
+      updateAction: {
+        case: 'state',
+        value: 'CLOSED',
+      },
+    });
+    expect(closeResponse.response?.code).toBe(EnumStatusCode.OK);
+
+    // A check whose schema matches only the CLOSED proposal must fail: checks
+    // consider draft and approved proposals only, never closed/published ones.
+    const checkResponse = await client.checkSubgraphSchema({
+      subgraphName,
+      namespace: DEFAULT_NAMESPACE,
+      schema: Uint8Array.from(Buffer.from(updatedSubgraphSDL)),
+    });
+    expect(checkResponse.response?.code).toBe(EnumStatusCode.ERR_SCHEMA_MISMATCH_WITH_APPROVED_PROPOSAL);
+    expect(checkResponse.response?.details).toBe(
+      `The subgraph ${subgraphName}'s schema does not match to this subgraph's schema in any approved or draft proposals.`,
+    );
+  });
+
+  test('check does not match a PUBLISHED proposal (checks only consider draft and approved)', async (testContext) => {
+    const { client, server } = await SetupTest({
+      dbname,
+      chClient,
+      setupBilling: { plan: 'enterprise' },
+      enabledFeatures: ['proposals'],
+    });
+    testContext.onTestFinished(() => server.close());
+
+    const subgraphName = genID('subgraph1');
+    const fedGraphName = genID('fedGraph');
+    const label = genUniqueLabel('label');
+    const proposalName = genID('proposal');
+
+    const subgraphSchemaSDL = `
+      type Query {
+        hello: String!
+      }
+    `;
+
+    await createThenPublishSubgraph(
+      client,
+      subgraphName,
+      DEFAULT_NAMESPACE,
+      subgraphSchemaSDL,
+      [label],
+      DEFAULT_SUBGRAPH_URL_ONE,
+    );
+
+    await createFederatedGraph(client, fedGraphName, DEFAULT_NAMESPACE, [joinLabel(label)], DEFAULT_ROUTER_URL);
+
+    const enableResponse = await enableProposalsForNamespace(client);
+    expect(enableResponse.response?.code).toBe(EnumStatusCode.OK);
+
+    // Check severity error so an unmatched check fails.
+    const { response } = await setProposalSeverity(client, DEFAULT_NAMESPACE, 'error', 'error');
+    expect(response.response?.code).toBe(EnumStatusCode.OK);
+
+    const updatedSubgraphSDL = `
+      type Query {
+        hello: String!
+        newField: Int!
+      }
+    `;
+
+    const createProposalResponse = await createTestProposal(client, {
+      federatedGraphName: fedGraphName,
+      proposalName,
+      subgraphName,
+      updatedSubgraphSDL,
+    });
+    expect(createProposalResponse.response?.code).toBe(EnumStatusCode.OK);
+
+    // Move the proposal to PUBLISHED — published proposals must never be matched.
+    const publishStateResponse = await client.updateProposal({
+      proposalName: createProposalResponse.proposalName,
+      federatedGraphName: fedGraphName,
+      namespace: DEFAULT_NAMESPACE,
+      updateAction: {
+        case: 'state',
+        value: 'PUBLISHED',
+      },
+    });
+    expect(publishStateResponse.response?.code).toBe(EnumStatusCode.OK);
+
+    // A check whose schema matches only the PUBLISHED proposal must fail: checks
+    // consider draft and approved proposals only.
+    const checkResponse = await client.checkSubgraphSchema({
+      subgraphName,
+      namespace: DEFAULT_NAMESPACE,
+      schema: Uint8Array.from(Buffer.from(updatedSubgraphSDL)),
+    });
+    expect(checkResponse.response?.code).toBe(EnumStatusCode.ERR_SCHEMA_MISMATCH_WITH_APPROVED_PROPOSAL);
+    expect(checkResponse.response?.details).toBe(
+      `The subgraph ${subgraphName}'s schema does not match to this subgraph's schema in any approved or draft proposals.`,
+    );
+  });
+
+  test('publish does not match a CLOSED proposal (writes require an approved proposal)', async (testContext) => {
+    const { client, server } = await SetupTest({
+      dbname,
+      chClient,
+      setupBilling: { plan: 'enterprise' },
+      enabledFeatures: ['proposals'],
+    });
+    testContext.onTestFinished(() => server.close());
+
+    const subgraphName = genID('subgraph1');
+    const fedGraphName = genID('fedGraph');
+    const label = genUniqueLabel('label');
+    const proposalName = genID('proposal');
+
+    const subgraphSchemaSDL = `
+      type Query {
+        hello: String!
+      }
+    `;
+
+    await createThenPublishSubgraph(
+      client,
+      subgraphName,
+      DEFAULT_NAMESPACE,
+      subgraphSchemaSDL,
+      [label],
+      DEFAULT_SUBGRAPH_URL_ONE,
+    );
+
+    await createFederatedGraph(client, fedGraphName, DEFAULT_NAMESPACE, [joinLabel(label)], DEFAULT_ROUTER_URL);
+
+    const enableResponse = await enableProposalsForNamespace(client);
+    expect(enableResponse.response?.code).toBe(EnumStatusCode.OK);
+
+    // Publish severity error so an unmatched publish fails.
+    const { response } = await setProposalSeverity(client, DEFAULT_NAMESPACE, 'warn', 'error');
+    expect(response.response?.code).toBe(EnumStatusCode.OK);
+
+    const updatedSubgraphSDL = `
+      type Query {
+        hello: String!
+        newField: Int!
+      }
+    `;
+
+    const createProposalResponse = await createTestProposal(client, {
+      federatedGraphName: fedGraphName,
+      proposalName,
+      subgraphName,
+      updatedSubgraphSDL,
+    });
+    expect(createProposalResponse.response?.code).toBe(EnumStatusCode.OK);
+
+    // Close the proposal — writes match only APPROVED proposals.
+    const closeResponse = await client.updateProposal({
+      proposalName: createProposalResponse.proposalName,
+      federatedGraphName: fedGraphName,
+      namespace: DEFAULT_NAMESPACE,
+      updateAction: {
+        case: 'state',
+        value: 'CLOSED',
+      },
+    });
+    expect(closeResponse.response?.code).toBe(EnumStatusCode.OK);
+
+    const publishResponse = await client.publishFederatedSubgraph({
+      name: subgraphName,
+      namespace: DEFAULT_NAMESPACE,
+      schema: updatedSubgraphSDL,
+    });
+    expect(publishResponse.response?.code).toBe(EnumStatusCode.ERR_SCHEMA_MISMATCH_WITH_APPROVED_PROPOSAL);
+    expect(publishResponse.response?.details).toBe(
+      `The subgraph ${subgraphName}'s schema does not match to this subgraph's schema in any approved proposal.`,
+    );
+  });
+
+  test('publish does not match a PUBLISHED proposal (writes require an approved proposal)', async (testContext) => {
+    const { client, server } = await SetupTest({
+      dbname,
+      chClient,
+      setupBilling: { plan: 'enterprise' },
+      enabledFeatures: ['proposals'],
+    });
+    testContext.onTestFinished(() => server.close());
+
+    const subgraphName = genID('subgraph1');
+    const fedGraphName = genID('fedGraph');
+    const label = genUniqueLabel('label');
+    const proposalName = genID('proposal');
+
+    const subgraphSchemaSDL = `
+      type Query {
+        hello: String!
+      }
+    `;
+
+    await createThenPublishSubgraph(
+      client,
+      subgraphName,
+      DEFAULT_NAMESPACE,
+      subgraphSchemaSDL,
+      [label],
+      DEFAULT_SUBGRAPH_URL_ONE,
+    );
+
+    await createFederatedGraph(client, fedGraphName, DEFAULT_NAMESPACE, [joinLabel(label)], DEFAULT_ROUTER_URL);
+
+    const enableResponse = await enableProposalsForNamespace(client);
+    expect(enableResponse.response?.code).toBe(EnumStatusCode.OK);
+
+    // Publish severity error so an unmatched publish fails.
+    const { response } = await setProposalSeverity(client, DEFAULT_NAMESPACE, 'warn', 'error');
+    expect(response.response?.code).toBe(EnumStatusCode.OK);
+
+    const updatedSubgraphSDL = `
+      type Query {
+        hello: String!
+        newField: Int!
+      }
+    `;
+
+    const createProposalResponse = await createTestProposal(client, {
+      federatedGraphName: fedGraphName,
+      proposalName,
+      subgraphName,
+      updatedSubgraphSDL,
+    });
+    expect(createProposalResponse.response?.code).toBe(EnumStatusCode.OK);
+
+    // Move the proposal to PUBLISHED — writes match only APPROVED proposals.
+    const publishStateResponse = await client.updateProposal({
+      proposalName: createProposalResponse.proposalName,
+      federatedGraphName: fedGraphName,
+      namespace: DEFAULT_NAMESPACE,
+      updateAction: {
+        case: 'state',
+        value: 'PUBLISHED',
+      },
+    });
+    expect(publishStateResponse.response?.code).toBe(EnumStatusCode.OK);
+
+    const publishResponse = await client.publishFederatedSubgraph({
+      name: subgraphName,
+      namespace: DEFAULT_NAMESPACE,
+      schema: updatedSubgraphSDL,
+    });
+    expect(publishResponse.response?.code).toBe(EnumStatusCode.ERR_SCHEMA_MISMATCH_WITH_APPROVED_PROPOSAL);
+    expect(publishResponse.response?.details).toBe(
+      `The subgraph ${subgraphName}'s schema does not match to this subgraph's schema in any approved proposal.`,
     );
   });
 });

--- a/docs-website/concepts/proposals.mdx
+++ b/docs-website/concepts/proposals.mdx
@@ -86,21 +86,21 @@ When enabled, changes to the schema will need to go through a proposal process, 
 
 ### Proposal Configuration
 
-The proposal configuration allows you to set severity levels for subgraph checks and publishes. This makes sure that the schema used for checks and publishes matches a proposal in the namespace. Proposal matching considers proposals in any state.
+The proposal configuration allows you to set severity levels for subgraph checks and publishes. This makes sure that the schema used for a check or publish matches a proposal in the namespace. The proposals considered depend on the operation. Checks match against draft and approved proposals. Publishes match against approved proposals only.
 
 #### Check Severity Level
 
-This sets the severity level for subgraph checks during proposal evaluation. Available levels include:
+This sets the severity level for subgraph checks during proposal evaluation. A check matches against draft and approved proposals. Available levels include:
 
-- **Error**: Returns an error if the schema used for the check doesn't match any proposal in the namespace.
-- **Warn**: Returns a warning if the schema used for the check doesn't match any proposal in the namespace.
+- **Error**: Returns an error if the schema used for the check doesn't match any draft or approved proposal in the namespace.
+- **Warn**: Returns a warning if the schema used for the check doesn't match any draft or approved proposal in the namespace.
 
 #### Publish Severity Level
 
-This determines the severity level for subgraph publishes during proposal evaluation. Options include:
+This determines the severity level for subgraph publishes during proposal evaluation. A publish matches against approved proposals only. Options include:
 
-- **Error**: Returns an error if the schema used for the publish doesn't match any proposal in the namespace.
-- **Warn**: Returns a warning if the schema used for the publish doesn't match any proposal in the namespace.
+- **Error**: Returns an error if the schema used for the publish doesn't match any approved proposal in the namespace.
+- **Warn**: Returns a warning if the schema used for the publish doesn't match any approved proposal in the namespace.
 
 Configuring these severity levels allows you to enforce different levels of strictness in your proposal workflow.
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened proposal matching: publish/delete (write) operations now consider only approved proposals for blocking writes; schema checks report matches from approved or draft proposals and message text reflects this.

* **Tests**
  * Added tests covering draft, approved, closed, and published proposal behaviors for schema checks and publish/delete flows.

* **Documentation**
  * Clarified proposal configuration docs to explain approved-only vs. draft+approved matching rules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wundergraph/cosmo/pull/2898?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [x] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [x] Tests or benchmarks have been added or updated.
- [x] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).
