### PR TITLE
docs: RFC — at-least-once delivery for GraphQL subscriptions (EDFS)

### DIFF
--- a/rfc/at-least-once/00-research-dossier.md
+++ b/rfc/at-least-once/00-research-dossier.md
@@ -1,0 +1,374 @@
+# DOSSIER: At-Least-Once Delivery for GraphQL Subscriptions on Cosmo Streams / EDFS
+
+> **Purpose.** Single source of truth for the next phase: writing competing RFCs that restore end-to-end at-least-once delivery (broker → router → client) on top of Cosmo's existing EDFS / Cosmo Streams capability, adaptable across heterogeneous backends with explicit, documented degradation when a backend cannot meet the bar.
+>
+> **Version pins (as researched).** Router pubsub layer `router/pkg/pubsub/`; engine `graphql-go-tools/v2` (datapath agent verified against `v2.4.1`; transport agent verified against the router's pinned `v2.1.1-0.20260504064838-5a00844995b5`). Broker clients: `nats.go v1.50.0`, `franz-go v1.16.1`, `go-redis/v9 v9.7.3`.
+>
+> **Note on engine version.** The two codebase agents read two different pinned engine snapshots. Both describe the *same synchronous, fire-and-forget* model; minor line-number drift between them (`v2.4.1` vs the router go.mod pin) is noted inline where it matters. Treat the architectural conclusions as stable; re-verify exact line numbers against the engine version the RFC will target.
+
+---
+
+## 1. Current EDFS / Cosmo Streams Architecture
+
+### 1.1 The two configuration planes
+
+EDFS wiring is split across two planes that join only at router runtime:
+
+1. **Control-plane / execution config (proto).** Composition (TypeScript) parses `@edfs__*` directives and serializes *per-field event routing only*: which field publishes/subscribes to which subject/topic/channel, on which logical `providerId`, and whether it is `PUBLISH` / `REQUEST` / `SUBSCRIBE`. It does **not** store broker URLs or credentials. Carrier: `DataSourceCustomEvents { nats, kafka, redis }` (`proto/wg/cosmo/node/v1/node.proto:430-434`), built in `shared/src/router-config/graphql-configuration.ts:113-219`, attached in `shared/src/router-config/builder.ts:257-314`.
+2. **Router YAML — provider connection details.** Local to the router, never in the control plane. `EventsConfiguration { Providers, Handlers }` (`router/pkg/config/config.go:779-782`), `EventProviders { Nats, Kafka, Redis }` (`config.go:773-777`).
+
+They join in `router/core/factoryresolver.go:531-538` → `pubsub.BuildProvidersAndDataSources` (`router/pkg/pubsub/pubsub.go:56-128`), which matches each event's `providerId` (from proto) against a provider defined in YAML, erroring with `ProviderNotDefinedError` (`pubsub.go:166-173`) if missing. `routerEngineConfig.Events` is supplied via `WithEvents(config.Events)` (`router/core/router.go:2128`).
+
+### 1.2 Directive surface (composition layer)
+
+All `@edfs__*` parsing/validation is in `composition/`, never in the router. Name constants: `composition/src/utils/string-constants.ts:33-41`.
+
+- **NATS** (`demo/.../schema.graphqls:1-3`): `@edfs__natsRequest(subject, providerId="default")`, `@edfs__natsPublish(subject, providerId="default")`, `@edfs__natsSubscribe(subjects: [String!]!, providerId="default", streamConfiguration: edfs__NatsStreamConfiguration)`. Parsed in `composition/src/v1/normalization/normalization-factory.ts:2887-3081`.
+  - `edfs__NatsStreamConfiguration { consumerInactiveThreshold: Int! = 30, consumerName: String!, streamName: String! }` (`schema.graphqls:115-119`). A `streamConfiguration` block is only emitted when **both** `consumerName` and `streamName` are present (`normalization-factory.ts:3076-3081`). `DEFAULT_CONSUMER_INACTIVE_THRESHOLD = 30` (`composition/src/v1/constants/integers.ts:1`).
+- **Kafka**: `@edfs__kafkaPublish(topic, providerId="default")`, `@edfs__kafkaSubscribe(topics: [String!]!, providerId="default")` (`composition/src/v1/constants/directive-definitions.ts:274-298`). Parsed in `normalization-factory.ts:2804-2885`.
+- **Redis**: `@edfs__redisPublish(channel, providerId="default")`, `@edfs__redisSubscribe(channels: [String!]!, providerId="default")` (`directive-definitions.ts:424-475`). Parsed in `normalization-factory.ts:3088-3169`.
+
+### 1.3 End-to-end data path (one subscription event)
+
+The entire chain from broker callback to client socket write is **one synchronous call stack**. The engine in this generation has **no internal buffered events channel** — the broker-reader goroutine drives resolution and the socket write directly and synchronously.
+
+1. **Broker delivers to the provider adapter's reader goroutine** (spawned inside `Adapter.Subscribe`):
+   - NATS JetStream: `consumer.FetchNoWait(300)` then `for msg := range msgBatch.Messages()` — `router/pkg/pubsub/nats/adapter.go:130-159`.
+   - NATS core: `case msg := <-msgChan:` — `nats/adapter.go:186`.
+   - Kafka: `client.PollRecords(p.ctx, 10_000)` then `iter.Next()` — `router/pkg/pubsub/kafka/adapter.go:61-119`.
+   - Redis: `case msg, ok := <-msgChan:` — `router/pkg/pubsub/redis/adapter.go:116-136`.
+2. **Adapter calls `updater.Update([]datasource.StreamEvent{...})`** (`nats/adapter.go:146`, `kafka/adapter.go:110`, `redis/adapter.go:132`). `updater` is a `datasource.SubscriptionEventUpdater` (interface `router/pkg/pubsub/datasource/subscription_event_updater.go:19-24`).
+3. **`subscriptionEventUpdater.Update`** (`subscription_event_updater.go:36-129`):
+   - No hooks → directly `s.eventUpdater.Update(event.GetData())` per event (`:37-42`).
+   - With `on_receive_events` hooks → per-subscription fan-out under a `semaphore.Weighted` with a deadline, then `s.eventUpdater.UpdateSubscription(subID, data)` (`:44-129`).
+4. **Engine `subscriptionUpdater.Update` → `resolver.handleTriggerUpdate`** (graphql-go-tools `pkg/engine/resolve/resolve.go`).
+5. **`handleTriggerUpdate`** filters subscriptions and, **synchronously (`wg.Wait()`)**, runs `executeSubscriptionUpdate` for each subscriber.
+6. **`executeSubscriptionUpdate`** does the full GraphQL resolve (`InitSubscription` + `LoadGraphQLResponseData`, fetching federated/nested data) then `sub.writer.Flush()`.
+7. **`Flush()` writes directly to the client socket**:
+   - WebSocket: `websocketResponseWriter.Flush` → `protocol.WriteGraphQLData` → `wsConnectionWrapper.WriteText/WriteJSON` → `wsutil.WriteServerText` under a write deadline (`router/core/websocket.go:704-736`, `187-217`).
+   - SSE/multipart: `HttpFlushWriter.Flush` → `f.writer.Write(...)` then `f.flusher.Flush()` (`router/core/flushwriter.go:116-167`).
+
+The engine interface docs say delivery is "not guaranteed immediate," but the v2.4.1 implementation is in fact fully synchronous.
+
+### 1.4 Trigger sharing / deduplication
+
+Triggers are keyed by a hash of rendered input + subgraph headers (`prepareTrigger`/`prepareTrigger` keying in `resolve.go`). Multiple clients with identical subscriptions share **one trigger and one broker subscription**; `handleTriggerUpdate` fans the single event out to every subscriber. The Kafka adapter comment confirms: "The engine already deduplicates subscriptions with the same topics…" (`kafka/adapter.go:124-125`). The trigger is keyed by data, **not by client identity** — a reconnecting client gets a new `ConnectionID` (`resolve.NewConnectionID()`, `websocket.go:367`) and a brand-new subscription id (`websocket.go:1160-1185`).
+
+### 1.5 Publish path (GraphQL mutation → broker)
+
+Identical in shape for all three providers; only the adapter's broker call differs:
+
+- Plan time: `router/pkg/pubsub/datasource/planner.go:45-88` (`ConfigureFetch`) → for `EventTypePublish` returns a `PublishDataSource`.
+- Execution: engine calls `PublishDataSource.Load` → `PubSubProvider.Publish` (`datasource/pubsubprovider.go:81-94`, runs any `OnPublishEvents` hooks) → adapter `Publish`.
+- **GraphQL-layer result is always synthetic**: `{"__typename":"edfs__PublishResult","success":true}` on success, `success:false` on failure. A **broker error is swallowed** (logged, not returned) to avoid an "unable to fetch from subgraph" error (e.g. `redis/engine_datasource.go:205-209`). The `edfs__PublishResult!` type is `NON_NULLABLE_EDFS_PUBLISH_EVENT_RESULT` (`composition/src/utils/string-constants.ts:103`).
+- Broker-confirmation strength differs: **Kafka** waits for the produce callback + `wg.Wait()` (`kafka/adapter.go:234-249`) and flushes on shutdown; **NATS Publish** always uses **core NATS** `p.client.Publish` (`nats/adapter.go:254`) — even when the subject is stream-backed; **Redis** `PUBLISH` (`redis/adapter.go:191`) returns only the subscriber-count int, not a delivery confirmation, so `success:true` can mean "zero subscribers, message dropped."
+
+### 1.6 Transport layer to the client
+
+- **WebSocket** (3 subprotocols, negotiated at upgrade): `graphql-transport-ws` (modern graphql-ws), `graphql-ws` (legacy subscriptions-transport-ws / Apollo), `absinthe` (Phoenix, opt-in). Supported set: `router/internal/wsproto/proto.go:102-112`. WS path → `AsyncResolveGraphQLSubscription` (`websocket.go:1141-1149`).
+- **HTTP streaming**: SSE (`text/event-stream` or `?wg_sse`), `multipart/mixed` (`subscriptionSpec=1.0; boundary=graphql`), and "subscribe once" (`?wg_subscribe_once`). Handled by `HttpFlushWriter` (`router/core/flushwriter.go`), negotiated in `NegotiateSubscriptionParams` (`flushwriter.go:252-299`). HTTP path → `Resolver.ResolveGraphQLSubscription` (`graphql_handler.go:265-293`).
+- **Heartbeats**: SSE/multipart get server heartbeats (default `DefaultHeartbeatInterval = 5s`, suppressed while data flows; SSE writes `:heartbeat\n\n`, multipart writes `{}`). WS heartbeat is an explicit **no-op** (`websocket.go:659-662`); the router never proactively pings the downstream WS client. A failed heartbeat tears down the subscription (this is how SSE/multipart disconnects are detected).
+- **Lifecycle / teardown**: client drop → read error → `handler.Close(unsubscribe=true)` → `UnsubscribeClient(connectionID)` → removes every subscription for that connection; the last subscriber on a trigger cancels the trigger context, stopping the adapter goroutine (which unsubscribes from the broker). A failed `Flush` mid-update also calls `UnsubscribeSubscription`.
+
+---
+
+## 2. Where At-Least-Once Is Lost — "The GraphQL Subscription Gap"
+
+The framework abstraction is **fire-and-forget by construction**: `datasource.Adapter` (`router/pkg/pubsub/datasource/provider.go:22-28`) and the engine's `SubscriptionUpdater.Update(data)` return **no error and have no ack hook back to the broker**. The generic glue never reports delivery success back to the adapter. Therefore **durability is a per-adapter property, not a property of EDFS** — and today only one adapter (NATS JetStream) attempts it.
+
+### 2.1 The exact hops where guarantees evaporate
+
+**Hop A — Broker → router read.** Only NATS JetStream consumes durably (durable consumer, explicit ack). Kafka, NATS core, and Redis Pub/Sub never commit/ack — see §3.
+
+**Hop B — Router resolve → client flush.** Even on the durable JetStream path, ack timing is wrong:
+
+1. **Ack is gated on flush *attempt*, not client receipt.** JetStream `msg.Ack()` (`nats/adapter.go:154`) runs *after* `updater.Update()` returns, which (synchronously, with `wg.Wait()`) ran resolve + `writer.Flush()`. But `Flush()` is a single socket write under a write deadline — a successful flush only means **bytes handed to the kernel/TCP buffer**, not an application ack from the client. A client that crashes after TCP-buffering but before processing loses the message, yet it is acked → **lost**.
+2. **Ack fires even when delivery failed.** The no-hooks path ignores the result of `executeSubscriptionUpdate` (`subscription_event_updater.go:37-42`); the engine's `Update` returns void. If resolve/flush fails (client mid-disconnect), the subscription is dropped but `msg.Ack()` still runs → **acked despite non-delivery**.
+3. **Multi-subscriber fan-out is acked-anyway.** One JetStream message fans out to N shared subscribers; some succeed, some fail; the single `msg.Ack()` acks the whole trigger → failed subscribers silently miss the event.
+4. **Hooks path can abandon and reorder.** With `on_receive_events` hooks, on timeout the updater **abandons** in-flight deliveries and proceeds (explicit warning "Events may arrive out of order," `subscription_event_updater.go:69-79`), while the JetStream loop still proceeds to `msg.Ack()` → abandoned-but-acked = **lost** + reordered.
+
+**Hop C — No client ack anywhere.** Neither WS writers (`websocket.go`) nor the SSE/multipart writer (`flushwriter.go`) implement a per-message client ACK. The recognized inbound WS message set is `Ping`, `Pong`, `Subscribe`, `Complete`, `Terminate` (`wsproto/proto.go:88-94`) — there is **no "ack received next" concept**. `connection_init`/`connection_ack` is a one-time *connection* handshake, not a data ack. (Note: the `AckTimeout` in config is for the *upstream* router→subgraph WS client, unrelated to downstream delivery.)
+
+**Hop D — No resume / replay.** A reconnecting client always starts a brand-new subscription from "now." No `Last-Event-ID` handling anywhere (grep of `core/` + `internal/wsproto/` for `Last-Event-ID`/`LastEventID`/`resume`/`cursor`/`resumeToken` returns nothing). The SSE writer never emits an `id:` field (only `event:`/`data:`), so even SSE auto-resume cannot work. The delivered event structs carry only `Data`, `Headers` (and Kafka `Key`) — **no sequence/offset cursor is ever surfaced** (`nats/engine_datasource.go:39-42`, `kafka/engine_datasource.go:58-63`). JetStream `msg.Metadata()` (which carries stream/consumer sequence) is never read.
+
+### 2.2 Buffering, backpressure, and slow-consumer behavior
+
+There is **no application-level queue** in the engine; the only channel (`maxConcurrency`) is explicitly excluded from subscription updates. Flow control is whatever the broker-client library provides plus the synchronous backpressure of the call stack:
+
+- Because `updater.Update` blocks until resolve+flush completes for all subscribers, **a slow client blocks the broker-reading goroutine for that trigger** (per-trigger-serial backpressure). JetStream delays the next `FetchNoWait` and the `msg.Ack()`; Kafka delays the next `PollRecords`; Redis/NATS-core stall the channel read.
+- **NATS core uses an unbuffered Go channel** (`make(chan *nats.Msg)`, `nats/adapter.go:168`); on overflow the nats.go client **drops events** and logs `nats.ErrSlowConsumer`: "NATS slow consumer detected. Events are being dropped." (`provider_builder.go:96-105`).
+- **Kafka**: franz-go internal fetch buffering; poll caps at 10k records.
+- **Redis Pub/Sub**: go-redis internal channel; on overflow messages are **dropped** by the client.
+- **Per-update resolve timeout**: `context.WithTimeout(ctx, r.maxSubscriptionFetchTimeout)`; `MaxSubscriptionFetchTimeout` defaults to **30s** (`router/pkg/config/config.go:454`, wired `router/core/executor.go:89`). A failed flush → `UnsubscribeSubscription`.
+
+### 2.3 Restart / disconnect / broker-drop behavior
+
+| Event | NATS JetStream | NATS core | Kafka | Redis Pub/Sub |
+|---|---|---|---|---|
+| **Client disconnects mid-stream** | In-flight event's flush fails & is discarded; if disconnect precedes `msg.Ack()`, message redelivered after AckWait (~30s) — but to the *same* per-instance durable consumer | In-flight + subsequent events lost | Same — lost | Same — lost |
+| **Router restarts** | Durable consumer survives **only if** instance identity (`hostname + listenAddr + subjects`) is stable; un-acked redelivered. Lost if `deleteConsumersOnShutdown` set or `ConsumerInactiveThreshold` expires | No persistence — anything published during downtime lost | Re-subscribes with `ConsumeResetOffset(AfterMilli(now))` → **skips everything produced during downtime** | No backlog — lost |
+| **Broker connection drops** | Auto-reconnect (jitter); un-acked redelivered after AckWait | Messages during gap lost; slow-consumer overflow dropped | franz-go internal reconnect continues from in-memory position (no re-skip mid-subscription) | Messages during gap lost |
+
+**Durable consumer naming caveat (NATS):** the user-supplied `consumerName` is **advisory only** — it is a prefix to a hash of `hostname-routerListenAddr` + subjects (`getDurableConsumerName`, `nats/adapter.go:69-83`). This deliberately makes the consumer unique per router instance + subject set so multiple routers don't fight over one consumer — but it also means HA / horizontal scaling and durable resume are at odds (see §6).
+
+### 2.4 One-line summary of the gap
+
+> Today, **only NATS JetStream achieves any durability, and only because its adapter independently calls `msg.Ack()`** after a *flush attempt*. There is no client acknowledgement, no resume token, no replay, and no per-subscriber delivery accounting anywhere in EDFS. Everywhere else delivery is at-most-once by construction.
+
+---
+
+## 3. Per-Backend Capability Matrix
+
+### 3.1 Cosmo's current support & semantics (from the codebase)
+
+| Backend | Cosmo client lib | Cosmo transport used | Ack/commit in Cosmo today | Cursor surfaced? | Effective Cosmo guarantee | Cross-restart durability |
+|---|---|---|---|---|---|---|
+| **NATS core** | nats.go v1.50.0 | `ChanSubscribe` (core pub/sub) | None | No | At-most-once; drops on slow consumer | None |
+| **NATS JetStream** | nats.go v1.50.0 | Durable pull consumer, `FetchNoWait(300)`, `msg.Ack()` after delivery attempt | `AckExplicit` (default), default 30s `AckWait`, unlimited `MaxDeliver` | No (`Metadata()` never read) | "Close to" at-least-once *relative to router read*, with loss windows | Only if consumer survives (instance-stable, not deleted/expired) |
+| **Kafka** | franz-go v1.16.1 | Groupless direct consumer, `ConsumeResetOffset(AfterMilli(now))` | **None** (no group, no commit) | No (`r.Offset` never read) | At-most-once / fire-and-forget | None — skips downtime backlog |
+| **Redis** | go-redis/v9 v9.7.3 | **Pub/Sub** (`PSubscribe`/`PUBLISH`) — **not Streams** | None (Pub/Sub has no ack) | No | At-most-once / fire-and-forget | None |
+| **SQS, Google Pub/Sub, Kinesis, Event Hubs, RabbitMQ** | — | **Not supported in EDFS today** | — | — | — | — |
+
+**Cosmo-side knobs exposed today:** NATS — `consumerName`, `streamName`, `consumerInactiveThreshold` (schema), plus `experiment_delete_durable_consumers_on_shutdown`, auth, TLS (router YAML). No `AckPolicy`/`AckWait`/`MaxDeliver`/`DeliverPolicy`/`replicas` surfaced. Kafka — `brokers`, auth (SASL plain/SCRAM), TLS, `fetch_max_wait`; **no** consumer-group/offset-reset/commit config. Redis — `urls`, `cluster_enabled`.
+
+### 3.2 Backend-native capability matrix (what's *possible*, from external research)
+
+| Backend | Default guarantee | Ack/commit mechanism | Cursor/offset primitive | Replay window | Ordering | Native dedup |
+|---|---|---|---|---|---|---|
+| **NATS core** | At-most-once | None | None | None | Per-subject best-effort | No |
+| **NATS JetStream** | At-least-once (exactly-once optional) | `AckAck`/`AckNak`/`AckProgress`(+WPI)/`AckTerm`(+TERM)/`AckNext`; double-ack | **Stream sequence** (canonical) + **consumer sequence** + **ack floor** `(cons,stream)` | Retention-bound (`LimitsPolicy`); `DeliverByStartSequence`/`ByStartTime` resume | Linearizable writes; single global order per stream | **Yes** — `Nats-Msg-Id` + duplicate window (default **2 min**) |
+| **Kafka** | At-least-once | Offset commit (`commitSync`/`commitAsync`), manual or auto; commit = *next* offset to read | **`(partition, offset)`**; `seek`, `offsetsForTimes` (timestamp cursor) | `retention.ms` (data) — note `__consumer_offsets` evicts at `offsets.retention.minutes`, **7d default** | Strict **within a partition** | Idempotent producer (PID+seq) dedups producer retries; consumer dedup = app's job |
+| **AWS SQS (Standard)** | At-least-once (dupes) | `DeleteMessage` after processing; visibility timeout (default 30s) | None — ephemeral receipt handle | **None** | Best-effort (none) | No |
+| **AWS SQS (FIFO)** | Exactly-once *processing* | `DeleteMessage`; visibility timeout | None — receipt handle | **None** | Strict FIFO per **message group ID** | **Yes** — 5-min dedup via `MessageDeduplicationId` |
+| **Redis Streams** (vs Pub/Sub) | At-least-once (consumer groups + PEL) | `XACK` clears the Pending Entries List; `XREADGROUP` adds to PEL | **Entry ID** `<ms>-<seq>`; group `last-delivered-id`; `XPENDING`/`XCLAIM`/`XAUTOCLAIM` | Bounded by `MAXLEN`/`MINID` trimming | Total order by entry ID per stream | No (PEL prevents loss, not dupes) |
+| **Google Cloud Pub/Sub** | At-least-once | `ack`/`nack`; ack deadline default 10s (60s for EOS), `modifyAckDeadline` | Server-managed ack state; **snapshots** | `seek` to timestamp/snapshot; retention up to **31d**, snapshots **7d** | Optional per **ordering key** (same region) | **Yes** when exactly-once subscription enabled (opt-in) |
+| **AWS Kinesis Data Streams** | At-least-once | No per-msg ack — consumer **checkpoints** sequence number (KCL/DynamoDB) | **Shard iterator** + **sequence number** (`AT_/AFTER_SEQUENCE_NUMBER`, `TRIM_HORIZON`, `LATEST`; iterator expires 5 min) | Retention **24h** default → **7d** → up to **365d** | Strict **within a shard** | No |
+| **Azure Event Hubs** | At-least-once | No broker ack — consumer **checkpoints** offset (external store, e.g. blob) per partition/group | **Offset** + **sequence number** per partition | Standard **7d** max / Premium & Dedicated **90d** max; rewind by offset/timestamp | Ordered **within a partition** | No |
+| **RabbitMQ / AMQP** | At-least-once (manual ack) | `basic.ack` / `basic.nack` / `basic.reject` (optional requeue); unacked auto-requeued on channel/connection loss | None — `redelivered=true` flag only | **None built-in** | FIFO per queue, **broken by requeue** | No |
+
+### 3.3 Two architectural families (decisive for replay)
+
+- **Delete-on-ack queues** (SQS, RabbitMQ, NATS core): no cursor, no historical replay. Durability = redelivery of un-acked messages only. **Cannot support cursor/resume patterns** (§5b).
+- **Log/cursor stores** (Kafka, Redis Streams, Kinesis, Event Hubs, NATS JetStream): retained append-only log addressable by a position primitive → any consumer can re-read within retention. **Natural fit for cursor/resume.**
+- **Hybrid** (Google Pub/Sub): queue + retention + snapshots + `seek`.
+
+**Universal caveat: native dedup is rare** (only SQS FIFO and Pub/Sub EOS). Everywhere else, at-least-once means **consumers must be idempotent**, and **ordering is partition/group-scoped, never global**.
+
+---
+
+## 4. Client-Side Landscape
+
+**Bottom line:** the mainstream GraphQL subscription stack is **at-most-once**. On reconnect, clients resubscribe from "now" and do **not** replay missed events. At-least-once exists only where an explicit mechanism is bolted on (app-level acks, cursor/offset resume, or client dedup).
+
+### 4.1 Protocols — current capability
+
+| Protocol | Per-message ack? | Resume/cursor? | Notes |
+|---|---|---|---|
+| **graphql-ws** (`graphql-transport-ws`) | **No** | **No** | Message set: `ConnectionInit/Ack`, `Ping/Pong`, `Subscribe`, `Next`, `Error`, `Complete`. `ConnectionAck` acks the *connection*; `Ping/Pong` are liveness only. Dropped socket → must `Subscribe` again from "now." |
+| **subscriptions-transport-ws** (legacy `graphql-ws`) | **No** | **No** | Deprecated/unmaintained. Has keep-alive only. |
+| **graphql-sse** | **No** | **No** | Event types `next`/`complete`. Does **not** implement SSE `Last-Event-ID` resumption; the operation `id` is correlation, not an SSE event id. |
+| **Plain SSE `Last-Event-ID`** | No | **Yes (wire primitive only)** | WHATWG: browser tracks `id:` and sends `Last-Event-ID` on auto-reconnect. **Replay is entirely the server's responsibility** (persist a log keyed by id; reconnect must land on a replica that has it). Server-tunable `retry:` backoff; `204` stops reconnection. The only protocol-native resume primitive in this space. |
+
+### 4.2 Client libraries — current behavior
+
+- **Apollo Client**: subscriptions on graphql-ws (or legacy). On reconnect, active subscriptions are **re-established from scratch — no replay**. Supports subscription *deduplication* (identical concurrent subscriptions share a stream) but this dedups *subscriptions*, not *messages*. Reconnect-after-error historically fiddly.
+- **Relay**: behavior **inherited from the transport**; Relay adds no offset/cursor resume.
+- **urql**: non-fatal close → auto-reconnect and **all active subscriptions resubscribe** (restart, not resume). Explicitly disclaims delivery guarantees ("it's up to you to define a system that ensures … don't lose events").
+- **Mobile (iOS/Android)**: OS suspends/closes long-lived sockets on background; standard pattern is silent/background push (APNs/PushKit) to wake the app and re-establish + re-fetch. No transport-level replay. Notable SDK exception: AWS AppSync **Android** SDK v2.6.27 set MQTT **QoS 1** for at-least-once on that client.
+
+**Recommended app-level pattern across all three libraries (none does it for you):** on reconnect, run a catch-up *query*, queue incoming live deltas while it's in flight, then merge (query first, then deltas), deduping with idempotency keys. This is "eventually consistent on reconnect," **not** true at-least-once.
+
+### 4.3 Comparable systems — which give at-least-once / resume, and how
+
+| System | Guarantee | Mechanism |
+|---|---|---|
+| **Hasura streaming subscriptions** | **Exactly-once** | Per-subscription **cursor** over an append-only, unique+sortable column; client resumes `stream(cursor: lastSeen)`. Client-driven catch-up + live. |
+| **MQTT QoS 1 / QoS 2** | At-least-once / exactly-once | App-level **ACK + redelivery** (`PUBACK`); QoS 2 = 4-way handshake + packet-id dedup. The only mainstream client transport with native per-message ack. |
+| **AWS AppSync** | Best-effort / at-most-once (general) | No ack/retry; expects re-pull on reconnect. (Android SDK exception above.) |
+| **Phoenix Channels / Supabase Realtime** | At-most-once default | No persistence; rejoin resumes *live*, no replay. Stronger = DIY `last_seen_id` on `join` + server-side replay. |
+| **Meteor DDP** | At-least-once for method calls | Reconnect re-establishes **same session id**, re-runs subs, retries methods (use idempotency key). Data is state reconciliation, not replay. |
+| **Custom GraphQL-over-SSE replay proxy** | At-least-once / resumable | Reconnect with a cursor, server replays missed events then switches to live. The `Last-Event-ID` idea done properly. (e.g. Platformatic "WebSocket Recovery for GraphQL Subscriptions.") |
+
+### 4.4 Protocol extensions Cosmo would need
+
+To support genuine at-least-once on the client wire, **at least one** of:
+
+1. **Per-message id + client ack** (new inbound WS message type, e.g. `ack {id}`; new SSE/multipart back-channel). Requires extending `wsproto` (`proto.go:88-94`) and the writers — currently impossible since SSE/multipart are one-directional.
+2. **Resume token / cursor on (re)subscribe** (carry a `cursor`/`lastEventId` in the `Subscribe` payload; emit `id:` on SSE; honor `Last-Event-ID`). Lighter on the client; server does the heavy lifting (persist + replay).
+3. **No protocol change — client-side dedup/backfill** (§5f). Works with stock clients but only achieves "eventually consistent on reconnect."
+
+---
+
+## 5. Distinct Architectural Patterns for At-Least-Once GraphQL Subscriptions
+
+Each pattern below is a candidate RFC. Complexity scale: **S** (config/adapter tweak) → **M** (new adapter state, no protocol change) → **L** (new wire protocol + server state) → **XL** (durable per-subscriber state + protocol + HA).
+
+---
+
+### Pattern A — End-to-End Client-Ack Protocol Extension
+**Mechanism.** Every delivered message carries a monotonic `id`. The client sends an explicit `ack {id}` back. The router holds the broker ack (e.g. JetStream `msg.Ack()`, Kafka offset commit, Redis `XACK`, SQS `DeleteMessage`) **until the client ack arrives**, with a window/timeout that triggers `nak`/redelivery. Mirrors MQTT QoS 1.
+
+**Guarantee.** True end-to-end at-least-once (broker → client *receipt*). Duplicates possible (client must be idempotent). With double-ack + dedup → exactly-once on capable backends.
+
+**Backends + degradation.** Natural on backends with per-message ack/redelivery: **JetStream** (`AckWait`/`AckNak`/`MaxAckPending`/double-ack), **SQS** (visibility timeout + `DeleteMessage`), **RabbitMQ** (`basic.ack`/`nack`), **Redis Streams** (PEL + `XACK`/`XCLAIM`), **Google Pub/Sub** (`ack`/`modifyAckDeadline`). Degrades on **Kafka/Kinesis/Event Hubs** (no per-message ack — only offset/sequence commit) → must map client-ack onto *cursor advance*, which only works in-order (becomes Pattern B-ish). **No** support on NATS core / Redis Pub/Sub (no ack primitive) → falls back to at-most-once.
+
+**Client protocol changes.** New `ack` inbound message in graphql-ws; SSE/multipart need a back-channel (a separate HTTP `POST /ack` keyed by stream id, since SSE is one-way). Stock clients won't ack → must negotiate capability and fall back.
+
+**Server/state.** Per in-flight message: `(client, messageId) → broker ack handle` map, plus `MaxAckPending`-style cap. Held broker handles bound memory and stall the broker reader (backpressure). Router HA: ack handles are per-process — a router restart loses un-acked-to-client handles unless the broker redelivers (JetStream/SQS/Rabbit do; Kafka-by-offset doesn't per-message).
+
+**Ordering.** Preserved if acks are processed in order and `MaxAckPending=1` (kills throughput) — otherwise out-of-order acks are fine for non-ordered backends but break the "cursor = ack" mapping on log backends.
+
+**Pros.** Strongest, most general guarantee; matches the problem statement directly. **Cons.** Requires client protocol changes (adoption cost); per-message state; SSE/multipart awkward. **Complexity: L–XL.**
+
+---
+
+### Pattern B — Cursor / Resume-Token Replay on Reconnect
+**Mechanism.** The router surfaces an opaque **cursor** with every message (encoding backend position: JetStream stream-seq, Kafka `(partition,offset)`, Redis entry-id, Kinesis seq, Event Hubs offset, Pub/Sub snapshot/time). On (re)subscribe the client sends its last cursor; the router seeks the backend to that position, **replays missed events, then switches to live**. This is the Hasura / `Last-Event-ID`-done-properly model.
+
+**Guarantee.** At-least-once across disconnect gaps **if the gap is within the backend's replay window**; reduces to at-most-once for events evicted by retention/trimming (surface "cursor expired" — Kafka `auto.offset.reset=none`).
+
+**Backends + degradation.** Excellent on **log/cursor stores** (Kafka, Redis Streams, Kinesis, Event Hubs, JetStream, Pub/Sub-with-retention). **Impossible** on delete-on-ack queues (SQS, RabbitMQ) and NATS core / Redis Pub/Sub — no durable position to seek → degrade to at-most-once or to Pattern A.
+
+**Client protocol changes.** Lightest of the durable patterns: emit `id:` on SSE (honor `Last-Event-ID`), carry `cursor` in `Subscribe` payload + each `Next` for WS. No per-message ack needed. Stock SSE browsers get auto-resume *for free* once the server emits `id:` and replays.
+
+**Server/state.** Mostly **stateless on the router** — durability lives in the broker; the router only translates cursor ↔ backend seek (`DeliverByStartSequence`, `seek`, `XREAD from id`, `GetShardIterator`). Must read & surface the sequence the code ignores today (`msg.Metadata()`, `r.Offset`). Watch: Kafka `offsets.retention.minutes` 7d eviction; iterator/snapshot expiry.
+
+**Ordering.** Naturally ordered within a partition/stream (the cursor *is* the order). Gaps are contiguous by construction.
+
+**Pros.** Minimal router state; leverages existing broker durability; works with near-stock SSE; clean degradation story. **Cons.** Only as good as the replay window; cursor must be opaque + signed (security); reconnect must be sticky to a replica/partition that has the data; per-client cursor handoff needs per-client (not shared) consumption on some backends (Kafka per-session group). **Complexity: M–L.**
+
+---
+
+### Pattern C — Durable-Consumer-Per-Subscription + Router-Side Checkpoint Store
+**Mechanism.** Each logical client subscription is backed by its **own durable consumer / checkpoint** (JetStream durable consumer, Kafka per-session group + committed offset, Kinesis/Event Hubs checkpoint, Redis Streams consumer group). The router persists the per-subscriber checkpoint (in the broker where possible, else an external store — Redis/DynamoDB/Postgres) and only advances it after delivery is confirmed.
+
+**Guarantee.** At-least-once across router restart *and* client reconnect, bounded by retention. Strongest cross-restart story.
+
+**Backends + degradation.** Works wherever durable per-consumer state exists: JetStream (durable consumer — but **must fix the per-instance-hash naming**, `nats/adapter.go:69-83`, so the name is per-*subscription* not per-*router-process*), Kafka (per-session `group.id` + `group.instance.id` static membership + `CooperativeStickyAssignor`), Redis Streams (consumer group), Kinesis/Event Hubs (external checkpoint), Google Pub/Sub (per-subscription). Degrades to Pattern B's window or at-most-once on queues without per-consumer durable state.
+
+**Client protocol changes.** None strictly required if checkpoint advance is gated on flush — but flush ≠ receipt (today's exact bug, §2.1). For real guarantees, combine with A (client ack) or B (cursor). Best as the *server-side substrate* under A or B.
+
+**Server/state.** Heaviest: one durable consumer/checkpoint per active subscription (not per shared trigger — this **breaks trigger dedup**, §1.4, since fan-out currently shares one broker subscription). Memory/connection cost scales with subscriber count; multi-tenant fan-out becomes N broker consumers. Checkpoint store is a new dependency + HA concern.
+
+**Ordering.** Per-consumer ordered. **Pros.** Survives router restarts; per-client isolation; precise redelivery. **Cons.** Explodes broker consumer count; kills the shared-trigger optimization; external state store; consumer lifecycle/GC (inactive cleanup) is fiddly. **Complexity: XL.**
+
+---
+
+### Pattern D — Broker-Native Ack Mapped to Client Delivery Confirmation (Fix the Ack Timing)
+**Mechanism.** Keep today's shared-trigger model but **fix the ack so it reflects real delivery**: make `SubscriptionUpdater.Update` return a per-subscriber delivery result, propagate it back through the `datasource.Adapter` boundary, and only `Ack()`/commit when *all* (or a quorum/policy of) subscribers flushed successfully — `Nak`/redeliver otherwise. This is the minimal correctness fix to the four bugs in §2.1.
+
+**Guarantee.** At-least-once *relative to flush success* (bytes to kernel), still not client-receipt — but closes bugs #2/#3/#4 (ack-on-failure, fan-out-all-acked, abandon-but-acked). A strict upgrade over today.
+
+**Backends + degradation.** JetStream gets correct `Ack`/`Nak`; Redis Streams `XACK`/no-ack; SQS delete/no-delete; Rabbit ack/nack. Kafka/Kinesis (offset-based) can only "commit up to the lowest successfully-delivered offset across shared subscribers" → head-of-line blocking on a slow subscriber. NATS core / Redis Pub/Sub: nothing to map → unchanged.
+
+**Client protocol changes.** **None.** Pure server-side. **Server/state.** Requires changing the framework's fire-and-forget contract: `Adapter` interface + `SubscriptionUpdater` must carry a delivery result (touches `provider.go:22-28`, `subscription_event_updater.go`, and the engine `resolve.go` `Update` signature). Shared-trigger fan-out forces an "ack only when the slowest subscriber flushed" policy, coupling subscribers.
+
+**Ordering.** Unchanged. **Pros.** No client changes; biggest correctness-per-effort; foundation for A/B/C. **Cons.** Flush≠receipt ceiling; couples shared subscribers; cross-process restart still drops un-acked-to-client (no per-subscriber durable state). **Complexity: M.**
+
+---
+
+### Pattern E — Hybrid Buffered-with-Redelivery (Router-Side Replay Buffer)
+**Mechanism.** The router keeps a bounded, ordered **per-trigger (or per-subscriber) ring buffer** of recently delivered events keyed by a router-assigned sequence. On reconnect within a short window the client presents its last seq and the router replays from the buffer, then resumes live. Broker ack is held until the event leaves the buffer (or a TTL). Effectively a small router-side log in front of backends that have none.
+
+**Guarantee.** At-least-once for disconnects **shorter than the buffer window**; degrades to at-most-once beyond it. Bridges backends that lack native replay (NATS core, Redis Pub/Sub, SQS, RabbitMQ).
+
+**Backends + degradation.** **Backend-agnostic** — this is its whole point: it manufactures a replay window for non-log backends. For log backends it's redundant with B (prefer B there). Cross-router-restart durability requires an external buffer store (else buffer is in-process, lost on restart).
+
+**Client protocol changes.** Router-assigned `id` + resume token on reconnect (like B but router-scoped, not backend-scoped). **Server/state.** Bounded memory per trigger/subscriber (the explicit cost knob); eviction policy; the *only* pattern that gives any guarantee on NATS core / Redis Pub/Sub / SQS-standard without changing the backend.
+
+**Ordering.** Router assigns the order; preserved within the buffer. **Pros.** Works everywhere, including the at-most-once backends; tunable memory/guarantee tradeoff; no broker feature needed. **Cons.** Memory cost under fan-out; short window only; in-process buffer lost on restart (needs external store for XL guarantee); duplicates the broker's job where the broker already has a log. **Complexity: M (in-process) → L (durable buffer).**
+
+---
+
+### Pattern F — Outbox / Dedup-on-Client (Reconnect-Backfill)
+**Mechanism.** No durable delivery; instead each event carries a stable **idempotency key** (e.g. `Nats-Msg-Id`, Kafka key, or a content hash). On reconnect the client runs a normal **catch-up query**, queues live deltas, merges, and dedups by key. The router optionally exposes a "since" query argument backed by an application outbox/table.
+
+**Guarantee.** "Eventually consistent on reconnect," **not** true at-least-once delivery of every event — but no permanent loss of *state* if the backing store is queryable. Matches today's recommended client pattern.
+
+**Backends + degradation.** **Fully backend-agnostic** (works even on NATS core / Redis Pub/Sub) because durability lives in the application's own datastore, not the stream. Degradation is about *event* delivery (you may miss intermediate events) vs *state* convergence (final state is correct).
+
+**Client protocol changes.** None to the subscription protocol; needs a companion catch-up query + client dedup logic (or an SDK helper). Pairs with mobile silent-push to trigger the backfill.
+
+**Server/state.** Minimal in the router; pushes responsibility to the application schema (a `since`/`cursor` query + outbox). **Ordering.** Not guaranteed for intermediate events; final state converges. **Pros.** Cheapest server-side; works with stock clients + any backend; great for mobile. **Cons.** Not real at-least-once for discrete events (loses intermediate transitions); requires app cooperation (outbox + idempotency keys); double the surface (query + subscription). **Complexity: S–M (router) but pushes cost to the app/client.**
+
+---
+
+### Pattern G — Tiered Capability Negotiation (Meta-Pattern / "Policy Engine")
+**Mechanism.** A subscription declares (per field, via directive, or per client via protocol capability) a *desired* delivery class — `at-most-once` (today), `at-least-once`, `exactly-once` — and the router selects the strongest mechanism the **chosen backend + client** can satisfy, transparently degrading and reporting the *actual* class delivered (e.g. via an `extensions.delivery` field). Composes A/B/C/D/E/F per backend.
+
+**Guarantee.** Whatever the negotiated floor is; the value is *honesty* — the system never silently pretends. Directly answers the problem statement's "pick a backend even if degraded."
+
+**Backends + degradation.** All — this is the routing layer. Maps: JetStream/Pub/Sub → A or B+C; Kafka/Kinesis/Event Hubs → B (cursor); Redis Streams → A/B; SQS/Rabbit → A (ack, no replay) or E (buffer); NATS core / Redis Pub/Sub → E or F only.
+
+**Client protocol changes.** Capability handshake in `connection_init` payload (advertise `supports: [ack, resume]`); server replies with negotiated class. **Server/state.** A policy/registry layer plus whichever underlying pattern(s) are enabled. **Ordering.** Per chosen mechanism. **Pros.** The product-level answer; lets one router serve heterogeneous backends with explicit guarantees; future-proof. **Cons.** Only as good as the patterns beneath it; negotiation + observability surface; risk of confusing matrix of "what you actually get." **Complexity: L (as a layer) on top of whichever of A–F ship.**
+
+---
+
+### 5.x Pattern selection guide
+
+- **Strongest, most general, willing to change the client:** A (+ C substrate, + double-ack for EOS).
+- **Lightest durable win on log backends, near-stock SSE clients:** B.
+- **Cross-restart survival, per-client isolation:** C (accept broker-consumer fan-out cost).
+- **Cheapest correctness fix, no client change, ship first:** **D** (fixes the actual bugs in §2.1 and is the substrate for everything else).
+- **Make at-most-once backends usable:** E (router buffer) or F (client backfill).
+- **The product framing that ties it together:** G.
+
+A plausible RFC sequencing: **D** (correctness) → **B** (cursor resume on log backends, emit `id:`/expose sequence) → **A** (client ack for true end-to-end) → **G** (negotiation) → **C/E** as backend-specific reinforcements.
+
+---
+
+## 6. Cross-Cutting Concerns
+
+### 6.1 Ordering vs at-least-once
+These conflict. At-least-once via redelivery (Nak, AckWait, requeue) can **reorder** unless `MaxAckPending=1` / single in-flight, which destroys throughput. RabbitMQ requeue reinserts near the head, breaking FIFO. Cosmo's hooks path *already* warns about reordering on timeout (`subscription_event_updater.go:77-79`). **Ordering is partition/group/stream-scoped on every backend, never global** — any pattern that fans one stream to many clients (Cosmo's shared trigger) preserves per-partition order at best. Decide per RFC whether ordering is a guarantee or best-effort.
+
+### 6.2 Dedup / idempotency keys
+At-least-once ⇒ duplicates ⇒ the client (or a router dedup layer) **must be idempotent**. Native broker dedup exists only on **SQS FIFO** (5-min window) and **Google Pub/Sub EOS**; **JetStream** offers publisher-side dedup via `Nats-Msg-Id` + 2-min duplicate window. For everything else Cosmo must define a **stable idempotency key** (Kafka record key, `Nats-Msg-Id`, content hash) and surface it to the client so it can dedup — this is also the join key for Pattern F backfill.
+
+### 6.3 Exactly-once feasibility
+Exactly-once is a *composition*, not a switch: publisher dedup (`Nats-Msg-Id` / Kafka idempotent producer + transactions) **plus** consumer-side confirmed ack (JetStream double-ack; Kafka offset-in-same-transaction; or "store cursor in the same store as the delivered data" — the strongest, broker-independent trick). End-to-end EOS to a *GraphQL client* additionally needs client-ack (A) + client dedup. Realistically: **at-least-once + idempotent client = effective exactly-once**; true broker-level EOS only on JetStream / Pub/Sub / Kafka-EOS, and only with `read_committed`-style consumption (which can stall the cursor at the LSO on an open upstream transaction — a head-of-line failure mode to surface).
+
+### 6.4 Backpressure
+Today: synchronous, per-trigger-serial backpressure into the broker reader (good — it doesn't lose data on JetStream) but **silent drops** on NATS core / Redis Pub/Sub overflow. Patterns A/C/E add explicit caps (`MaxAckPending`, buffer size) — these become the **memory/guarantee tradeoff knob**. A slow client must either backpressure the shared trigger (penalizing co-subscribers) or be isolated (Pattern C, at consumer-count cost). Per-update timeout (`MaxSubscriptionFetchTimeout`, 30s) and write deadlines remain the liveness guards.
+
+### 6.5 Multi-tenant fan-out
+Cosmo's **shared trigger** (one broker subscription per unique input+headers hash, fanned to N clients) is the central tension: it is great for scale but means **one broker ack covers N heterogeneous client outcomes** (§2.1 #3). Per-subscriber durability (C) or per-subscriber ack (A) **breaks dedup** → N broker consumers. Patterns B (cursor, stateless router) and E (router buffer) preserve sharing better. Any RFC must state explicitly what it does to trigger dedup.
+
+### 6.6 Router HA / horizontal scaling & sticky sessions
+- **JetStream durable naming today is per-router-instance** (`hostname-listenAddr` hash, `nats/adapter.go:69-83`) — deliberately so instances don't fight, but it means a *different* router instance after failover gets a *different* consumer and **does not resume** un-acked state. For HA at-least-once the durable name must key on the *subscription* (stable identity), which then needs coordination so two instances don't double-consume (queue group / `WorkQueuePolicy` / Kafka group).
+- **Kafka** offers `group.instance.id` (static membership) + `CooperativeStickyAssignor` for stable cursors under churn; a `ConsumerRebalanceListener` must flush cursors before revocation.
+- **Cursor patterns (B)** need reconnect **stickiness** to a replica/partition that holds the position (or a shared external cursor store). **Client-ack patterns (A/E)** need either sticky routing (in-process ack state) or an external ack/state store survivable across instances. This is the single biggest HA design axis for every pattern.
+
+### 6.7 Memory / state cost
+- A (client ack): O(in-flight per client) held broker handles + map.
+- B (cursor): ~O(1) router state (durability in broker) — cheapest.
+- C (durable per-sub): O(active subscriptions) broker consumers + external checkpoint store — most expensive.
+- E (router buffer): O(window × triggers/subscribers) RAM (the tunable knob), + external store for restart-survival.
+- F (backfill): ~O(1) router, cost pushed to app datastore + client.
+
+### 6.8 Security / authz interplay with existing Cosmo Streams hooks
+- **Cursors/resume tokens must be opaque, signed, and tenant-scoped** — a raw `(partition, offset)` or stream-seq lets a client seek to data it shouldn't see (especially with `DeliverAll`/replay). Replay must re-run the same authz as live delivery, per event.
+- **Existing hooks** (`on_receive_events` / `OnReceiveEvents`, `OnPublishEvents`) are the natural enforcement points but today the receive-hook path is also where **abandon-on-timeout reordering/loss** happens (§2.1 #4) — any durability RFC must reconcile hook execution with ack/redelivery so a hook that drops/filters an event still results in a correct broker ack (drop ≠ failure). 
+- Publish errors are currently **swallowed** (`success:false`, logged not returned) — an at-least-once *publish* story (idempotent ingest with `Nats-Msg-Id`) should reconsider whether the client learns about broker failures.
+- Replay across a long window can resurface data whose authz has since changed (revoked tenant/user) — replayed events need **current** authorization, not the authorization at original publish time.
+
+---
+
+### Appendix — Key file:line index (codebase touchpoints for the RFCs)
+
+- Generic fire-and-forget updater (sync fan-out, hooks, abandon-on-timeout): `router/pkg/pubsub/datasource/subscription_event_updater.go:19-24, 36-129, 142-164`
+- Adapter interface (no ack hook, no error): `router/pkg/pubsub/datasource/provider.go:22-28`
+- Engine entry from router: `router/pkg/pubsub/datasource/subscription_datasource.go:35-54`
+- NATS JetStream durable + ack-after-delivery (ack `:154`); consumer config (no AckPolicy/AckWait override) `:413-442`; per-instance durable naming `:61-83`; core NATS unbuffered chan `:168`: `router/pkg/pubsub/nats/adapter.go`
+- NATS reconnect + slow-consumer drop log: `router/pkg/pubsub/nats/provider_builder.go:79-110`
+- Kafka stateless, groupless, reset-to-now, no commit: `router/pkg/pubsub/kafka/adapter.go:32-34, 51-122, 142-153`
+- Redis **Pub/Sub** (not Streams) fire-and-forget: `router/pkg/pubsub/redis/adapter.go:88-152, 191`
+- Synchronous fan-out + resolve + flush; per-update timeout; no internal events queue: graphql-go-tools `pkg/engine/resolve/resolve.go` (`handleTriggerUpdate`, `executeSubscriptionUpdate`, flush, `MaxSubscriptionFetchTimeout` wiring)
+- WS writer (direct socket write, write deadline; WS heartbeat no-op): `router/core/websocket.go:187-217, 659-662, 704-736`
+- SSE/multipart writer (direct write+flush, no `id:` field): `router/core/flushwriter.go:116-167, 252-299`
+- Inbound WS message set (no client ack): `router/internal/wsproto/proto.go:88-94, 102-112`
+- Default `MaxSubscriptionFetchTimeout` = 30s: `router/pkg/config/config.go:454`; wired `router/core/executor.go:89`
+- Router config event sources (NATS/Kafka/Redis): `router/pkg/config/config.go:704-710, 751-757, 763-767, 773-782`
+- Proto event config: `proto/wg/cosmo/node/v1/node.proto:395-434`
+- Composition directive parsing: `composition/src/v1/normalization/normalization-factory.ts:2804-3169`
+- Two-plane join at runtime: `router/core/factoryresolver.go:531-538`, `router/pkg/pubsub/pubsub.go:56-128, 166-173`

--- a/rfc/at-least-once/CONCLUSION.md
+++ b/rfc/at-least-once/CONCLUSION.md
@@ -1,0 +1,194 @@
+# At-Least-Once for GraphQL Subscriptions — Conclusion & Recommended Pick
+
+> **Decision document.**
+> Summarizes the seven competing RFCs,
+> the combined evaluation (adversarial critique + independent codex review),
+> my recommended pick,
+> codex's independent pick,
+> the discussion between us,
+> and the final jointly-locked conclusion with sequencing and honest per-piece guarantees.
+
+## TL;DR
+
+The problem: an application may already have at-least-once in its event-driven backend (Kafka offsets, NATS JetStream durable consumers),
+but the moment a GraphQL Subscription is layered on top via Cosmo's EDFS / Cosmo Streams,
+that guarantee is lost —
+the router consumes the event and pushes it to the client fire-and-forget,
+so a client disconnect, a router restart, or a slow consumer silently drops events.
+
+We wrote **seven competing RFCs** (patterns A–G),
+adversarially critiqued each,
+had **codex independently review all seven**,
+then reconciled.
+
+**The seven collapse into one coherent layered architecture, not seven alternatives.**
+Both my analysis and codex's independent pick converged on the same answer:
+
+- **Build `D` first** — a server-only fix to broker-ack timing that creates the missing engine contract.
+- **`B` (cursor / resume) is the product flagship** — the best default for heterogeneous backends.
+- **A thin "delivery-class core" ships *with* D+B** — so "pick any backend, get an explicit, honest guarantee (degrade on purpose)" is true from v1.
+- **`B + batched cursor-ack`** ("checkpointed cursor resume") reaches the client-*processed* boundary on log backends cheaply, subsuming most of `A`'s value.
+- **`A` (per-message client ack) is a selective premium add-on**, mainly for delete-on-ack queues (SQS, RabbitMQ) and in-flight redelivery.
+- **`G` (tiered negotiation) comes last**, as the dynamic policy/handshake layer on top of real mechanisms.
+- **`C`, `E`, `F` are folded in as supporting components**, not shipped as first-class answers.
+
+**Primary pick: `B` (cursor/resume), anchored on the `D` foundation.**
+Single most important first milestone: **the coordinated `graphql-go-tools` engine contract**, then **`D`**.
+
+---
+
+## The seven candidate RFCs
+
+| ID | RFC | Mechanism (one line) | File |
+|----|-----|----------------------|------|
+| A | End-to-End Client-Ack | Per-message id + client `ack`; hold broker ack until client acks (MQTT QoS-1). | [`rfc-A-client-ack-protocol.md`](./rfc-A-client-ack-protocol.md) |
+| B | Cursor / Resume Replay | Opaque per-event cursor; on reconnect client sends last cursor, router seeks + replays then goes live. | [`rfc-B-cursor-resume.md`](./rfc-B-cursor-resume.md) |
+| C | Durable-Consumer + Checkpoint | One durable consumer/checkpoint per subscription; advance only after delivery confirmed. | [`rfc-C-durable-consumer-checkpoint.md`](./rfc-C-durable-consumer-checkpoint.md) |
+| D | Broker Ack-Timing Fix | Server-only: per-subscriber delivery result flows back; ack/commit only after flush. | [`rfc-D-broker-ack-timing.md`](./rfc-D-broker-ack-timing.md) |
+| E | Router Replay Buffer | Bounded router-side ring buffer; replay on short reconnects; backend-agnostic. | [`rfc-E-router-replay-buffer.md`](./rfc-E-router-replay-buffer.md) |
+| F | Outbox / Dedup-on-Client | Stable idempotency keys + reconnect catch-up query + client dedup; state convergence. | [`rfc-F-outbox-client-dedup.md`](./rfc-F-outbox-client-dedup.md) |
+| G | Tiered Capability Negotiation | Declare desired delivery class; router picks strongest the backend+client support; report achieved class. | [`rfc-G-tiered-capability-negotiation.md`](./rfc-G-tiered-capability-negotiation.md) |
+
+Shared factual ground truth (current architecture, code anchors, per-backend matrix): [`00-research-dossier.md`](./00-research-dossier.md).
+
+## Where the guarantee is lost today (from the dossier)
+
+- **Hop A (broker → router read):** only NATS JetStream consumes durably; Kafka is groupless + reset-to-now, NATS core and Redis Pub/Sub never ack/commit.
+- **Hop B (resolve → flush):** JetStream ack is mistimed — it acks on flush *attempt* not receipt, acks even when delivery failed, a single `msg.Ack()` covers a whole multi-subscriber fan-out, and the hooks path can abandon/reorder yet still ack.
+- **Hop C (client):** no per-message client ack exists in the WS protocol (`Ping/Pong/Subscribe/Complete/Terminate` only).
+- **Hop D (resume):** reconnect always starts from "now"; no `Last-Event-ID`, no cursor; events carry no position.
+- **Slow consumers:** NATS core unbuffered channel and Redis Pub/Sub overflow drop events silently.
+
+## Combined evaluation
+
+Adversarial critique (in-workflow) + independent codex review (`codex exec`, read-only).
+Codex scores are 1–5.
+
+| ID | Corr | Feas | Adapt | V/E | Codex verdict | Why |
+|----|:----:|:----:|:-----:|:---:|---------------|-----|
+| **D** | 3 | 4 | 2 | **4** | **KEEP** | Necessary server-side foundation; ships now; fixes real bugs. Only "at-least-once to flush". |
+| **B** | 3 | 3 | 4 | **4** | **KEEP** | Distinct, high-value durable mechanism; best multi-backend fit; low router state. |
+| A | 3 | 2 | 3 | 3 | MERGE→D | Strongest semantics (true client receipt) but not standalone; rides D's contract. |
+| F | 3 | 4 | 4 | 3 | MERGE→D | Cheap reconnect state-convergence; not stream durability. |
+| G | 3 | 3 | 4 | 3 | MERGE→B | Policy/reporting layer; "G first is an elaborate way to say at-most-once." |
+| E | 3 | 3 | 3 | 3 | MERGE→G | Bounded best-effort replay for no-log backends; redundant with B on log backends. |
+| C | 3 | 2 | 3 | **2** | MERGE→A | Most expensive; breaks trigger dedup; still needs A to close flush-vs-processing. |
+
+**Merge graph collapses to two anchors (`D`, `B`) + two layers (`A`, `G`) + three components (`C`, `E`, `F`).**
+
+## My recommended pick
+
+`D` (foundation) → `B` (flagship) → `G` (policy),
+with `A` as an opt-in premium layer and `C`/`E`/`F` folded in as components.
+
+Rationale:
+`B` is the highest value-for-effort *user-facing* mechanism and the best fit for Cosmo's multi-backend future,
+because it leans on the broker's own retained log instead of turning the router into a database —
+but it can only be correct if it sits on `D`,
+because today the engine's fire-and-forget boundary cannot report whether a flush actually succeeded.
+`G` makes "pick a backend even if degraded" honest,
+but only has value once real mechanisms exist underneath it.
+
+## Codex's independent pick
+
+Asked fresh and decisively, codex returned:
+
+> **PRIMARY PICK:** `B` cursor/resume replay.
+> **SEQUENCE:** D → B → G → selective A → optional C/E → F as SDK/docs.
+> **DROP/FOLD:** drop standalone-C-first and durable-E-generalization; fold D/G/F/E into substrate/policy/docs/degraded-mode components.
+> First engineering milestone should still be `D`, because the engine boundary is currently too fire-and-forget to support the rest cleanly.
+
+This matched the independent conclusion above almost exactly.
+Full text: [`codex/codex-pick-round1.md`](./codex/codex-pick-round1.md).
+
+## The discussion (reconciliation)
+
+Given the strong convergence, I pressure-tested three refinements with codex; it agreed on all three (one with a modification).
+Full text: [`codex/codex-pick-round2.md`](./codex/codex-pick-round2.md).
+
+**1. A thin "delivery-class core" ships with D+B (not deferred to G).**
+Agreed — *with a modification*: do not hard-error every mismatch.
+Separate **policy intent** from **capability truth**:
+`required_delivery: at_least_once` → hard startup error if unmet;
+`preferred_delivery: at_least_once` → start and report degradation.
+The contract is `{ requested_class, achieved_class, boundary, mechanism, degraded_reason }`,
+emitted in `extensions.delivery`.
+Boundary labels must be brutally precise:
+`socket_write` (D), `cursor_resume` (B), `client_receipt`/`client_processed` (ack modes), `state_converged` (F).
+
+**2. `B + batched cursor-ack` = "checkpointed cursor resume", the 80/20.**
+Agreed strongly.
+The client advances a high-water mark only *after processing*, batched (per N events / per window, not per message),
+and resumes from the last *acknowledged* cursor, not merely the last received cursor —
+so `B` reaches the **client-processed boundary** on log backends without classic per-message `A`.
+Correctness traps documented:
+it works cleanly only for **ordered prefixes per partition/stream** (a sparse ack set becomes A-like complexity);
+multi-partition Kafka cursors are **vectors**, so batched ack must advance per partition;
+adding *server-side* committed cursor state means you have introduced a checkpoint store (that is scoped `C`);
+and it does **not** help delete-on-ack queues (SQS/RabbitMQ) — those still need `A` or `E`.
+
+**3. One coordinated engine contract, shipped in phases.**
+Agreed — do not pay the cross-repo `graphql-go-tools` coordination tax twice.
+Design a single resolve-layer contract that serves both `D` and `B`, then turn router behavior on incrementally.
+
+## Final, locked conclusion
+
+**Kept as RFCs:** `D`, `B`, the thin delivery-class core, and (later) `G`.
+**Kept as a selective premium add-on:** `A`.
+**Folded into supporting roles:** `C` (durable checkpoint substrate), `E` (degraded no-log replay window), `F` (SDK/docs state-convergence).
+
+### The one coordinated `graphql-go-tools` engine contract
+
+Land once; carries everything D and B need:
+
+- per-event **opaque metadata forward** to the writer (cursor / position / idempotency key) — opaque bytes, no broker-specific types in the engine;
+- per-subscriber **delivery outcome back** from fan-out (`flushed | failed | skipped | filtered | closed`);
+- **post-filter** subscriber accounting;
+- a **resume / start-from** position path (`SubscribeFrom`, at the datasource/source-config level);
+- writer support to emit metadata into **WS `extensions`** and **SSE `id:`**.
+- Keep the at-most-once **fast path cheap and stable** as an internal optimization beneath the single new semantic contract.
+
+### Sequence
+
+1. **Engine contract PR** — delivery metadata forward, delivery outcomes back, resume-capable source path.
+2. **`D` in the router** — JetStream / no-hooks first; ack/nak on the delivery outcome; flush GraphQL error payloads in v1 to avoid deterministic redelivery loops; metrics for stall/redelivery/dropped-subscriber.
+3. **Thin delivery-class core (with D)** — declared/achieved class, boundary, mechanism, degradation reason; `required_` vs `preferred_` enforcement.
+4. **`B` flagship** — signed opaque cursors, SSE `id:` / `Last-Event-ID`, WS resume extension, backend seek/replay, `CURSOR_EXPIRED`.
+5. **`B + cursor-ack`** — client-processed checkpoint mode for log backends (ordered-prefix, per-partition vectors).
+6. **`G` later** — dynamic negotiation, client capability handshake, policy selection matrix.
+7. **`A` selectively** — SQS / RabbitMQ / Pub/Sub / JetStream cases needing explicit client ack over broker ack handles.
+8. **`C` / `E` / `F` folded** — C as checkpoint substrate (premium isolation/HA), E as degraded no-log replay window, F as SDK/docs for state convergence.
+
+### Honest guarantee each kept piece delivers
+
+| Piece | Guarantee (precise) |
+|-------|---------------------|
+| **D** | At-least-once to **successful socket write** (bytes accepted by the kernel), not client receipt. |
+| **B** | At-least-once **replay across reconnect/restart within retention**; boundary depends on when the client persists the cursor. |
+| **B + cursor-ack** | At-least-once to the **client-processed prefix**, within retention, per partition/stream. |
+| **A** | At-least-once to **explicit client acknowledgement** (receipt; or processing if the client acks after processing). |
+| **G** | No durability itself — **honest selection and reporting** of the achieved class. |
+| **C** | Durable **checkpoint substrate** (cross-restart), not a standalone answer. |
+| **E** | **Window-bounded degraded replay** for non-log backends (NATS core, Redis Pub/Sub). |
+| **F** | **State convergence** on reconnect, not event delivery. |
+
+### "Pick a backend even if degraded" — the explicit answer
+
+- **Log / cursor backends** (Kafka, NATS JetStream stream-backed, Redis Streams; future Kinesis, Event Hubs, Google Pub/Sub): full `B` and `B + cursor-ack` → at-least-once within retention, up to client-processed boundary.
+- **Delete-on-ack queues** (SQS, RabbitMQ — not in EDFS today): `A` (ack/delete/nack) or `E` (short router buffer); no cursor replay.
+- **Fire-and-forget** (NATS core, Redis Pub/Sub): `E` bounded best-effort replay or `F` state convergence; otherwise **explicit at-most-once**, reported via `extensions.delivery`, never silent.
+
+## Residual open questions
+
+- Multi-partition Kafka cursors as vectors vs the single-value SSE `Last-Event-ID` header — needs an envelope/encoding decision.
+- JetStream replay requires replayable retention; current Cosmo config exposes `streamName` but not the retention/ack policy — must validate and surface `WorkQueuePolicy` / interest-based deletion conflicts.
+- Whether `B + cursor-ack` with a *server-side* committed cursor (scoped `C`) is worth it for clients that cannot persist a cursor (e.g. some mobile/web cases), vs leaving cursor ownership with the client.
+- Shared-trigger interaction: resuming/acking clients may need their own trigger; reclaiming shared fan-out for long-lived resumed subscriptions is an engine-side state-machine question.
+- Exact `MaxDeliver` / poison-message handling under `ack_policy: all` to avoid one slow/failing subscriber stalling co-subscribers.
+
+## Artifacts
+
+- Research dossier: [`00-research-dossier.md`](./00-research-dossier.md)
+- RFCs: [`rfc-A`](./rfc-A-client-ack-protocol.md) · [`rfc-B`](./rfc-B-cursor-resume.md) · [`rfc-C`](./rfc-C-durable-consumer-checkpoint.md) · [`rfc-D`](./rfc-D-broker-ack-timing.md) · [`rfc-E`](./rfc-E-router-replay-buffer.md) · [`rfc-F`](./rfc-F-outbox-client-dedup.md) · [`rfc-G`](./rfc-G-tiered-capability-negotiation.md)
+- Per-RFC codex reviews: [`codex/codex-review-{A..G}.md`](./codex/)
+- Codex independent pick + discussion: [`codex/codex-pick-round1.md`](./codex/codex-pick-round1.md) · [`codex/codex-pick-round2.md`](./codex/codex-pick-round2.md)

--- a/rfc/at-least-once/README.md
+++ b/rfc/at-least-once/README.md
@@ -1,0 +1,28 @@
+# RFC bundle: At-Least-Once for GraphQL Subscriptions (Cosmo Streams / EDFS)
+
+Goal: restore end-to-end at-least-once delivery (broker → router → client) for GraphQL subscriptions built on Cosmo's EDFS,
+adaptable across heterogeneous backends (NATS, Kafka, Redis, SQS, …),
+allowing a backend of choice even when that yields a weaker — but explicit, never silent — guarantee.
+
+**Start here → [`CONCLUSION.md`](./CONCLUSION.md)** — summary of all RFCs, the combined scorecard, the recommended pick, codex's independent pick, the discussion, and the final locked sequence + honest per-piece guarantees.
+
+## Contents
+
+- [`00-research-dossier.md`](./00-research-dossier.md) — ground truth: current EDFS architecture, code anchors, where the guarantee is lost, per-backend matrix, the 7 patterns.
+- Seven competing RFCs (each authored → adversarially critiqued → revised):
+  - [`rfc-A-client-ack-protocol.md`](./rfc-A-client-ack-protocol.md) — end-to-end per-message client acks.
+  - [`rfc-B-cursor-resume.md`](./rfc-B-cursor-resume.md) — cursor / resume-token replay **(flagship)**.
+  - [`rfc-C-durable-consumer-checkpoint.md`](./rfc-C-durable-consumer-checkpoint.md) — durable consumer + checkpoint store.
+  - [`rfc-D-broker-ack-timing.md`](./rfc-D-broker-ack-timing.md) — server-only ack-timing fix **(foundation)**.
+  - [`rfc-E-router-replay-buffer.md`](./rfc-E-router-replay-buffer.md) — router-side replay buffer.
+  - [`rfc-F-outbox-client-dedup.md`](./rfc-F-outbox-client-dedup.md) — outbox / dedup-on-client.
+  - [`rfc-G-tiered-capability-negotiation.md`](./rfc-G-tiered-capability-negotiation.md) — tiered capability negotiation (policy layer).
+- [`codex/`](./codex/) — independent codex reviews per RFC, plus codex's independent pick and the discussion.
+
+## Outcome in one line
+
+Build the coordinated engine contract once,
+ship **D** (foundation) then **B** (flagship) with a thin honest delivery-class core,
+add **B + cursor-ack** for the client-processed boundary on log backends,
+keep **A** selective and **G** last,
+and fold **C/E/F** in as supporting components.

--- a/rfc/at-least-once/codex/codex-pick-round1.md
+++ b/rfc/at-least-once/codex/codex-pick-round1.md
@@ -1,0 +1,19 @@
+Build **D first**, but do not sell it as end-to-end at-least-once. Build it because it creates the missing engine contract: per-subscriber delivery outcomes flowing back from `graphql-go-tools` to the adapter. Without that, A, C, and honest ack/commit behavior are all hand-waving. Its guarantee is only **at-least-once relative to successful socket flush**: bytes accepted by the kernel/TCP buffer, not client application processing. That is still the right first cut because it fixes the current JetStream “ack even on failure” bug and gives Cosmo the substrate for stronger modes.
+
+The end-state should be **B as the product anchor, with G as the policy/reporting layer**. Cursor/resume is the best default architecture for heterogeneous brokers because it uses the broker’s retained log instead of making the router a database. Kafka, JetStream, Redis Streams, Kinesis, Event Hubs, and Pub/Sub all have position primitives; surface them as signed opaque cursors, emit SSE `id:`, accept WS resume tokens, replay from cursor, then go live. The guarantee is **at-least-once across reconnect/restart gaps within retention**, not proof of client processing. If the client only stores the cursor after applying the event, B is very strong operationally; if it stores cursors on receipt, the boundary is receipt/parsing, not business processing. For true processing acknowledgement, layer A later.
+
+Sequence:
+
+1. **D:** engine/router delivery-result contract; JetStream no-hooks ack/nak on flush success; explicit metrics for stall/redelivery.
+2. **B:** signed cursor envelope, backend positions, `SubscribeFrom`, SSE `id:` / `Last-Event-ID`, WS resume extension, `CURSOR_EXPIRED`.
+3. **G:** capability negotiation and `extensions.delivery` reporting once there are real mechanisms underneath. G first is just an elaborate way to say “at-most-once.”
+4. **A selectively:** client ack for JetStream, SQS, RabbitMQ, Redis Streams, Pub/Sub where receipt acknowledgement matters. This is the only path that moves the boundary from socket write/resume to client receipt.
+5. **C only for premium isolation/HA:** per-subscription durable consumers/checkpoints where customers accept N broker consumers and external state.
+6. **E only for no-cursor backends:** short in-memory replay window for NATS core / Redis Pub/Sub; no durable-store variant unless a customer cannot move to a log backend.
+7. **F as SDK/docs pattern:** useful for state convergence, not stream durability.
+
+Do **not** build C as the first-class answer. It is expensive, breaks trigger dedup, requires external checkpoint semantics, and still does not close flush-vs-processing without A. Do **not** build durable E as a general solution; if you are willing to run a durable replay store, run a real log backend and use B. Do **not** ship F as “at-least-once”; it is a backfill/state-convergence recipe. Fold D into the substrate, G into policy/observability, F into SDK guidance, and E into an explicit degraded-mode component.
+
+Forced single best pick: **B, cursor/resume replay**. It best matches Cosmo’s multi-backend future, keeps router state low, gives an honest degradation story, and works especially well with SSE. But the first engineering milestone should still be D because the engine boundary is currently too fire-and-forget to support the rest cleanly.
+
+PRIMARY PICK: B cursor/resume replay; SEQUENCE: D → B → G → selective A → optional C/E → F as SDK/docs; DROP/FOLD: drop standalone C-first and durable-E-generalization, fold D/G/F/E into substrate/policy/docs/degraded-mode components.

--- a/rfc/at-least-once/codex/codex-pick-round2.md
+++ b/rfc/at-least-once/codex/codex-pick-round2.md
@@ -1,0 +1,64 @@
+1. **Agree, with one modification.**  
+A thin delivery-class core belongs in **D+B v1**, not in full G. Make it a shared contract, not a negotiator: `requested_class`, `achieved_class`, `boundary`, `mechanism`, `degraded_reason`.
+
+The modification: do **not** hard-error every mismatch by default. Use hard startup errors only when the operator declares a required class, e.g. `required_delivery: at_least_once`. If the field merely has `preferred_delivery: at_least_once`, start and report degradation. Otherwise you will make mixed-backend deployments painful. The key is separating **policy intent** from **capability truth**.
+
+Boundary labels should be brutally precise:
+
+- `socket_write`: D, flush succeeded; not client receipt.
+- `cursor_resume`: B, replayable after reconnect within retention; client processing depends on when the client persists cursor.
+- `client_receipt` or `client_processed`: only explicit client ack modes.
+- `state_converged`: F, not event delivery.
+
+2. **Agree, strongly, but name it differently.**  
+For log/cursor backends, **B + batched cursor acknowledgement** is the 80/20 and will subsume most of A’s value. It is not classic per-message A; it is **checkpointed cursor resume**.
+
+Correct model: the router/client maintain a high-water mark, and the client advances it only after processing. On reconnect, the client resumes from the last acknowledged cursor, not merely the last received cursor. B then reaches the **client-processed boundary**, bounded by retention and ordered prefix semantics.
+
+Correctness traps:
+
+- It only works cleanly for **ordered prefixes** per partition/stream. You cannot ack cursor 100 while 97 failed unless you accept loss of 97 or maintain a sparse ack set, which becomes A-like complexity.
+- Multi-partition Kafka cursors are vectors, not scalars. Batched ack must advance per partition.
+- The router does not need to “commit” for replay if the client owns the cursor, but if you add server-side committed cursor state, you have introduced a checkpoint store: scoped C.
+- Cursor ack does not help delete-on-ack queues with no replayable log. SQS/RabbitMQ still need A-style ack/delete/nack semantics or E’s short router buffer.
+
+So yes: make **B + cursor-ack** the premium mode for log backends. Full A becomes selective for ack-only queues, low-latency in-flight redelivery, and cases where backend handles must be released only after client confirmation.
+
+3. **Agree. One coordinated engine contract, shipped in phases.**  
+Do not pay the `graphql-go-tools` coordination tax twice. Design one resolve-layer contract that supports both D and B, then let router behavior turn on incrementally.
+
+The engine contract should carry:
+
+- per-event opaque metadata to the writer: cursor/position/idempotency metadata;
+- per-subscriber delivery outcome back from fan-out: flushed, failed, skipped, filtered, closed;
+- post-filter subscriber accounting;
+- a resume/start-from position path, whether named `SubscribeFrom` at datasource level or expressed as subscription source config;
+- writer support for emitting metadata into WS extensions and SSE `id:`.
+
+Correctness trap: keep the at-most-once fast path cheap and stable. The old void path can remain internally optimized, but the new contract must be the single semantic contract above it. Also avoid baking broker-specific cursor types into the engine; the engine should see opaque bytes plus enough routing identity to echo them safely.
+
+**Final Lockable Conclusion**
+
+Keep **D, B, thin delivery-class core, and later G**. Keep **A** as a selective premium add-on. Fold **C, E, F** into supporting roles.
+
+Sequence:
+
+1. **Engine contract PR:** delivery metadata forward, delivery outcomes back, resume-capable source path.
+2. **D first in router:** JetStream/no-hooks initially; ack/nak on delivery outcome.
+3. **Thin delivery core with D:** declared/achieved class, boundary, mechanism, degradation reason, startup enforcement for required guarantees.
+4. **B flagship:** signed cursors, SSE `id:`, WS resume, backend seek/replay, cursor-expired errors.
+5. **B+cursor-ack:** client-processed checkpoint mode for log backends.
+6. **G later:** dynamic negotiation, client capability handshake, policy selection matrix.
+7. **A selectively:** SQS/RabbitMQ/Pub/Sub/JetStream cases needing explicit client ack over broker ack handles.
+8. **C/E/F folded:** C as checkpoint substrate, E as degraded no-log replay window, F as SDK/docs for state convergence.
+
+Honest guarantees:
+
+- **D:** at-least-once to successful socket write, not client receipt.
+- **B:** at-least-once replay across reconnect within retention.
+- **B+cursor-ack:** at-least-once to client-processed prefix, within retention.
+- **A:** at-least-once to explicit client acknowledgement.
+- **G:** no durability itself; honest selection and reporting.
+- **C:** durable checkpoint substrate, not a standalone answer.
+- **E:** window-bounded degraded replay for non-log backends.
+- **F:** state convergence, not event delivery.

--- a/rfc/at-least-once/codex/codex-review-A.md
+++ b/rfc/at-least-once/codex/codex-review-A.md
@@ -1,0 +1,47 @@
+## Pattern A Review
+
+**1. Does the claimed guarantee hold?**
+
+Mostly, but only in a narrow envelope: ack-capable client, `graphql-transport-ws`, native per-message-ack backend, same router instance or broker redelivery independent of instance identity, and `ack_policy: all`. In that envelope, the design does close the current flush-vs-receipt gap by moving broker ack behind a client ack.
+
+The RFC correctly admits major remaining windows: lost client ack before router broker-ack causes duplicates; router crash relies on broker redelivery; shared triggers cannot selectively ack one subscriber and redeliver to another; JetStream failover is broken by today’s per-instance durable naming. The biggest overclaim is “per-subscriber at-least-once” as a general statement. Under `quorum`/`any`, slow subscribers can be sacrificed. Under `silent_downgrade_after`, a buggy ack-capable client can be downgraded to at-most-once after already negotiating stronger delivery; that is not “never silently” unless the client receives an explicit terminal downgrade/error and the field policy permits it. “Client receipt” also means only “client sent ack”; Cosmo cannot prove application processing unless the client library defines ack-after-processing semantics.
+
+The “effectively exactly-once” language is too optimistic. JetStream double-ack confirms the broker observed the ack; `Nats-Msg-Id` dedups publisher retries, not arbitrary consumer redelivery outside the window. SQS FIFO and Pub/Sub EOS still require careful client dedup and bounded windows. I would phrase this as at-least-once plus idempotency support, not exactly-once.
+
+**2. Backend adaptability / degradation**
+
+The matrix is unusually honest, but several entries are more “future ecosystem roadmap” than Pattern A support. SQS, Google Pub/Sub, RabbitMQ, Redis Streams, Kinesis, and Event Hubs are not supported by EDFS today, so their rows imply new adapters, auth/config surfaces, local/integration test infrastructure, and operational docs. The RFC calls this out, which is good, but the product claim should not read as “Pattern A supports these” until those adapters exist.
+
+Kafka/Kinesis/Event Hubs are correctly downgraded into cursor/checkpoint behavior, effectively Pattern B with ack-driven commits. Kafka in particular is not realistic as a simple adaptation: today Cosmo is groupless and reset-to-now; switching to consumer groups changes restart semantics, rebalance behavior, and instance ownership. With shared triggers, one slow subscriber pins the committed offset for all.
+
+NATS core and Redis Pub/Sub are correctly marked at-most-once only. JetStream is a native fit only for single-instance or stable durable identity; today’s per-router durable consumer naming defeats cross-instance recovery.
+
+**3. Engine / protocol / client feasibility**
+
+The RFC is correct that this cannot be done in `router/pkg/pubsub` alone. It requires cross-repo `graphql-go-tools` work: delivery id threading, post-filter subscriber reporting, and per-subscriber delivery results. That is the real critical path and a major feasibility risk.
+
+The WebSocket extension is feasible for modern `graphql-transport-ws`, but it needs client-library changes or a Cosmo-specific client layer. SSE/multipart ack via side-channel POST is much less attractive: sticky routing, signed stream keys, replayed affinity cookies, and peer routing/shared ack bus are all nontrivial. The RFC’s XL estimate is honest for the minimum viable path; full backend matrix is XL+.
+
+**Top strengths**
+
+1. Correctly identifies the engine contract as load-bearing rather than pretending this is an adapter tweak.
+2. Gives a concrete non-silent degradation model with negotiated classes, `REJECT` vs `DOWNGRADE`, and observability.
+3. Faces the shared-trigger impossibility: one broker handle cannot be acked for A and nacked for B.
+
+**Top weaknesses**
+
+1. Highest adoption cost: no stock client gets the guarantee without protocol/client changes.
+2. Shared-trigger coupling makes the strongest mode vulnerable to one slow subscriber causing duplicates/backpressure for all.
+3. HA story is incomplete, especially JetStream with current durable naming and SSE side-channel routing.
+
+**Relationship To Other Patterns**
+
+Pattern A is not standalone. It depends on Pattern D’s engine delivery-result contract. On Kafka/Kinesis/Event Hubs it collapses into a Pattern B-style cursor/checkpoint scheme. For cross-router restart and per-subscriber isolation it needs Pattern C. Pattern G should wrap it as one negotiated capability, but A itself should be sequenced after D.
+
+**Verdict**
+
+Scores: correctness **3/5**, feasibility **2/5**, backend_adaptability **3/5**, value_for_effort **3/5**.
+
+Recommendation: **MERGE-WITH-D**
+
+Pattern A is the strongest semantic model for true client-receipt acknowledgement, but it is not independently shippable and its minimum viable implementation is already Pattern D plus protocol, ledger, and client work. Keep the client-ack design as an optional layer after D lands, preferably WebSocket + JetStream first. Do not advance it as the primary RFC until the engine contract is accepted and the downgrade/downgrade-after-timeout semantics are tightened.

--- a/rfc/at-least-once/codex/codex-review-B.md
+++ b/rfc/at-least-once/codex/codex-review-B.md
@@ -1,0 +1,80 @@
+## Pattern B Review: Cursor / Resume-Token Replay
+
+Pattern B is a strong RFC after the revisions: it correctly abandons the unsafe “replay then splice into shared trigger” idea, admits the engine interface work, and limits the guarantee to retained log backends. But its headline “at-least-once” still needs tightening. This is not an end-to-end receipt guarantee; it is replay-from-client-checkpoint within retention.
+
+### 1. Does The Claimed Guarantee Hold?
+
+Mostly, but only under stricter conditions than the RFC headline implies.
+
+For exact cursor backends, the core seek-then-live design can provide no-gap replay after reconnect if the cursor represents the last event the client has durably processed, not merely the last event the client received. Without client ack, the router cannot know that distinction. A WS client that persists the cursor before processing the payload can crash and resume after the event, losing it. Stock `EventSource` is worse: browser-managed `Last-Event-ID` advances around event dispatch, not after application-level durable processing. So the guarantee is “at-least-once to a correctly checkpointing resume-aware client,” not end-to-end at-least-once to application processing.
+
+Remaining loss/overclaim areas:
+
+- `CURSOR_EXPIRED` is honest, but it means permanent loss beyond retention.
+- Timestamp fallback is correctly downgraded, but should not be marketed as at-least-once.
+- Multi-partition Kafka cursors are under-specified. A per-event cursor must be a delivery-progress vector, not a fetched high-watermark vector, or it can skip records from other partitions.
+- JetStream replay assumes replayable stream retention. Existing Cosmo config exposes `streamName`, not retention policy. `WorkQueuePolicy` or aggressive interest-based deletion can invalidate the replay story after ack.
+- WS half-open detection remains weak; reconnect may happen late, increasing retention pressure and duplicate live/replay overlap.
+
+### 2. Backend Adaptability / Degradation
+
+The RFC is directionally realistic and unusually explicit about degradation, but a few backend claims need sharper boundaries.
+
+Good claims:
+
+- NATS core and Redis Pub/Sub are correctly downgraded to at-most-once.
+- Kafka exact `(partition, offset)` replay is the right primitive.
+- Redis Streams requires a real topology/publisher migration; the RFC calls that out.
+- SQS and RabbitMQ classic are correctly not cursor-replay fits.
+
+Problems:
+
+- JetStream must validate stream retention semantics, not just `streamConfiguration` presence. A stream-backed subject is not automatically a durable replay log suitable for arbitrary client resume.
+- Google Pub/Sub snapshot seek is oversimplified. Snapshots are subscription-level state and seeking affects a subscription; using them as per-client cursors likely requires ephemeral subscriptions or maintained snapshots, breaking the RFC’s “cursor only, no router state” posture.
+- Kafka compaction deserves more attention. Offset seek may land on deleted compacted records; that is fine if detected as expired/gapped, but not if treated as contiguous replay.
+- Redis Streams `XREAD` from `<lastId>` is plausible, but trimming checks must be exact enough to avoid silently starting at the earliest retained entry.
+- Event Hubs/Kinesis claims are plausible but non-shippable scope; they should remain illustrative, not part of the RFC’s implementation promise.
+
+The degradation story is mostly non-silent, which is a major strength.
+
+### 3. Engine / Protocol / Client Feasibility
+
+Feasible, but L/XL is the honest estimate. This is cross-repo work:
+
+- `graphql-go-tools` exported subscription writer/updater interfaces change.
+- Router WS/SSE writers change.
+- PubSub adapter contracts change.
+- Cursor metadata must flow through `StreamEvent`, hooks, resolver fan-out, and flush.
+- Optional composition/proto changes may be needed for per-field policy.
+- Client documentation and likely SDK examples are required, because WS clients must persist and return cursors correctly.
+
+The RFC scopes this better than most patterns, especially by identifying that resuming clients require their own trigger. The hidden hard part is not the cursor codec; it is making the engine route resume-trigger creation reliably without accidental shared-trigger attachment, then proving no partition-vector advancement bug exists.
+
+### 4. Strengths
+
+1. Correct architectural fit for log-backed systems: Kafka, JetStream with replayable retention, Redis Streams.
+2. Preserves current shared-trigger fan-out for fresh subscriptions.
+3. Excellent degradation posture: explicit `CURSOR_EXPIRED`, `delivery.class`, authz mode, and non-seekable reporting.
+
+### 5. Weaknesses
+
+1. No client receipt ack means the guarantee depends on client checkpoint discipline; stock SSE auto-resume is not true application-level at-least-once.
+2. Resumed subscriptions create one broker reader per client for the lifetime of the subscription, which can be severe during reconnect storms.
+3. Backend edge cases remain: JetStream retention policy, Kafka vector cursors/compaction, Pub/Sub snapshot impracticality.
+
+### 6. Relationship To Other Patterns
+
+Pattern B is a standalone mechanism for retained log backends and a foundation for Pattern G capability negotiation. It complements Pattern D, which should still ship first to fix current ack timing bugs. It is not a substitute for Pattern A when application-level receipt is required, and not a substitute for Pattern E on ephemeral backends. Pattern C is stronger for per-client durable state but much more expensive.
+
+### 7. Verdict
+
+Scores:
+
+- correctness: 3
+- feasibility: 3
+- backend_adaptability: 4
+- value_for_effort: 4
+
+Recommendation: **KEEP**
+
+Keep Pattern B, but narrow the guarantee language: “at-least-once replay within retention for exact-cursor log backends, assuming the client checkpoints only after processing.” Require explicit validation/reporting for JetStream retention policy, Kafka vector cursor semantics, and Redis trim boundaries. Treat D as a prerequisite sequencing item and G as the product negotiation layer, but do not merge B into them; it is a distinct, valuable mechanism with clear backend scope.

--- a/rfc/at-least-once/codex/codex-review-C.md
+++ b/rfc/at-least-once/codex/codex-review-C.md
@@ -1,0 +1,83 @@
+## Review: Pattern C
+
+Pattern C is much more honest than the naive version of this design, but it still should not be accepted as a standalone answer to “end-to-end at-least-once.” It is a durable server-side substrate. The real end-to-end guarantee only exists when combined with Pattern A-style client acknowledgements and careful client ack semantics.
+
+### 1. Does The Guarantee Hold?
+
+Partially.
+
+The RFC correctly admits that stock Pattern C advances checkpoints on writer flush, not client receipt. That means the core silent-loss window remains: router flush succeeds, checkpoint advances, client crashes before reading or before application processing. This is not end-to-end at-least-once.
+
+The stronger claim holds only under all of these conditions:
+
+- `per-subscriber` isolation is enabled.
+- The client is patched to send per-message acks.
+- The client sends the ack only after the application has processed or durably accepted the event, not merely after the transport library decoded it.
+- Checkpoint commits are fenced and monotonic under failover.
+- Hook timeout delivery is cancellable, not abandoned.
+- Resume identity is stable or token-carried.
+- Retention and checkpoint TTL outlive the promised resume window.
+
+The default `shared` mode is not at-least-once per client. The RFC admits the mid-batch disconnect hole: the router eventually drops the stuck subscriber so the shared prefix can advance, and that subscriber loses the unconfirmed suffix. That is explicit, but it means the default class should not be marketed as at-least-once, even with qualifiers.
+
+One concrete bug: the startup validation says `inactive_ttl >= resume_window` should warn, but the earlier failure-mode text says the dangerous case is `inactive_ttl < resume_window`. The latter is the correctness risk, especially for broker-native checkpoints whose durable consumer may be the only stored position.
+
+### 2. Backend Adaptability
+
+Mostly realistic, with two caveats.
+
+The RFC is strong on separating log/cursor systems from delete-on-ack queues. It correctly rejects durable mode for NATS core and Redis Pub/Sub, requires Redis Streams plus `XADD`, rejects Kafka per-client consumer groups, and treats Kafka/Kinesis/Event Hubs as prefix-commit systems with head-of-line blocking.
+
+But several “Pattern C supports this” cases are really Pattern B or Pattern A:
+
+- Kafka, Kinesis, and Event Hubs with external checkpoints are cursor replay systems. That is Pattern B with a router-owned checkpoint store.
+- SQS and RabbitMQ do not have historical replay; they are Pattern A-style ack/delete windows, not durable per-subscription checkpoints.
+- Google Pub/Sub is correctly rejected for per-client subscriptions, but then it is not really Pattern C except as an ack-window backend.
+- Redis Streams support is plausible but not backward-compatible with today’s Redis EDFS semantics, because `PUBLISH` to Pub/Sub and `XADD` to Streams are different products operationally.
+
+The degradation story is non-silent in intent, but it will only stay non-silent if the capability class is surfaced at startup, subscription start, and client negotiation. Logging alone is not enough.
+
+### 3. Engine, Protocol, And Client Scope
+
+The scope is correctly classified as XL. This is not a router-only change.
+
+Hidden or easily underestimated work includes:
+
+- `graphql-go-tools` must expose per-subscriber delivery results instead of discarding flush failures.
+- Trigger keying must change to include per-client identity for `per-subscriber`, intentionally defeating trigger dedup.
+- Router must coordinate an engine release and `go.mod` pin bump.
+- WebSocket ack is a non-standard protocol extension requiring patched clients.
+- SSE ack requires a side-channel endpoint.
+- Redis durable support requires publish-path changes, not only subscribe-path changes.
+- External checkpoint stores need leasing/fencing, schema, GC, observability, and operational documentation.
+
+The RFC is honest about much of this. The remaining risk is that “client ack” is underspecified: the protocol frame alone does not prove application processing unless the SDK contract makes ack timing explicit.
+
+### 4. Top Strengths
+
+1. It correctly identifies the shared-trigger optimization as incompatible with true per-client durability.
+2. The backend matrix is materially better than a generic “durable consumer everywhere” claim.
+3. It has the right fail-closed instinct: refuse on checkpoint load errors, do not restart from “now.”
+
+### 5. Top Weaknesses
+
+1. Pattern C alone still has the flush-versus-receipt loss window.
+2. The default `shared` mode is not per-client at-least-once and may confuse operators despite the RFC’s caveats.
+3. The cost is very high: engine changes, client protocol extensions, per-subscriber broker resources, and external state.
+
+### 6. Relationship To Other Patterns
+
+Pattern C is not standalone. It is a foundation for Pattern A when true client-receipt acknowledgement is required. On Kafka/Kinesis/Event Hubs it overlaps heavily with Pattern B, because external checkpoints plus seek are cursor replay. The default shared mode is close to Pattern D plus restart-survivable checkpointing. Pattern G should eventually negotiate and report the actual class, but G does not make C correct by itself.
+
+### 7. Verdict
+
+Scores:
+
+- correctness: 3/5
+- feasibility: 2/5
+- backend_adaptability: 3/5
+- value_for_effort: 2/5
+
+Recommendation: **MERGE-WITH-A**
+
+Pattern C should not ship as the primary at-least-once RFC. Keep its durable per-subscriber checkpoint machinery as the server-side substrate, but merge it with Pattern A so checkpoint advancement can be gated on real client acknowledgement. Without that, the design remains restart-survivable flush-at-least-once, not end-to-end at-least-once. Pattern B should be reused for cursor-oriented backends rather than forcing all of them through the heavier Pattern C framing.

--- a/rfc/at-least-once/codex/codex-review-D.md
+++ b/rfc/at-least-once/codex/codex-review-D.md
@@ -1,0 +1,31 @@
+## Pattern D Review
+
+Pattern D’s claimed guarantee holds only in its narrowed form: **at-least-once relative to successful router flush on NATS JetStream, no hooks, no client receipt guarantee**. The RFC is unusually honest about this ceiling, and that honesty matters. It does **not** restore end-to-end at-least-once broker → client application. The remaining silent-loss window is the fundamental one: `Flush()` only proves bytes were accepted by the socket/TCP stack; a client crash after flush but before application processing is still acked and lost. This requires Pattern A.
+
+There are also important residual races and overclaims. The mutable shared-trigger set means redelivery targets “whoever is subscribed now,” not the subscriber that failed. Departed subscribers are never satisfied; new subscribers may receive pre-join events. Under `quorum` or `any`, failed subscribers still miss events; metrics make this operationally visible, but not client-visible. The RFC should not call that non-silent from the client’s perspective. The biggest correctness concern is the v1 “option b” for init/load/resolve errors: classifying non-flushed GraphQL errors as `DeliveryFailed` can turn deterministic resolver failures into redelivery loops until `MaxDeliver` and then `Term`, stalling unrelated healthy co-subscribers. I would make “flush GraphQL error payloads and classify successful error flush as delivered” part of v1, not a follow-up.
+
+Backend adaptability is realistic for current Cosmo only because the RFC scopes v1 to **JetStream only** and rejects Kafka/hooks at startup. That is the right call. NATS core and Redis Pub/Sub correctly degrade to unchanged at-most-once with warn/error behavior. Kafka is correctly deferred; the current groupless reset-to-now consumer cannot support commit semantics without becoming Pattern C/B territory. Redis Streams, SQS, Pub/Sub, RabbitMQ, Kinesis, and Event Hubs are discussed too hand-wavily as “map cleanly when added.” They do not all map cleanly: Pub/Sub needs ack-deadline extension while waiting on downstream delivery, RabbitMQ requeue/prefetch can reorder and thrash, SQS visibility timeouts need extension and DLQ policy, and Kinesis/Event Hubs are checkpoint-floor systems with head-of-line blocking. Since they are future backends, this is not fatal, but the matrix should say “plausible family fit,” not imply implementation confidence.
+
+Engine and router feasibility is good but not as “surgical” as the RFC sometimes suggests. Changing `SubscriptionUpdater.Update` to return a report touches `graphql-go-tools`, router datasource plumbing, adapter tests, mocks, and module versioning. It is cross-repo work and a public Go interface change, not just an internal router patch. Existing call sites can ignore a return value, but existing implementers of the interface must be updated. No wire-protocol or stock-client changes are needed; that scope is correct. Complexity **M** for JetStream/no-hooks is credible if error-flush behavior is handled in v1; full Kafka/hooks support is rightly **L**.
+
+Top strengths:
+1. Correctly attacks the real ack-timing bug with minimal client impact.
+2. Explicitly names the shared-trigger coupling, duplicate delivery, mutable subscriber set, and stall blast radius.
+3. Provides concrete validation, metrics, and startup rejection for unsupported combinations.
+
+Top weaknesses:
+1. It is not end-to-end at-least-once; flush is a weak delivery boundary.
+2. Shared-trigger `policy: all` can stall healthy subscribers and redeliver stale/pre-join events.
+3. Current v1 error-branch handling risks poison redelivery loops unless flushed error delivery is included.
+
+Relationship to other patterns: Pattern D is **not standalone** for the overall goal. It is a necessary server-side foundation for A, B, and parts of C, and a useful immediate JetStream correctness fix. It should precede Pattern A/B work, but should not be marketed as solving end-to-end delivery by itself.
+
+Scores:
+- `correctness`: 3/5
+- `feasibility`: 4/5
+- `backend_adaptability`: 2/5
+- `value_for_effort`: 4/5
+
+Recommendation: **KEEP**
+
+Keep Pattern D as the first server-side ack-correctness increment, limited to JetStream/no-hooks and framed as “at-least-once to router flush,” not end-to-end at-least-once. Require v1 to flush GraphQL error payloads or otherwise explicitly prevent deterministic error redelivery loops, and tighten the future-backend matrix so unsupported or checkpoint-based systems do not look cleaner than they are.

--- a/rfc/at-least-once/codex/codex-review-E.md
+++ b/rfc/at-least-once/codex/codex-review-E.md
@@ -1,0 +1,31 @@
+**Pattern E Review**
+
+The RFC is now much more honest than the naïve router-buffer version, but its claimed guarantee should be narrowed further. It does **not** restore end-to-end at-least-once delivery. It restores **same-router, same-trigger, within-window replay of frames the router actually captured**. That is useful, but weaker than the title implies.
+
+The biggest remaining correctness issue is the gap between “client disconnected” and “router continues producing frames for that subscriber.” In default `cursor_only` warm-keep, a sole subscriber that disconnects does **not** get frames produced during the gap, because no resolved frames are captured for an absent subscriber. That means the flagship no-replay backends, NATS core and Redis Pub/Sub, only benefit when some live path keeps the trigger reading and the router is configured to keep capturing for the detached subscriber. Otherwise the client gets an explicit gap, not at-least-once. Explicit is better than silent, but it is not the advertised guarantee.
+
+There is also a race around capture-vs-flush semantics. The RFC says the writer stamps, captures, then writes. If the socket write fails, the frame may be in the ring even though it was never delivered, which is acceptable as duplicate/redelivery behavior on reconnect. But if the subscriber is torn down before a frame reaches this wrapper, no frame exists. The guarantee therefore depends on precise teardown ordering between disconnect detection, engine subscription removal, warm ring retention, and replay reassociation. That needs to be specified as a state machine, not prose.
+
+Backend adaptability is directionally right but still overstates the “backend-agnostic” value. For NATS core and Redis Pub/Sub, the buffer can only replay what the router observed; broker/client slow-consumer drops before the adapter reads are still unrecoverable. For Kafka as currently implemented, Pattern E is a poor fit because groupless reset-to-now skips broker backlog on trigger rebuild or restart. JetStream, Kafka, Redis Streams, Kinesis, Event Hubs, and Google Pub/Sub are better served by Pattern B-style broker cursors. SQS and RabbitMQ fit ack/redelivery better than replay-buffer semantics, but they are not supported today. Kinesis and Event Hubs checkpointing are correctly flagged as coarse and not per-message ack compatible.
+
+The engine and wire-protocol scope is now mostly honest. This is not a router-only patch: it needs `graphql-go-tools` changes for single-subscriber replay, subscription identity exposure, replay/live serialization, and post-resolve writer stamping. It also changes downstream WS/SSE/multipart behavior, adds resume-token client behavior, requires SDK support for durable token persistence, and needs router config/metrics. The `L` estimate for in-process mode is plausible but optimistic at 6-8 weeks because concurrency, replay ordering, engine API review, and HA/stickiness testing are all load-bearing. The Redis durable-store variant is effectively a new log of resolved frames and should be treated as a separate XL project.
+
+Top strengths:
+
+1. Correctly identifies that replay must store **post-resolve frames**, not raw broker events.
+2. Makes degradation visible with gap signaling instead of pretending old clients or expired windows are safe.
+3. Preserves broker-side shared trigger fan-out for the live path, which matters for Cosmo scale.
+
+Top weaknesses:
+
+1. The useful guarantee collapses for sole subscribers unless `frame_capture` is enabled, which means resolving for absent clients.
+2. In-process replay is weak under restart, rolling deploys, non-sticky load balancing, and trigger rebuilds.
+3. It duplicates broker-log functionality on backends where Pattern B is simpler, more durable, and less memory-intensive.
+
+Relationship to the other patterns: Pattern E is not a general standalone answer. It is a fallback mechanism for no-cursor/no-replay backends, a partial complement to Pattern F for explicit client backfill, and mostly redundant with Pattern B on log backends. It is not a subset of A because it lacks client receipt ack, and not a substitute for C because it has no durable per-subscriber checkpoint. Product-wise it belongs under Pattern G as one negotiated delivery tier: `at-least-once-window`, not “at-least-once.”
+
+Scores: correctness `3/5`, feasibility `3/5`, backend_adaptability `3/5`, value_for_effort `3/5`.
+
+Recommendation: **MERGE-WITH-G**.
+
+Pattern E is valuable only when presented as a negotiated, explicitly degraded short-window replay mode for backends that cannot seek or replay. Kept alone, it invites overclaiming and expensive engine work for a narrow guarantee. Under Pattern G, it becomes the right fallback tier for NATS core and Redis Pub/Sub, while log backends use Pattern B and long-disconnect/mobile cases pair with Pattern F.

--- a/rfc/at-least-once/codex/codex-review-F.md
+++ b/rfc/at-least-once/codex/codex-review-F.md
@@ -1,0 +1,42 @@
+**Review: Pattern F**
+
+Pattern F is honest about its core tradeoff: it does **not** restore at-least-once event delivery. It restores state convergence for a narrow class of subscriptions: state-shaped payloads backed by a complete, queryable outbox/changelog with aligned `idempotencyKey` and monotonic `since`. Within that scope, the guarantee mostly holds, but the RFC should avoid calling this “at-least-once” except as “at-least-once recovery of persisted state via backfill.”
+
+Remaining silent-loss/staleness windows:
+
+- If a live event is dropped while the client remains connected, no reconnect occurs, so no backfill is triggered. The client can remain silently stale indefinitely unless the SDK periodically reconciles or uses heartbeats/version checks.
+- If the client advances `lastSeen` before durably applying the update locally, a crash can skip state. The SDK contract must require “apply first, persist watermark second.”
+- The lower-boundary gap is correctly identified, but “safety margin” is hand-wavy for non-contiguous cursors like ULIDs unless the backfill query supports time/window overlap rather than arithmetic decrement.
+- Key misalignment remains catastrophic and largely outside router enforcement. The proposed lint cannot prove the live and query resolvers use the same key space.
+- “Snapshot reset” must be mandatory when retention is exceeded; otherwise truncated backfill is silent state loss.
+
+Backend adaptability is directionally right because F barely depends on the broker. But the backend table overstates some key-source claims. Broker-assigned positions such as JetStream stream sequence, Kafka offset, Redis auto entry ID, Pub/Sub `messageId`, Kinesis sequence number, and Event Hubs offset are not generally usable as the outbox dedup key under commit-then-publish, because they are assigned after publish and are not available when the outbox row is committed. Using them requires a post-publish outbox update, which reintroduces the lower-boundary race. The RFC should distinguish app-assigned IDs (`Nats-Msg-Id`, Kafka record key, AMQP `message-id`, SQS FIFO dedup ID, explicit outbox ID) from broker-assigned offsets. Also, SQS Standard and FIFO should be split; the current row mixes them.
+
+Degradation is mostly non-silent in prose, but not in runtime behavior. A non-participating client silently gets today’s at-most-once semantics. A participating client with a bad resolver, expired retention, or missing outbox rows can still fail silently unless the SDK requires explicit backfill completeness signals.
+
+Engine and protocol scoping is accurate. The RFC correctly withdraws router-stamped `extensions.cosmo`, SSE `Last-Event-ID`, and content-hash claims. Primary path needs no `graphql-go-tools` change, no router wire change, and no broker adapter change. The hidden cross-repo work is only in the deferred engine-stamped alternative, and the RFC calls that L effort. The honest miss is product effort: the “S router” story is true, but the deliverable that matters is a client SDK plus application templates/tests. Without those, this is mostly documentation.
+
+Top strengths:
+
+1. Very low router operational risk: no held broker acks, no per-subscriber consumers, no HA state.
+2. Works across NATS core, Redis Pub/Sub, SQS Standard, and RabbitMQ because durability is moved to the app datastore.
+3. Correctly documents its ceiling: state convergence, not event fidelity.
+
+Top weaknesses:
+
+1. Does not solve the original “end-to-end at-least-once event delivery” problem.
+2. Depends on application discipline that Cosmo cannot strongly verify.
+3. Can create reconnect thundering herds and expensive per-client backfills.
+
+Relationship to other patterns: F is standalone only for state-convergent subscriptions. It is not a foundation for A/B/C/D; it is an application-level fallback. It pairs best with D, because D fixes real broker ack bugs while F gives cheap recovery for app-state use cases. For log backends, B is the stronger native solution. For transient streams, E or A is required.
+
+Scores:
+
+- correctness: 3/5
+- feasibility: 4/5
+- backend_adaptability: 4/5
+- value_for_effort: 3/5
+
+Recommendation: **MERGE-WITH-D**
+
+Pattern F is useful, but it should not stand as an at-least-once delivery RFC. Merge it with Pattern D as the application-state recovery layer: D improves the actual router/broker delivery semantics, while F provides cheap reconnect convergence where applications already maintain an outbox. Keep F’s scope gates loud, remove broker-assigned key overclaims, and require explicit backfill completeness/error signaling in the SDK.

--- a/rfc/at-least-once/codex/codex-review-G.md
+++ b/rfc/at-least-once/codex/codex-review-G.md
@@ -1,0 +1,60 @@
+## Review: Pattern G
+
+Pattern G is directionally valuable, but it should not be accepted as an at-least-once delivery mechanism. It is a capability-reporting and routing framework whose correctness depends entirely on A/B/C/D/E/F. That is mostly admitted by the RFC, but several rows still overclaim the achieved class.
+
+1. **Does the guarantee hold?**
+
+Not by itself. G’s real guarantee is “honest negotiation,” not delivery. That is useful, but the RFC sometimes lets “selected mechanism says at-least-once” bleed into “end-to-end at-least-once holds.”
+
+The biggest correctness problem is Pattern D. The RFC classifies “correct broker ack on flush” as `at-least-once` with no client participation. That is not end-to-end at-least-once. A successful `Flush()` only proves bytes were written to the socket/kernel buffer. If the client crashes after the write and before application processing, the broker message is acked/committed and the event is lost. The RFC even contradicts itself in §7 by saying this event “is not acked,” but D’s whole mechanism is ack-on-flush-success. G must never report D as `achieved: at-least-once` for broker-to-client semantics. It needs a weaker reported class, or a separate dimension like `deliveryBoundary: socket-write`.
+
+B is stronger, but only if the client persists and resumes from the last processed cursor. Native SSE `Last-Event-ID` is not “at-least-once for free” across browser/tab/app restarts; it is mainly automatic reconnect state for the active EventSource. Without application-level durable cursor storage, there is still a client crash window.
+
+E is also overstated for NATS core / Redis Pub/Sub. A router buffer can replay only events that reached the router and survived the buffer window/store. It cannot recover broker-side drops, slow-consumer drops before adapter receipt, router restart with memory store, or gaps while no router instance is subscribed. It should be reported as bounded best-effort replay, not generic `at-least-once`.
+
+2. **Backend adaptability / degradation**
+
+The matrix is useful and mostly honest about current Cosmo support: NATS core and Redis Pub/Sub are at-most-once; Redis Streams, SQS, Pub/Sub, Kinesis, Event Hubs, RabbitMQ require new adapters.
+
+Problematic claims:
+
+- **JetStream exactly-once** is too strong. Double-ack confirms the server processed the ack; `Nats-Msg-Id` dedups publishes within a bounded window. It does not prove exactly-once client processing unless the client participates transactionally/idempotently. Report “at-least-once with bounded producer dedup,” not hard EOS.
+- **Kafka EOS** is hand-wavy. Kafka exactly-once is producer/transaction/read-process-write scoped. GraphQL subscription delivery to arbitrary clients cannot inherit Kafka EOS unless cursor advancement and client side effects are in one transaction, which they are not.
+- **SQS FIFO exactly-once-processing** is misleading. FIFO has deduplication windows and ordering constraints, but consumers can still receive duplicates; client idempotency remains required.
+- **Google Pub/Sub EOS** applies to supported pull subscriptions and ack semantics, not arbitrary downstream GraphQL client processing.
+- **NATS core listed as delete-on-ack queue** in the structural note is wrong; core NATS has no ack/delete primitive.
+
+The non-silent degradation idea is strong, but only if labels are more precise than `at-least-once` / `exactly-once`.
+
+3. **Engine / protocol / client feasibility**
+
+Feasible, but not “thin” in practice. Required work crosses router, composition, proto, graphql-go-tools, WS/SSE writers, client libraries, metrics, config validation, cursor signing/key rotation, and adapter contracts. Changing `SubscriptionEventUpdater` and engine `SubscriptionUpdater` from void fire-and-forget to outcome-bearing delivery is a real cross-repo contract change. Shared-trigger fanout with per-subscriber outcomes is especially invasive.
+
+Wire changes are plausible for `graphql-transport-ws` because payload/extensions are flexible. Legacy clients may ignore `extensions.delivery`, so “non-silent” is only true for observability/logs unless clients surface extensions. The out-of-band ack endpoint for SSE/multipart is conceptually feasible but large enough to deserve its own RFC.
+
+4. **Top strengths**
+
+- Establishes an honest negotiation model instead of pretending one mechanism fits all brokers.
+- Cleanly separates backend capability, client capability, transport capability, and router HA capability.
+- Makes degradation observable through `extensions`, metrics, traces, and strict-mode startup validation.
+
+5. **Top weaknesses**
+
+- Does not itself restore delivery; it can only route to mechanisms implemented elsewhere.
+- Overclaims D, E, and several “exactly-once” backend rows.
+- Underestimates cross-repo complexity, especially engine outcome propagation, shared-trigger fanout, and client cursor/ack behavior.
+
+6. **Relationship to A-F**
+
+G is not standalone. It is a foundation/meta-pattern over A-F. It is best merged with Pattern B as the first practical implementation path: B gives real value on Kafka/JetStream/log backends, while G supplies negotiation and reporting. D can be a substrate fix, but must not be advertised as end-to-end at-least-once.
+
+**Scores**
+
+- correctness: 3/5
+- feasibility: 3/5
+- backend_adaptability: 4/5
+- value_for_effort: 3/5
+
+**Recommendation: MERGE-WITH-B**
+
+Merge G with Pattern B as the negotiation/reporting layer for cursor-capable backends, and downgrade D/E/exactly-once claims before acceptance. As written, G is a good product and policy framework, but not a delivery guarantee. Its value becomes concrete when paired with cursor replay, where the backend durability model actually supports reconnect backfill with bounded, explainable degradation.

--- a/rfc/at-least-once/rfc-A-client-ack-protocol.md
+++ b/rfc/at-least-once/rfc-A-client-ack-protocol.md
@@ -1,0 +1,919 @@
+# RFC: At-Least-Once for GraphQL Subscriptions — End-to-End Client-Ack Protocol Extension (Pattern A)
+
+**Status:** Draft (revised after adversarial review)
+
+**TL;DR.**
+Today Cosmo's EDFS pushes broker events to the client fire-and-forget:
+the broker ack/commit is gated on a *flush attempt* (or never happens at all), not on the client actually receiving the message,
+so a disconnect, a router restart, or a slow consumer silently drops events even when the backend itself has at-least-once.
+This RFC closes that gap end to end.
+Every delivered message carries a monotonic, subscription-scoped `id` plus a stable idempotency key;
+the client returns an explicit `ack {id}`;
+and the router holds the broker ack/commit (`msg.Ack()`, `XACK`, `DeleteMessage`, Pub/Sub `Ack`, AMQP `basic.ack`) until that client ack arrives,
+with a per-subscriber in-flight window and an ack-timeout that triggers `nak`/redelivery.
+This is MQTT QoS 1 for GraphQL subscriptions; with an optional double-ack plus a dedup window it reaches effectively exactly-once on capable backends.
+It is opt-in, negotiated per client, and degrades explicitly (never silently) on backends and transports that cannot participate.
+
+**The load-bearing dependency, stated up front.**
+Pattern A *cannot* be built purely in the router's pubsub layer, as an earlier draft assumed.
+The engine (`graphql-go-tools/v2`, pinned at `v2.4.1` per `router/go.mod:34`) owns subscriber fan-out, subscriber filtering, and **discards every per-subscriber delivery outcome** (`executeSubscriptionUpdate` returns `void`).
+A delivery id assigned router-side never reaches the wire, and the router cannot learn whether any individual subscriber actually received an event.
+Pattern A therefore *requires* the Pattern D bidirectional delivery-result engine contract — plus delivery-id threading to the writer, plus post-filter subscriber reporting — to land in the engine first.
+That is an upstream, separately-versioned, maintainer-gated change.
+Rough complexity: **XL**, gated on an upstream engine change being accepted.
+
+---
+
+## 1. Problem & Context
+
+A common Cosmo deployment looks like this:
+an application already has at-least-once *inside* its event backbone — Kafka with committed offsets, NATS JetStream with durable consumers, SQS with visibility timeouts, Redis Streams with a PEL.
+The application team reasonably assumes that wiring that backbone into a GraphQL subscription via EDFS preserves the guarantee end to end.
+It does not.
+EDFS is **fire-and-forget by construction**, and the durability stops at the router.
+
+The framework boundary makes this structural, not incidental.
+The adapter contract `datasource.Adapter.Subscribe` hands the engine a `SubscriptionEventUpdater` whose only delivery method is `Update(events []StreamEvent)` — it returns no error and exposes no ack hook back toward the broker (`router/pkg/pubsub/datasource/provider.go:24-28`, `router/pkg/pubsub/datasource/subscription_event_updater.go:19-24`).
+The generic glue therefore *cannot* report delivery success back to the adapter.
+Durability is a per-adapter side effect, and today only one adapter even attempts it.
+
+Concretely, here is where the guarantee evaporates:
+
+**Ack is gated on a flush attempt, not client receipt.**
+The NATS JetStream reader calls `updater.Update(...)` and then, on the very next line, `msg.Ack()` (`router/pkg/pubsub/nats/adapter.go:146-158`).
+`Update` runs the full synchronous resolve + `writer.Flush()` for every shared subscriber, but `Flush()` is a single socket write under a write deadline —
+a successful flush means *bytes handed to the kernel TCP buffer*, not an application-level ack from the client.
+A client that drops between TCP-buffering and processing loses the message, and the message has already been acked → permanently lost.
+
+**Ack fires even when delivery failed — and the engine swallows every failure signal.**
+This is the deepest part of the gap, and it determines the whole shape of this RFC.
+The no-hooks path calls `s.eventUpdater.Update(event.GetData())` with **only the payload, no subscriber identity** (`subscription_event_updater.go:37-42`).
+The actual fan-out to N subscribers happens *inside the engine*, in `resolver.handleTriggerUpdate` (`graphql-go-tools/v2@v2.4.1/.../resolve.go:1086-1110`), which calls `trig.filterSubscriptions(data)` and then spawns one goroutine per surviving subscriber via `wg.Go(...)`.
+Each goroutine runs `executeSubscriptionUpdate` (`resolve.go:616-687`), which **returns `void`** and `return`s silently on every failure: `InitSubscription` failure (line 632), `LoadGraphQLResponseData` failure (line 645), `Resolve` failure (line 663), and `Flush` failure (line 678, which additionally calls `UnsubscribeSubscription` internally).
+None of these outcomes propagate back to the router.
+If resolve/flush fails mid-disconnect the subscription is torn down, but `msg.Ack()` still runs → acked despite non-delivery.
+
+**One ack covers N heterogeneous subscribers.**
+Cosmo's shared-trigger optimization fans a single broker message out to every client with an identical subscription (the Kafka adapter even documents it: "The engine already deduplicates subscriptions with the same topics…", `router/pkg/pubsub/kafka/adapter.go:124-125`).
+The single `msg.Ack()` acks the trigger for *all* of them, so a subset that failed to flush silently misses the event.
+
+**Most backends never ack at all.**
+Kafka consumes groupless with `ConsumeResetOffset(AfterMilli(now))` and never commits (`kafka/adapter.go`); NATS core uses an unbuffered channel and the nats.go client *drops* events on slow-consumer overflow; Redis uses Pub/Sub (`PSubscribe`/`PUBLISH`), which has no ack primitive at all.
+These are at-most-once by construction.
+
+**There is no client ack anywhere, and no resume.**
+The recognized inbound WebSocket message set is exactly `Ping, Pong, Subscribe, Complete, Terminate` (`router/internal/wsproto/proto.go:88-94`); there is no "I received message N" concept.
+`connection_init`/`connection_ack` is a one-time *connection* handshake, not a data ack (`graphql_ws.go:49-65`).
+SSE/multipart are one-directional: `HttpFlushWriter` writes and flushes, and never emits an `id:` field (`router/core/flushwriter.go`), so even native SSE `Last-Event-ID` resume cannot work.
+The delivered event structs carry only `Data`, `Headers` (and Kafka `Key`); no sequence/offset cursor is ever surfaced, and JetStream `msg.Metadata()` is never read.
+
+The one-line summary from the dossier holds:
+*only NATS JetStream achieves any durability, and only because its adapter independently calls `msg.Ack()` after a flush attempt; everywhere else delivery is at-most-once.*
+
+**Why this RFC is structurally larger than an earlier draft claimed.**
+The fan-out, the `filterSubscriptions` step, and the discarded per-subscriber outcomes all live *in the engine*, not in the router's `subscriptionEventUpdater`.
+The router-side updater the earlier draft wanted to host the ledger **does not know which or how many subscribers exist** in the no-hooks path, and cannot, without re-implementing trigger/subscription bookkeeping that lives in the engine.
+That single fact reshapes the design (§3) and the cost (§11): Pattern A's core promise — *broker-ack only after a specific subscriber's receipt, nak on that subscriber's failure* — requires the engine to (a) thread a delivery id through to the writer, (b) report, per `handleTriggerUpdate` call, **which** subscribers were actually written to (post-filter), and (c) return a **per-subscriber success/failure result** so the router can ack vs. nak.
+(b) and (c) are exactly the engine contract the dossier scoped as **Pattern D** (`dossier §5 Pattern D`).
+Pattern A is therefore Pattern D's engine work *plus* an ack protocol and ledger layered on top; it cannot ship before the Pattern D engine change lands upstream.
+
+**Relationship to Cosmo Streams v1.**
+This RFC builds on the Cosmo Streams v1 hook substrate.
+The `SubscriptionOnStart` hook is the natural place to evaluate per-client ack capability and per-field `@edfs__delivery` class, and to reject clients whose declared delivery class cannot be honored.
+The `StreamBatchEventHook` (`OnStreamEvents`) sits on the per-subscriber path where drop-vs-failure semantics must be reconciled (`subscription_event_updater.go:104-129`).
+Pattern A does **not** replace those hooks; it adds an ack-tracking layer underneath them.
+
+---
+
+## 2. Goals & Non-Goals
+
+**Goals.**
+
+- Provide *true end-to-end* at-least-once: a message is broker-acked only after the **client** confirms receipt of it, not merely after a socket write.
+- Make the guarantee **per-client and negotiated** — a stock client that cannot ack falls back to today's behavior, explicitly and observably, never silently.
+- Make the guarantee **per-subscriber** within a shared trigger, *to the extent the backend's ack primitive allows it* (§7.4 confronts the cases where it cannot).
+- Support an **optional double-ack + dedup window** path that reaches effectively exactly-once on backends that can dedup or whose ack is idempotent.
+- Provide an explicit, documented **degradation matrix**: a user may pick any backend, learn the guarantee they actually get, and never be lied to.
+- Keep the broker as the source of truth for redelivery wherever the broker can redeliver (JetStream, SQS, Rabbit, Redis Streams, Pub/Sub) — the router holds ack handles, it does not become a durable store.
+
+**Non-Goals.**
+
+- **Replay across long disconnect gaps / resume-from-cursor.** That is Pattern B's job. Pattern A guarantees delivery of *in-flight* (un-acked) messages; it does not seek the backend to an old position to backfill a multi-minute gap. (Combining A with B is discussed in §8.)
+- **Cross-router-restart durability of in-flight ack state** beyond what the broker itself redelivers. If the router process dies holding un-acked-to-client handles, recovery relies on the broker's redelivery (JetStream/SQS/Rabbit/Redis-Streams/Pub/Sub do this); Kafka-by-offset does not per-message. A router-side durable ack store is explicitly Pattern C territory and out of scope here.
+- **Per-subscriber redelivery under a shared trigger on per-message-ack backends.** As §7.4 establishes, a single broker handle cannot be both acked (for subscriber A) and redelivered (for subscriber B) on a per-message-ack backend without per-subscriber consumers. That is Pattern C. Pattern A's shared-trigger story is "redeliver to all on any nak under `ack_policy: all`, accepting duplicates for the subscribers who already acked."
+- **Global ordering.** Ordering remains partition/stream/group-scoped, exactly as the backend provides it. Redelivery can reorder; we make the tradeoff explicit and tunable, we do not invent a total order.
+- **Changing the publish path.** Idempotent ingest (`Nats-Msg-Id`, Kafka idempotent producer) is a separate concern; this RFC is about the *delivery* (subscribe) leg.
+- **Inventing ack on backends that have no ack/redelivery primitive.** NATS core and Redis Pub/Sub cannot participate; they fall back to at-most-once. Manufacturing a window for them is Pattern E, not A.
+
+---
+
+## 3. Design — the mechanism in depth
+
+### 3.1 The core idea
+
+Insert a **per-subscriber in-flight ledger** between the broker reader and the engine's fan-out, and gate the broker ack on a *per-subscriber* client ack.
+Each event the engine actually delivers to a given subscriber is assigned a monotonic `DeliveryID` (subscription-scoped) and is paired with an opaque **broker ack handle** — the thing the adapter needs to later confirm/redeliver that specific message (a JetStream `jetstream.Msg`, an SQS receipt handle, a Redis Streams entry id, a Pub/Sub ack id, an AMQP delivery tag).
+The router records `(subID, DeliveryID → ackHandle, refcount)` in the ledger and **does not** ack the broker yet.
+When the client sends `ack {id: DeliveryID}`, the router decrements the handle's refcount; when the policy is satisfied (§7.4) it calls the adapter's `Ack(handle)` and removes the entry.
+If the ack does not arrive within `ack_wait`, or the client disconnects with the entry still open, the router calls `Nak(handle)` (or lets the broker's own redelivery timer fire) so the broker redelivers.
+
+The id and the idempotency key are assigned router-side but only become real **once the engine reports the subscriber was actually written to** (§3.2). A subscriber filtered out by `filterSubscriptions` is never charged a delivery (§3.2 item 3).
+
+This is QoS 1.
+The double-ack / QoS 2 variant (§7.3) adds a second round trip and a dedup window for backends whose ack is not idempotent.
+
+### 3.2 What must change — and where it actually lives
+
+The earlier draft claimed three "surgical" router-side changes and one additive engine method.
+Verification against `v2.4.1` shows that is wrong: the per-subscriber accounting Pattern A needs lives **inside the engine**, which fans out, filters, and discards outcomes.
+The honest decomposition is:
+
+1. **`StreamEvent` gains an optional ack handle (router-side).**
+   The adapter, when it reads a message it *can* later confirm, attaches an opaque handle to the event it pushes through `updater.Update`.
+   Events from non-ackable transports (NATS core, Redis Pub/Sub) attach `nil` — the ledger treats a `nil` handle as "ack immediately, nothing to hold," i.e. today's behavior.
+
+2. **The engine must thread a `DeliveryID` (+ idempotency key) to the writer (engine-side).**
+   In the no-hooks path the router never sees individual subscribers, so the id cannot be attached router-side.
+   It must be threaded `handleTriggerUpdate` → `executeSubscriptionUpdate` → `t.resolvable.Resolve(..., sub.writer)` → `writer.Flush()` so it lands on the wire next to the payload (`resolve.go:616-687`). See §3.6.
+
+3. **The engine must report, per `handleTriggerUpdate` call, the post-filter subscriber set (engine-side).**
+   `handleTriggerUpdate` runs `subs, filterErrors := trig.filterSubscriptions(data)` *before* fan-out (`resolve.go:1093`).
+   Subscriptions can be filtered out (skip filters, `@skip`/`@include`, field-level filtering) so that a given broker message reaches only a subset of the N shared subscribers, and filtered-out subscribers get a `writeError`, not data.
+   The ledger refcount must be seeded from this **post-filter** set, not from "N subscribers on the trigger." A filtered-out subscriber must be excluded (or counted as immediately satisfied), or the refcount never reaches zero and the broker handle stalls forever (§7.4).
+
+4. **The engine must return a per-subscriber delivery result (engine-side — this is the Pattern D contract).**
+   `executeSubscriptionUpdate` currently returns `void` and swallows init/load/resolve/flush failure.
+   For Pattern A to *nak on failure* — its core promise — the engine must hand back, per subscriber per update, a success/failure result so the router can ack vs. nak that subscriber's slice of the broker handle.
+   This is exactly the dossier's Pattern D engine change. It is bidirectional: id flows out, result flows back.
+
+5. **A new inbound control path carries the client ack back to the ledger (router-side).**
+   For WebSocket this is a new `ack` message in `wsproto`; for SSE/multipart it is a side-channel `POST /graphql/stream-ack` (§4.2, §7.1).
+   Both resolve to the same `AckController.Ack(streamKey, deliveryIDs)` call.
+
+Crucially, the adapter no longer acks inline.
+The JetStream reader's `msg.Ack()` at `nats/adapter.go:154` moves *out* of the reader loop and *into* the ledger, fired when the per-subscriber ack policy is satisfied.
+The reader loop instead attaches `msg` as the ack handle.
+
+### 3.3 The components touched
+
+```
+router/pkg/pubsub/datasource/
+  provider.go                      Adapter gains Ack/Nak/Caps; StreamEvent gains AckHandle()
+  subscription_event_updater.go    wires the ledger; forwards per-subscriber delivery results
+  ack_ledger.go                    NEW: per-subscriber in-flight ledger + window + timeout + refcount
+  delivery.go                      NEW: DeliveryClass, capability negotiation result
+
+router/pkg/pubsub/nats/adapter.go     move msg.Ack() into Ack(handle); add Nak; double-ack opt
+router/pkg/pubsub/kafka/adapter.go    ack -> cursor advance (in-order only); degrade to B-variant
+router/pkg/pubsub/redis/adapter.go    Streams path: XACK on Ack; Pub/Sub path: no-op (at-most-once)
+
+router/core/websocket.go         parse inbound `ack`; route to AckController; per-subscription class
+router/internal/wsproto/proto.go new MessageTypeAck; graphql_ws.go encode/decode (modern subprotocol only)
+router/core/flushwriter.go       emit DeliveryID + idempotency key with each SSE/multipart frame
+router/core/graphql_handler.go   mount POST /graphql/stream-ack back-channel for HTTP transports
+
+router/pkg/config/config.go      new events.delivery block + per-provider delivery override
+
+graphql-go-tools (ENGINE, UPSTREAM, BLOCKING):
+  resolve.SubscriptionUpdater + handleTriggerUpdate + executeSubscriptionUpdate:
+    (a) thread DeliveryID + idempotency key to writer.Flush
+    (b) report post-filter subscriber set per update
+    (c) return per-subscriber delivery result (== Pattern D)
+
+composition (optional)           @edfs__delivery directive to declare a per-field desired class
+```
+
+The changes that reach *into the engine* are not one additive method — they are the Pattern D bidirectional delivery-result contract plus id threading plus post-filter reporting (§3.6).
+Everything else lives in the router's pubsub and transport layers, consistent with the Cosmo Streams v1 principle of keeping changes Cosmo-side where possible — but the engine change is the critical path and must land upstream first.
+
+### 3.4 Lifecycle — one event, one ackable backend (QoS 1)
+
+```
+ BROKER          ADAPTER (reader)      LEDGER            ENGINE (fan-out)        WRITER         CLIENT
+   │                   │                 │                    │                    │              │
+   │ deliver msg ─────▶│                 │                    │                    │              │
+   │ (+ack handle H)   │ Update([evt{H}])│                    │                    │              │
+   │                   │────────────────▶│ stash H            │                    │              │
+   │                   │                 │ eventUpdater.Update(data, H)──────────▶ │              │
+   │                   │                 │           filterSubscriptions(data)     │              │
+   │                   │                 │           post-filter subs = {A, B}     │              │
+   │                   │                 │◀── reports {A,B} ──│                    │              │
+   │                   │                 │ refcount[H] = 2    │ per sub:           │              │
+   │                   │                 │ id_A, id_B assigned│  resolve+Flush(id) │──next{id}──▶ │ (A,B receive)
+   │                   │                 │◀── result{A:ok,B:ok}                    │              │
+   │                   │                 │ (failures here ⇒ nak that subscriber's slice)          │
+   │                   │                 │◀──────────────────── ack{id_A} ───────────────────────│ (A)
+   │                   │                 │ refcount[H]-- = 1   │                    │              │
+   │                   │                 │◀──────────────────── ack{id_B} ───────────────────────│ (B)
+   │                   │                 │ refcount[H]-- = 0   │                    │              │
+   │◀── Ack(H) ────────│◀── adapter.Ack ─│ (policy=all satisfied)                  │              │
+   │ (commit/XACK/del) │                 │                    │                    │              │
+   │                   │                 │                    │                    │              │
+   ════ failure paths ════
+   (a) ack_wait elapses for a subscriber's id: that slice is nak'd (or broker AckWait fires).
+       Under ack_policy=all this redelivers H to ALL subscribers (incl. those who already acked) → dup.
+   (b) per-subscriber resolve/flush failure (engine result = fail): that slice is nak'd immediately (§7.7).
+   (c) subscriber disconnects with id in-flight: that slice is nak'd; ledger drained for the subscriber (§7.1/§7.9).
+```
+
+The broker's own redelivery is the durability mechanism; the router only decides *when* to confirm vs. nak.
+On reconnect the client re-subscribes (today: a brand-new subscription id, `websocket.go`), the broker redelivers the un-acked message to whichever router instance now owns the consumer, and delivery completes.
+Note the gap Pattern A does *not* close: redelivery lands "from now-ish" on the broker's schedule, not from a precise client cursor — for an exact gap-fill you compose with Pattern B.
+
+### 3.5 The in-flight window (backpressure & memory)
+
+Each subscriber has a bounded window `max_ack_pending`.
+While the ledger holds `max_ack_pending` un-acked entries for a subscriber, the router stops delivering *new* events to that subscriber.
+Because deliveries flow from a shared broker reader, a stalled subscriber's window backpressures into the reader exactly as today's synchronous flush does — but now bounded and explicit rather than via the accident of a blocked socket write.
+
+Two policy choices, both configurable:
+
+- `max_ack_pending = 1` → strict in-order, at-least-once, lowest throughput. The "cursor = ack" mapping (needed for Kafka, §6) requires this.
+- `max_ack_pending = N` → pipelined; out-of-order acks are fine for per-message-ack backends, but break the cursor mapping (so Kafka is forced to `1`).
+
+When the window is full and the broker keeps delivering, the router must *not* drop:
+on JetStream the held `msg` simply isn't acked (broker stops sending past `MaxAckPending` natively);
+on SQS/Pub/Sub the router stops calling receive;
+on Redis Streams the router stops `XREADGROUP`.
+The shared-trigger interaction (one slow subscriber vs. the rest) is handled in §7.4.
+
+### 3.6 The engine contract: id threading + post-filter reporting + per-subscriber result
+
+This is the critical-path, upstream-gated change. Stated against the *real* `v2.4.1` interface (`resolve.go:1586`):
+
+```go
+// graphql-go-tools/v2/pkg/engine/resolve — CURRENT interface (v2.4.1), for reference
+type SubscriptionUpdater interface {
+    Update(data []byte)
+    UpdateSubscription(id SubscriptionIdentifier, data []byte)
+    Complete()
+    Error(data []byte)               // terminal error, bypasses resolve pipeline
+    Done()
+    CloseSubscription(id SubscriptionIdentifier)
+    Subscriptions() map[context.Context]SubscriptionIdentifier
+}
+// (the subscription writer also exposes Heartbeat(); executeSubscriptionUpdate returns void.)
+```
+
+Pattern A needs three additive-but-bidirectional changes to this engine layer. We deliberately keep the existing methods byte-for-byte so non-ack-tracked subscriptions are unaffected:
+
+```go
+// graphql-go-tools/v2/pkg/engine/resolve — PROPOSED additions (engine-side)
+
+// Delivery carries the router-assigned id + idempotency key for one update.
+// Zero value (empty ID) => not ack-tracked => current behavior, nothing written to the wire.
+type Delivery struct {
+    ID          string // subscription-scoped monotonic delivery id
+    IdemKey     string // stable dedup key (Nats-Msg-Id / Kafka key / SQS dedup id / content hash)
+    Phase       string // "" | "committed" (QoS 2)
+}
+
+// DeliveryResult is returned per subscriber per update so the router can ack/nak that slice.
+type DeliveryResult struct {
+    Sub       SubscriptionIdentifier
+    Delivered bool   // true iff Resolve+Flush succeeded for this subscriber
+    Filtered  bool   // true iff filterSubscriptions excluded this subscriber (no delivery charged)
+    Err       error  // non-nil on init/load/resolve/flush failure
+}
+
+type SubscriptionUpdater interface {
+    Update(data []byte)
+    UpdateSubscription(id SubscriptionIdentifier, data []byte)
+    Complete()
+    Error(data []byte)
+    Done()
+    CloseSubscription(id SubscriptionIdentifier)
+    Subscriptions() map[context.Context]SubscriptionIdentifier
+
+    // UpdateWithDelivery is the ack-tracked path. It:
+    //   - threads d.ID/d.IdemKey through handleTriggerUpdate -> executeSubscriptionUpdate
+    //     -> Resolve -> writer.Flush so they land on the wire next to the payload, and
+    //   - returns one DeliveryResult per POST-FILTER subscriber (Filtered subs reported too,
+    //     so the router can seed the refcount correctly).
+    // executeSubscriptionUpdate must stop swallowing outcomes: each init/load/resolve/flush
+    // return path populates a DeliveryResult instead of returning void.
+    UpdateWithDelivery(data []byte, d Delivery) []DeliveryResult
+}
+```
+
+On WebSocket the id + idempotency key ride in the `next` message's `extensions` (which already exist on `graphQLWSMessage`, `graphql_ws.go:28-33`) under a `delivery` key, leaving the GraphQL `payload` untouched.
+On SSE the id becomes the native `id:` line and the idempotency key rides in a `: idem=<key>` comment / `extensions`.
+On multipart it rides in `extensions.delivery` of the part body.
+
+**Why this is not "one additive method":** `UpdateWithDelivery` is the surface, but its contract forces `handleTriggerUpdate` to (a) propagate the post-filter `subs` set and `filterErrors` outward, and `executeSubscriptionUpdate` to (b) carry `d` to the writer and (c) populate a result on every `return`. That is a structural change to the engine's resolve pipeline, not a thin wrapper. It is the same work the dossier scoped as Pattern D, and Pattern A is blocked on it.
+
+### 3.7 Capability negotiation: per-connection capability, per-subscription class
+
+Ack tracking is meaningless if the client never acks — un-acked entries would pile up to `max_ack_pending` and then stall every subscriber.
+So the router must know, per client, whether the client *will* ack, **before** it starts holding broker handles.
+But a single graphql-ws connection multiplexes arbitrarily many subscriptions of different classes (`websocket.go` multiplexes by operation id), so the negotiated artifact must be split in two:
+
+- **Client ack *capability* is per-connection.** Negotiated once in the `connection_init` payload for WebSocket and via a request header / query param for HTTP transports (§5). The client advertises `supports:["ack","double-ack"]` once. The connection-level result is simply *"this connection can / cannot ack."*
+- **Effective *class* is per-subscription.** It is computed at `Subscribe` time (in `SubscriptionOnStart`) as `class = resolve(capability ∧ field directive ∧ backend caps ∧ config default)`. A connection can host one `at-most-once` field and one `AT_LEAST_ONCE, REJECT` field simultaneously; each subscription gets its own class, and `@edfs__delivery(... REJECT)` fires per field in `SubscriptionOnStart`.
+
+```
+client connection_init { payload: { "cosmo": { "delivery": { "supports": ["ack","double-ack"] } } } }
+        │   (per-connection capability only)
+        ▼
+connection_ack { payload: { "cosmo": { "delivery": { "canAck": true, "ackWaitMs": 30000 } } } }
+        │
+        ▼   (per subscription, in SubscriptionOnStart)
+effective class = min(field-directive-desired, config-default, backend-achievable) constrained by canAck
+        │
+        ▼
+the class is reported back per subscription (and in the `next` extensions on first delivery)
+```
+
+If the connection advertises nothing, every subscription on it resolves to `at-most-once` and the router behaves exactly as today (eager ack, `nil` ledger) — zero overhead, full backward compatibility.
+
+---
+
+## 4. Wire protocol & client changes
+
+### 4.1 graphql-transport-ws (modern graphql-ws) — `Next` carries id + idempotency key, client sends `Ack`
+
+The server already sends data via the `next` message (`graphql_ws.go:117-124`).
+We add the delivery id **and the idempotency key** to its `extensions` and introduce a new **inbound** `ack` message.
+The idempotency key is on the wire *now* (not deferred), because the client's only correct dedup key across reconnect is the idempotency key, not the `DeliveryID` (see §11.2 note and the reconnect hazard below).
+
+Server → client (unchanged shape, new extension):
+
+```json
+{
+  "id": "<operationId>",
+  "type": "next",
+  "payload": { "data": { "employeeUpdates": { "id": 1 } } },
+  "extensions": { "delivery": { "id": "42", "idemKey": "Nats-Msg-Id:8f3c…", "class": "at-least-once" } }
+}
+```
+
+Client → server (new message type):
+
+```json
+{ "id": "<operationId>", "type": "ack", "payload": { "delivery": ["42"] } }
+```
+
+`payload.delivery` is an array so a client may batch-ack (cumulative or selective) several ids in one frame — important for throughput at `max_ack_pending > 1`.
+For QoS 2 the round trip is `next{id}` → client `ack{id}` → server `next` with `extensions.delivery.phase: "committed"` → client may now release dedup state.
+
+**Reconnect dedup hazard (why `idemKey` is mandatory on the wire).**
+A reconnecting client gets a brand-new subscription id (`resolve.NewConnectionID()`, `websocket.go`), so `DeliveryID` 42 on the old subscription and 42 on the new subscription are unrelated.
+A redelivered message after reconnect is the *same logical event* but arrives with a *different* `DeliveryID`.
+The client's dedup key must therefore be `idemKey`, which is stable across reconnect; `DeliveryID` is only the ack handle for the *current* subscription. Shipping `idemKey` in the first `next` extension is what makes the at-least-once guarantee actionable by clients.
+
+This requires extending `wsproto`:
+
+```go
+// wsproto/proto.go — add to the inbound enum
+const (
+    MessageTypePing MessageType = iota + 1
+    MessageTypePong
+    MessageTypeSubscribe
+    MessageTypeComplete
+    MessageTypeTerminate
+    MessageTypeAck // NEW
+)
+```
+
+and decoding the `ack` type in `graphql_ws.go` `ReadMessage`.
+**Only `graphql-transport-ws` gets ack in v1** (§4.4 justifies excluding the legacy and absinthe subprotocols).
+
+### 4.2 graphql-sse — native `id:` + a back-channel POST (with a fully specified stickiness contract)
+
+SSE is one-directional, so the ack cannot return on the same stream.
+The router emits the delivery id as the **native SSE `id:` field** (today `flushwriter.go` only writes `event:`/`data:`) and the idempotency key as a comment line:
+
+```
+event: next
+id: 42
+: idem=Nats-Msg-Id:8f3c…
+data: {"data":{"employeeUpdates":{"id":1}}}
+
+```
+
+and the client acks out-of-band via a sibling endpoint:
+
+```
+POST /graphql/stream-ack
+Content-Type: application/json
+Cookie: cosmo_stream_affinity=<lb-stickiness-cookie>      # see stickiness contract below
+X-Cosmo-Stream-Key: <streamKey>
+{ "stream": "<streamKey>", "delivery": ["42"] }
+```
+
+`<streamKey>` is an opaque, signed token the router minted at subscription start and sent as the first SSE comment frame (`: stream=<streamKey>\n\n`).
+It is the join key from the stateless POST back to the in-memory ledger entry on the router instance that owns the stream.
+
+**The stickiness contract (previously hand-waved — now explicit).**
+SSE ack is structurally harder than WebSocket ack, because the ack POST is a *different request* than the SSE GET. We specify the contract rather than assert it solvable:
+
+- The router encodes its instance identity inside the signed `streamKey` *and* sets a load-balancer affinity cookie (`cosmo_stream_affinity`) on the SSE GET response.
+- The client **must** replay that affinity cookie (and the `X-Cosmo-Stream-Key` header) on every `POST /graphql/stream-ack`. This is a hard requirement of SSE ack participation; a client that cannot replay the cookie cannot do SSE ack and is downgraded.
+- Most managed LBs (ALB, GCLB) do cookie-based stickiness for HTTP requests; the affinity cookie is what carries instance affinity from the GET to the POST. If the LB ignores the cookie, the router falls back to routing the POST by the instance id embedded in the signed `streamKey` (requires the router fleet to expose a peer-routing path, or a shared ack bus — called out as a risk in §11.1).
+- **Orphaned handles after reconnect (structural double-delivery window).** When a client reconnects, it gets a *new* SSE stream on a *possibly different* instance with a *new* `streamKey`. The old instance still holds the old stream's un-acked handles until `ack_wait` elapses, then nak's them → the broker redelivers them on the new stream → duplicate. This duplicate-on-reconnect window is **structural for SSE**, not an edge case; it is bounded by `ack_wait` and deduplicated by the client via `idemKey`. We document it rather than pretend it away.
+
+The `multipart/mixed` transport uses the same back-channel, carrying the id in each part's `extensions.delivery.id`.
+
+Because of this added complexity and the dossier's own assessment that SSE's strength is Pattern B's `Last-Event-ID` auto-resume, **SSE/multipart ack is opt-in and explicitly second-class** in Pattern A. §5 marks the recommended default for SSE-heavy deployments as Pattern B. See §11.1.
+
+### 4.3 Fallback when a client/transport cannot participate
+
+This is the non-negotiable part of the design: **fallback is explicit and observable, never silent.**
+
+- **Stock graphql-ws client** (Apollo/urql/Relay, no ack support): advertises nothing in `connection_init` → every subscription resolves to `at-most-once` → router acks eagerly (today's behavior). `connection_ack` reports `canAck:false`, and the router emits a metric `cosmo_delivery_class{class="at-most-once",reason="client_no_ack"}`.
+- **`@edfs__delivery(class: AT_LEAST_ONCE, onUnsupported: REJECT)` field + non-acking client**: `SubscriptionOnStart` rejects *that subscription* (not the connection) with a typed GraphQL error `DELIVERY_CLASS_UNSUPPORTED`, so the application fails loud rather than quietly degrading a field its author marked as critical. Whether a class mismatch is a hard reject or a soft downgrade is configurable per field (`onUnsupported: REJECT | DOWNGRADE`) and per provider.
+- **SSE without the back-channel reachable** (a proxy strips the ack POST, or the client never replays the affinity cookie): the router's `ack_wait` elapses, entries are nak'd, the broker redelivers — but if the *client never acks at all*, every redelivery re-nak's and the window stalls. The router detects "subscriber never acked any of its first `silent_downgrade_after` deliveries" and downgrades that subscriber to `at-most-once` with a warning, rather than wedging the trigger.
+
+The justification for *not* skipping protocol changes: there is no way to get true broker→client-receipt at-least-once without a client→server signal. Patterns that avoid the protocol change (B's cursor resume, F's backfill) buy a weaker guarantee. Pattern A's entire value proposition *is* the round trip, so the protocol extension is intrinsic, not incidental.
+
+### 4.4 Subprotocol scope: only `graphql-transport-ws` in v1
+
+Cosmo negotiates three WS subprotocols (`wsproto/proto.go:102-112`): modern `graphql-transport-ws`, legacy `graphql-ws` (subscriptions-transport-ws / Apollo), and `absinthe` (Phoenix).
+**Only `graphql-transport-ws` gets ack support in v1.**
+The dossier (§4.1) marks subscriptions-transport-ws as deprecated/unmaintained; investing new ack support in a deprecated subprotocol is poor ROI.
+Legacy `graphql-ws` and `absinthe` connections report `canAck:false` in their connection handshake and every subscription on them is `at-most-once` — reported honestly, never silently. This is a deliberate scope cut, documented as such (§11.4 cut-line).
+
+---
+
+## 5. Per-backend adaptability & degradation matrix
+
+The mechanism's natural shape is "hold a per-message ack handle, confirm on a per-subscriber client ack."
+Backends split into three families: those with a real per-message ack/redelivery primitive (native fit), those with only a cursor/offset (degrade to an in-order B-variant), and those with no ack at all (fall back to at-most-once).
+
+| Backend | Supported? | How the client-ack maps onto the backend | Guarantee achieved | Degradation / fallback | New-dep / test-infra cost |
+|---|---|---|---|---|---|
+| **NATS core** | ❌ No | No ack primitive; `ChanSubscribe` (`nats/adapter.go:168-199`). Handle is `nil`. | **At-most-once** (drops on slow consumer today) | Hard fallback, reason `backend_no_ack`. Recommend JetStream. | None (existing adapter) |
+| **NATS JetStream** | ✅ Native | Hold `jetstream.Msg`; per-subscriber ack policy satisfied → `msg.Ack()` (moved out of `adapter.go:154`); timeout/disconnect → `msg.Nak()`. Double-ack via `msg.DoubleAck()`. `MaxAckPending` from window. | **At-least-once**; **effectively exactly-once** with double-ack + 2-min `Nats-Msg-Id` dedup | Full support. Must set `AckExplicit`, finite `AckWait`, `MaxDeliver`, not surfaced today. Cross-instance failover blocked by per-instance durable naming (§7.1). | None (existing adapter); config surface for AckPolicy/AckWait/MaxDeliver |
+| **Kafka** | ⚠️ Degraded → B-variant | No per-message ack. Client-ack → **cursor advance**: commit = highest *contiguously acked across all shared subscribers*. Forces `max_ack_pending=1`. Requires a committed consumer group (today groupless). | **At-least-once, in-order only** (Pattern-B-like) | Out-of-order acks can't advance one offset → window pinned to 1. No per-message redelivery. Cross-subscriber replay amplification + restart-backlog semantic change (§7.4, §9). | Existing adapter; new consumer-group config + rebalance handling + migration note |
+| **Redis Pub/Sub** | ❌ No | No ack primitive (`PSubscribe`/`PUBLISH`). Handle is `nil`. | **At-most-once** | Hard fallback, reason `backend_no_ack`. Recommend Redis Streams. | None (existing adapter) |
+| **Redis Streams** | ✅ Native (new adapter) | `XREADGROUP` into PEL; hold entry id; ack → `XACK`; timeout → leave in PEL / `XCLAIM` on reconnect. | **At-least-once** (PEL prevents loss; dupes possible) | No native dedup → client must dedup on `idemKey`. | **New adapter** + go-redis Streams API + new integration test infra |
+| **AWS SQS** | ✅ Native (new adapter) | Receive w/ visibility timeout; hold receipt handle; ack → `DeleteMessage`; timeout → visibility expiry or `ChangeMessageVisibility(0)` for fast nak. | Standard: **at-least-once**. FIFO: **exactly-once processing** per group | `ack_wait` ≤ visibility timeout (receipt handle is ephemeral). No replay/cursor. | **New adapter** + AWS SDK dep + IAM/credential config surface + visibility lifecycle mgmt + new test infra |
+| **Google Pub/Sub** | ✅ Native (new adapter) | Hold ack id; `modifyAckDeadline` to extend; ack → `Ack()`; timeout → `Nack()`. | **At-least-once**; **exactly-once** on EOS subscription | Ack id valid only within the (extendable) deadline. | **New adapter** + GCP SDK dep + service-account config surface + deadline lifecycle mgmt + new test infra |
+| **AWS Kinesis** | ⚠️ Degraded → B-variant | No per-message ack; checkpoint a sequence number. Ack → checkpoint advance, `max_ack_pending=1`, in-order. | **At-least-once, in-order only** per shard | Same as Kafka: cursor-advance, not per-message redelivery. Shard iterator expiry (5 min) is a liveness constraint. | **New adapter** + AWS/KCL dep + DynamoDB checkpoint store + new test infra |
+| **Azure Event Hubs** | ⚠️ Degraded → B-variant | No broker ack; checkpoint offset per partition. Ack → checkpoint advance, in-order. | **At-least-once, in-order only** per partition | Same family as Kafka/Kinesis. Blob checkpoint store needed for cross-restart. | **New adapter** + Azure SDK dep + blob checkpoint store + new test infra |
+| **RabbitMQ / AMQP** | ✅ Native (new adapter) | Consume w/ manual ack; hold delivery tag; ack → `basic.ack`; timeout/disconnect → `basic.nack(requeue=true)`. | **At-least-once** (manual ack) | Requeue reinserts near the head → ordering broken on redelivery. No replay/cursor, no native dedup. | **New adapter** + AMQP client dep + channel/connection lifecycle + new test infra |
+
+Two structural notes the matrix encodes:
+
+- **Per-message-ack backends are the home turf.** JetStream, SQS, Pub/Sub, Redis Streams, RabbitMQ all give per-message redelivery, which is exactly what per-subscriber client-ack-gated confirmation wants. Most of these (SQS, Pub/Sub, Streams, Rabbit) need *new* adapters — EDFS supports none of them today (dossier §3.1), and each new adapter is **not just "an `Ack`/`Nak` pair"** but a new broker-client dependency, a new credential/config surface, visibility/deadline lifecycle management, and new integration test infrastructure (the rightmost column). Pattern A's reach is bounded as much by adapter engineering as by protocol work.
+- **Log/offset backends become a B-variant under A.** Kafka/Kinesis/Event Hubs have no per-message ack; mapping client-ack onto cursor advance only works in strict order and cannot redeliver a single message without rewinding everything after it. On these, "Pattern A" collapses into "Pattern B with an ack-driven commit," and we say so in the negotiated class (`at-least-once-inorder`).
+
+The product rule: **a user may select any backend.** The router computes the achievable class at startup (and per subscription) and reports it. Selecting Redis Pub/Sub for an `AT_LEAST_ONCE` field is allowed but produces a startup warning and a per-subscription `at-most-once` class — the degradation is loud.
+
+**Recommended-transport note.** For SSE-dominant deployments, the dossier and §11.1 both conclude Pattern B (cursor / `Last-Event-ID`) is the better fit. The matrix above describes what Pattern A *can* do on each backend; it does not claim SSE ack is the right default. v1 ships WebSocket + JetStream as the supported path; SSE ack is opt-in and second-class (§4.2, §11.4).
+
+---
+
+## 6. Delivery semantics achieved
+
+**Per-message-ack backends (JetStream, SQS, Pub/Sub, Redis Streams, RabbitMQ).**
+
+- **At-least-once, broker → client receipt, per subscriber.** A broker message is confirmed only after the ack policy over its post-filter subscriber set is satisfied (§7.4), so every confirmed slice was provably received by that client application. Any subscriber un-acked at disconnect/timeout/router-crash triggers redelivery — to *all* shared subscribers under `ack_policy: all`, because a single broker handle cannot be selectively redelivered (§7.4). Duplicates for already-acked co-subscribers are expected.
+- **Duplicates are possible and expected. The client must be idempotent.** The stable idempotency key is on the wire next to the delivery id (`idemKey`, §4.1) — `Nats-Msg-Id`, SQS `MessageDeduplicationId`, Kafka record key, or a content hash. This is the client's dedup key across reconnect (where `DeliveryID` resets).
+- **Effectively exactly-once** with the double-ack variant (§7.3) on JetStream (`DoubleAck` + 2-min dedup window) and Pub/Sub EOS, or SQS FIFO (5-min dedup). "Effectively" because the dedup window is finite; outside it, a very late redelivery can still duplicate.
+
+**Offset/cursor backends (Kafka, Kinesis, Event Hubs).**
+
+- **At-least-once, in-order only.** The committed cursor advances to the highest contiguously-acked delivery *across all shared subscribers*, so a gap cannot advance past it. `max_ack_pending` is pinned to 1.
+- **No single-message redelivery; cross-subscriber replay amplification.** A nak rewinds the cursor and replays *everything* from that offset — and because the committed offset is the minimum across all shared subscribers, one slow client pins the offset for *every* co-subscriber on that partition, and on restart *all* of them replay from that pinned offset. The guarantee is real but coarser, and the blast radius is the whole fan-out (§7.4).
+
+**No-ack backends (NATS core, Redis Pub/Sub).**
+
+- **At-most-once, unchanged.** Reported honestly at negotiation.
+
+**Ordering implications.**
+At `max_ack_pending=1`, order is preserved.
+At `max_ack_pending>1` on per-message-ack backends, the router *delivers* in broker order but a redelivered message arrives *after* later messages → out-of-order on the wire.
+RabbitMQ requeue and any nak-then-redeliver reorder by construction.
+We promise per-stream/partition order *modulo redelivery*, and expose `ordering: strict | best-effort`.
+
+**The exact failure windows that remain.**
+
+1. **Lost client ack, then router crash.** Client acked, the frame was in flight, router crashed before `adapter.Ack(H)` → broker redelivers → duplicate. (At-least-once with idempotent client.)
+2. **Router crash holding un-acked-to-client handles.** In-memory ledger lost. On per-message-ack backends the broker's own `AckWait`/visibility timer redelivers → recovered. On Kafka-by-offset, the uncommitted offset means a new consumer resumes from the last commit → recovered, with replay of everything after it.
+3. **`ack_wait` shorter than client processing.** A slow-but-alive client gets its message redelivered → duplicate. Tunable; double-ack and `modifyAckDeadline` (Pub/Sub) mitigate.
+4. **Resolve timeout.** `executeSubscriptionUpdate` wraps resolve in `context.WithTimeout(ctx, maxSubscriptionFetchTimeout)` (30s, `resolve.go:621`). Under the new contract a resolve timeout produces a `DeliveryResult{Delivered:false}` → that subscriber's slice is nak'd *immediately* and counts toward `silent_downgrade_after` (§7.5). Without this rule it would be an infinite redelivery loop on a slow-to-resolve field (see §11.2).
+5. **Client never acks (buggy/old client through a capable transport).** Window fills, subscriber is downgraded to at-most-once after `silent_downgrade_after` un-acked deliveries (§4.3) — bounded, not a permanent wedge.
+6. **`ack_policy: all` on a shared trigger** — one slow subscriber backpressures the shared reader and, on any nak, forces redelivery to all co-subscribers (§7.4). The central tension Pattern A inherits from the shared-trigger model.
+
+---
+
+## 7. Cross-cutting concerns
+
+### 7.1 Router HA / horizontal scaling & sticky sessions
+
+The ledger is **per-process, in-memory** — un-acked handles live on the instance that read them.
+This creates two HA realities:
+
+- **Inbound ack must reach the holding instance.** For WebSocket the ack returns on the same socket → automatically on the right instance (sticky by connection). For SSE/multipart the `POST /graphql/stream-ack` must be routed to the same instance via the affinity contract in §4.2 (LB cookie, or peer-routing by the instance id in the signed `streamKey`). This makes SSE ack the harder HA case and is a reason SSE ack is second-class.
+- **Failover relies on broker redelivery, not handoff.** If instance A dies, its un-acked handles vanish. We do *not* hand them to instance B. The client reconnects (to B), and the broker — JetStream durable consumer, SQS visibility expiry, Rabbit channel-close requeue, Pub/Sub deadline — redelivers to whichever instance now consumes. This works **only** because we kept the broker as the durability source.
+
+The JetStream per-instance durable naming (`getDurableConsumerName` = hash of `hostname-listenAddr` + subjects, `nats/adapter.go:61-83`) is in direct tension here: a failover instance gets a *different* consumer and will *not* inherit A's un-acked messages.
+For Pattern A to survive instance failover on JetStream, the durable name must key on the *subscription identity* (stable across instances) with a queue/`WorkQueuePolicy` so two instances don't double-consume — which is Pattern C substrate.
+**v1 scope:** within a single instance and across client reconnects to the *same* instance, full at-least-once; across *instance* failover, at-least-once only on backends whose redelivery is instance-independent (SQS, Pub/Sub, Rabbit, Kafka-by-group) and explicitly *not* on the current JetStream per-instance-durable naming until that naming is fixed.
+
+### 7.2 Per-subscription state / memory cost
+
+Ledger memory is `O(in-flight per subscriber)` = `O(max_ack_pending × active subscribers)`.
+Each entry holds a small struct: `DeliveryID`, the broker ack handle (a pointer/handle, not the payload), the subscriber id, the idempotency key, and a deadline timestamp.
+With `max_ack_pending=10` and 100k subscribers that's ~1M small entries — bounded and tunable; the window is a first-class capacity-planning knob.
+Critically, the *payload* is not retained (unlike Pattern E's buffer); we hold only what we need to confirm or nak.
+
+### 7.3 Exactly-once via double-ack + dedup (QoS 2)
+
+When `class: EXACTLY_ONCE` is requested and the backend supports it:
+
+- **JetStream:** the ledger calls `msg.DoubleAck(ctx)` instead of `msg.Ack()`, which waits for server-persisted ack, and relies on the 2-min `Nats-Msg-Id` duplicate window for ingest-side dedup. The client runs a dedup set keyed by `idemKey`.
+- **Pub/Sub EOS / SQS FIFO:** native dedup windows do the deduplication; the client still keeps a short dedup window for the receipt→ack gap.
+- **Everywhere else:** `EXACTLY_ONCE` is *not achievable* and the negotiator downgrades to `at-least-once` (loudly). We never claim exactly-once we cannot deliver.
+
+The wire flow for QoS 2 is `next{id}` → client `ack{id}` → router persists the broker ack (double-ack) → router sends `next` with `extensions.delivery.phase:"committed"` → client drops `idemKey` from its dedup set.
+
+### 7.4 Multi-tenant shared-trigger fan-out — the central impossibility, stated honestly
+
+This is Pattern A's hardest interaction, and the place an earlier draft papered over a fundamental tension with a refcount.
+
+One broker subscription fans to N clients. The engine filters that set per message (`filterSubscriptions`, §3.2 item 3), so a given broker message reaches a **post-filter subset** of the N. The ledger seeds a refcount from that post-filter subset (reported by the engine — §3.6), excluding filtered-out and error-written subscribers:
+
+```go
+ledger[brokerHandle] = ledgerEntry{
+    remaining: len(postFilterDeliveredSubs), // NOT N; filtered/errored subs excluded
+    perSub:    map[SubscriptionIdentifier]DeliveryID{...},
+    policy:    AckPolicyAll,
+}
+```
+
+The broker `Ack(H)` fires when the policy over that subset is satisfied (`all`: every delivered subscriber acked; `quorum(k)`/`any`: k / the first).
+
+**Three problems the refcount alone does not solve — and the honest answers:**
+
+1. **Membership churns between delivery and ack.** A subscriber can join (new `Subscribe`) or leave (disconnect) at any instant; the engine mutates the trigger set concurrently (`sub.removed.Load()` checks throughout `handleTriggerUpdate`/`executeSubscriptionUpdate`). The refcount is *snapshotted from the post-filter set at delivery time* and never grows after — a subscriber that joins later was never charged this handle. A subscriber that disconnects with the id in-flight has its slice nak'd and the entry drained (§7.9). Late joiners simply do not participate in already-delivered handles; this is correct, not a bug, because they never received that message.
+
+2. **The "A acked, B nak'd, same single broker handle" impossibility.** On a per-message-ack backend (JetStream, SQS, Pub/Sub, Rabbit), you get **exactly one** `msg.Ack()` *or* one `msg.Nak()` for that `jetstream.Msg` / receipt handle. You **cannot** satisfy A (ack) and redeliver to B (nak) from the same handle. There is no way around this under a shared trigger without per-subscriber consumers (Pattern C). We confront it rather than hide it:
+   - **`ack_policy: all` means "redeliver to ALL on any nak, accept duplicates for the subscribers who already acked."** If B fails/times out, the router `Nak(H)` → the broker redelivers the message to *every* shared subscriber, including A who already received and acked it. A must dedup on `idemKey`. This is the documented cost of preserving the shared-trigger optimization.
+   - **Per-subscriber redelivery is impossible under shared triggers** without breaking the dedup optimization (one consumer per subscriber = Pattern C). The RFC does not pretend otherwise. If an application needs per-subscriber redelivery without duplicates to co-subscribers, it must accept Pattern C's per-consumer fan-out cost.
+   - `ack_policy: quorum(k)`/`any` bound the coupling: a stuck subscriber is nak'd/downgraded after `ack_wait` so it cannot pin the trigger indefinitely, at the cost of acking the handle before every subscriber confirmed (weaker guarantee for the slow subscriber, which is then downgraded).
+
+3. **Offset backends amplify this across the whole fan-out.** On Kafka, "ack once for N" + "cursor advance" means the committed offset is the *minimum contiguously-acked offset across all shared subscribers* → one slow client head-of-line-blocks the committed offset for every co-subscriber, and on restart *all* of them replay from that pinned offset (the cross-subscriber replay amplification, §6). We surface this as a hard constraint of choosing Kafka with shared at-least-once.
+
+The policy is configurable because the right answer is workload-dependent:
+
+- `ack_policy: all` → strongest guarantee, worst backpressure coupling, duplicates-to-already-acked on any nak.
+- `ack_policy: quorum(k)` / `any` → bounded coupling; a stuck subscriber is nak'd/downgraded.
+
+### 7.5 Backpressure
+
+The window is the backpressure mechanism (§3.5).
+A full window stops new deliveries to that subscriber; on `ack_policy: all` it stops broker reads for the whole trigger.
+This replaces today's *silent* slow-consumer drops (NATS core/Redis Pub/Sub) and *accidental* socket-blocking backpressure with an *explicit, bounded* mechanism.
+The existing per-update resolve timeout (`MaxSubscriptionFetchTimeout`, 30s, `config.go:454`; `resolve.go:621`) remains a liveness guard, but under Pattern A a resolve-timeout is no longer silent: it yields `DeliveryResult{Delivered:false}` → immediate nak for that subscriber + counts toward `silent_downgrade_after` (§6 window 4). `ack_wait` must be configured larger than the realistic resolve-and-process time to avoid spurious redelivery loops; the router warns at startup if `ack_wait <= max_subscription_fetch_timeout`.
+
+### 7.6 Security / authz
+
+- **Delivery ids and stream keys must be opaque + signed + tenant-scoped.** The SSE `streamKey` is a capability: anyone who can POST it can ack (or probe) another tenant's stream. It must be an HMAC/JWT bound to `(tenant, connection, subscription, instance)` and validated on the `POST /graphql/stream-ack` path. Delivery ids are per-subscription monotonic integers and carry no cross-tenant meaning, but the *stream key* that scopes them does.
+- **Redelivery re-runs authz.** A nak'd message redelivered after a token expiry or revoked scope must pass *current* authz (`SubscriptionOnStart`, `OnStreamEvents`), not the authz at original delivery. Pattern A's window is short (in-flight only), so this is far less exposed than Pattern B's long-window replay — but the rule holds.
+- **Forged-ack DoS (data loss).** A client (or attacker with a valid stream key) that forges an *ack* for a `deliveryID` it never received causes premature broker confirmation → data loss for the real recipient. Signing + binding the stream key to the connection mitigates; the back-channel must reject unknown/expired keys and never leak whether a `deliveryID` exists (anti-enumeration).
+- **Forged-nak / ack-withholding DoS (redelivery amplification).** The dual attack: a client that *withholds* acks or floods naks forces unbounded redelivery and, under `ack_policy: all`, pins a shared trigger's window — a DoS amplification specific to shared triggers. **Mitigations:** per-subscriber nak/redelivery rate limiting; the `silent_downgrade_after` cap (a withholding subscriber is downgraded to at-most-once and stops pinning the trigger); and a bounded `MaxDeliver` on the broker so a single message cannot be redelivered forever. The back-channel POST is rate-limited per stream key.
+
+### 7.7 Interaction with existing Cosmo Streams hooks — drop semantics reconciled with the refcount
+
+- `SubscriptionOnStart`: gains read access to the negotiated per-subscription `DeliveryClass`; may reject on class mismatch (§4.3).
+- `OnStreamEvents` (`StreamBatchEventHook`): runs **per subscriber** in the hooks path (`subscription_event_updater.go:104-129`). This is the subtle case: subscriber A's hook may *drop* the event while subscriber B's keeps it, for the *same single broker handle*.
+  - **Drop ≠ delivery failure, but a per-subscriber drop must NOT `Ack(handle)` outright.** Acking the handle for A's drop would ack-away B's still-in-flight delivery, re-introducing exactly the §1 "one ack covers N" bug.
+  - **Correct reconciliation:** a per-subscriber drop *decrements `remaining`* for that subscriber (it is treated as satisfied for that subscriber — the drop was intentional, not a loss), exactly like a successful ack from that subscriber. The broker `Ack(H)` fires only when `remaining == 0` over the whole post-filter subset (all dropped or all acked). A per-subscriber delivery *failure* (engine `DeliveryResult{Delivered:false}`) instead nak's that subscriber's slice (§7.4).
+  - The ledger API reflects this: the drop signal carries **both** the handle and the subscriber id (`AckDropped(subID, handle)`), never the handle alone (§10).
+  - This fixes the v1 abandon-on-timeout hazard (`subscription_event_updater.go:69-79`): under Pattern A a hook-abandoned (timed-out) delivery is a *failure* for that subscriber → nak, not a silent ack.
+- `OnPublishEvents`: unaffected (publish leg out of scope).
+
+### 7.8 Negotiation payload compatibility
+
+The `connection_ack` payload carries `payload.cosmo.delivery`. graphql-ws clients treat the `connection_ack` payload as opaque and ignore unknown keys, so the additive `cosmo` namespace is safe; some Apollo middleware echoes/validates the payload, but echoing an additive namespace is harmless. We confirm against the graphql-ws client's `connection_ack` handling (it ignores the payload today) and document the `cosmo` namespace as additive and ignorable. Low risk, stated explicitly.
+
+### 7.9 Ledger ↔ subscription-removal ordering (TOCTOU)
+
+There is a TOCTOU window between the engine reporting a post-filter subscriber and that subscriber being removed: the engine independently removes subscriptions (`sub.removed.Load()` checks; `UnsubscribeSubscription` on flush failure, `resolve.go:678`). If the ledger registers `(subID → deliveryID)` for a subscriber the engine removes before the result lands, the entry would never be acked (no client) nor nak'd-by-disconnect (the disconnect path may have already run).
+**Ordering contract:** ledger registration for a subscriber is driven by the engine's `DeliveryResult` for that subscriber, *not* by an independent enumeration of `Subscriptions()`. Because the result is produced inside `executeSubscriptionUpdate` under the same `sub.writeMu` that the removal path takes (`resolve.go:656-687`), registration and removal are serialized: a `DeliveryResult{Delivered:false, Err: removed}` for a subscriber removed mid-flight cleanly nak's that slice and never creates a dangling entry. The removal path must drain any already-registered ledger entries for the subscriber. This cross-layer locking is non-trivial and is called out as a risk in §11.1.
+
+---
+
+## 8. Configuration surface
+
+### 8.1 Router YAML — new `delivery` block
+
+```yaml
+version: "1"
+
+events:
+  # NEW: global delivery defaults; per-provider override below
+  delivery:
+    default_class: at-most-once       # at-most-once | at-least-once | at-least-once-inorder | exactly-once
+    on_unsupported: downgrade          # downgrade | reject
+    ack_wait: 30s                      # time to wait for client ack before nak/redelivery
+    max_ack_pending: 10                # per-subscriber in-flight window (1 = strict in-order)
+    ack_policy: all                    # all | quorum | any  (shared-trigger fan-out, §7.4)
+    ack_quorum: 1                      # used when ack_policy = quorum
+    ordering: best-effort              # strict | best-effort
+    silent_downgrade_after: 5          # consecutive un-acked deliveries before downgrading a silent subscriber
+    max_redeliver: 8                   # broker MaxDeliver cap (anti-redelivery-DoS, §7.6)
+
+  providers:
+    nats:
+      - id: my-jetstream
+        url: "nats://localhost:4222"
+        delivery:                      # per-provider override
+          default_class: at-least-once
+          double_ack: true             # use msg.DoubleAck for exactly-once requests
+    kafka:
+      - id: my-kafka
+        brokers: ["localhost:9092"]
+        delivery:
+          default_class: at-least-once-inorder
+          max_ack_pending: 1           # forced anyway on offset backends
+          consumer_group: cosmo-edfs   # NEW: required for ack->commit (today groupless) — see §9 migration note
+    redis:
+      - id: my-redis
+        urls: ["redis://localhost:6379"]
+        mode: streams                  # NEW: streams | pubsub (pubsub = at-most-once only)
+```
+
+The `POST /graphql/stream-ack` endpoint is mounted automatically when any provider has a non-`at-most-once` class and HTTP subscription transports are enabled; its path is configurable under the existing GraphQL handler block.
+
+### 8.2 Schema directive (optional, composition)
+
+To let a *schema author* declare a field's required delivery class, add an optional `@edfs__delivery` modifier parsed in composition alongside the existing `@edfs__*` directives (`composition/src/v1/normalization/normalization-factory.ts:2804-3169`) and serialized into the per-field event config (`DataSourceCustomEvents`, `proto/wg/cosmo/node/v1/node.proto:430-434`):
+
+```graphql
+type Subscription {
+  criticalEmployeeUpdates: Employee!
+    @edfs__natsSubscribe(subjects: ["employeeUpdates"], providerId: "my-jetstream")
+    @edfs__delivery(class: AT_LEAST_ONCE, onUnsupported: REJECT)
+}
+```
+
+This is the loud-failure lever, evaluated **per subscription** in `SubscriptionOnStart` (§3.7): a field marked `AT_LEAST_ONCE, onUnsupported: REJECT` refuses to serve a non-acking client (rejecting that subscription, not the whole connection) rather than degrade.
+If the schema does not use it, behavior is governed entirely by router YAML, and the proto carries a zero value (fully backward compatible).
+
+---
+
+## 9. Migration & backward compatibility
+
+- **Opt-in, off by default.** `default_class: at-most-once` means an upgraded router with no config change behaves *exactly* as today: eager ack on JetStream, fire-and-forget elsewhere, no new wire fields, no ledger allocated, the engine `UpdateWithDelivery` path never taken. The JetStream `msg.Ack()` only moves out of the reader loop when a non-`at-most-once` class is configured.
+- **No client change required to keep working.** A stock graphql-ws/SSE client that never advertises ack support negotiates `at-most-once` and is unaffected.
+- **Wire additions are additive.** The `extensions.delivery` on `next`, the SSE `id:` line + `: idem=` comment, and the new `ack` inbound type are all ignorable by clients that don't understand them.
+- **Engine change is gated upstream.** The Pattern D delivery-result contract (§3.6) must land in `graphql-go-tools/v2` and the router must bump its pin before any non-`at-most-once` class can function. Until then the feature is dark. This is the single hardest migration dependency.
+- **Kafka opt-in changes restart-backlog semantics (explicit migration note).** Enabling `at-least-once-inorder` on Kafka switches the adapter from groupless `ConsumeResetOffset(AfterMilli(now))` to a committed consumer group. This changes behavior: today a router restart *skips* the downtime backlog (dossier §2.3); under a committed group it *replays everything since the last commit*. It also changes HA topology — a single `cosmo-edfs` group across replicas distributes partitions across replicas, so a subscriber's events may arrive on a different replica than the one holding its WebSocket/ledger (the ack model assumes the acking instance owns the offset, which group rebalancing breaks). Operators must choose: **one shared group across replicas** (partition assignment, but ack-owner ≠ socket-owner mismatch under rebalance) **or per-replica groups** (each replica consumes all partitions → duplicate consumption across replicas). v1 documents this trade-off and defaults Kafka at-least-once to *off*; enabling it is a deliberate, breaking opt-in.
+- **Adapter rollout is incremental.** JetStream first; Kafka B-variant second; SQS / Pub/Sub / Redis Streams / RabbitMQ as new adapters as they land. NATS core and Redis Pub/Sub never gain it and report `at-most-once` forever.
+- **Rollout sequence (recommended):** (0) land the Pattern D engine contract upstream + bump pin; (1) ship negotiation + ledger + JetStream ack-on-client-ack behind `default_class` opt-in (WS only); (2) SSE back-channel; (3) Kafka ack→commit (B-variant) with the migration note; (4) new ackable adapters; (5) double-ack/exactly-once. Each post-(0) step is independently shippable and observable via `cosmo_delivery_class`.
+
+---
+
+## 10. Appendix: new/changed Go types
+
+```go
+// router/pkg/pubsub/datasource/delivery.go  (NEW)
+
+// DeliveryClass is the negotiated/achieved delivery guarantee for a subscription.
+type DeliveryClass string
+
+const (
+    DeliveryAtMostOnce         DeliveryClass = "at-most-once"
+    DeliveryAtLeastOnce        DeliveryClass = "at-least-once"
+    DeliveryAtLeastOnceInOrder DeliveryClass = "at-least-once-inorder" // offset backends
+    DeliveryExactlyOnce        DeliveryClass = "exactly-once"
+)
+
+// AckHandle is an opaque, backend-specific token that lets the adapter later
+// confirm or redeliver one specific message. nil = nothing to hold (no-ack backend
+// or hook-dropped event with no co-subscribers) -> treated as immediate ack.
+type AckHandle interface {
+    // String returns a log-safe identifier for the handle (never the payload).
+    String() string
+}
+
+// AckController is the negotiation + ack ingress seen by the transport layer.
+// WebSocket and the POST /graphql/stream-ack endpoint both call into it.
+type AckController interface {
+    // Negotiate resolves a per-connection ack CAPABILITY (not a class).
+    NegotiateCapability(connCaps ClientDeliveryCaps) ConnectionAckCaps
+    // ResolveClass computes the per-SUBSCRIPTION effective class at Subscribe time.
+    ResolveClass(canAck bool, desired DeliveryClass, backend BackendCaps) (DeliveryClass, error)
+    // Ack confirms one or more delivery ids for a subscription/stream.
+    Ack(streamKey StreamKey, deliveryIDs []DeliveryID) error
+    // Committed (QoS 2) marks ids whose broker-ack is persisted.
+    Committed(streamKey StreamKey, deliveryIDs []DeliveryID) ([]DeliveryID, error)
+}
+
+type DeliveryID string
+
+// StreamKey is an opaque, signed, tenant+connection+subscription+instance-scoped
+// capability used by the SSE/multipart back-channel to locate the ledger entry.
+type StreamKey string
+
+type ClientDeliveryCaps struct {
+    SupportsAck       bool
+    SupportsDoubleAck bool
+}
+
+type ConnectionAckCaps struct {
+    CanAck    bool
+    AckWaitMs int
+}
+
+type BackendCaps struct {
+    PerMessageAck bool // true: JetStream, SQS, Pub/Sub, Redis Streams, Rabbit
+    CursorOnly    bool // true: Kafka, Kinesis, Event Hubs (forces in-order, window=1)
+    NativeDedup   bool // true: SQS FIFO, Pub/Sub EOS, JetStream (Nats-Msg-Id window)
+}
+```
+
+```go
+// router/pkg/pubsub/datasource/ack_ledger.go  (NEW)
+
+// AckLedger tracks in-flight (delivered-but-unacked) messages per subscriber,
+// enforces the in-flight window, applies the shared-trigger refcount/policy,
+// and fires broker Ack/Nak on client ack / timeout / per-subscriber failure.
+//
+// Registration is driven by the engine's per-subscriber DeliveryResult set
+// (post-filter), NOT by an independent Subscriptions() enumeration (§7.9).
+type AckLedger interface {
+    // Seed records a broker handle and the post-filter subscriber set the engine
+    // reported it was delivered to, returning the per-subscriber delivery ids.
+    // Filtered/errored subscribers are excluded from the refcount.
+    Seed(handle AckHandle, results []resolve.DeliveryResult) (map[resolve.SubscriptionIdentifier]DeliveryID, error)
+    // AckClient is called when the client confirms; decrements the handle refcount,
+    // applies the policy, and calls Adapter.Ack when due.
+    AckClient(subID resolve.SubscriptionIdentifier, id DeliveryID) error
+    // NakSubscriber nak's every open delivery slice for a subscriber (disconnect /
+    // per-subscriber failure / resolve-timeout path).
+    NakSubscriber(subID resolve.SubscriptionIdentifier) error
+    // AckDropped marks a hook-dropped event for ONE subscriber as satisfied
+    // (decrements remaining for that subscriber). It takes BOTH the subscriber id
+    // and the handle — never the handle alone — so a drop for A does not ack-away
+    // B's still-in-flight delivery (§7.7).
+    AckDropped(subID resolve.SubscriptionIdentifier, handle AckHandle) error
+}
+
+// ledgerEntry is held per (broker message) and refcounts shared subscribers.
+type ledgerEntry struct {
+    handle    AckHandle
+    remaining int                                         // post-filter refcount (§7.4)
+    deadline  time.Time                                   // ack_wait
+    perSub    map[resolve.SubscriptionIdentifier]DeliveryID
+    policy    AckPolicy
+}
+
+type AckPolicy string
+
+const (
+    AckPolicyAll    AckPolicy = "all"
+    AckPolicyQuorum AckPolicy = "quorum"
+    AckPolicyAny    AckPolicy = "any"
+)
+```
+
+```go
+// router/pkg/pubsub/datasource/provider.go  (CHANGED)
+
+// Adapter grows confirm/redeliver. Existing methods unchanged.
+type Adapter interface {
+    Lifecycle
+    Subscribe(ctx context.Context, cfg SubscriptionEventConfiguration, updater SubscriptionEventUpdater) error
+    Publish(ctx context.Context, cfg PublishEventConfiguration, events []StreamEvent) error
+
+    // Ack confirms the message behind handle to the broker
+    // (JetStream msg.Ack / SQS DeleteMessage / Redis XACK / Pub/Sub Ack / AMQP basic.ack /
+    //  Kafka+Kinesis+EventHubs: advance committed cursor when in-order).
+    Ack(ctx context.Context, handle AckHandle) error
+    // Nak requests redelivery (msg.Nak / visibility reset / XCLAIM / Nack / basic.nack(requeue)).
+    Nak(ctx context.Context, handle AckHandle) error
+    // Caps reports what guarantee this adapter can support, used by the negotiator.
+    Caps() BackendCaps
+}
+
+// StreamEvent grows an optional ack handle. GetData/Clone unchanged.
+type StreamEvent interface {
+    GetData() []byte
+    Clone() MutableStreamEvent
+    // AckHandle returns the broker confirm/redeliver token, or nil if the
+    // transport has no per-message ack (NATS core, Redis Pub/Sub).
+    AckHandle() AckHandle
+}
+```
+
+```go
+// router/pkg/pubsub/datasource/subscription_event_updater.go  (CHANGED)
+
+// When class != at-most-once, Update forwards the event + handle through the
+// engine's UpdateWithDelivery path and seeds the ledger from the per-subscriber
+// DeliveryResult set the engine returns. With a nil handle or at-most-once class,
+// behavior is byte-for-byte today's path (s.eventUpdater.Update(data)).
+type SubscriptionEventUpdater interface {
+    Update(events []StreamEvent)
+    Complete()
+    Done()
+    SetHooks(hooks Hooks)
+    // SetLedger wires the ack ledger + negotiated per-subscription class.
+    SetLedger(ledger AckLedger, class DeliveryClass)
+}
+```
+
+```go
+// router/internal/wsproto/proto.go  (CHANGED)
+
+const (
+    MessageTypePing MessageType = iota + 1
+    MessageTypePong
+    MessageTypeSubscribe
+    MessageTypeComplete
+    MessageTypeTerminate
+    MessageTypeAck // NEW: client confirms receipt of one or more delivery ids
+)
+
+// AckPayload is the decoded payload of an inbound `ack` message.
+type AckPayload struct {
+    Delivery []DeliveryID `json:"delivery"`
+}
+```
+
+```go
+// router/pkg/config/config.go  (CHANGED) — Go struct sketch
+
+type EventsConfiguration struct {
+    Providers EventProviders
+    Handlers  EventHandlers
+    Delivery  DeliveryConfiguration `yaml:"delivery"` // NEW
+}
+
+type DeliveryConfiguration struct {
+    DefaultClass         string        `yaml:"default_class" default:"at-most-once"`
+    OnUnsupported        string        `yaml:"on_unsupported" default:"downgrade"` // downgrade|reject
+    AckWait              time.Duration `yaml:"ack_wait" default:"30s"`
+    MaxAckPending        int           `yaml:"max_ack_pending" default:"10"`
+    AckPolicy            string        `yaml:"ack_policy" default:"all"` // all|quorum|any
+    AckQuorum            int           `yaml:"ack_quorum" default:"1"`
+    Ordering             string        `yaml:"ordering" default:"best-effort"`
+    SilentDowngradeAfter int           `yaml:"silent_downgrade_after" default:"5"`
+    MaxRedeliver         int           `yaml:"max_redeliver" default:"8"`
+}
+```
+
+---
+
+## 11. Risks, open questions, test plan, and a complexity/effort estimate
+
+### 11.1 Where this pattern is weakest (vs. the other six)
+
+- **Hard upstream dependency on the engine (Pattern D contract).** Pattern A cannot ship until `graphql-go-tools/v2` gains the bidirectional delivery-result contract + id threading + post-filter reporting (§3.6), and the router bumps its pin (currently `v2.4.1`, `router/go.mod:34`). This is a separately-versioned, maintainer-gated repo with documented version drift (dossier version-pin note). **This is the single biggest risk.**
+- **Highest adoption cost.** Pattern A is the only pattern that *requires a client protocol change* to deliver its guarantee. Stock Apollo/urql/Relay/graphql-sse clients get nothing until they ship ack support. Pattern B gives stock SSE browsers auto-resume for free; Pattern F works with stock clients.
+- **SSE/multipart are second-class.** The back-channel `POST /graphql/stream-ack` is a genuinely new, stateful, sticky, security-sensitive surface (§4.2, §7.6) with a structural duplicate-on-reconnect window. WebSocket is clean; HTTP transports are not. For SSE-dominant deployments, Pattern B is the recommended fit (§5), and the dossier agrees.
+- **Shared-trigger coupling and the per-message-ack impossibility.** `ack_policy: all` lets the slowest client hold the broker handle and the window; any nak redelivers to all co-subscribers (duplicates for those who already acked, §7.4). On Kafka this becomes hard head-of-line blocking with cross-subscriber replay amplification. Per-subscriber redelivery without duplicates is impossible under shared triggers — that is Pattern C.
+- **Cross-instance failover is not solved in-pattern.** The in-memory ledger means failover relies entirely on broker redelivery, and on JetStream the current per-instance durable naming actively defeats it (§7.1). True cross-restart durability is Pattern C.
+- **Ledger ↔ removal cross-layer locking (§7.9)** is non-trivial and must be implemented carefully against the engine's `sub.writeMu`/`removed` semantics to avoid leaked entries.
+- **Adapter surface is large and underestimated by adapter count alone.** Four natural-fit backends (SQS, Pub/Sub, Redis Streams, RabbitMQ) need *new adapters* — each carrying a new broker-client dependency, credential/config surface, lifecycle management, and integration test infra (matrix §5, rightmost column).
+
+### 11.2 Open questions
+
+1. **Engine contract acceptance (the top open question).** Will the `graphql-go-tools` maintainers accept the Pattern D bidirectional `DeliveryResult` + id-threading + post-filter-reporting change additively, or will it require an engine fork / major version bump? Everything downstream is gated on this. Needs maintainer sign-off before any router work starts.
+2. **Shared-trigger default policy and the duplicate-to-acked cost.** Is `ack_policy: all` (strongest guarantee, but any nak redelivers to already-acked co-subscribers → duplicates they must dedup) the right default, or should we default to `quorum`/`any` to bound coupling at the cost of weaker guarantees for slow subscribers? This is the residual tension §7.4 documents and cannot fully resolve — it is inherent to shared triggers on per-message-ack backends.
+3. **Cumulative vs. selective ack.** Selective on the wire, adapter collapses to cumulative on offset backends (offset backends *require* cumulative). Confirm clients can express selective acks ergonomically.
+4. **`ack_wait` granularity.** Per-provider with a `@edfs__delivery(ackWait:)` field override is proposed; confirm per-field is worth the config surface.
+5. **Idempotency key standardization.** Pinned to on-wire `idemKey` (§4.1); confirm the canonical key per backend (`Nats-Msg-Id` / Kafka key / SQS dedup id / content hash) and the content-hash algorithm for backends without a native id.
+
+### 11.3 Test plan (§4 success-criteria, per the project's TDD norms)
+
+Correctness here is dominated by failure-window behavior (§6), so the test plan is failure-injection-first. Each row is a reproducing test written before the corresponding code.
+
+- **Per-backend ack/nak/redelivery (integration).** For each supported backend (JetStream first; then Kafka B-variant; then each new adapter): deliver → client ack → assert exactly one broker `Ack(H)`; deliver → no ack within `ack_wait` → assert `Nak(H)` and broker redelivery.
+- **Forced-disconnect-mid-flight.** Deliver an id, drop the client socket before ack, assert the slice is nak'd and the broker redelivers on reconnect; assert no leaked ledger entry (§7.9).
+- **Shared-trigger partial-ack refcount.** Two subscribers on one trigger, post-filter set = both: A acks, B does not → assert handle held until B acks; then B times out under `ack_policy: all` → assert `Nak(H)` redelivers to *both* and A's redelivery is deduplicated by `idemKey`.
+- **Filtered-subscriber refcount.** `filterSubscriptions` excludes one of two subscribers → assert refcount seeded to 1, not 2, and the broker handle acks after the single delivered subscriber acks (regression test for the stall in §3.2 item 3).
+- **Hook drop vs. failure.** Subscriber A's `OnStreamEvents` drops the event, B keeps it → assert A decrements `remaining` (not `Ack(H)`), handle acks only after B acks (§7.7).
+- **Resolve-timeout nak.** Force a resolve longer than `max_subscription_fetch_timeout` → assert `DeliveryResult{Delivered:false}`, immediate nak, increment of the silent-downgrade counter, and no infinite redelivery loop (§6 window 4, §11.2 note).
+- **No-ack-client downgrade.** Capable transport, client never acks → assert downgrade to `at-most-once` after `silent_downgrade_after` deliveries and a `cosmo_delivery_class{reason="client_no_ack"}` metric.
+- **SSE stickiness + duplicate-on-reconnect.** Reconnect to a different instance → assert the old instance's orphaned handles nak after `ack_wait`, the new stream redelivers, and the client dedups on `idemKey` (§4.2).
+- **Negotiation matrix.** Stock client → `at-most-once`; ack-capable client + `REJECT` field on incapable backend → `DELIVERY_CLASS_UNSUPPORTED` on that subscription only (not the connection).
+
+### 11.4 Explicit v1 cut-line (what we will NOT build in v1)
+
+- **In:** Pattern D engine contract (upstream) → WebSocket (`graphql-transport-ws` only) + JetStream + ledger + per-connection capability / per-subscription class negotiation + the `cosmo_delivery_class` metric.
+- **Out of v1:** SSE/multipart ack; Kafka B-variant; all new adapters (SQS, Pub/Sub, Redis Streams, RabbitMQ, Kinesis, Event Hubs); double-ack/exactly-once; legacy `graphql-ws` and `absinthe` ack; cross-instance-failover-safe JetStream durable naming (Pattern C). These ship in the §9 rollout sequence steps (2)–(5), each independently.
+
+### 11.5 Complexity / effort estimate: **XL (gated on an upstream engine change)**
+
+| Work item | Size |
+|---|---|
+| **Engine: Pattern D delivery-result contract + id threading to writer + post-filter subscriber reporting** (`UpdateWithDelivery`, `handleTriggerUpdate`, `executeSubscriptionUpdate`) — **cross-repo, maintainer-gated, blocking** | **L–XL** |
+| `wsproto` `ack` message + WS inbound routing (`websocket.go`) | M |
+| Ack ledger + window + timeout + shared-trigger refcount + ledger/removal locking (§7.9) | L |
+| Adapter `Ack`/`Nak`/`Caps` + move JetStream `msg.Ack` into ledger | M |
+| Kafka ack→commit (consumer group, in-order, B-variant) + restart-backlog migration | L |
+| SSE/multipart `id:`+`idemKey` emission + `POST /graphql/stream-ack` + signed stream key + stickiness contract | L |
+| Per-connection capability + per-subscription class negotiation | M |
+| New adapters (SQS, Pub/Sub, Redis Streams, RabbitMQ) — *each*: new broker dep + auth/config surface + lifecycle + integration test infra | L (×4) |
+| Double-ack / exactly-once path (JetStream `DoubleAck`, dedup) | M |
+| Config plumbing + `@edfs__delivery` directive + proto field | M |
+| Observability (`cosmo_delivery_class`, in-flight gauges, nak/redelivery counters) + test plan (§11.3) | M |
+
+The "minimum viable" path — engine contract + WS + JetStream + ledger + negotiation — is **not** "solidly L" as an earlier draft claimed, because it *includes* the upstream engine change and cannot proceed without it. Realistically the minimum viable is **XL**, dominated by the engine work and gated on upstream acceptance.
+The full matrix (all transports, all adapters, exactly-once, HA-aware) is **XL+** and overlaps materially with Patterns B (offset backends become a B-variant), C (cross-instance durable ledger / per-subscription consumers), and D (the engine contract Pattern A is built on).
+This argues for **sequencing Pattern D first as an independently valuable correctness fix** (it closes §1's ack-on-failure / fan-out-all-acked / abandon-but-acked bugs with no client change), then layering Pattern A's ack protocol and ledger on top — exactly as the dossier's selection guide recommends.

--- a/rfc/at-least-once/rfc-B-cursor-resume.md
+++ b/rfc/at-least-once/rfc-B-cursor-resume.md
@@ -1,0 +1,957 @@
+# RFC: At-Least-Once for GraphQL Subscriptions — Cursor / Resume-Token Replay on Reconnect (Pattern B)
+
+**Status:** Draft (revised after adversarial review)
+
+**Verified against.**
+Router pins `github.com/wundergraph/graphql-go-tools/v2 v2.4.1` (`router/go.mod:34`).
+All engine line numbers in this RFC are re-cited against `v2.4.1`, **not** the dossier's `v2.1.1-...` snapshot.
+Key engine locations used below: `SubscriptionUpdater` interface at `resolve/resolve.go:1586`; `SubscriptionResponseWriter` at `resolve/response.go:69`; `addSubscription` at `resolve.go:771`; `executeSubscriptionUpdate` at `resolve.go:616`; `handleTriggerUpdate` at `resolve.go:1086`; `handleUpdateSubscription` at `resolve.go:1113`; `prepareTrigger` at `resolve.go:1277`.
+Where the dossier and the pinned engine disagree on line numbers, the pinned engine wins.
+
+**TL;DR.**
+Cosmo's EDFS pushes broker events to subscribers fire-and-forget,
+so any disconnect, router restart, or slow-consumer overflow drops every event that arrives while the client is not reading.
+This RFC restores at-least-once delivery without a per-message ack protocol,
+by surfacing an **opaque, signed cursor** alongside every delivered message and, on reconnect, **replaying the missed events from the broker's own retained log before going live**.
+This is the "`Last-Event-ID` done properly" / Hasura-streaming model.
+
+Two honest corrections versus the previous draft, forced by reading the pinned engine:
+
+1. **There is no "splice the replayed client into the shared live trigger" primitive in the engine, and adding one is an L/XL change.**
+   `addSubscription` (`resolve.go:771`) either attaches a new subscriber to an existing trigger (no `Source.Start` re-run) or creates a trigger and starts the source once.
+   There is no code path that runs a per-subscriber backlog reader and then re-parents that subscriber onto a *different*, already-running trigger.
+   This RFC therefore **abandons shared-trigger splicing for resuming clients**.
+   A resuming client gets its **own trigger** whose key includes a replay marker, runs a single contiguous *seek-then-live* read on one consumer, and never joins the shared live trigger.
+   Fresh (cursor-less) clients keep the shared-trigger fan-out exactly as today.
+   The cost: resuming clients do not share fan-out and pay their own broker reader for the lifetime of the resumed subscription, not just during catch-up.
+   We accept and document this trade-off (§4, §8.3, §12.1) rather than claim an unbuildable optimization.
+
+2. **The engine change is not a one-line additive widening.**
+   Threading a per-message cursor to the writer touches `SubscriptionUpdater` (`resolve.go:1586`), `handleTriggerUpdate`/`handleUpdateSubscription`, `executeSubscriptionUpdate` (`resolve.go:616`), and the **exported** `SubscriptionResponseWriter` interface (`response.go:69`) which the *router* implements (`websocketResponseWriter`, `HttpFlushWriter`).
+   It is a coordinated engine+router release, graded **L** (§11, §12.3).
+
+The cursor encodes the backend's own position primitive (JetStream stream sequence, Kafka `(partition, offset)`, Redis Streams entry id, Kinesis sequence number, Event Hubs offset, Pub/Sub snapshot/time).
+The guarantee is bounded by the backend's retention/replay window:
+within the window it is at-least-once across gaps;
+beyond it (retention-evicted events) it cleanly degrades to at-most-once and surfaces a non-silent `CURSOR_EXPIRED` error.
+It works only on **log/cursor backends with a configured durable log** (JetStream subjects with a stream, Kafka topics within `retention.ms`, Redis Streams).
+On core NATS, Redis Pub/Sub, and delete-on-ack queues there is no durable position to seek, so those degrade explicitly to at-most-once or compose with a router-side buffer (Pattern E).
+
+**Hard dependency.**
+Pattern B's per-event authz-on-replay safety claim depends on **Cosmo Streams v1** landing first (its `OnStreamEvents`/`StreamEvent` envelope).
+The current code ships `OnReceiveEvents` (`router/pkg/pubsub/datasource/hooks.go:14`), not `OnStreamEvents`, and has no `WriteEvent`.
+See the new **§0 Dependencies** section; the per-event guarantee is explicitly gated on a configured hook, and the no-hook default is documented as a known residual exposure (§8.5).
+
+---
+
+## 0. Dependencies
+
+Pattern B is **not** self-contained. It has two hard dependencies and one soft one.
+
+| Dependency | Status today | What Pattern B needs | If absent |
+|---|---|---|---|
+| **Cosmo Streams v1 event envelope** (`StreamEvent` carrying per-provider metadata) | Live code has `StreamEvent` with `GetData()` only (`subscription_event_updater.go`); v1's richer envelope is an unmerged draft (`rfc/cosmo-streams-v1.md`). | Extend `StreamEvent` with `Position()` (§4.3). This is the *same* "richer envelope" change v1 proposes. | Pattern B cannot read/surface a position. Blocking. |
+| **Cosmo Streams v1 receive hook** — proposed `OnStreamEvents`; **current symbol is `OnReceiveEvents`** (`hooks.go:14`) | `OnReceiveEvents` ships today; `OnStreamEvents`/`WriteEvent` exist only in the v1 draft. | A per-event filter/authz hook that runs identically on live and replayed events (§8.5). The current `OnReceiveEvents` signature is sufficient for the minimal subset. | Per-event authz on replay is **not** enforced (only operation-level authz at resubscribe). Documented residual exposure, not a silent one — see §8.5. |
+| **Engine cursor threading** (`SubscriptionUpdater` + `SubscriptionResponseWriter` change) | Neither interface carries a per-message id (`resolve.go:1586`, `response.go:69`). | Coordinated engine+router change (§11). | No cursor reaches the wire. Blocking. |
+
+**Minimal hook subset Pattern B requires (so it can ship without the full v1 surface).**
+Pattern B does **not** need `OnStreamEvents`/`WriteEvent` by those names.
+It needs exactly one capability: *a per-event filter that runs on replayed events with the same semantics as on live events*.
+The existing `OnReceiveEvents` hook (`hooks.go:14`, signature `func(subscriptionCtx, updaterCtx, subConf, eventBuilder, evts []StreamEvent) ([]StreamEvent, error)`) already provides this for live events; Pattern B routes replayed events through the **same** call.
+If v1 renames `OnReceiveEvents`→`OnStreamEvents`, Pattern B follows the rename; nothing in the design depends on the new name.
+All references to `OnStreamEvents` in this RFC mean "the v1 receive hook, currently `OnReceiveEvents`."
+
+**Timeline gate.** Ship order: (1) engine cursor threading + `StreamEvent.Position()` envelope (can land with or just after v1), (2) seekable adapters + SSE/WS wire, (3) per-event authz-on-replay once the v1 hook contract is final. Steps (1)–(2) deliver at-least-once with operation-level authz; step (3) closes the per-event authz gap.
+
+---
+
+## 2. Problem & Context
+
+An application that publishes to Kafka or NATS JetStream already *has* at-least-once on the ingest side:
+Kafka tracks committed offsets, JetStream tracks consumer/stream sequence and redelivers un-acked messages.
+But the moment an event crosses from the broker into a GraphQL subscription, Cosmo throws that guarantee away.
+
+The dossier establishes that the entire path from broker callback to client socket write is **one synchronous, fire-and-forget call stack** with no internal buffer
+(`00-research-dossier.md` §1.3).
+The concrete loss points:
+
+- **The framework abstraction is fire-and-forget by construction.**
+  `datasource.Adapter` (`router/pkg/pubsub/datasource/provider.go:22-28`) and the engine's `SubscriptionUpdater.Update(data)` (`resolve.go:1586-1588`) return **no error and have no ack hook back to the broker**.
+  Durability is therefore a per-adapter property, not a property of EDFS, and today only NATS JetStream even attempts it (dossier §2).
+- **No cursor is ever surfaced.**
+  The delivered event structs carry only `Data`, `Headers` (and Kafka `Key`) — no sequence/offset/position field exists
+  (`nats/engine_datasource.go:39-42`, `kafka/engine_datasource.go:58-63`).
+  JetStream's `msg.Metadata()` (which carries stream and consumer sequence) is **never read** (dossier §2.1 Hop D).
+  Kafka's `r.Offset` is never read (dossier §3.1).
+- **No resume / replay anywhere.**
+  A grep of `core/` and `internal/wsproto/` for `Last-Event-ID` / `LastEventID` / `resume` / `cursor` / `resumeToken` returns nothing (dossier §2.1 Hop D).
+  A reconnecting client always starts a brand-new subscription "from now":
+  it gets a new `ConnectionID` (`resolve.NewConnectionID()`, `websocket.go:367`) and a brand-new subscription id (`websocket.go:1160-1185`),
+  and the trigger is keyed by data hash, **not** by client identity (dossier §1.4; `prepareTrigger`, `resolve.go:1277`).
+- **The SSE writer never emits `id:`.**
+  `HttpFlushWriter.Flush` writes only `event:` / `data:` (`router/core/flushwriter.go:116-167`),
+  so even the *stock browser* `Last-Event-ID` auto-resume cannot work, because there is no id to track.
+- **The WS inbound message set has no resume concept.**
+  Recognized inbound messages are `Ping`, `Pong`, `Subscribe`, `Complete`, `Terminate` (`router/internal/wsproto/proto.go:88-94`).
+  `connection_init` / `connection_ack` is a one-time *connection* handshake, not a data position (dossier §2.1 Hop C).
+- **The WS heartbeat is a no-op, so half-open WS sockets are not detected promptly.**
+  `websocket.go:659-662` is an explicit no-op; the router never pings the downstream WS client (dossier §1.6).
+  A suspended-mobile or NAT-timed-out WS is not noticed until the next *write* fails.
+  This matters for resume: the "client reconnects and replays" story assumes the disconnect is detected so the client *knows* to reconnect (§5.5).
+- **Backends actively skip the gap.**
+  Kafka re-subscribes with `ConsumeResetOffset(AfterMilli(now))` (`kafka/adapter.go:32-34, 142-153`),
+  so on every (re)subscribe and after every restart it **skips everything produced during downtime**.
+  NATS core uses an unbuffered channel and the nats.go client **drops** on slow-consumer overflow (`nats/adapter.go:168`, `provider_builder.go:96-105`).
+  Redis uses Pub/Sub (not Streams) and drops on overflow (`redis/adapter.go:88-152`).
+
+The gap in one line (dossier §2.4): there is no client acknowledgement, no resume token, no replay, and no per-subscriber delivery accounting anywhere in EDFS.
+
+**This RFC attacks Hop D directly** (no resume/replay) and, as a side effect, neutralizes most of the damage from Hops A and B for log backends —
+because if the client can always re-read from where it left off, an in-flight loss is simply re-delivered on reconnect rather than permanently lost.
+It is deliberately the *lightest durable option for cursor-able backends* in the seven-pattern space:
+it adds no per-message ack protocol and leans on the durability the broker already provides.
+It does **not** claim to be "essentially stateless" — resuming subscribers carry a per-subscriber broker reader for the life of the resumed subscription (§4.4, §8.3).
+
+**Relationship to Cosmo Streams v1.**
+See §0. Pattern B extends the v1 `StreamEvent` envelope with a position and reuses the v1 receive hook (currently `OnReceiveEvents`) for per-event authz on replay.
+It does not replace v1; it is gated on it.
+
+---
+
+## 3. Goals & Non-Goals
+
+### Goals
+
+1. **Restore at-least-once across disconnect gaps** (client reconnect, router restart, broker reconnect) on log/cursor backends *with a configured durable log*, bounded by the backend's retention/replay window.
+2. **Make degradation explicit and non-silent.**
+   When the guarantee weakens, the router surfaces it (capability negotiation + an `extensions.cosmo.delivery` report + a hard `CURSOR_EXPIRED` error when a replay request lands outside the window).
+3. **Keep the router's *steady-state, non-resuming* footprint unchanged.**
+   No per-subscriber broker consumer and no external checkpoint store for cursor-less clients; they keep the shared-trigger fan-out.
+   Resuming clients accept a per-subscriber reader (the honest cost — §8.3). Durability stays in the broker; the router persists no checkpoint.
+4. **Make stock SSE clients resume for free.**
+   Emit `id:` and honor `Last-Event-ID`;
+   a standards-compliant browser `EventSource` then auto-resumes with zero client code, subject to the `Last-Event-ID` caveats in §5.1.
+5. **Preserve the shared-trigger fan-out for live (cursor-less) delivery** (one broker subscription, N live subscribers — dossier §1.4).
+6. **Reuse the existing resolve + receive-hook + flush path** for replayed events, so filtering, data mapping, and authz behave identically live and on replay *when a hook is configured* (§8.5).
+
+### Non-Goals
+
+- **Per-message client ack / end-to-end receipt confirmation.** That is Pattern A.
+- **Cross-restart durability on backends with no durable log** (NATS core, Redis Pub/Sub, SQS, RabbitMQ). They degrade or compose with Pattern E.
+- **Exactly-once.** At-least-once implies duplicates on replay. Clients must be idempotent.
+- **Global ordering across a fan-out.** Ordering is per-partition/per-stream (dossier §6.1).
+- **Changing the publish path.** Idempotent ingest (`Nats-Msg-Id`, Kafka idempotent producer) is out of scope, referenced only where dedup matters.
+- **Detecting half-open WS sockets.** Pattern B does not add WS keepalive (the heartbeat is a no-op — §2); WS resume depends on disconnect detection the router does not currently provide. Cross-referenced to Pattern D / a WS-keepalive change (§5.5).
+
+---
+
+## 4. Design — the mechanism in depth
+
+### 4.1 The core idea
+
+Every backend in the "log/cursor" family addresses its retained log by a **position primitive**:
+a JetStream stream sequence, a Kafka `(partition, offset)`, a Redis Streams entry id `<ms>-<seq>`, a Kinesis sequence number, an Event Hubs offset, a Pub/Sub snapshot or publish time (dossier §3.2, §3.3).
+Pattern B does three things the current code does not:
+
+1. **Read** that primitive on every event (the code already has it in hand and throws it away — `msg.Metadata()`, `r.Offset`, the Redis entry id).
+2. **Surface** it to the client as an **opaque, signed cursor** attached to the delivered message (SSE `id:` line; WS `Next` extension).
+3. **Honor** a returned cursor on (re)subscribe by translating it into a backend **seek**, then running a *single contiguous reader* from that position through to live (§4.4).
+
+The router persists no per-subscriber durable checkpoint.
+The cursor *is* the persisted state, and it lives on the client.
+The broker *is* the durable buffer, and it already exists.
+
+### 4.2 The cursor
+
+A cursor is an opaque base64url token the client must treat as a blob.
+Internally it is a signed envelope:
+
+```go
+// router/pkg/pubsub/datasource/cursor.go (new)
+
+// Cursor is the provider-agnostic, opaque resume token surfaced to the client.
+// It is signed (HMAC) and tenant-scoped so a client cannot forge a position
+// or seek into data it is not authorized to read (see §8.5).
+type Cursor struct {
+    Version    uint8  // envelope version, for forward-compat
+    ProviderID string // must match the live subscription's provider
+    // Position is the provider-native encoding of the backend offset/sequence.
+    // For multi-partition/shard subscriptions this is a *vector* (one entry per
+    // partition/shard), encoded in a single opaque blob (§12.1).
+    Position   ProviderPosition
+    // ResumeKey binds the cursor to a STABLE subscription identity (rendered
+    // operation input + provider + subject set) — explicitly EXCLUDING volatile
+    // forwarded headers, so a token refresh does not invalidate resume (§8.5).
+    ResumeKey  uint64
+    // Subject identifies the authenticated principal/tenant at issue time.
+    // On resume the router checks the *current* principal is still in scope.
+    // May be empty for unauthenticated/API-key subscriptions (§8.5).
+    Subject    string
+    IssuedAt   int64 // unix seconds; used for max-resume-age policy
+    KeyID      uint8 // signing-key id, for current+previous rotation (§8.1)
+}
+
+// ProviderPosition is implemented per backend. It must round-trip through
+// Encode/Decode and translate to a native seek request.
+type ProviderPosition interface {
+    ProviderType() string // "nats" | "kafka" | "redis" | ...
+    Encode() []byte       // bytes embedded in the signed cursor envelope
+}
+```
+
+The signing key is fleet-shared and rotatable with a current+previous overlap window (§8.1).
+A client never sees the raw `(partition, offset)` — only the signed blob.
+This matters: a raw offset would let a client seek to data it should never see (dossier §6.8).
+
+**Why `ResumeKey`, not `TriggerHash`.**
+The engine trigger key (`prepareTrigger`, `resolve.go:1277-1291`) folds `SubgraphHeadersBuilder.HeadersForSubgraph(...)` — i.e. *forwarded subgraph headers* — into the hash.
+Forwarded headers routinely include request-derived values (Authorization bearer tokens, `Accept-Language`, trace ids, cookies).
+Binding the cursor to the engine trigger hash would mean a client presenting a **refreshed token** on reconnect computes a different hash → `CURSOR_INVALID` → forced at-most-once on every normal token refresh.
+So the cursor binds to a **stable** identity (`ResumeKey` = hash of rendered operation input + `ProviderID` + the authenticated subject set), explicitly excluding volatile forwarded headers.
+Header-propagation configs that route on *non-identity* headers (e.g. a per-request trace id forwarded to the subgraph) are compatible with resume because those headers are not in `ResumeKey`; configs that *partition tenants by a forwarded header* must include that header in the subject set (a documented configuration requirement, §8.5).
+
+### 4.3 The adapter contract change
+
+Today the adapter pushes data with no position and accepts no seek.
+Pattern B widens the contract on both ends.
+
+**Outbound (read path): events carry a position.**
+The v1 envelope replaces the bare payload with a per-provider `StreamEvent`.
+Pattern B requires that envelope to carry the backend position:
+
+```go
+// router/pkg/pubsub/datasource/subscription_event_updater.go (extended)
+
+type StreamEvent interface {
+    GetData() []byte
+    // Position returns the backend position of THIS event, or nil if the
+    // backend has no durable position (NATS core / Redis Pub/Sub) — in which
+    // case no cursor is surfaced and the field degrades to at-most-once.
+    Position() ProviderPosition
+}
+```
+
+For NATS JetStream this is `msg.Metadata().Sequence` (currently ignored).
+For Kafka it is `(record.Partition, record.Offset)`.
+For Redis Streams it is the entry id.
+For core NATS / Redis Pub/Sub, `Position()` returns `nil` and the cursor machinery is disabled for that field.
+
+**Inbound (subscribe path): the adapter can start from a position and replay-then-live on a single reader.**
+We add an optional capability interface that durable adapters implement.
+The base `Adapter` interface (`provider.go:22-28`) is **not** changed:
+
+```go
+// router/pkg/pubsub/datasource/provider.go (additive — capability interface)
+
+type SeekableAdapter interface {
+    Adapter
+
+    // SubscribeFrom behaves like Subscribe but, before going live, replays
+    // every retained event strictly AFTER `from` through the same `updater`,
+    // in backend order, then transitions to live ON THE SAME READER without a
+    // gap. This is the load-bearing requirement: replay and live MUST be the
+    // same consumer/iterator (§4.4), so there is no two-consumer boundary race.
+    //
+    // If `from` is older than the backend retention window, it returns
+    // ErrCursorExpired and DOES NOT start a live subscription.
+    //
+    // If `from` is nil, it is identical to Subscribe (start live from now).
+    SubscribeFrom(ctx context.Context, from ProviderPosition, cfg SubscriptionEventConfiguration, updater SubscriptionEventUpdater) error
+
+    // RetentionWindow reports the backend's approximate replay horizon. It is
+    // BEST-EFFORT and may be stale (§9.1): for Kafka it requires a broker
+    // round-trip; for JetStream a stream-info call; for Redis a config read.
+    RetentionWindow() time.Duration
+}
+
+var ErrCursorExpired = errors.New("pubsub: cursor outside backend retention window")
+```
+
+**Single-reader replay-then-live is mandatory, not an optimization.**
+The previous draft allowed "open a transient replay reader, then attach to the shared live trigger."
+Reading the engine shows that is unbuildable (no splice primitive — §4.4 below), and even if it existed it would be a *two-consumer* design (durable live consumer + ephemeral replay consumer) with a genuine boundary race that can **skip** events published between "replay caught up to head H" and "live consumer's position at attach" (review issues 7, 8).
+We forbid it. `SubscribeFrom` MUST use one consumer that seeks then continues:
+
+- **Kafka:** one groupless consumer, `assign(partition)` + `seek(partition, offset+1)`, then `poll` continues seamlessly through head into live. Same reader throughout.
+- **JetStream:** one ephemeral `OrderedConsumer` with `DeliverByStartSequence = cursor.seq + 1`; an ordered consumer delivers from the start sequence and keeps delivering live with no second consumer.
+- **Redis Streams:** one `XREAD` (groupless, BLOCK) starting from `<lastId>`, which naturally continues blocking for new entries after draining history.
+
+If a backend *cannot* express replay-then-live on a single reader (e.g. a hypothetical backend offering only "snapshot read" + "separate live subscription"), it MUST NOT advertise `SeekableAdapter` and is reported at-most-once.
+
+### 4.4 Trigger model: resuming clients get their own trigger (no shared-trigger splice)
+
+The shared trigger is Cosmo's central scaling optimization (dossier §1.4, §6.5): one broker subscription per `(rendered input + headers)` hash, fanned to N subscribers via `addSubscription` (`resolve.go:771`).
+
+**What the engine actually supports (verified, `v2.4.1`).**
+`addSubscription` does exactly one of two things:
+
+1. If a trigger with the computed `triggerID` already exists, the new subscriber is attached via `registerSubscriptionLocked` (`resolve.go:800-801`, `831`) and **`Source.Start` is never called again** — it joins the existing fan-out.
+2. Otherwise it creates the trigger, builds a `subscriptionUpdater`, and starts the source **once** for the whole fan-out (`resolve.go:813-833`).
+
+There is **no** code path that (a) starts a per-subscriber broker reader, (b) drains it into one `subscriptionState`, then (c) re-parents that subscriber onto a different already-running trigger.
+The only per-subscriber delivery primitive is `UpdateSubscription(id, data)` (`resolve.go:1500`, dispatching to `handleUpdateSubscription`, `resolve.go:1113`), a one-shot synchronous write used by startup hooks (`executeStartupHooks`, invoked from `addSubscription` at `resolve.go:802-810`). It is not a streaming source with a lifecycle.
+
+**Consequence — and the design decision.**
+"Replay into a transient reader, then splice into the shared live trigger" is **unbuildable without a new engine concept** (a replay-source attached to a single `subscriptionState` with an explicit hand-off state machine — an L/XL engine change we are not taking).
+We therefore make the opposite, buildable choice:
+
+> A subscriber that presents a cursor gets its **own trigger**, distinct from the shared live trigger, running one `SubscribeFrom` reader (seek-then-live, §4.3). It never joins the shared trigger.
+
+Concretely:
+
+- A subscriber arriving **without** a cursor (or `nil`) joins the **shared live trigger** exactly as today (`addSubscription` path 1/2). Zero new cost. It receives a cursor on each message so it can resume later.
+- A subscriber arriving **with** a valid cursor is routed to a **replay trigger**. The trigger key is widened to include a replay discriminator (the cursor's `ResumeKey` plus a per-subscription nonce) so it can never collide with — and therefore never be attached to — the shared live trigger (§4.5). The engine creates a fresh trigger and calls `Source.Start` → the adapter's `SubscribeFrom`, which seeks and then goes live on one reader.
+
+**Trade-off, stated honestly (do not gloss over this).**
+Resuming clients do **not** share the broker fan-out. Each resuming client runs its own broker reader **for the lifetime of the resumed subscription**, not merely during catch-up. This is more expensive than the old (unbuildable) splice claim. We accept it because:
+
+1. It is the only design the current engine supports without an L/XL splice primitive.
+2. It is *correct* — one reader, no two-consumer boundary race, no loss at a hand-off (there is no hand-off).
+3. Resuming is the exception (reconnect), not the steady state; the shared fan-out is preserved for the common cursor-less case.
+
+The cost is bounded by `delivery.max_concurrent_replays` (a global cap, §9.1) to contain reconnect storms (§8.3). It is the price of correctness over the unbuildable optimization.
+
+**Optional future optimization (out of scope).** A "rejoin the shared trigger once caught up" hand-off would reduce steady-state cost for long-lived resumed subscriptions, but it requires the new engine replay-source concept and the splice state machine (L/XL). Listed in Open Questions (§12.2), not in scope here.
+
+### 4.5 Trigger-key interaction with resume (closing the collision hole)
+
+The previous draft carried the cursor only in `Subscribe.extensions.cosmo.cursor`, which is **not** part of `prepareTrigger`'s hash (`resolve.go:1277-1291` hashes rendered input + subgraph headers only).
+A cursor-bearing subscribe would therefore compute the **same** `triggerID` as a fresh subscribe and be silently attached to the shared live trigger (`addSubscription` path 1) — the cursor ignored, the client resuming "from now," i.e. the exact at-most-once bug, now *silently*.
+
+**Fix.** The router computes the trigger key for a resuming subscription so it cannot match the shared live trigger:
+
+- The subscription input passed to `ResolveGraphQLSubscription` for a resuming client includes a **replay marker** (the cursor's `ResumeKey` + a fresh per-subscription nonce). Because `prepareTrigger` hashes the input, the resulting `triggerID` is guaranteed distinct from the shared live trigger's id and from every other resuming client's id.
+- Therefore `addSubscription` always takes path 2 (create trigger, `Source.Start` → `SubscribeFrom`) for resuming clients. It can never take path 1 (attach to shared live trigger) before its backlog is drained, because the keys cannot collide.
+
+This is a router-side change to how the subscription input/trigger discriminator is built for resuming clients; it does not require an engine change beyond the cursor threading (§11).
+A test MUST assert: *a resuming client (cursor present) is never attached to the shared live trigger* — i.e. `Source.Start`/`SubscribeFrom` is invoked for it, and its `triggerID` differs from the cursor-less trigger's id (§ Testing).
+
+### 4.6 Components touched
+
+| Layer | Component | Change |
+|---|---|---|
+| Adapters | `router/pkg/pubsub/{nats,kafka,redis}/adapter.go` | Read backend position (`msg.Metadata()`, `record.Offset`, entry id) into `StreamEvent.Position()`; implement `SeekableAdapter.SubscribeFrom` as single-reader seek-then-live (JetStream stream-backed subjects, Kafka, Redis Streams). |
+| Adapters | new `redis/streams_adapter.go` | Redis Streams adapter (`XADD`/`XREAD`/`XREADGROUP`), distinct from today's Pub/Sub adapter; selected by config. **Requires publisher `PUBLISH`→`XADD` migration (breaking) and has no native dedup** (§10, §18). |
+| Engine boundary | `router/pkg/pubsub/datasource/subscription_event_updater.go` | Carry `Position` through to the engine; build the cursor alongside data. |
+| Engine boundary | `router/pkg/pubsub/datasource/subscription_datasource.go:35-54` | Thread the inbound resume cursor + replay marker into `SubscribeFrom` and into the trigger-input discriminator (§4.5). |
+| Engine | graphql-go-tools (`resolve.go:1586`, `1113`, `616`; `response.go:69`) | Thread a per-message opaque id (the cursor) from the updater through `handleTriggerUpdate`/`handleUpdateSubscription` and `executeSubscriptionUpdate` to the writer. **`SubscriptionResponseWriter` (exported, router-implemented) gains per-flush id.** See §11. Graded **L**, not additive. |
+| Transport (WS) | `router/core/websocket.go`, `router/internal/wsproto/proto.go` | Read `cursor` from `Subscribe` payload `extensions`; emit `cursor` in each `Next` `extensions`. No new message type. |
+| Transport (SSE) | `router/core/flushwriter.go:116-167` | Emit `id: <cursor>` per event (omit the `id:` line entirely for the synthetic initial message — §8.6); read `Last-Event-ID` request header on (re)connect; set `retry:`. |
+| Negotiation | `router/core/graphql_handler.go`, `websocket.go` upgrade | Advertise `delivery` capability; report achieved class in `extensions`. |
+| Config | `router/pkg/config/config.go` | New `delivery` block + global `max_concurrent_replays` (§9). |
+| Composition | optional `@edfs__*` directive arg (§9) | Mark a field replay-eligible and set max resume age; otherwise no proto change. |
+
+### 4.7 Lifecycle diagram
+
+```
+FIRST CONNECT (no cursor)                          RECONNECT (with cursor C)
+─────────────────────────                          ─────────────────────────
+
+client ── Subscribe (no cursor) ──▶ router         client ── Subscribe(cursor=C) ─▶ router
+                                      │                                              │
+                              compute trigger key            verify+decode C (HMAC w/ current|prev key,
+                              (input+headers)                ResumeKey, Subject scope, IssuedAt<maxAge)
+                                      │                                              │
+                              addSubscription:                          ┌───────────┴───────────┐
+                              JOIN shared live trigger                  │ valid?  in retention?  │
+                              (path 1/2, resolve.go:771)                └──┬────────┬────────┬───┘
+                                      │                            invalid │   no   │        │ yes
+                              OnReceiveEvents (filter/authz)    CURSOR_INVALID  CURSOR_EXPIRED  build replay
+                                      │                                                        input w/ marker
+                              resolve + Flush(data, cursor)                                    (ResumeKey+nonce)
+                                      │                                                              │
+                              SSE:  id:<cursor> / data:{...}                          addSubscription: NEW trigger
+                              WS:   Next{payload, ext:{cursor}}                       (path 2 — cannot collide,§4.5)
+                                                                                       Source.Start→SubscribeFrom(C)
+                                                                                              │
+                                                                          ONE reader: seek C+1 → drain backlog
+                                                                                       → continue LIVE (same reader)
+                                                                                              │
+                                                                          each event ─▶ OnReceiveEvents (authz re-run
+                                                                                       IF hook configured — §8.5)
+                                                                                              │
+                                                                                       resolve + Flush(data, cursor)
+                                                                                       (own trigger, own reader,
+                                                                                        for the subscription's life)
+```
+
+### 4.8 Why this is the right shape
+
+- It exploits a property the dossier calls out explicitly: log/cursor stores are "addressable by a position primitive → any consumer can re-read within retention. Natural fit for cursor/resume" (dossier §3.3).
+- It keeps router state to **O(1) durable** (no checkpoint store; the broker is the buffer). The non-O(1) cost is the per-resuming-subscriber broker reader, bounded by `max_concurrent_replays` (§8.3) — stated, not hidden.
+- It is the only pattern that gives stock browser clients durability **for free** (emit `id:`, the browser does the rest — dossier §4.1), subject to §5.1 caveats.
+
+---
+
+## 5. Wire protocol & client changes
+
+The design principle: **no new message *types***, only new *fields* (extensions and the SSE `id:` line), so existing clients keep working and resume-aware clients opt in.
+
+### 5.1 SSE (`graphql-sse` and plain `EventSource`)
+
+**Server → client (per event):**
+
+```
+id: eyJ2IjoxLCJwIjoia2Fma...   <-- opaque signed cursor
+event: next
+data: {"payload":{"data":{...}}}
+
+```
+
+`HttpFlushWriter.Flush` (`flushwriter.go:116-167`) currently writes only `event:`/`data:`.
+We add the `id:` line and, once, a `retry: <ms>` line.
+
+**Client → server (on reconnect):**
+A standards-compliant `EventSource` automatically re-issues the request with header `Last-Event-ID: <last id seen>`.
+
+**Two honest caveats (review issue 11), documented, not waved away:**
+
+1. **Explicit reopen does not carry `Last-Event-ID`.** The browser sends `Last-Event-ID` only on its *own automatic* reconnect. If the app explicitly `close()`s and re-creates the `EventSource` (route change, manual retry, framework remount), the header is **not** sent and resume silently does not happen — the client restarts at-most-once. Resume-aware SSE apps must therefore persist the last cursor themselves and pass it explicitly (query param `?cosmo_cursor=` as a fallback to `Last-Event-ID`) on manual reopen.
+2. **Cursor size vs proxy header limits.** A signed JSON+HMAC base64url cursor is ~200–400 bytes for a single-partition position, and larger for a multi-partition *vector* cursor. `Last-Event-ID` rides in a request header; some proxies cap header line length (nginx `large_client_header_buffers`, default 8k total but per-line 8k; corporate proxies are often tighter). **Sizing table** (single-partition, base64url of `{v,provider,pos,resumeKey,subject,iat,keyid}` + 32-byte HMAC):
+
+   | Backend | Position bytes | Typical cursor size | Multi-partition (8 shards) |
+   |---|---|---|---|
+   | JetStream | 8 (stream seq) | ~180 B | n/a (single stream order) |
+   | Kafka | 12 (partition+offset) | ~190 B | ~700–900 B (vector) |
+   | Redis Streams | ~18 (`<ms>-<seq>`) | ~200 B | n/a (single stream) |
+   | Kinesis/Event Hubs | ~24 (seq) | ~210 B | ~900 B–1.6 KB (vector) |
+
+   Single-partition cursors are comfortably under common 8k limits. **Multi-partition vector cursors over SSE `Last-Event-ID` are the risk**: an 8-partition Kafka vector approaches 1 KB and a 32-partition topic blows past conservative proxy limits. Mitigations (§12.2): cap the partition fan-in for SSE-resumable fields; or store the vector server-side keyed by a short opaque handle (reintroduces a small router-side map — a deliberate trade for large fan-ins, off by default).
+
+**Result:** stock browsers resume with **zero client code** for single-partition backends within proxy limits. `graphql-sse` JS clients get the same once they forward `Last-Event-ID`.
+
+If a replay request fails the retention check, the server emits a terminal `event: next` carrying a GraphQL error with code `CURSOR_EXPIRED`, then `event: complete`, and responds with a final HTTP status that stops the browser's auto-reconnect loop (`204` per WHATWG; dossier §4.1). The client restarts from "now" and self-reconciles (Pattern F territory).
+
+### 5.2 WebSocket (`graphql-transport-ws` and legacy `graphql-ws`)
+
+No new inbound message type — we stay within `Ping/Pong/Subscribe/Complete/Terminate` (`wsproto/proto.go:88-94`).
+
+**Client → server: cursor in the `Subscribe` payload extensions.**
+
+```jsonc
+{
+  "id": "1",
+  "type": "subscribe",
+  "payload": {
+    "query": "subscription { employeeUpdates { id } }",
+    "extensions": { "cosmo": { "cursor": "eyJ2IjoxLCJwIjoia2Fma..." } }
+  }
+}
+```
+
+**Server → client: cursor in each `Next` extensions.**
+
+```jsonc
+{
+  "id": "1",
+  "type": "next",
+  "payload": {
+    "data": { "employeeUpdates": { "id": "42" } },
+    "extensions": { "cosmo": { "cursor": "eyJ2IjoxLCJwIjoia2Fma..." } }
+  }
+}
+```
+
+A resume-aware client persists the last `cursor` from `Next` and replays it in the next `Subscribe.extensions.cosmo.cursor`.
+A stock client that ignores extensions never resumes (at-most-once) — no breakage.
+`CURSOR_EXPIRED` / `CURSOR_INVALID` are delivered as a normal graphql-ws `Error` message for that subscription id, followed by `Complete`.
+
+### 5.3 Capability negotiation
+
+Two layers, both additive:
+
+1. **Connection-level.** The client advertises `{"cosmo":{"delivery":{"resume":true}}}` in `connection_init` (WS) or `X-Cosmo-Delivery: resume` (SSE). The router replies in `connection_ack` with the per-connection achieved ceiling.
+2. **Per-subscription report.** The first `Next` (and SSE response headers) carries `extensions.cosmo.delivery = { "class": "at-least-once" | "at-most-once", "window": "PT24H", "authz": "per-event" | "operation-only", "reason": "..." }`, so the client learns the *actual* class **and** whether per-event authz is enforced on replay (§8.5) — the dossier's "never silently pretends" requirement.
+
+### 5.4 Fallback when a client/transport cannot participate
+
+| Situation | Behavior |
+|---|---|
+| Stock WS client ignores extensions | Receives data normally; never sends a cursor → at-most-once. Reported in `extensions.cosmo.delivery`. No error. |
+| Stock browser `EventSource`, single-partition backend, auto-reconnect | Resumes via `Last-Event-ID` with no code → at-least-once for free (within proxy limits, §5.1). |
+| `EventSource` explicit reopen | No `Last-Event-ID` sent → at-most-once unless the app passes the cursor explicitly (§5.1). |
+| `multipart/mixed` (Apollo HTTP default for some Apollo Client/Server combos) | No per-part id, no reconnect concept → **no resume, at-most-once, reported**. Migration guidance: use SSE or WS for at-least-once (§5.4 note, §21). |
+| `subscribe once` | One-shot, N/A. |
+| Backend has no durable position | `Position()` nil; no cursor; reported at-most-once (§6). |
+
+**Migration guidance (called out, not buried).** Multipart-subscription users get **no** resume. To obtain at-least-once they must switch the client transport to SSE (stock-browser auto-resume) or WS (explicit cursor). State this prominently in upgrade docs.
+
+No transport is *broken* by this RFC. Resume is strictly opt-in and degrades to today's behavior.
+
+### 5.5 WS disconnect detection (the resume precondition)
+
+Resume presumes the client *notices* the disconnect and reconnects. For WS this is not guaranteed today: the downstream WS heartbeat is an explicit no-op (`websocket.go:659-662`), so a half-open socket (mobile suspend, NAT timeout) is undetected until the next write fails. SSE/multipart get server heartbeats (5s default) that detect this; WS does not.
+
+Pattern B does **not** add WS keepalive — that is a separate, small change (a real WS `Ping` on an interval, cross-referenced to Pattern D / a dedicated WS-keepalive RFC). We document the dependency: **WS resume reliability is bounded by disconnect-detection latency, which for WS is currently "until the next failed write."** Clients that drive their own reconnect on app-level liveness (e.g. graphql-ws `keepAlive` pings) are unaffected; clients that rely on the server to detect the half-open socket will resume late. This is a residual limitation, listed in Risks (§12.1).
+
+---
+
+## 6. Per-backend adaptability & degradation matrix
+
+The architectural split is decisive (dossier §3.3): log/cursor stores can replay; delete-on-ack queues and ephemeral fan-out cannot.
+Crucially, **seekability is a per-subscription (per-field) property, not a per-provider one** for NATS (review issue 6): the JetStream consumer path runs only when `StreamConfiguration != nil` on `@edfs__natsSubscribe` (requires both `consumerName` and `streamName`, `normalization-factory.ts:3076-3081`); the *same* `providerId` serves both stream-backed and core-NATS subjects. The matrix below is therefore keyed by **subscription configuration**, not provider.
+
+| Backend / subscription config | Replay? How | Position → seek | Guarantee | Degradation / loss risk |
+|---|---|---|---|---|
+| **NATS core** (no `streamConfiguration`) | **No.** Ephemeral pub/sub, drops on overflow (`nats/adapter.go:168`). | none | **At-most-once** | Non-silent: `Position()=nil`, reported `at-most-once`. Recommend a stream-backed subject, or Pattern E. |
+| **NATS JetStream subject** (`streamConfiguration` present) | **Yes.** `msg.Metadata().Sequence`; `SubscribeFrom` = one ephemeral `OrderedConsumer` with `DeliverByStartSequence`, seek-then-live on **one** consumer (§4.3). | stream sequence | **At-least-once** within stream retention (`LimitsPolicy`) | Outside retention → `CURSOR_EXPIRED`. **No two-consumer race** because replay+live share the ordered consumer. Native publisher dedup (`Nats-Msg-Id`, 2-min window) aids idempotency. |
+| **Kafka** | **Yes.** `(partition, offset)`; `SubscribeFrom` = groupless `assign`+`seek(offset+1)`+`poll`, **same reader** continues live (replaces `AfterMilli(now)`, `kafka/adapter.go:32-34`). | `(partition, offset)` | **At-least-once** within `retention.ms` | Outside `retention.ms`/compacted → `CURSOR_EXPIRED`. Per-partition order only. **Timestamp fallback (`offsetsForTimes`) is best-effort and can SKIP a boundary event → loss**, not just dups (see note below). Per-resuming-client consumer (§8.3). |
+| **Redis Pub/Sub** (`topology: pubsub`, default) | **No.** No log (`redis/adapter.go:88-152`). | none | **At-most-once** | Non-silent. Migrate to Redis Streams (below) or Pattern E. |
+| **Redis Streams** (`topology: streams`, new adapter) | **Yes.** `XADD` ids; `SubscribeFrom` = `XREAD` BLOCK from `<lastId>`, same reader continues live. | entry id `<ms>-<seq>` | **At-least-once** within `MAXLEN`/`MINID` trim window | Trimmed below cursor → `CURSOR_EXPIRED`. **No native dedup** (dossier §3.2): idempotency is fully the client's job; the only stable key is the entry id (§7, §18). Publisher must `XADD` (breaking, §10). |
+| **AWS SQS** | **No.** Delete-on-ack, ephemeral receipt handle. | none | **At-most-once** for *gap* | Use Pattern A (visibility/redelivery) or E. Not an EDFS backend today. |
+| **Google Pub/Sub** | **Snapshot: yes. Timestamp: best-effort.** `seek` to snapshot or publish time. | snapshot / publish time | **At-least-once only via snapshot seek**; **timestamp seek is best-effort and can SKIP boundary events → loss** (see note). | Snapshot seek is loss-free within snapshot retention (7d). Timestamp seek may over-replay (dups, safe) *or* drop a boundary event whose server timestamp slightly exceeds the cursor time (loss). Matrix class for timestamp-only is **"at-least-once except a bounded boundary window"**. EOS subs add native dedup. |
+| **AWS Kinesis** | **Yes.** `GetShardIterator(AFTER_SEQUENCE_NUMBER)` from stored sequence. | shard + sequence | **At-least-once** within retention, **per shard** | Iterator expires 5 min → re-derive from stored seq (we store the seq, not the iterator). Outside retention → `CURSOR_EXPIRED`. |
+| **Azure Event Hubs** | **Yes.** `EventPosition.FromSequenceNumber`. | offset / sequence per partition | **At-least-once** within retention, **per partition** | Outside retention → `CURSOR_EXPIRED`. Per-partition order only. |
+| **RabbitMQ / AMQP** | **No.** Delete-on-ack, `redelivered` flag only. | none | **At-most-once** for *gap* | Pattern A (ack/requeue) or E. (Rabbit *Streams* plugin would qualify; out of scope.) |
+
+**Loss-risk note for time/timestamp seek (review issue 13).**
+"Seek to a timestamp" (Google Pub/Sub time seek; Kafka `offsetsForTimes` fallback when only a time cursor is available) is **approximate**. If the seek lands *after* an event whose server-assigned timestamp is slightly later than the cursor's recorded time, that event is **skipped → permanent loss**, not merely duplicated. This is the same silent-loss failure mode this RFC exists to eliminate. Therefore:
+
+- The **canonical** cursor for Kafka is `(partition, offset)` and for Pub/Sub is a **snapshot**, both of which are exact and loss-free.
+- The **timestamp** cursor is a *fallback* only (e.g. an old cursor whose offset/snapshot is gone but whose time is still in retention), and when used the per-subscription report sets `delivery.class = "at-least-once-boundary-approx"` with a `reason`, so the client knows the boundary is best-effort. We do **not** silently advertise plain "at-least-once" for timestamp seeks.
+
+Kinesis, Event Hubs, Google Pub/Sub, SQS, RabbitMQ are **not EDFS backends today** (dossier §3.1); the matrix shows what Pattern B *would* give. The shippable scope (§12) is **JetStream (stream-backed subjects) + Kafka + Redis Streams**.
+
+**Degradation is never silent.** A non-seekable subscription, a non-opted-in client, or a timestamp-only resume gets an explicit `extensions.cosmo.delivery` report with a `reason`. A replay outside the window gets a hard `CURSOR_EXPIRED`, never a silent skip-to-now.
+
+---
+
+## 7. Delivery semantics achieved
+
+**Steady state (no disconnect), cursor-less client:** identical to today — shared-trigger fan-out. The only addition is a cursor per message (a position read + sign, cheap).
+
+**Steady state, resumed subscription:** runs on its own trigger/reader (§4.4) — more broker cost, same delivery semantics. Per-message cursor still emitted.
+
+**Across a gap, on a seekable subscription, within retention, with an *exact* (offset/sequence/snapshot/entry-id) cursor:**
+**At-least-once.** Every event after the cursor and within retention is replayed before live resumes, on one contiguous reader (no boundary race).
+
+**Across a gap with a *timestamp* cursor:** at-least-once except a bounded boundary window that can drop an event whose timestamp straddles the cursor (§6 note). Reported explicitly; not silent.
+
+**Duplicates: yes, expected.** Sources: (1) the boundary event at/just-after the cursor (cursors are "after this position," but the first replayed event may equal the last delivered one if the client recorded the cursor *before* processing); (2) timestamp-seek over-replay. There is **no** replay→live splice (single reader, §4.4), so the previous draft's splice-overlap duplicates are gone. We surface a stable idempotency key (the position; or `Nats-Msg-Id`/Kafka key; for Redis Streams *only* the entry id, §18) so the client can dedup.
+
+**Ordering:** per-partition / per-stream, preserved; never global (dossier §6.1). The cursor *is* the order; replay is contiguous and in-order within a partition. Multi-partition/shard subscriptions restore each shard's order independently.
+
+**Beyond retention (evicted/trimmed):** degrades to at-most-once, loudly (`CURSOR_EXPIRED`). Permanent loss = events between the cursor and "now" that fell off the log.
+
+**Remaining failure windows (honest):**
+
+1. **Retention eviction during a long disconnect.** Fundamental; surfaced as `CURSOR_EXPIRED`.
+2. **Lossy client cursor persistence.** If the client crashes before durably recording cursor N, it resumes from an older cursor → **more duplicates (safe)**, never loss. Erring on the duplicate side is correct.
+3. **Non-seekable subscription / non-participating client.** At-most-once, reported.
+4. **Timestamp-seek boundary (§6 note).** A bounded window that can *skip* an event → loss. The reason it is *not* in the "no loss" column. Mitigated by preferring exact cursors; reported when a timestamp fallback is used.
+5. **WS late disconnect detection (§5.5).** Resume happens, but late — bounded by failed-write latency, not by a heartbeat.
+6. **Per-event authz on the no-hook path (§8.5).** Without a configured receive hook, replay re-checks only operation-level authz, not per-event field-level authz.
+
+**Net (precise):** within retention, with an exact cursor and a configured authz hook, **at-least-once with idempotency-required duplicates and per-partition ordering**. This is **not** exactly-once: failure windows #1, #2, #4 mean it is at-least-once-with-possible-gaps even with an idempotent client. We claim "effective exactly-once" **only** for the strict case — events within retention, exact (non-timestamp) cursor, lossless client cursor persistence — and otherwise call it what it is: at-least-once within the window, at-most-once beyond it.
+
+---
+
+## 8. Cross-cutting concerns
+
+### 8.1 Router HA / horizontal scaling & sticky sessions
+
+Durable state is the cursor on the client, not in-process router state — so HA is lighter than for stateful patterns.
+
+- **Cursor is portable across instances.** It encodes the *backend* position, so a client can reconnect to **any** router instance and that instance `SubscribeFrom`s the same position. No sticky session required for correctness — only the **signing key must be shared** across the fleet.
+- **Signing-key rotation is a correctness requirement, not an open question (review issue 16).** The codec verifies with **current OR previous** key (`Cursor.KeyID` selects which), with an overlap window ≥ `max_resume_age`. A naive single-key rotation would invalidate every outstanding cursor fleet-wide → forced at-most-once for all reconnecting clients during the rotation. The two-key scheme is part of the design body (§4.2 `KeyID`, §11 `CursorCodec`), not deferred.
+- **JetStream HA.** Replay uses an **ephemeral ordered consumer** with `DeliverByStartSequence` — no durable name, no cross-instance coordination (unlike the per-instance durable-name scheme, `nats/adapter.go:69-83`). Live for cursor-less clients continues to use the shared-trigger consumer.
+- **Kafka HA.** Replay uses groupless `assign`+`seek` — no consumer group, no rebalance. Any instance seeks any partition.
+- **Conclusion:** Pattern B is the most HA-friendly durable pattern. The only shared state is the fleet signing key (current+previous).
+
+### 8.2 Per-subscription state / memory cost
+
+- **Cursor-less subscriber:** ~O(1), identical to today plus a few bytes of cursor on each message.
+- **Resuming subscriber:** one extra broker reader (consumer/iterator) **for the lifetime of the resumed subscription** (§4.4) — not just during catch-up. This is the honest cost of having no splice primitive. Plus the catch-up backlog buffered in the synchronous resolve path.
+- A `delivery.max_replay_events` / `max_replay_duration` cap (§9) bounds a single pathological catch-up; past the cap the router truncates and surfaces `delivery.truncated=true` (better than silent loss; client reconciles).
+
+### 8.3 Reconnect-storm capacity & the shared-trigger interaction
+
+Because resuming clients do **not** share fan-out, a reconnect storm (deploy, LB failover, mobile network flap) spins up **one broker reader per reconnecting client**, each (for Kafka/Kinesis/Event Hubs) assigned to *all* partitions it subscribes and seeking each. This is the cost the previous draft wrongly dismissed as "a few bytes of cursor."
+
+**Capacity analysis (Kafka, worst case).** Concurrent replay readers = (reconnecting clients) × 1 consumer each; broker-side partition assignments = readers × (partitions per topic). A 5,000-client reconnect on a 32-partition topic = 5,000 transient consumers × 32 partition assignments = 160,000 partition fetches against the broker. This is a real blast radius.
+
+**Controls:**
+
+- **Global cap `delivery.max_concurrent_replays`** (§9.1): a fleet-wide-intent, per-instance-enforced ceiling on concurrent replay readers. Beyond it, new resuming subscribers either (a) queue with a short timeout, or (b) fall back to `restart_live` with a *loud* `delivery.class=at-most-once`+`gap=true` marker (§19) — operator-chosen.
+- **Per-client caps** `max_replay_events` / `max_replay_duration` bound each reader's catch-up.
+- **Steady-state fan-out is preserved** for cursor-less clients (the common case), so the dossier's "per-subscriber durability → N broker consumers" tension (dossier §6.5) is paid **only by resuming clients, only while resumed**, not by the whole population.
+
+Operators must size `max_concurrent_replays` against broker connection/partition limits. This is documented as a deployment requirement (§9.1, §12.1), not hidden behind an "O(1)" claim.
+
+### 8.4 Backpressure
+
+Live backpressure for cursor-less clients is unchanged (per-trigger-serial into the shared reader — dossier §2.2).
+A resuming client's reader is **its own** trigger/reader, so a slow catch-up stalls only that client, not co-subscribers — correct isolation, and a genuine benefit of the own-trigger model.
+`max_replay_*` and the existing `MaxSubscriptionFetchTimeout` (30s, `config.go:454`) bound it.
+
+**Subgraph load amplification (review issue 20).** Each replayed event runs the *full* synchronous resolve path — `InitSubscription` + `LoadGraphQLResponseData` + `Resolve` (`executeSubscriptionUpdate`, `resolve.go:616`) — which can issue federated/nested **subgraph fetches per event**, all under the 30s `MaxSubscriptionFetchTimeout`. Replaying thousands of events therefore amplifies load on **subgraphs**, not just router memory. Consequently `max_replay_events` must be sized against *downstream subgraph cost*, not only router RAM. Documented in §9.1 guidance.
+
+### 8.5 Security / authz — the critical requirement (corrected)
+
+Two rules from the dossier (§6.8), with the honest caveat the previous draft omitted:
+
+1. **Cursors must be opaque, signed, tenant-scoped.**
+   A raw `(partition, offset)` lets a client seek to data it should not see.
+   Our cursor is HMAC-signed (current/previous key), carries `ResumeKey` (binds to a *stable* identity excluding volatile forwarded headers, §4.2) and `Subject` (the principal at issue time).
+   On resume the router (a) verifies signature, (b) checks `ResumeKey` matches the current subscription's stable identity, (c) checks the *current* authenticated principal is still in scope, (d) checks `IssuedAt` against `max_resume_age`.
+   A forged / cross-subscription / stale cursor → `CURSOR_INVALID` (distinct from `CURSOR_EXPIRED`).
+
+2. **Per-event authz on replay requires a configured receive hook — otherwise replay re-checks only operation-level authz. This is the corrected claim.**
+   The previous draft asserted replay "automatically re-runs current authz because we reuse the live path." Reading the code, that is **only true when a hook is configured.** The no-hooks branch of `subscriptionEventUpdater.Update` (`subscription_event_updater.go:37-42`) calls `s.eventUpdater.Update(event.GetData())` directly with **zero per-event filtering**. For the *default* deployment (no `OnReceiveEvents` hook):
+   - **GraphQL-layer authz (operation auth, `@requiresScopes`) does re-run** on every resubscribe via the normal handler, and `SubscriptionOnStart` (when present) fires once before replay — so a client whose access is *entirely* revoked is rejected before any replay.
+   - **But per-event, content-dependent field-level filtering does NOT run** on replay (nor on live) without a hook. So a client whose access to *a subset* of events was revoked *during* the disconnect can be replayed events it could see when they were published but should no longer see.
+   - This makes Pattern B **strictly worse than today for that narrow case**: today there is no replay, so a revoked-mid-disconnect client simply gets nothing; with Pattern B (no hook) it is replayed in-window data authored while it still had access.
+
+   **Resolution (explicit, not silent):**
+   - When `delivery.mode: at-least-once` is set, the per-subscription report advertises `delivery.authz = "operation-only"` unless a receive hook is configured, in which case it advertises `"per-event"`.
+   - Config validation **warns loudly** (and offers `delivery.require_event_authz_hook: true` to make it a hard error) when at-least-once is enabled on a field without a receive hook, so operators consciously accept the residual exposure.
+   - The residual exposure — *replay of in-window events authored while access was valid, after a partial access revocation during the disconnect, on the no-hook path* — is documented as a known limitation (§12.1). Closing it fully requires the v1 receive-hook contract (§0) and a configured hook.
+
+`SubscriptionOnStart` (when present) still fires once at (re)subscribe before any replay, so a fully-revoked client is rejected before replay begins regardless of the per-event hook.
+
+### 8.6 Interaction with existing Cosmo Streams hooks
+
+- **`SubscriptionOnStart`** (currently `hooks.go:10`) — fires once on (re)subscribe, before replay. Natural place to additionally validate the resume request (reject resume for fields the tenant may not replay).
+- **`OnReceiveEvents`** (currently `hooks.go:14`; v1-proposed name `OnStreamEvents`) — when configured, runs on **both** live and replayed events identically (§8.5). When *not* configured, neither live nor replay gets per-event filtering (the honest default).
+- **`OnPublishEvents`** — unaffected (publish path unchanged).
+- **v1 synthetic initial message (`WriteEvent` in the v1 draft; not in current code)** — the synthetic initial message has **no** backend position. Its wire encoding (review issue 15):
+  - SSE: the `id:` line is **omitted entirely** (not emitted empty), so the browser does not record it as `Last-Event-ID` and never tries to resume from it.
+  - WS: `extensions.cosmo.cursor` is **absent** for the initial message (not a sentinel value), so a resume-aware client has nothing to persist for it.
+  - No signed sentinel is needed because no cursor is emitted at all — avoiding the "sentinel must pass HMAC or client gets `CURSOR_INVALID`" problem. A behavior table:
+
+    | Message | SSE `id:` | WS `extensions.cosmo.cursor` | Resumable? |
+    |---|---|---|---|
+    | Synthetic initial | omitted | absent | No (intentionally) |
+    | Live/replayed event with position | `id: <cursor>` | `<cursor>` | Yes |
+    | Event on non-seekable backend | omitted | absent | No (at-most-once) |
+
+---
+
+## 9. Configuration surface
+
+### 9.1 Router YAML — new `delivery` block
+
+```yaml
+version: "1"
+
+events:
+  # NEW: fleet-wide delivery controls
+  delivery:
+    cursor_signing_key: ${COSMO_CURSOR_SIGNING_KEY}            # current key (required to enable resume)
+    cursor_signing_key_previous: ${COSMO_CURSOR_SIGNING_KEY_PREV}  # previous key for rotation overlap (§8.1)
+    max_resume_age: 24h            # reject cursors older than this regardless of retention
+    max_replay_events: 100000      # per-catch-up cap (size vs SUBGRAPH cost too, §8.4)
+    max_replay_duration: 20s       # wall-clock cap per catch-up
+    max_concurrent_replays: 500    # global ceiling on concurrent replay readers (§8.3)
+    require_event_authz_hook: false # if true, at-least-once without a receive hook is a HARD error (§8.5)
+
+  providers:
+    nats:
+      - id: my-jetstream
+        url: "nats://localhost:4222"
+        # NOTE: seekability is PER-SUBJECT (stream-backed), validated at subscription time, not here (§9.1 validation)
+        delivery:
+          mode: at-least-once       # at-most-once (default) | at-least-once
+
+    kafka:
+      - id: my-kafka
+        brokers: ["localhost:9092"]
+        delivery:
+          mode: at-least-once
+          on_cursor_expired: error  # error (default) | restart_live (still loud, §19)
+
+    redis:
+      - id: my-redis
+        urls: ["redis://localhost:6379"]
+        topology: streams            # pubsub (default) | streams (publisher must XADD — breaking, §10)
+        delivery:
+          mode: at-least-once        # only valid when topology: streams
+```
+
+**What is validated when (review issue 9) — the honest staging.**
+The previous draft promised "hard config error at startup" for at-least-once on a non-seekable provider. That is only partly possible, because seekability and retention are not all known at startup:
+
+| Check | When | Behavior |
+|---|---|---|
+| `at-least-once` + `cursor_signing_key` unset | **Startup** | Hard error (you cannot sign cursors). |
+| `at-least-once` on Redis `topology: pubsub` | **Startup** | Hard error (Pub/Sub has no log; config-local fact). |
+| `at-least-once` on a NATS *subject* with no `streamConfiguration` | **Subscription time** (per-field) — the proto/exec config is a control-plane artifact loaded after startup and changeable via config push (review issue 6) | Per-subscription: report `at-most-once` with a loud `reason` for that field; emit a one-time startup warning listing all such fields once the exec config is loaded. |
+| `at-least-once` + no receive hook | **Startup** | Warn loudly; hard error iff `require_event_authz_hook: true` (§8.5). |
+| Retention (`RetentionWindow()`) ≥ `max_resume_age` | **Best-effort at startup** (broker round-trip) **and continuously** | Startup: warn if a round-trip shows retention < `max_resume_age`. Runtime: retention can shrink underneath the router; we cannot *prevent* it. Detection is the rising `cursor_expired` rate (§10), wired to an alert. A re-validation probe re-reads `RetentionWindow()` on an interval and flips the per-field `delivery.window` report + raises a `delivery_retention_below_max_resume_age` gauge. |
+| Publisher actually `XADD`s to Redis Streams | **Never verifiable by the router** | The router cannot verify the publisher's behavior; documented operator responsibility (§10). |
+
+So the promise is precisely: **config-local non-seekability is a startup error; per-field and broker-property degradation is detected and reported (not silently lossy), with continuous re-validation and an alert path** — not "always caught at startup." This is the honest version.
+
+### 9.2 Schema directive — optional per-field replay control
+
+Replay is primarily a *runtime* (YAML) concern, so **no proto change is required** for the basic mechanism.
+One *optional* composition addition, mirroring `streamConfiguration` on `@edfs__natsSubscribe`:
+
+```graphql
+type Subscription {
+  employeeUpdates: Employee!
+    @edfs__natsSubscribe(
+      subjects: ["employeeUpdates"]
+      providerId: "my-jetstream"
+      streamConfiguration: { consumerName: "...", streamName: "..." }  # required for JetStream seekability
+      deliveryConfiguration: { resume: true, maxResumeAge: "24h" }     # NEW optional
+    )
+}
+```
+
+If added, it serializes one optional message on `DataSourceCustomEvents` (`node.proto:430-434`), parsed in `normalization-factory.ts` next to `streamConfiguration` (`:3076-3081`).
+**Recommendation:** ship the YAML surface first; add the directive only if per-field policy must differ from the provider default.
+
+---
+
+## 10. Migration & backward compatibility
+
+- **Opt-in, default off.** With no `cursor_signing_key`, behavior is byte-for-byte today's: no SSE `id:`, no WS `cursor`, at-most-once. Existing deployments unaffected.
+- **Per-provider/per-field rollout.** Enable `delivery.mode: at-least-once` incrementally; left at default keeps today's semantics.
+- **Backward-compatible wire format.** New fields are additive (SSE `id:`, WS `extensions.cosmo.cursor`). Stock clients ignore them. No subprotocol/message-type change → Apollo, urql, Relay, legacy `graphql-ws` keep working (and get free SSE auto-resume per §5.1).
+- **Redis migration (breaking for that field).** `topology: streams` requires the **publisher** to `XADD` instead of `PUBLISH` — a breaking change for existing Redis EDFS users. Gated behind the explicit `topology` switch so nobody flips it accidentally. Redis Streams has **no native dedup**; the client's only stable idempotency key is the entry id (§18).
+- **Kafka behavior change.** Replacing `AfterMilli(now)` with seek-from-cursor changes restart behavior **only when resume is enabled**; with resume off, `AfterMilli(now)` is retained.
+- **Observability.** Metrics: `cosmo_subscription_replay_events_total`, `cosmo_subscription_replay_duration_seconds`, `cosmo_subscription_cursor_expired_total`, `cosmo_subscription_cursor_invalid_total`, `cosmo_subscription_concurrent_replays` (gauge, vs `max_concurrent_replays`), `cosmo_subscription_replay_truncated_total`, `delivery_retention_below_max_resume_age` (gauge). Achieved `delivery.class` and `delivery.authz` as labels on subscription metrics. SLO/alert mapping in §13.
+
+---
+
+## 11. Appendix: new / changed Go types
+
+```go
+// ============================================================================
+// router/pkg/pubsub/datasource/cursor.go  (NEW)
+// ============================================================================
+
+type Cursor struct {
+    Version    uint8
+    ProviderID string
+    Position   ProviderPosition // provider-native, opaque above the adapter; vector for multi-partition
+    ResumeKey  uint64           // STABLE identity: input + provider + subject set, EXCLUDING volatile headers (§4.2)
+    Subject    string           // principal at issue time; may be empty (§8.5)
+    IssuedAt   int64            // unix seconds (max_resume_age)
+    KeyID      uint8            // signing-key id (current|previous rotation, §8.1)
+}
+
+type ProviderPosition interface {
+    ProviderType() string
+    Encode() []byte
+}
+
+// CursorCodec signs/verifies with current OR previous key (rotation, §8.1).
+type CursorCodec interface {
+    Encode(c Cursor) (string, error)
+    // Decode verifies against current then previous key (by KeyID), checks
+    // ResumeKey, Subject scope, and maxAge. Returns ErrCursorInvalid otherwise.
+    Decode(token string, currentResumeKey uint64, currentSubject string, maxAge time.Duration) (Cursor, error)
+}
+
+var (
+    ErrCursorInvalid = errors.New("pubsub: cursor invalid, forged, or out of scope")
+    ErrCursorExpired = errors.New("pubsub: cursor outside backend retention window")
+)
+
+// ============================================================================
+// router/pkg/pubsub/datasource/provider.go  (ADDITIVE — capability interface)
+// ============================================================================
+
+type SeekableAdapter interface {
+    Adapter
+    // SubscribeFrom: single-reader seek-then-live (§4.3). ErrCursorExpired if
+    // `from` predates retention (starts NO live subscription). from==nil ≡ Subscribe.
+    SubscribeFrom(ctx context.Context, from ProviderPosition, cfg SubscriptionEventConfiguration, updater SubscriptionEventUpdater) error
+    RetentionWindow() time.Duration // best-effort; may be stale (§9.1)
+}
+
+// ============================================================================
+// router/pkg/pubsub/datasource/subscription_event_updater.go  (EXTENDED)
+// ============================================================================
+
+type StreamEvent interface {
+    GetData() []byte
+    Position() ProviderPosition // nil on non-durable backends (NATS core / Redis Pub/Sub)
+}
+
+// ============================================================================
+// graphql-go-tools  (COORDINATED ENGINE+ROUTER CHANGE — graded L, NOT additive)
+// ============================================================================
+//
+// The cursor must reach the writer per-message. Tracing v2.4.1:
+//   Update(data) -> handleTriggerUpdate(id, data) (resolve.go:1086)
+//                -> executeSubscriptionUpdate(ctx, sub, data) (resolve.go:616)
+//                -> ... -> sub.writer.Flush()  (SubscriptionResponseWriter, response.go:69)
+// A single Update fans out to N subscribers, each doing an independent
+// resolve + Flush. The cursor is the SAME for all N (it is the broker
+// position), so it must travel alongside `data` through the fan-out and be
+// matched to each subscriber's flush.
+//
+// EVERY touched signature (enumerated honestly):
+//   1. SubscriptionUpdater (resolve.go:1586): add per-message id to Update /
+//      UpdateSubscription, e.g. UpdateWithID(data []byte, id string) and
+//      UpdateSubscriptionWithID(subID, data, id). Existing Update(data) kept
+//      as UpdateWithID(data, "").
+//   2. handleTriggerUpdate(id uint64, data []byte) -> must carry the cursor.
+//   3. handleUpdateSubscription(...) (resolve.go:1113) -> per-subscriber id path.
+//   4. executeSubscriptionUpdate(resolveCtx, sub, sharedInput) (resolve.go:616)
+//      -> thread the id to the flush.
+//   5. SubscriptionResponseWriter (response.go:69): per-flush id. THIS IS AN
+//      EXPORTED INTERFACE IMPLEMENTED OUTSIDE THE ENGINE (router's
+//      websocketResponseWriter, HttpFlushWriter). Changing it is a BREAKING
+//      interface change for every writer, hence a coordinated engine+router
+//      release — NOT an additive one-liner. Graded L (§12.3).
+//
+// Proposed minimal shape:
+type SubscriptionUpdater interface {
+    UpdateWithID(data []byte, id string) // id == "" => no cursor (at-most-once)
+    UpdateSubscriptionWithID(subID SubscriptionIdentifier, data []byte, id string)
+    // ... existing Complete/Error/Done unchanged ...
+}
+
+// SubscriptionResponseWriter gains a way to attach the id to the next flush,
+// e.g. FlushWithID(id string) error, or SetNextID(id string) before Flush().
+// Both router writers (websocketResponseWriter, HttpFlushWriter) implement it.
+
+// ============================================================================
+// router/core  — transport-side (sketch)
+// ============================================================================
+
+type resumeRequest struct {
+    Token   string // WS Subscribe.extensions.cosmo.cursor OR SSE Last-Event-ID / ?cosmo_cursor
+    Present bool
+}
+
+type deliveryReport struct {
+    Class     string `json:"class"`            // "at-least-once" | "at-least-once-boundary-approx" | "at-most-once"
+    Authz     string `json:"authz"`            // "per-event" | "operation-only" (§8.5)
+    Window    string `json:"window,omitempty"` // ISO-8601 duration, if known (best-effort, §9.1)
+    Reason    string `json:"reason,omitempty"`
+    Truncated bool   `json:"truncated,omitempty"`
+    Gap       bool   `json:"gap,omitempty"`    // restart_live happened (§19)
+}
+
+// ============================================================================
+// router/pkg/config/config.go  (NEW)
+// ============================================================================
+
+type DeliveryGlobalConfiguration struct {
+    CursorSigningKey         string        `yaml:"cursor_signing_key"`
+    CursorSigningKeyPrevious string        `yaml:"cursor_signing_key_previous"`
+    MaxResumeAge             time.Duration `yaml:"max_resume_age"`
+    MaxReplayEvents          int           `yaml:"max_replay_events"`
+    MaxReplayDuration        time.Duration `yaml:"max_replay_duration"`
+    MaxConcurrentReplays     int           `yaml:"max_concurrent_replays"`
+    RequireEventAuthzHook    bool          `yaml:"require_event_authz_hook"`
+}
+
+type ProviderDeliveryConfiguration struct {
+    Mode            string `yaml:"mode"`              // "at-most-once" | "at-least-once"
+    OnCursorExpired string `yaml:"on_cursor_expired"` // "error" | "restart_live"
+}
+
+// Provider-native positions:
+type natsPosition struct{ StreamSeq uint64 }                  // msg.Metadata().Sequence.Stream
+type kafkaPosition struct{ Partitions []kafkaPartPos }        // VECTOR for multi-partition
+type kafkaPartPos struct{ Partition int32; Offset int64 }
+type redisStreamsPosition struct{ EntryID string }            // "<ms>-<seq>"
+```
+
+---
+
+## 12. Risks, open questions, and complexity/effort estimate
+
+### 12.1 Where this pattern is weakest (honest)
+
+- **The guarantee is only as good as the retention window.** A client gone longer than retention gets `CURSOR_EXPIRED` and permanent gap-loss. Patterns C/A can hold a position open without relying on broad retention; B cannot. **Biggest weakness.**
+- **Resuming clients do not share fan-out (the corrected cost).** Each runs its own broker reader for the subscription's life (§4.4, §8.3) — not "free after catch-up." Reconnect storms must be capped (`max_concurrent_replays`). This is the price of the engine having no splice primitive.
+- **No receipt confirmation, ever.** B knows where the client *resumed from*, never that it *processed* a message. Lossy client cursor persistence → duplicates (safe), never loss, but weaker liveness feedback than Pattern A.
+- **Timestamp-seek boundary loss.** Pub/Sub time seek and Kafka `offsetsForTimes` fallback can *skip* a boundary event → loss (§6 note). Exact cursors avoid it; timestamp use is reported, not silent.
+- **No-hook per-event authz gap.** Without a configured receive hook, replay re-checks only operation-level authz; a partial-revocation-during-disconnect client can be replayed in-window data (§8.5). Strictly worse than today for that narrow case; documented and operator-gated (`require_event_authz_hook`).
+- **WS late disconnect detection.** The WS heartbeat is a no-op (§5.5); half-open sockets resume late.
+- **Multi-partition SSE resume.** Vector cursors can exceed proxy `Last-Event-ID` limits (§5.1).
+- **Hard dependency on log backends and on Cosmo Streams v1** (§0).
+
+### 12.2 Open questions
+
+1. **Multi-partition vector cursor vs SSE header limits.** Cap SSE-resumable partition fan-in, or store the vector server-side behind a short opaque handle (small router-side map, off by default)? (§5.1)
+2. **"Rejoin the shared trigger once caught up" (the optimization we dropped).** Worth a future engine replay-source + splice state machine (L/XL) to reclaim steady-state fan-out for long-lived resumed subscriptions? (§4.4)
+3. **Replay-then-live single-reader proofs per backend.** JetStream `OrderedConsumer` continuity; Kafka assign+seek+poll continuity; Redis `XREAD` BLOCK continuation — each needs a tested no-gap proof (§ Testing).
+4. **`on_cursor_expired: restart_live` loudness.** Kept, but must emit `delivery.class=at-most-once`+`gap=true` (§19).
+5. **Empty/unstable `Subject`.** Behavior for API-key/anonymous/rotating-identity tenants (§17 below).
+6. **Continuous retention re-validation cadence** vs broker round-trip cost (§9.1).
+
+### 12.3 Complexity / effort estimate (re-graded)
+
+**Overall: L–XL.** The previous "M–L / lightest" framing understated the engine writer-interface fan-out (§11) and the per-resuming-subscriber reader state (§4.4, §8.3). Honest grade:
+
+| Work item | Size | Notes |
+|---|---|---|
+| Cursor codec (sign/verify, current+previous key, scope checks, vector positions) | M | Was S; rotation + vector raise it. |
+| `StreamEvent.Position()` + read backend metadata | S | Data already in hand. |
+| `SeekableAdapter.SubscribeFrom` — JetStream (ordered, single-reader) | M | |
+| `SeekableAdapter.SubscribeFrom` — Kafka (assign+seek+poll, single-reader) | M | Replace `AfterMilli(now)` under resume. |
+| Redis Streams adapter (new) + publisher `XADD` migration | M | Breaking publisher change; no native dedup (§18). |
+| **Engine cursor threading** (`SubscriptionUpdater` + `handleTriggerUpdate` + `executeSubscriptionUpdate` + **`SubscriptionResponseWriter`** + router writers) | **L** | Was mis-graded M. Breaking exported-interface change; coordinated engine+router release (§11). |
+| Resuming-client own-trigger routing + replay-marker trigger key (§4.4, §4.5) | **L** | The genuinely hard router-side work; collision-avoidance + no-shared-attach test. |
+| SSE `id:`/`Last-Event-ID`/`?cosmo_cursor`/`retry:` | S | |
+| WS `cursor` extension in Subscribe/Next | S | |
+| Negotiation + `extensions.cosmo.delivery` (class + authz) | S | |
+| Config + staged validation (§9.1) + `max_concurrent_replays` | M | More than the previous S: staged, continuous re-validation, authz-hook gate. |
+| Composition `deliveryConfiguration` directive (optional) | M | Defer unless per-field policy needed. |
+
+Risk is concentrated in **two L items**: the engine cursor threading (breaking writer interface) and the resuming-client own-trigger routing. Pattern B is **not** "essentially stateless" — it is O(1)-durable but pays a per-resuming-subscriber broker reader. It remains the lightest *cursor-able* durable option relative to C (which explodes consumer count for *all* subscribers), but the L–XL grade is the honest one.
+
+Recommended sequencing (dossier §5.x): **D** (fix the existing ack timing) → **B** (cursor resume on log backends, emit `id:`), once Cosmo Streams v1 (§0) lands.
+
+---
+
+## 13. Testing & Verification
+
+A concrete matrix, not a TODO.
+
+**Correctness (per backend: JetStream stream-backed, Kafka, Redis Streams):**
+- **No-gap replay:** publish N events, disconnect after event k, reconnect with cursor k, assert events k+1..N all delivered, in order, exactly via the single reader (no skip). Assert the *full* delivered sequence with `assert.Equal` on the ordered list — no `Contains`.
+- **No two-consumer race:** publish continuously across the reconnect; assert no event published during the seek→live transition is skipped (the single-reader invariant).
+- **Bounded duplicates:** assert duplicates only at the boundary (cursor recorded pre-processing), never loss.
+- **`CURSOR_EXPIRED`:** force retention eviction below the cursor; assert a `CURSOR_EXPIRED` error frame and that **no** live subscription starts (loud, not silent skip-to-now).
+- **Timestamp-seek boundary:** Pub/Sub/Kafka time fallback — assert the report flips to `at-least-once-boundary-approx`.
+
+**Trigger model (engine):**
+- **Resuming client never joins the shared trigger:** assert a cursor-bearing subscribe creates a *new* trigger (`Source.Start`/`SubscribeFrom` invoked) with a `triggerID` distinct from the cursor-less trigger (§4.5). This is the regression guard for review issue 2.
+- **Cursor-less client still shares fan-out:** assert two identical cursor-less subscribes share one broker subscription.
+
+**Security:**
+- **Token-refresh resume:** reconnect with a *refreshed* auth token; assert resume **succeeds** (because `ResumeKey` excludes volatile headers — §4.2). This is the regression guard for review issue 10.
+- **Forged/cross-subscription/stale cursor → `CURSOR_INVALID`.**
+- **Key rotation:** rotate the signing key; assert in-flight cursors signed with the previous key still verify within the overlap window (§8.1).
+- **Per-event authz on replay (hook configured):** revoke access to a subset mid-disconnect; assert replay filters those events. **No-hook path:** assert the report says `authz: operation-only` (documents the gap, §8.5).
+
+**Load / capacity:**
+- **Reconnect storm:** 5,000 concurrent resuming clients on a 32-partition Kafka topic; assert `max_concurrent_replays` caps concurrent readers and the overflow path (`restart_live`+`gap=true` or bounded queue) behaves as configured (§8.3).
+- **Subgraph amplification:** replay 10k events that each trigger a federated fetch; assert `max_replay_events` bounds downstream fetch volume (§8.4).
+- **Repeated reconnect during replay (§22):** disconnect mid-catch-up, reconnect; assert intermediate cursors (if emitted) prevent full re-replay, or that the original-cursor re-replay is bounded and the transient reader is torn down (no leak/livelock).
+
+**Wire:**
+- **SSE initial-message:** assert the `id:` line is **omitted** for the synthetic initial message (§8.6).
+- **Cursor size:** assert single-partition cursors stay under the configured proxy header limit; assert multi-partition vector behavior matches the §5.1 mitigation.
+
+## 14. Rollback
+
+- **Instant disable:** remove `cursor_signing_key` (and `_previous`). The router stops emitting `id:`/`cursor` and stops honoring inbound cursors; behavior reverts **byte-for-byte** to today's at-most-once (asserted by a golden-output test per §10). No data migration, no schema change to undo.
+- **Per-provider disable:** set `delivery.mode: at-most-once` (or remove the block) on the affected provider; other providers unaffected.
+- **Redis Streams:** rollback is *not* free for a field already migrated to `topology: streams` (publisher now `XADD`s). Rolling back that field to `pubsub` requires reverting the publisher too — call this out as the one non-instant rollback (§10).
+- **Engine change:** because the writer-interface change is coordinated (§11), rolling back the engine requires rolling back the router build together. Pin both.
+- **Failure trigger:** if resume corrupts delivery in prod (e.g. observed loss, mis-routed cursors), disable via signing-key removal first (instant), then investigate. The kill switch is config-only and requires no redeploy if `cursor_signing_key` is hot-reloadable; otherwise a config push + restart.
+
+## 15. SLO / observability targets
+
+- **`cursor_expired` rate** is the primary health signal: a sustained rate > X% of resume attempts means **retention is too short for `max_resume_age`** → operator action: raise broker retention or lower `max_resume_age`. Alert threshold: `rate(cosmo_subscription_cursor_expired_total) / rate(resume_attempts) > 0.01` for 10m.
+- **`concurrent_replays` near `max_concurrent_replays`** → reconnect storm / under-provisioned cap → alert at 80% saturation.
+- **`delivery_retention_below_max_resume_age`** gauge true → guaranteed future `cursor_expired` → page.
+- **`cursor_invalid` rate** spike → client/clock/rotation misconfig or an attack → alert.
+- **`replay_truncated` rate** → `max_replay_events`/`duration` too low for real backlogs → tune.
+
+## 16. Alternatives considered
+
+- **Why B over E (router buffer) for log backends:** E manufactures a replay window in router RAM, duplicating the broker's own log and bounding the window by memory; B reuses the broker's retained log (durable, larger, free). For log backends B is strictly better; E is for *non-log* backends (NATS core, Redis Pub/Sub, SQS), which B cannot serve.
+- **Why not just D:** D fixes ack *timing* (flush-success), but flush ≠ receipt and D has no resume — a client gone during downtime still misses everything. D is the prerequisite correctness fix; B adds the resume D lacks. They compose (D then B).
+- **Why not C (durable per-subscriber consumer):** C survives router restart without relying on broad retention, but explodes broker consumer count for *every* subscriber (breaks shared-trigger dedup for all) and needs an external checkpoint store. B pays the per-subscriber-reader cost **only for resuming clients** and needs no checkpoint store. B is the lighter durable win where a retention window suffices; C is the answer when retention is too short to lean on.
+- **Why not A (client ack) here:** A is the strongest guarantee but requires a new inbound ack message and an SSE back-channel (SSE is one-way) — a heavier client-protocol change. B reuses the existing one-way SSE primitive (`Last-Event-ID`) and adds only optional WS extension fields.

--- a/rfc/at-least-once/rfc-C-durable-consumer-checkpoint.md
+++ b/rfc/at-least-once/rfc-C-durable-consumer-checkpoint.md
@@ -1,0 +1,1202 @@
+# RFC: At-Least-Once for GraphQL Subscriptions — Durable-Consumer-Per-Subscription + Router-Side Checkpoint Store (Pattern C)
+
+**Status:** Draft
+
+**TL;DR.**
+Today EDFS delivers broker events to GraphQL clients fire-and-forget,
+and only NATS JetStream achieves any durability — by accident,
+because its adapter calls `msg.Ack()` after a *flush attempt*.
+This RFC proposes a server-side durability substrate:
+give each logical client subscription its own durable consumer / checkpoint
+(JetStream durable consumer, Redis Streams consumer group,
+or an external checkpoint in Redis/DynamoDB/Postgres for Kafka/Kinesis/Event Hubs),
+and advance that checkpoint only after the router has confirmed the event left the subscriber's writer.
+
+**Be honest about what the *default* deployment buys you.**
+With a stock client (Apollo, urql, Relay, graphql-sse) and the default `shared` isolation,
+Pattern C delivers **at-least-once relative to flush, restart-survivable**, with shared-trigger
+head-of-line risk and a documented silent-loss window where a stuck/dropped subscriber loses events.
+That is a real improvement over today (which loses everything on restart), but it is **not** end-to-end at-least-once.
+The strong claim — "at-least-once to client receipt, across both router restart and client reconnect" —
+holds **only** when you opt into `per-subscriber` isolation *and* run a patched client that sends per-message acks.
+Neither is the default, and both carry the costs spelled out below:
+per-subscriber isolation defeats Cosmo's shared-trigger fan-out (one broker consumer becomes N),
+and per-message ack requires forking every client SDK because the graphql-ws protocol has no native ack frame.
+Because a confirmed *flush* is still not a confirmed *client receipt*,
+Pattern C is best framed not as a complete answer on its own,
+but as the substrate that Pattern A (client ack) and Pattern B (cursor resume) ride on
+to close the last hop to the client.
+
+This draft has been revised after adversarial review. Several earlier claims were materially wrong
+(Kafka per-message at-least-once, "minimal engine change," a single contiguous-prefix invariant
+that only holds in one isolation mode, Redis Streams without a publisher change, Google Pub/Sub
+per-client subscriptions). Those are corrected below, and the honest trade-offs are documented in §6, §7, and §12.
+
+---
+
+## 1. Problem & Context
+
+A team running Cosmo EDFS already has at-least-once *in their backend*.
+Their Kafka topic commits offsets,
+their JetStream stream retains messages and tracks a durable consumer's ack floor,
+their Redis Stream keeps a Pending Entries List.
+The durability they paid for stops at the router's front door.
+
+Cosmo's EDFS layer is fire-and-forget by construction.
+The generic glue between a broker adapter and the GraphQL engine carries **no delivery result and no ack hook back to the broker**.
+`datasource.Adapter` (`router/pkg/pubsub/datasource/provider.go:22-28`) exposes
+`Subscribe(ctx, cfg, updater)` and the engine's `SubscriptionUpdater.Update(data)` returns `void`.
+There is nowhere for "the client got it" to travel back to "advance the broker position."
+Durability is therefore a *per-adapter property*, not a property of EDFS,
+and today exactly one adapter even tries.
+
+The concrete current behavior, anchored in the code:
+
+- **NATS JetStream acks on a flush attempt, not on receipt.**
+  The reader loop fetches a batch (`consumer.FetchNoWait(300)`),
+  calls `updater.Update(...)` which synchronously runs resolve + `writer.Flush()` for every subscriber,
+  then calls `msg.Ack()` (`router/pkg/pubsub/nats/adapter.go:146,154`).
+  A successful `Flush()` means *bytes handed to the kernel TCP buffer*,
+  not an application ack from the client.
+  A client that crashes after TCP-buffering but before processing loses the message — yet it is acked.
+- **The durable consumer is named per *router process*, not per *subscription*.**
+  `getDurableConsumerName` hashes `instanceID + subjects`
+  (`router/pkg/pubsub/nats/adapter.go:61-83`).
+  This is deliberate — it stops two routers from fighting over one consumer —
+  but it means a *different* router instance after failover gets a *different* consumer,
+  and a reconnecting client gets a brand-new subscription id from "now" anyway
+  (`resolve.NewConnectionID()`, `websocket.go:367`; new sub id `websocket.go:1160-1185`).
+  Durable resume and HA are at odds.
+- **Kafka and Redis don't even read durably.**
+  Kafka uses a groupless direct consumer with `ConsumeResetOffset(AfterMilli(now))`
+  and never commits (`router/pkg/pubsub/kafka/adapter.go:32-34,51-122`) —
+  it *skips everything produced during downtime*.
+  Redis uses Pub/Sub, not Streams, on **both** the publish (`PUBLISH`, `redis/adapter.go:191`)
+  and subscribe (`PSubscribe`, `redis/adapter.go:88-152`) sides — no ack, no backlog.
+  NATS core uses an unbuffered Go channel that drops on overflow (`nats/adapter.go:168`).
+- **There is no client-side ack and no resume token anywhere.**
+  The inbound WS message set is `Ping`, `Pong`, `Subscribe`, `Complete`, `Terminate`
+  (`router/internal/wsproto/proto.go:88-94`) — no "ack received" concept.
+  The SSE writer never emits an `id:` field (`router/core/flushwriter.go:116-167`),
+  so even native `Last-Event-ID` auto-resume cannot work.
+  A reconnecting client always starts fresh from "now."
+
+This RFC builds on the **Cosmo Streams v1** hook surface where relevant.
+The v1 `StreamBatchEventHook` / `SubscriptionOnStartHandler` (see `rfc/cosmo-streams-v1.md`)
+are the natural place to plug per-subscription identity, replay authz, and checkpoint policy,
+and the per-provider `StreamEvent` types that v1 introduces are exactly where we will surface the broker position
+(stream sequence, partition+offset, entry id) that today's code throws away.
+
+The goal of Pattern C is narrow and deep:
+**make the broker position advance reflect confirmed router-side delivery,
+per logical subscription, and survive a router restart.**
+
+### 1.1 The engine model this RFC must change (verified against `graphql-go-tools/v2 v2.4.1`)
+
+The single most consequential correction in this revision: the engine is **not** structured to return per-subscriber
+delivery results to the adapter, and making it do so is **not** a "minimal change." The verified facts:
+
+- The adapter's reader goroutine calls `updater.Update(data []byte)`. The engine's `subscriptionUpdater.Update`
+  (`resolve.go:1479`) takes `s.mu.Lock()`, calls `r.handleTriggerUpdate`, and **returns `void`**.
+- `handleTriggerUpdate` (`resolve.go:1086`) fans subscribers out via `wg.Go(...)`, then `wg.Wait()`,
+  and **discards every per-subscriber result**. `executeSubscriptionUpdate` (`resolve.go:616`) returns nothing;
+  on flush failure it calls `r.UnsubscribeSubscription(sub.id)` *internally* (`resolve.go:679`).
+- The `s.mu.Lock()/defer Unlock()` in `Update` is held **across the entire trigger update including `wg.Wait()`**.
+  The comment marks this as an "event serialization gate": event A fully completes before event B begins.
+- The actual delivery happens on the resolver's **own event-loop goroutine** (`AsyncResolveGraphQLSubscription`);
+  the `subscriptionUpdater` is a thin proxy. The adapter's reader goroutine does **not** synchronously observe
+  per-subscriber flush results.
+
+This means the back-channel Pattern C needs (collect `[]DeliveryResult`, drive the broker commit) requires four concrete engine changes,
+detailed in §3.2. Treat the engine work as **L–XL on its own**, not "M, shared with Pattern D."
+
+---
+
+## 2. Goals & Non-Goals
+
+### Goals
+
+1. Each logical client subscription is backed by **its own durable consumer or checkpoint**,
+   independent of which router process or instance serves it (in `per-subscriber` isolation; `shared` keeps one checkpoint per trigger).
+2. The router **advances the checkpoint only after delivery is confirmed** at the writer boundary
+   (flush success by default; client ack when combined with Pattern A).
+3. Survive **router restart and instance failover**: a reconnecting client
+   (or the same client re-routed to a new instance) resumes from its last committed checkpoint,
+   bounded by broker retention.
+4. Survive **client reconnect**: an un-acked window is redelivered, not lost (in `per-subscriber`; see §6 for the `shared`-mode hole).
+5. Provide a **pluggable checkpoint store** abstraction so backends without per-consumer durable state
+   (Kafka per-client, Kinesis, Event Hubs) get the same guarantee via an external store (Redis/DynamoDB/Postgres).
+6. **Degrade explicitly and non-silently** to Pattern B's window or to at-most-once
+   on backends that cannot support per-consumer durable state,
+   surfacing the *actual* delivery class to the operator and (optionally) the client.
+
+### Non-Goals
+
+1. **End-to-end exactly-once to the client.** Out of scope here — requires Pattern A's client ack + client dedup.
+   Pattern C is the substrate; it does not, alone, prove the client processed the event.
+2. **Closing the flush ≠ receipt gap by itself.** Without Pattern A, the checkpoint can advance past an event
+   the client TCP-buffered but never processed. We make this gap explicit (§7) rather than hide it.
+3. **Preserving the shared-trigger optimization unchanged.** Per-subscription durability is fundamentally at odds
+   with one-broker-subscription-per-input-hash. We will offer a hybrid (§8) but the durable path is per-subscriber.
+4. **Inventing replay on delete-on-ack queues.** SQS-standard, RabbitMQ, NATS core, Redis Pub/Sub have no durable position.
+   They degrade; Pattern E (router buffer) is the right tool there, not C.
+5. **Global ordering across a fanned-out stream.** Ordering is per-consumer / per-partition, never global. Same as every backend.
+6. **Per-message at-least-once on prefix-commit backends (Kafka, Kinesis, Event Hubs).** These commit a single
+   monotonic offset per partition; there is no per-message nak. Pattern C on these backends advances a *prefix*,
+   which means head-of-line blocking, not per-message redelivery. We route per-client durability on Kafka to the
+   external-checkpoint path and document the head-of-line semantics honestly (§5, §6).
+
+---
+
+## 3. Design — the mechanism in depth
+
+### 3.1 The core idea
+
+Replace the implicit, per-process, flush-gated ack with an explicit, per-subscription, delivery-gated **checkpoint**.
+
+Three new concepts:
+
+1. **A stable subscription identity** — `SubscriptionKey` — derived from a *server-validated* client principal
+   (a signed, tenant-scoped subscription token), the root field, and a *deterministically rendered* destination set.
+   This is the key that survives reconnect and failover.
+   It is deliberately *not* the engine's data-only trigger hash (§1.4 of the dossier),
+   because that hash is shared across clients and reborn on reconnect.
+   Its determinism and forgery resistance are load-bearing and are specced in §3.6 and §8.5.
+
+2. **A `DurableConsumer`** — a per-`SubscriptionKey` durable read position in the broker.
+   On JetStream it is a durable pull consumer named from the `SubscriptionKey`
+   (the fix for `nats/adapter.go:61-83`).
+   On Redis Streams it is a consumer-group + consumer-name pair.
+   On Kafka, Kinesis, and Event Hubs there is **no viable per-client broker-side consumer state**
+   (see §5 for why Kafka per-client consumer groups are an anti-pattern), so the position lives entirely in the checkpoint store
+   and the adapter seeks by `(partition, offset)` / sequence number per read.
+
+3. **A `CheckpointStore`** — an interface that loads/commits a `Checkpoint` (an opaque, backend-specific position)
+   for a `SubscriptionKey`.
+   For broker-native backends (JetStream ack floor, Redis PEL/last-delivered-id),
+   the store is a thin wrapper over the broker's own commit primitive.
+   For external-checkpoint backends (Kafka per-client, Kinesis, Event Hubs), it is Redis/DynamoDB/Postgres.
+
+The reader loop changes from *"deliver, then ack the batch"* to
+*"deliver, collect a per-subscriber delivery result, advance the checkpoint to the highest contiguous confirmed position, redeliver the rest."*
+
+**Crucial distinction — two commit granularities (the reason the per-backend behavior differs):**
+
+- **Per-message-ack backends** (JetStream, Redis Streams PEL, Google Pub/Sub, SQS, RabbitMQ):
+  individual messages can be acked/nak'd; an unconfirmed message in the middle of a batch can be redelivered
+  while later confirmed messages are *not* re-sent. The contiguous-prefix invariant is a *policy choice* here, for ordering.
+- **Prefix-commit backends** (Kafka, Kinesis, Event Hubs):
+  the committable unit is a monotonic offset/sequence per partition. Committing offset N implicitly acks everything ≤ N.
+  There is **no per-message nak** — you can only *not advance*. "Nak the rest" from §3.1's prose is impossible here;
+  the only lever is to hold the commit at the lowest unconfirmed offset, which blocks the whole partition prefix (head-of-line).
+
+The `Checkpoint []byte` opaque type papers over this difference; §6 and §5 spell out where it bites.
+
+### 3.2 New interfaces (sketch) and the concrete engine change
+
+These slot into `router/pkg/pubsub/datasource/`, the boundary the dossier identifies as the fire-and-forget seam.
+
+```go
+// SubscriptionKey is the durable identity of a logical client subscription.
+// It survives reconnect and instance failover. Unlike the engine's trigger
+// hash, it is keyed on a *server-validated* client principal, not just the data,
+// and the destination component is deterministically rendered (see §3.6).
+type SubscriptionKey struct {
+    // Tenant + client identity, taken from a server-validated principal (see §8.5).
+    // ClientID MUST NOT be client-asserted (cross-user replay otherwise — §8.5).
+    Tenant   string
+    ClientID string
+    // Logical operation identity.
+    RootFieldName string
+    // Deterministically rendered destination set (subjects / topics / channels), hashed.
+    // Determinism across instances + engine versions is a correctness requirement (§3.6).
+    DestinationHash string
+}
+
+func (k SubscriptionKey) String() string // stable, URL-safe, used as the durable name
+
+// Checkpoint is an opaque, backend-specific read position.
+// JetStream: stream sequence (ack floor). Kafka: map[partition]offset (PREFIX commit).
+// Redis Streams: last-delivered entry id. Kinesis: per-shard sequence number.
+// Event Hubs: per-partition offset. It is always serializable for the store.
+//
+// NOTE: per-message-ack backends and prefix-commit backends differ in commit
+// granularity (§3.1). A Checkpoint on a prefix-commit backend represents
+// "everything up to and including this position is acked," not a single event.
+type Checkpoint []byte
+
+// DeliveryResult is what the framework now collects per delivered event,
+// per subscriber. This is the value that today is thrown away (Update returns void).
+type DeliveryResult struct {
+    Position    Checkpoint // backend position of this event
+    Confirmed   bool       // writer flush succeeded (or client ack, with Pattern A)
+    Err         error      // non-nil => redeliver (per-message-ack backends) / do-not-advance (prefix-commit)
+}
+
+// CheckpointStore persists the committed position for a subscription.
+// For broker-native backends this delegates to the broker's commit primitive.
+type CheckpointStore interface {
+    // Load returns the committed checkpoint for a subscription, or (nil, false)
+    // for a brand-new subscription. On a transport/store ERROR it returns (nil, false, err);
+    // callers MUST refuse to start the subscription rather than fall back to "now" (§6 #3, §7).
+    Load(ctx context.Context, key SubscriptionKey) (Checkpoint, bool, error)
+    // Commit advances the durable position. Must be idempotent and monotonic:
+    // a Commit to an older position than the stored one is a no-op.
+    Commit(ctx context.Context, key SubscriptionKey, cp Checkpoint) error
+    // Release marks a subscription inactive (for GC of external state).
+    Release(ctx context.Context, key SubscriptionKey) error
+}
+
+// DurableAdapter is the extended adapter contract. It replaces the
+// fire-and-forget Subscribe with one that takes a SubscriptionKey and a
+// start checkpoint, and whose updater reports DeliveryResults back.
+type DurableAdapter interface {
+    datasource.Lifecycle
+    SubscribeDurable(
+        ctx context.Context,
+        key datasource.SubscriptionKey,
+        start datasource.Checkpoint, // nil => use StartPolicy
+        cfg datasource.SubscriptionEventConfiguration,
+        updater datasource.DurableUpdater,
+    ) error
+    Publish(ctx context.Context, cfg datasource.PublishEventConfiguration, events []datasource.StreamEvent) error
+    // Capabilities advertises what this adapter can durably support, so the
+    // negotiation layer can degrade non-silently.
+    DurableCapabilities() DurableCapabilities
+}
+
+// DurableUpdater extends SubscriptionEventUpdater (subscription_event_updater.go:19-24)
+// with a back-channel. Because the engine delivers on its own event-loop goroutine
+// (resolve.go:1086, AsyncResolveGraphQLSubscription), confirmation is reported
+// ASYNCHRONOUSLY via a channel, NOT a synchronous return value (see "Engine change" below).
+type DurableUpdater interface {
+    datasource.SubscriptionEventUpdater
+    // UpdateDurable delivers events carrying their backend Position. Per-position
+    // DeliveryResults are delivered on the returned channel as each subscriber's
+    // flush (or ack) resolves on the engine goroutine. The adapter's commit loop
+    // (decoupled from the engine serialization gate, §6 / §3.3) consumes them.
+    UpdateDurable(events []datasource.PositionedEvent) <-chan datasource.DeliveryResult
+}
+
+// PositionedEvent is a StreamEvent plus its backend position. The position is
+// read from data the code ignores today: msg.Metadata() (JetStream),
+// r.Offset/r.Partition (Kafka), the entry id (Redis Streams).
+type PositionedEvent struct {
+    datasource.StreamEvent
+    Position datasource.Checkpoint
+}
+
+type DurableCapabilities struct {
+    PerConsumerDurable bool          // JetStream, Redis Streams, Pub/Sub, external-checkpoint backends
+    PrefixCommitOnly   bool          // Kafka, Kinesis, Event Hubs: no per-message nak (head-of-line)
+    ReplayWindow       time.Duration // retention bound; 0 => unbounded within store
+    NativeDedup        bool          // SQS FIFO, Pub/Sub EOS, JetStream Nats-Msg-Id window
+    Class              DeliveryClass // best achievable: AtLeastOnce | BWindow | AtMostOnce
+}
+```
+
+**The engine change, specified concretely (BLOCKER #1).**
+The earlier draft's `Update(data) []DeliveryResult` is *architecturally impossible* as a synchronous return,
+because the result must cross from the resolver's event-loop goroutine back to the adapter's reader goroutine.
+The concrete plan, naming the exact `graphql-go-tools` functions:
+
+1. **`subscriptionUpdater.Update` (`resolve.go:1479`) gains a positioned variant** that does not discard results.
+   Add `UpdatePositioned(events []PositionedEvent, results chan<- DeliveryResult)` (or attach a results sink to the
+   `subscriptionUpdater` at subscribe time). The existing void `Update` stays for the at-most-once path.
+2. **`handleTriggerUpdate` (`resolve.go:1086`) stops discarding per-subscriber outcomes.**
+   Each `wg.Go` worker reports `(subID, position, confirmed, err)` instead of swallowing it.
+3. **`executeSubscriptionUpdate` (`resolve.go:616`) returns a flush/ack outcome** rather than only calling
+   `UnsubscribeSubscription` internally on failure. The internal unsubscribe-on-flush-failure behavior is preserved,
+   but the *outcome* is now also surfaced upward.
+4. **The result crosses the goroutine boundary via a channel**, consumed by the adapter's **decoupled commit loop**
+   (§3.3), *not* inside the `s.mu`-guarded serialization gate (§6, MAJOR #7). The commit loop is keyed by position
+   so it can advance the contiguous confirmed prefix independently of which event batch the engine is currently processing.
+
+This is a cross-repo change to a separately-released, version-pinned engine (`router/go.mod`:
+`graphql-go-tools/v2 v2.4.1`, with a commented-out local `replace`). It requires cutting a new engine release and
+bumping the pin — a coordination cost listed as its own workstream in §12. Line numbers are against the `v2.4.1`
+snapshot and must be re-verified against the engine version the implementation targets (the dossier notes line drift between snapshots).
+
+### 3.3 Lifecycle — one durable subscription, happy path (decoupled commit)
+
+```
+                         ┌───────────────────────────────────────────────────────┐
+                         │                    Cosmo Router                        │
+  client ──Subscribe──▶  │  websocket.go / flushwriter.go                         │
+  (signed sub token,     │      │                                                 │
+   optional resume cp)   │      ▼                                                 │
+                         │  principal = verify(token)  // server-validated, §8.5  │
+                         │  SubscriptionKey = f(principal.tenant,                 │
+                         │     principal.clientID, rootField, destHash)  // §3.6  │
+                         │      │                                                 │
+                         │      ▼                                                 │
+                         │  CheckpointStore.Load(key)                            │
+                         │      ├─ ok    -> start checkpoint                      │
+                         │      ├─ miss  -> StartPolicy (new sub)                 │
+                         │      └─ ERROR -> REFUSE: surface `resume-failed` (§7)  │
+                         │      │                                                 │
+                         │      ▼                                                 │
+                         │  DurableAdapter.SubscribeDurable(key, start, cfg, upd) │
+                         └──────┬────────────────────────────────────────────────┘
+                                │
+            ┌───────────────────▼─────────────────────┐
+            │   Broker durable consumer (per key)      │
+            │   JetStream durable | Redis cons-group | │
+            │   external cp (Kafka/Kinesis/Event Hubs) │
+            └───────────────────┬─────────────────────┘
+                                │  fetch from `start`
+                                ▼
+   ┌────────────────────────────────────────────────────────────────────────┐
+   │  reader loop (per SubscriptionKey in per-subscriber; per trigger shared) │
+   │                                                                          │
+   │   batch = fetch()                                                        │
+   │   positioned = [(evt, position) ...]   // read msg.Metadata / r.Offset   │
+   │        │                                                                 │
+   │        ▼  Streams-v1 StreamBatchEventHook (map/filter/authz, §8.5)       │
+   │   resultsCh = updater.UpdateDurable(positioned)   // returns a channel   │
+   └────────────────────────────────────────────────────────────────────────┘
+                                │
+              (engine event-loop goroutine resolves + flushes per subscriber,
+               OUTSIDE the adapter reader goroutine; resolve.go:1086)
+                                │
+                                ▼  DeliveryResult{position, confirmed, err}
+   ┌────────────────────────────────────────────────────────────────────────┐
+   │  decoupled commit loop (NOT inside the s.mu serialization gate, §6)      │
+   │                                                                          │
+   │   per-message-ack backend (JetStream/Redis Streams/Pub/Sub):            │
+   │     advance ack floor to highest CONTIGUOUS confirmed position;          │
+   │     nak / leave-in-PEL the unconfirmed => redeliver                      │
+   │                                                                          │
+   │   prefix-commit backend (Kafka/Kinesis/Event Hubs):                     │
+   │     commit offset = (lowest unconfirmed) - 1  // do NOT advance past it  │
+   │     => head-of-line: a stuck position blocks the whole partition prefix  │
+   │                                                                          │
+   │   CheckpointStore.Commit(key, hwm)   // monotonic + idempotent          │
+   │   on Commit error: do NOT advance (fail-closed -> dup, never loss)       │
+   └────────────────────────────────────────────────────────────────────────┘
+```
+
+The critical invariant **for per-message-ack backends**: the checkpoint advances to the highest *contiguous*
+confirmed position, never past a gap. If positions 5,6,7 are delivered and 5 and 7 confirm but 6 fails,
+the checkpoint commits at 5, and 6 (and therefore 7 again) are redelivered.
+This trades duplicates for no-loss — the at-least-once bargain — and keeps ordering intact
+because we never commit past an unconfirmed hole.
+
+**This invariant is well-defined for one consumer reading one position sequence.** It is *not* a single universal
+invariant across both isolation modes; §6 splits the two modes because their correctness properties are opposite.
+
+### 3.4 Lifecycle — reconnect and restart
+
+```
+  t0  client subscribes, key=K, delivered+committed through position 100
+  t1  client disconnects (or router instance crashes)
+        - in-flight positions 101..105 were delivered but NOT committed
+        - CheckpointStore still holds 100 (broker-native: ack floor; external: stored offset)
+  t2  client reconnects -> verify(token) -> SAME principal -> SAME SubscriptionKey K
+        - K is stable ONLY if DestinationHash is deterministic (§3.6); else Load misses -> resume-failed (§7)
+        - may land on a DIFFERENT router instance
+  t3  CheckpointStore.Load(K) => 100   (on store ERROR: refuse, surface resume-failed; never start from "now")
+  t4  SubscribeDurable(K, start=100)
+        - JetStream: bind to durable consumer K; redelivers un-acked from ack floor
+        - Redis Streams: XAUTOCLAIM the PEL for consumer-group K, then XREADGROUP
+        - Kafka (external cp): seek partition to committed offset 100 (+1); NO consumer group churn
+        - Kinesis/Event Hubs (external cp): GetShardIterator AFTER_SEQUENCE_NUMBER(100)
+  t5  router replays 101..105 (re-running authz, §8.5), then resumes live from 106
+```
+
+Because the durable name / checkpoint is keyed on the *subscription*, not the *process*,
+a brand-new router instance reconstructs the exact read position and replays the gap —
+**provided** the resume identity (`SubscriptionKey`) is stable (§3.6) and `experiment_delete_durable_consumers_on_shutdown`
+is **off** (§3.5). The dossier calls HA the single biggest design axis;
+Pattern C resolves it by paying for per-subscription consumer state and a shared checkpoint store.
+
+### 3.5 Cosmo components touched
+
+| Component | Change |
+|---|---|
+| `router/pkg/pubsub/datasource/provider.go:22-28` | Add `DurableAdapter` / `DurableCapabilities`; keep `Adapter` for non-durable fields. |
+| `router/pkg/pubsub/datasource/subscription_event_updater.go:19-129` | Add `DurableUpdater.UpdateDurable` returning a `<-chan DeliveryResult`; collect outcomes instead of discarding. On hook timeout **cancel** in-flight deliveries (not abandon), see MAJOR #15. |
+| `router/pkg/pubsub/nats/adapter.go:61-83,130-159,413-442` | Durable name = `SubscriptionKey` (fix per-instance hash); read `msg.Metadata()` for stream seq; `Ack/Nak` from `DeliveryResult` in the decoupled commit loop, not unconditionally at `:154`. **Must force `experiment_delete_durable_consumers_on_shutdown` off** in durable mode (it deletes exactly the consumers we rely on). |
+| `router/pkg/pubsub/kafka/adapter.go:32-122` | Do **not** use per-client consumer groups (anti-pattern, §5). Keep a small pool of group-or-groupless readers; per-`SubscriptionKey` position lives in the external `CheckpointStore`; seek by `(partition, offset)`; commit = prefix only (head-of-line). |
+| `router/pkg/pubsub/redis/adapter.go:88-152,191` | New Redis **Streams** path (`XREADGROUP`/`XACK`/`XAUTOCLAIM`) for the subscribe side **and** a publisher change to `XADD` (see MAJOR #11); durable mode requires Streams on both producer and consumer. |
+| New `router/pkg/pubsub/checkpoint/` | `CheckpointStore` impls: `broker` (delegates), `redis`, `dynamodb`, `postgres`. |
+| `router/core/websocket.go:367,1141-1185` | Derive `SubscriptionKey` from a **server-validated** principal; carry resume checkpoint from `Subscribe` payload; new `ack` inbound (only when Pattern A enabled). Confirm `connection_init.payload.cosmo` is additive and does not clobber existing `connectionParams` auth handling (MINOR #19). |
+| `router/core/flushwriter.go:116-167,252-299` | Emit `id:` (the sealed checkpoint) on SSE; honor `Last-Event-ID`; `POST /ack` back-channel for Pattern A on SSE. |
+| `router/internal/wsproto/proto.go:88-94` | Add `MessageTypeAck` (Pattern A); negotiate capability in `connection_init` payload. **Non-standard graphql-ws extension** — requires patched clients (§4.4). |
+| `resolve.SubscriptionUpdater` (graphql-go-tools `v2.4.1`) | `Update` path must surface per-subscriber delivery success across the engine→adapter goroutine boundary (`resolve.go:1086,616,1479`). **L–XL engine change**, not minimal; requires an engine release + pin bump (§12). |
+| `router/pkg/config/config.go:773-782` | New `delivery` block (see §9). |
+| Composition / proto | Optional `@edfs__delivery(class: AT_LEAST_ONCE)` directive (see §9); otherwise pure router YAML. |
+
+### 3.6 `DestinationHash` determinism and resume identity (BLOCKER #5)
+
+The central premise — "same token on reconnect ⇒ same `SubscriptionKey` ⇒ `Load` hits" — fails if `DestinationHash`
+is not byte-stable across reconnects, instances, and engine versions. Subjects/topics/channels are templated from
+operation arguments (e.g. `employeeUpdates(id: $id)` → subject `employeeUpdates.{id}`), so the rendered destination
+depends on the variables the client sends on resubscribe and on header rendering, which can differ per instance.
+
+If the rendered destination differs even slightly on reconnect, the key changes, `Load` misses, and the naive design
+would silently start from "now" and lose the gap. That is the exact silent loss this RFC forbids. Two mitigations,
+both required:
+
+1. **Specify `DestinationHash` inputs exactly and render them deterministically.** The hash is computed over the
+   *canonicalized, sorted* rendered destination set only — not over raw variables or header maps. Canonicalization
+   (lowercase subject tokens, sorted topic list, stable JSON encoding) must be identical across instances and pinned
+   to the engine version. Header-derived destinations are excluded from the hash unless the header is part of the
+   declared routing key. This makes the hash a pure function of the declared routing template plus the resolved
+   routing arguments.
+
+2. **Prefer a client-presented opaque resume token that *carries* the key (Pattern B primitive).** Rather than
+   recompute the key on reconnect and hope it matches, the resume path uses the sealed `resumeFrom` token (§4.1, §8.5),
+   which embeds the `SubscriptionKey` it was minted against. On resume the router verifies the token, extracts the
+   embedded key, and loads against *that* key — eliminating recomputation drift entirely. Recomputation is used only
+   for the *first* subscribe (no token yet).
+
+**Failure mode (explicit, never silent):** if the resume token's embedded key does not match a recomputed key for the
+presenting principal, or if `Load` misses where a token was presented, the router surfaces `resume-failed`
+(WS `error` / SSE error event) and does **not** silently restart from "now." The client may then choose to resubscribe
+fresh (accepting the gap) — but that is the client's explicit decision, surfaced, not the router's silent one.
+
+---
+
+## 4. Wire protocol & client changes
+
+Pattern C, *strictly on its own*, **requires no client protocol change**:
+the checkpoint advances on flush success, and a reconnecting client that re-presents the same signed token
+resumes from the committed position transparently.
+That is the honest framing — and also its honest weakness:
+flush success is not client receipt, so "no client change" buys you only "at-least-once relative to flush,"
+not "at-least-once relative to the client actually processing the event" (§7).
+
+To close that last hop, Pattern C is designed to *carry* the wire primitives of Pattern A and Pattern B.
+The substrate is the same; only the gate on `CheckpointStore.Commit` changes
+(flush success → client ack).
+
+### 4.1 graphql-transport-ws / graphql-ws
+
+**Capability negotiation (connection scope).**
+The client advertises support in the `connection_init` payload; the server echoes the negotiated class in `connection_ack`.
+The `cosmo` key is **additive and namespaced** so it does not clobber the `connectionParams`/auth payload that Apollo,
+urql, and others already place at `connection_init.payload` (MINOR #19); the negotiation must be tested against
+Apollo/urql strict-parser configurations to confirm unknown keys in `connection_ack.payload` do not trip client validation.
+
+```jsonc
+// client -> server
+{ "type": "connection_init",
+  "payload": { "cosmo": { "delivery": { "supports": ["resume", "ack"] } } } }
+
+// server -> client
+{ "type": "connection_ack",
+  "payload": { "cosmo": { "delivery": { "class": "at-least-once",
+                                        "ack": true, "resume": true } } } }
+```
+
+**Resume on (re)subscribe (Pattern B primitive, optional).**
+The client carries its last checkpoint in the `Subscribe` payload. Opaque + signed; it *embeds* the `SubscriptionKey` (§3.6, §8.5).
+
+```jsonc
+{ "id": "1", "type": "subscribe",
+  "payload": { "query": "subscription { employeeUpdates { id } }",
+               "extensions": { "cosmo": { "resumeFrom": "eyJzZXEiOjEwMH0...signed" } } } }
+```
+
+**Per-message checkpoint + client ack (Pattern A primitive, optional).**
+Each `next` carries its checkpoint in `extensions`; the client acks by id+checkpoint via a **new inbound message type**.
+This is the addition to `wsproto/proto.go:88-94` (`MessageTypeAck`). It is a **non-standard graphql-ws extension**
+(§4.4): the graphql-ws message set is fixed, and a spec-compliant server rejects unknown inbound types, so a stock
+client cannot send this — every client SDK that wants end-to-end ack must be patched.
+
+```jsonc
+// server -> client
+{ "id": "1", "type": "next",
+  "payload": { "data": { "employeeUpdates": { "id": 7 } },
+               "extensions": { "cosmo": { "cp": "eyJzZXEiOjEwMX0...signed" } } } }
+
+// client -> server  (NEW: MessageTypeAck — non-standard, requires a patched client)
+{ "id": "1", "type": "ack",
+  "payload": { "cp": "eyJzZXEiOjEwMX0...signed" } }
+```
+
+When `ack` is negotiated, `CheckpointStore.Commit` is gated on the ack rather than the flush —
+this is the only change that makes the guarantee truly end-to-end.
+
+### 4.2 graphql-sse / plain SSE
+
+SSE is one-directional, so it splits along the two primitives:
+
+- **Resume (free with *native browser* EventSource only).**
+  Emit the checkpoint as the SSE `id:` field (today `flushwriter.go:116-167` emits only `event:`/`data:`).
+  On reconnect a native browser `EventSource` sends `Last-Event-ID`; the router maps it to a checkpoint and replays.
+  **Caveat:** the `graphql-sse` library does *not* implement `Last-Event-ID` resumption (dossier §4.1) — it treats the
+  operation `id` as correlation, not an SSE event id. So this zero-client-change resume works only for clients using a
+  native `EventSource`, not for the `graphql-sse` SDK.
+
+```
+id: eyJzZXEiOjEwMX0...signed
+event: next
+data: {"data":{"employeeUpdates":{"id":7}}}
+```
+
+- **Ack (needs a back-channel).**
+  Since SSE has no client→server frame, Pattern A on SSE uses a separate
+  `POST /graphql/subscriptions/{id}/ack` with `{ "cp": "...signed" }`.
+  Only required for end-to-end ack; resume alone does not need it.
+
+### 4.3 Fallback when the client cannot participate
+
+A stock client that advertises nothing gets:
+
+- the **server-side substrate transparently** (durable consumer + checkpoint committed on flush),
+- **no per-message ack** (so the flush ≠ receipt gap remains),
+- **no replay on reconnect** unless it is a native-`EventSource` browser (which gets `Last-Event-ID` resume for free).
+
+The negotiated class in `connection_ack` always reports the *actual* class
+(e.g. `at-least-once-on-flush` vs `at-least-once`), so the degradation is never silent.
+This composes directly with Pattern G (capability negotiation) if/when it ships.
+
+### 4.4 Realistic client adoption (MAJOR #9)
+
+This subsection states bluntly what the default deployment actually gets, because the rest of the RFC's strong claims
+are conditional on client capabilities that **no stock client has today** (dossier §4.1–4.2):
+
+- **graphql-ws, Apollo, Relay, urql, graphql-sse: none support per-message ack or resume.** The graphql-ws protocol
+  message set is fixed; a spec-compliant server rejects unknown inbound types.
+- **The WS `ack` frame is a non-standard protocol extension.** Every client SDK must be **forked/patched** to send it.
+  Until then, `commit_gate: client_ack` is unusable for that client, and the guarantee is `at-least-once-on-flush`.
+- **Only a native browser `EventSource` gets resume for free** via `Last-Event-ID` (once the router emits `id:` and
+  replays). The `graphql-sse` SDK does **not** — it ignores `Last-Event-ID`.
+- **Therefore the realistic default shipped class is `at-least-once-on-flush`, restart-survivable** — which is the same
+  flush ≠ receipt limitation as today, merely survivable across router restart and (for per-subscriber) client reconnect.
+  It is a real improvement, but it is not the headline "at-least-once to receipt."
+
+The honest framing: the strong guarantee is available, but it is **earned** by (a) opting into `per-subscriber`
+isolation and (b) patching the client to ack. The TL;DR leads with this reality.
+
+---
+
+## 5. Per-backend adaptability & degradation matrix
+
+The hard rule: **a user may pick any supported backend, even if it means a weaker guarantee,
+and the weaker guarantee is reported, never silently assumed.**
+`DurableCapabilities.Class` is logged at subscription start and surfaced in `connection_ack`.
+
+| Backend | Supported? | How (durable consumer / checkpoint) | Guarantee with Pattern C | Degradation / fallback |
+|---|---|---|---|---|
+| **NATS core** | No (durable) | No durable position, unbuffered chan drops (`nats/adapter.go:168`) | — | Degrades to **at-most-once**; refuse durable mode at startup, or fall back to Pattern E (router buffer). |
+| **NATS JetStream** | **Yes (per-message ack)** | Durable pull consumer named from `SubscriptionKey` (fix `nats/adapter.go:61-83`); checkpoint = ack floor `(cons,stream)`; `AckExplicit`, `MaxAckPending` cap | **At-least-once** across restart + reconnect, retention-bound; **exactly-once** with `Nats-Msg-Id` dedup window + Pattern A double-ack | Full support. Must force `experiment_delete_durable_consumers_on_shutdown` **off**. |
+| **Kafka** | **Yes (prefix-commit, external cp)** | **Not** per-client consumer groups (anti-pattern). Pooled reader + per-`SubscriptionKey` offset in the external `CheckpointStore`; seek by `(partition, offset)` | **At-least-once across restart + reconnect, but PREFIX granularity**: a slow/stuck subscriber blocks the partition prefix (head-of-line). No per-message nak. Bounded by `retention.ms` | This is effectively **Pattern B (stateless cursor)** for Kafka. Per-client `group.id` is explicitly rejected (see note below). Surface "cursor expired" on offset eviction. |
+| **Redis Pub/Sub** | No (durable) | Pub/Sub has no ack/PEL; producer uses `PUBLISH` (`redis/adapter.go:191`) | — | Degrades to **at-most-once**; require **Redis Streams** for durable mode on **both** producer (`XADD`) and consumer (`XREADGROUP`) (explicit config error otherwise). |
+| **Redis Streams** | **Yes (new, per-message ack)** | Consumer-group + consumer per `SubscriptionKey`; checkpoint = last-delivered-id + PEL; `XREADGROUP`/`XACK`/`XAUTOCLAIM`. **Requires publisher `XADD`** | **At-least-once** across restart + reconnect, bounded by `MAXLEN`/`MINID` trim | New adapter path on both producer and consumer. Mixed deployment (old `PUBLISH` producers + new `XREADGROUP` consumers) = **zero delivery** — must be gated (see note below). |
+| **SQS (Standard)** | Window only | Delete-on-ack queue, no cursor | **At-least-once within visibility window** only; no historical replay | Degrade to **Pattern A** (ack ↔ `DeleteMessage` / visibility timeout) or **Pattern E** buffer; cross-restart loses position. |
+| **Google Pub/Sub** | **Window / Pattern A** | One shared subscription, ack-based; **not** per-client subscriptions (quota + `seek` semantics, see note) | **At-least-once** within ack/redelivery scope; cross-client per-cursor resume is **not** supported via `seek` | Route to **Pattern A/B**, not per-subscriber-durable. Document why per-client subscriptions are infeasible (note below). |
+| **Kinesis** | **Yes (prefix-commit, external cp)** | No broker consumer state; checkpoint = per-shard sequence in `CheckpointStore` (DynamoDB, KCL-style); `GetShardIterator AFTER_SEQUENCE_NUMBER` | **At-least-once** across restart + reconnect, prefix/sequence granularity (head-of-line per shard); bounded by retention (24h→7d→365d) | Iterator expires 5 min (re-derive from checkpoint); requires external store. |
+| **Event Hubs** | **Yes (prefix-commit, external cp)** | No broker ack; checkpoint = per-partition offset+seq in `CheckpointStore` (blob/Postgres) | **At-least-once** across restart + reconnect, prefix granularity (head-of-line per partition); bounded by retention (7d / 90d premium) | Requires external store; per-partition ordering only. |
+| **RabbitMQ / AMQP** | Window only | `basic.ack`/`nack`, unacked auto-requeue; no cursor | **At-least-once within the unacked window**; no historical replay | Degrade to **Pattern A** (ack ↔ `basic.ack`) or **Pattern E**; requeue breaks FIFO. |
+
+**Why Kafka per-client `group.id` is rejected (BLOCKER #4).**
+The earlier draft proposed one `group.id` per `SubscriptionKey` with static membership. This is a known Kafka anti-pattern:
+(a) Kafka commits a single offset *per partition*, so per-message at-least-once is impossible — only prefix advance, with
+head-of-line blocking on a slow subscriber; (b) one consumer group per client means tens of thousands of single-member
+groups, and `__consumer_offsets` is itself a topic with `offsets.retention.minutes` (7d default) eviction plus
+group-coordinator memory/metadata load that scales with group count; (c) `group.instance.id` static membership with one
+member per group defeats partition parallelism and makes every reconnect to a different router fence/rejoin with a
+`session.timeout.ms` delay (and, during a network partition where the old member is still alive, fences a live member —
+the split-brain the HA story must avoid). **Decision:** Kafka per-client durability uses the external-checkpoint path
+(seek by `(partition, offset)`, no per-client consumer group) — this is Pattern B's model. The guarantee is
+"at-least-once with prefix granularity," and we say so.
+
+**Why Google Pub/Sub per-client subscriptions are rejected (MAJOR #12).**
+A Pub/Sub *subscription* is a heavyweight, quota-limited resource (default 10k subscriptions/topic, creation latency in
+seconds); one per client is infeasible at fan-out scale. `seek` to a snapshot is a *bulk* operation affecting the whole
+subscription's ack state, not a per-consumer cursor — it cannot resume one client without disturbing others sharing the
+subscription. EOS subscriptions cannot be created on the fly per client. **Decision:** Google Pub/Sub routes to Pattern
+A/B (one subscription, ack-based) and is **not** offered as a per-subscriber-durable backend.
+
+**Redis Streams requires a publisher change (MAJOR #11).**
+Cosmo's Redis publish path is `PUBLISH` (`redis/adapter.go:191`), which writes to Pub/Sub channels — **not** `XADD` to a
+stream. A Streams consumer group reads from a stream key nothing is writing to. Durable Redis mode therefore requires the
+**publisher** to switch to `XADD` (changing `@edfs__redisPublish` semantics: `XADD` always succeeds and returns an entry
+id, whereas `PUBLISH` returns a subscriber count, so `success:true` changes meaning). Mixed deployments (old `PUBLISH`
+producers, new `XREADGROUP` consumers) deliver **zero** events; the rollout must flip producer and consumer together, or
+gate durable Redis mode behind a check that the publisher is on the Streams path.
+
+**Two families decide everything (dossier §3.3).**
+Log/cursor stores (JetStream, Redis Streams, Kafka, Kinesis, Event Hubs) get a durable position + historical replay.
+Among these, **per-message-ack backends** (JetStream, Redis Streams) support true per-message redelivery; **prefix-commit
+backends** (Kafka, Kinesis, Event Hubs) support only prefix advance with head-of-line blocking — a strictly weaker shape
+that we route through the external-checkpoint / cursor path.
+Delete-on-ack queues (SQS-std, RabbitMQ, NATS core, Redis Pub/Sub, Google Pub/Sub-as-queue) cannot hold a seekable
+per-client position, so Pattern C *degrades to a redelivery window* (Pattern A scope) and **must say so**.
+The startup check is hard: `delivery.class: at-least-once` on NATS core or Redis Pub/Sub is a **config error**, not a silent downgrade.
+
+---
+
+## 6. Delivery semantics achieved — split by isolation mode (BLOCKER #3)
+
+The single most important correction in this revision: **`shared` and `per-subscriber` isolation have *opposite*
+correctness and backpressure properties.** The earlier draft presented one contiguous-prefix invariant that only holds
+in `per-subscriber`. They are now specified separately.
+
+### 6.1 `shared` isolation (default) — Pattern D semantics, one checkpoint, slowest-wins
+
+One trigger, one broker consumer, one checkpoint, **N clients fanned out** (today's shared-trigger model). The checkpoint
+advances only on the **slowest confirmed subscriber** across the fan-out (you cannot commit past an event some subscriber
+has not confirmed without losing it for that subscriber).
+
+Consequences, stated honestly:
+
+- **Head-of-line blocking is inherent.** A slow subscriber holds the checkpoint for *everyone* on the trigger.
+- **The drop-a-stuck-subscriber hole is real and is NOT at-least-once for that client.** If a subscriber disconnects
+  mid-batch and never confirms, the prefix cannot advance for the group. The router resolves this exactly as today:
+  it drops the stuck subscriber (`UnsubscribeSubscription`) so the healthy subscribers progress. **The dropped subscriber
+  loses its un-confirmed events** — this is at-most-once *for that client*, even in `shared` "at-least-once" mode.
+  This is an inherent trade-off of fan-out under one shared position; we document it rather than pretend the single
+  invariant covers it. A client that needs no-loss-on-disconnect **must** use `per-subscriber`.
+- **Guarantee class:** `at-least-once-on-flush-shared` — events are redelivered after a router restart from the shared
+  checkpoint, but an individual client that disconnects mid-batch can lose its in-flight suffix.
+
+`shared` mode is the correctness fix Pattern D makes (no longer ack-on-failure / fan-out-all-acked / abandon-but-acked),
+plus restart survival via the shared checkpoint. It is cheap and is the default precisely because most subscriptions do
+not need per-client no-loss.
+
+### 6.2 `per-subscriber` isolation — true per-client checkpoint
+
+One broker consumer / checkpoint per client (defeating trigger dedup, §8.3). Each client reads its own position sequence,
+so the contiguous-prefix invariant (§3.3) is well-defined per client:
+
+- **At-least-once relative to flush** with no client change. Every event whose flush succeeded, *and every event in an
+  unconfirmed prefix*, is (re)delivered after a gap, within retention.
+- **At-least-once relative to client receipt** when combined with Pattern A (client ack) — the commit gate moves from
+  flush to ack. This is the version that actually closes the dossier's §2.1 bug.
+- **A slow client stalls only its own consumer** (no co-subscriber penalty) — the property `shared` lacks.
+- **A disconnect does not lose the un-acked window** — it is redelivered on reconnect from the per-client checkpoint
+  (the property `shared` lacks).
+
+The two modes are not interchangeable: `shared` is cheap but has head-of-line + drop-loss; `per-subscriber` is expensive
+but isolates and never loses on disconnect. The config (§9) makes the choice explicit and the negotiated class (§4) reports
+which one is actually in force.
+
+### 6.3 Common semantics (both modes)
+
+- **Exactly-once (effective)** = at-least-once + an idempotent client (dedup on the surfaced idempotency key).
+- **Exactly-once (broker-level)** only on JetStream (`Nats-Msg-Id` + double-ack), Pub/Sub EOS, and Kafka EOS
+  (`read_committed` + transactional commit) — opt-in, with the usual LSO-stall caveat.
+
+**Duplicates.** Guaranteed possible. Any redelivery after an unconfirmed gap, any failover mid-batch, and any
+commit-then-crash re-runs the uncommitted suffix. **Clients must be idempotent.** We surface a stable idempotency key
+(`Nats-Msg-Id`, Kafka record key, Redis entry id, or content hash) in `extensions.cosmo.idk` so the client can dedup.
+
+**Ordering.** Preserved *within a consumer / partition / stream*, because we only ever commit a **contiguous confirmed
+prefix** — we never advance past an unconfirmed hole, so redelivery cannot reorder relative to the committed point. There
+is **no global order** across a fanned-out subscription set. See §6.4 for the hook-timeout reordering hazard, which must be
+fixed for this to hold.
+
+**Prefix-commit backends (Kafka, Kinesis, Event Hubs).** "Nak the rest" is impossible; the only lever is to not advance
+past the lowest unconfirmed offset. A stuck position blocks the whole partition prefix. This is head-of-line blocking, not
+per-message redelivery, and is why these backends route through the external-checkpoint / cursor path (§5).
+
+### 6.4 Hook-timeout reordering must be fixed with cancellation, not abandonment (MAJOR #15)
+
+Today, on a hook/resolve timeout, `subscription_event_updater.go:69-79` **abandons** in-flight deliveries and the loop
+proceeds (warning "Events may arrive out of order"); the abandoned goroutines **keep running, hold semaphore slots, and
+may push their events late** (`updateSubscription` lines ~95-129). Under Pattern C, a timeout must result in
+**no-commit / nak** — but if the abandoned goroutine later *succeeds*, the redelivered copy and the late original produce
+the event twice, with the redelivery possibly *reordered before* the late original. The "ordering preserved because
+contiguous prefix" claim does **not** survive this concurrency reality.
+
+**Fix:** on timeout the in-flight deliveries must be **cancelled** (context cancellation that actually aborts the resolve
+mid-`LoadGraphQLResponseData`), not merely abandoned, *before* the no-commit/nak. This requires the resolve to be
+cancellable mid-load. Without cancellation, the at-least-once + ordering claim is unsound on the hooks path.
+
+---
+
+## 7. Failure modes & remaining windows
+
+(Restored as a distinct section; the earlier draft folded this into §6 with a placeholder — MINOR #16.)
+
+1. **Flush ≠ receipt** (default, no Pattern A).
+   Event flushed to the kernel TCP buffer, checkpoint advanced, client crashes before reading the buffer → **lost**.
+   This is the *same* bug as today; Pattern C alone narrows it (per-subscriber, restart-survivable) but does not eliminate
+   it. Pattern A eliminates it.
+
+2. **`shared`-mode mid-batch disconnect** (default isolation).
+   A subscriber that disconnects before confirming its in-flight suffix is dropped so the group can progress; its
+   un-confirmed events are lost → **at-most-once for that client** (§6.1). Inherent to fan-out under one shared position;
+   the escape hatch is `per-subscriber`.
+
+3. **Checkpoint-store unavailability — two distinct cases (MAJOR #10).**
+   - *On `Commit` failure:* do **not** advance (fail-closed → duplicates on redelivery, never loss). A store outage
+     degrades throughput, not correctness.
+   - *On `Load` failure at (re)subscribe:* the router **must refuse to start the subscription** and surface
+     `resume-failed` to the client. It must **never** fall back to "now" — that would be silent loss of the entire gap.
+     This is explicit in the `CheckpointStore.Load` contract (§3.2): a transport/store error returns an error and the
+     caller refuses. Note the engine tears the subscription down on flush failure (`executeSubscriptionUpdate`,
+     `resolve.go:679`); if the store is also down at reconnect, the only correct behavior is refuse-and-surface, not
+     start-from-now.
+
+4. **Beyond retention.**
+   A disconnect longer than the broker's retention / offset-retention / trim window → the position is evicted →
+   **at-most-once for the gap**, surfaced as "checkpoint expired."
+
+5. **Consumer/checkpoint GC vs resume window (MAJOR #13).**
+   `inactive_ttl` GCs inactive consumers; `resume_window` promises replay. These are **two different lifetimes** and
+   must not be conflated. The *consumer* may be GC'd, but the *checkpoint position* must survive the full `resume_window`.
+   Startup validation: if `inactive_ttl < resume_window`, emit a **warning** that resume is not actually guaranteed for the
+   promised window (a client reconnecting after `inactive_ttl` but within `resume_window` would otherwise hit a deleted
+   position and silently restart). The fix is to keep the checkpoint row alive for `resume_window` independently of
+   consumer GC.
+
+6. **Unstable resume identity** (BLOCKER #5, §3.6).
+   If `DestinationHash` drifts on reconnect, `Load` misses. Mitigated by deterministic hashing + a resume token that
+   embeds the key; on mismatch the router surfaces `resume-failed`, never silent restart.
+
+7. **Authz-changed replay** (BLOCKER #6, §8.5).
+   Distinguishing transform-drop (advance) from authz-revoke (terminate) is required to avoid silently advancing past
+   data the client was entitled to. See §8.5.
+
+8. **Hook-timeout reorder/double-deliver** (MAJOR #15, §6.4).
+   Requires cancellation, not abandonment, of in-flight deliveries before nak.
+
+9. **Non-monotonic commit race.**
+   Two router instances briefly serving the same `SubscriptionKey` (split-brain during failover) could both commit;
+   `Commit` is monotonic + idempotent (older position = no-op) and broker-native consumers use single-active-consumer /
+   leasing to make double-consumption a transient duplicate, not a loss (§8.1).
+
+10. **`experiment_delete_durable_consumers_on_shutdown` (MINOR #21).**
+    This existing knob deletes JetStream consumers on shutdown — destroying exactly the consumers Pattern C relies on for
+    restart resume. Durable mode must **force it off**, or **error** if it is set, since otherwise the restart-survival
+    story silently breaks.
+
+---
+
+## 8. Cross-cutting concerns
+
+### 8.1 Router HA / horizontal scaling & sticky sessions
+
+This is where Pattern C earns its XL rating and also where it shines — but the stickiness story is **conditional on the
+checkpoint store** (MAJOR #8), not the blanket "not required" of the earlier draft.
+
+- **The durable name is keyed on the subscription, not the process** — the explicit fix to `nats/adapter.go:61-83`.
+  A reconnecting client (same verified principal → same `SubscriptionKey`) resumes on *any* instance.
+- **Single-active-consumer is mandatory** to avoid two instances double-consuming one durable position:
+  JetStream consumer with `MaxAckPending` + single-active or push-with-queue-group;
+  Redis Streams consumer name uniqueness within the group;
+  external-checkpoint backends (Kafka per-client, Kinesis, Event Hubs) fence via a **lease** in the `CheckpointStore`
+  (lease the `SubscriptionKey` to one instance, TTL-bounded).
+- **Stickiness requirement is conditional on `checkpoint.store`:**
+  - **External store** (`redis`/`dynamodb`/`postgres` + leasing): truly portable. A non-sticky reconnect to any instance
+    works (Load → lease → SubscribeDurable → replay). This is the case where "stickiness preferred, not required" holds.
+  - **Broker-native store** (`broker` on JetStream/Redis Streams): the position lives in the broker's consumer-group /
+    durable-consumer identity. A non-sticky reconnect to a new instance is **sensitive to instance identity** and needs
+    single-active enforcement via the broker primitive (queue group / single-active consumer). During a network partition
+    where the old instance is still alive, a naive takeover can double-consume; the broker's single-active primitive (or a
+    lease) bounds this to transient duplicates, never loss. **It is not "stickiness-free" in the unqualified sense the
+    earlier draft claimed.**
+- This is still strictly better than Pattern B for external-store mode, which needs stickiness for correctness on some backends.
+
+### 8.2 Per-subscription state / memory cost
+
+The dossier flags this as the most expensive pattern, correctly.
+
+- **One durable consumer / checkpoint per active subscription** in `per-subscriber`, not per shared trigger.
+- Broker resource cost scales **O(active subscriptions)**: JetStream consumers, Redis consumer-group entries, external
+  checkpoint rows.
+- External-checkpoint backends add a row/key per subscription in Redis/DynamoDB/Postgres.
+- **Consumer GC is fiddly and must respect `resume_window` (§7 #5):** inactive *consumers* are GC'd on `inactive_ttl`,
+  but the *checkpoint position* survives for `resume_window`. JetStream's `consumerInactiveThreshold`
+  (`schema.graphqls:115-119`, default 30s) is the existing knob to generalize for the consumer lifetime; the checkpoint
+  lifetime is separate.
+
+### 8.3 How per-subscriber isolation defeats trigger dedup (BLOCKER #2)
+
+Per-subscriber durability is **not** a pure broker-side cost — it requires a change to the *engine's* trigger keying. The
+engine assigns a broker subscription to a **trigger**, and the trigger is keyed by `prepareTrigger`
+(`resolve.go:1277-1289`) on a hash of *rendered input + subgraph headers* — explicitly **not** client identity (dossier
+§1.4). N clients with identical subscriptions collapse onto **one** trigger and **one** `Adapter.Subscribe` call.
+
+To get one durable consumer per client, you must **defeat trigger dedup**: the per-client `SubscriptionKey` (or a salt
+derived from it) must enter the trigger hash, so identical-query clients no longer share a trigger. Concretely, this is a
+change to `prepareTrigger`'s key generation in `graphql-go-tools`, gated on the field/provider being marked
+`per-subscriber`. The effect: at the engine level, one shared trigger becomes **N triggers** for N clients, each driving
+its own `SubscribeDurable`. This is a **structural engine change**, not a broker-only cost, and it deletes the
+shared-trigger optimization for any field marked `per-subscriber`.
+
+Cosmo's central optimization — one broker subscription per input+headers hash, fanned to N clients
+(`kafka/adapter.go:124-125`) — is therefore **broken by `per-subscriber`**: N clients now means N triggers and N broker
+consumers, at both the engine and broker levels.
+
+### 8.4 The hybrid: shared (default) vs per-subscriber (opt-in)
+
+We offer a **hybrid** rather than an absolute:
+
+- **Shared-trigger (default, today's behavior)** for `at-most-once` and `at-least-once-on-flush-shared` classes:
+  one consumer, one checkpoint, slowest-wins, **head-of-line blocking + mid-batch-disconnect drop-loss** (§6.1). Cheap.
+- **Per-subscription durable (opt-in via `delivery.isolation: per-subscriber`)** for true restart+reconnect survival:
+  one trigger + consumer per client, full isolation, no disconnect loss, **full engine + broker cost** (§8.3).
+
+The RFC's opinion: **default to shared, make per-subscriber an explicit, costed opt-in**, because most subscriptions do
+not need cross-restart per-client durability and the fan-out cost (engine triggers + broker consumers) is real. The
+directive/config must make the trade-off visible (§9), and the negotiated class (§4) must report which mode is in force,
+because they have opposite correctness properties (§6).
+
+### 8.5 Security / authz
+
+- **`ClientID` MUST be server-validated, never client-asserted (MAJOR #14).**
+  `SubscriptionKey` derives from a tenant-scoped principal. If `ClientID` were taken from a client-presentable token (a
+  router-minted token persisted client-side), a malicious member of the *same tenant* could mint/replay a token carrying
+  another user's `ClientID` and resume **their** stream — the AEAD seal proves the checkpoint is well-formed but does
+  **not** prove the presenter *is* that `ClientID`. Therefore `ClientID` must be derived from a server-validated auth
+  principal bound to the authenticated session. **Threat:** same-tenant cross-user replay. **Decision:** `at-least-once`
+  is **forbidden for unauthenticated/anonymous subscriptions** — this resolves the §12 open question in the negative.
+- **Resume checkpoints are opaque, signed, and embed the key.**
+  A raw `(partition, offset)` or stream-seq would let a client seek to data it shouldn't see. The `Checkpoint`/`resumeFrom`
+  on the wire is sealed (AEAD with a router key), embeds the `SubscriptionKey` it was minted against (§3.6), and is scoped
+  to the verified principal; the router rejects a token that doesn't verify against the presenting principal.
+- **Replay re-runs authz per event** — with a critical distinction (BLOCKER #6).
+  Replayed events pass through the *same* filter/authz hooks as live events, with the **current** authorization. But
+  "drop" is ambiguous, and the two meanings must be handled differently, or the RFC silently reintroduces at-most-once:
+  - **Transform/filter drop** (the event was never meant for this client — content filter, projection): **advance the
+    checkpoint** (drop ≠ failure). Otherwise a permanently-filtered event wedges the prefix forever.
+  - **Authz-revoked drop** (the client *was* entitled to this data when it disconnected, but its tenant/role was revoked
+    since): **terminate the subscription with an error** (`authz-revoked`); do **NOT** silently advance past data the
+    client was entitled to at disconnect time. Silently advancing here is exactly the at-most-once-presented-as-at-least-once
+    silent loss the RFC forbids.
+  - **Hook signal mapping:** the `StreamBatchEventHook` must distinguish these — e.g. a filter-drop return vs. an
+    authz-error return. A filter-drop marks the position confirmed (advance); an authz-error terminates the subscription
+    (client sees `authz-revoked`, no silent advance). There is no correct *universal* rule; the hook must tell us which
+    case it is, and the contract must make that explicit.
+
+### 8.6 Interaction with existing Cosmo Streams hooks
+
+Pattern C is *additive* to Streams v1:
+
+- `SubscriptionOnStartHandler` is where the `SubscriptionKey` is finalized and a custom resume policy can run.
+- `StreamBatchEventHook` runs on both live and replayed batches (re-authz, re-map). Its return must distinguish
+  (§8.5): *transform/filter-drop* → mark positions confirmed (advance, don't block the prefix); *authz-revoke* →
+  terminate with `authz-revoked` (no silent advance); *transient error* → no-commit/nak (redeliver).
+- `WriteEvent` (the v1 initial-message mechanism) emits a synthetic event with **no broker position**; synthetic events
+  are flagged so they are never checkpointed.
+- On hook/resolve timeout, in-flight deliveries are **cancelled** (not abandoned) before nak (§6.4).
+
+---
+
+## 9. Configuration surface
+
+### 9.1 Router YAML — new `delivery` block
+
+Per-provider, with a global default. Lives alongside `events.providers` (`config.go:773-782`).
+
+```yaml
+version: "1"
+
+events:
+  providers:
+    kafka:
+      - id: my-kafka
+        brokers: ["localhost:9092"]
+    nats:
+      - id: my-nats
+        url: "nats://localhost:4222"
+
+  # NEW: delivery durability substrate (Pattern C)
+  delivery:
+    default:
+      class: at-most-once          # at-most-once | at-least-once | exactly-once
+    providers:
+      my-nats:
+        class: at-least-once
+        isolation: per-subscriber  # per-subscriber | shared (default: shared)
+        commit_gate: flush         # flush | client_ack (client_ack needs Pattern A + patched client)
+        checkpoint:
+          store: broker            # JetStream ack floor (broker-native)
+        resume_window: 168h        # promised replay window; must be <= backend retention
+        inactive_ttl: 5m           # GC durable CONSUMER after last disconnect
+        checkpoint_ttl: 168h       # GC checkpoint POSITION; MUST be >= resume_window (§7 #5)
+        max_in_flight: 256         # backpressure cap (MaxAckPending equivalent)
+      my-kafka:
+        class: at-least-once       # prefix-commit: at-least-once with HEAD-OF-LINE, not per-message
+        isolation: per-subscriber
+        commit_gate: flush
+        checkpoint:
+          store: dynamodb          # external cp; NO per-client consumer group (§5)
+          dynamodb:
+            table: cosmo-checkpoints
+            region: eu-central-1
+        resume_window: 72h
+        checkpoint_ttl: 72h
+```
+
+**Hard validation at startup** (non-silent degradation):
+
+- `class: at-least-once` on a provider whose `DurableCapabilities.PerConsumerDurable == false`
+  (NATS core, Redis Pub/Sub, Google Pub/Sub-as-queue) → **fatal config error** listing the supported alternatives.
+- `commit_gate: client_ack` without Pattern A wire support enabled **and** a client that advertises `ack` → **fatal**
+  (and at runtime, a client that does not advertise `ack` falls back to `flush` with the reported class, never silently
+  promoted).
+- `checkpoint.store: broker` on Kafka/Kinesis/Event Hubs (no viable per-client broker consumer state) → **fatal** (must be external).
+- `class: at-least-once` on Redis without the publisher on the `XADD`/Streams path → **fatal** (MAJOR #11).
+- `inactive_ttl >= resume_window` or `checkpoint_ttl < resume_window` → **warning**: resume is not actually guaranteed
+  for the promised window (§7 #5).
+- `resume_window` exceeding the backend's known retention → **warning** (we cannot enforce broker config).
+- `class: at-least-once` for an unauthenticated/anonymous subscription path → **fatal** (§8.5, cross-user replay).
+- `experiment_delete_durable_consumers_on_shutdown: true` together with a durable provider → **fatal** (§7 #10).
+
+### 9.2 Schema directive (optional, per-field)
+
+For teams that want delivery class to travel with the schema (composition layer), an optional directive that composition
+serializes into the existing `DataSourceCustomEvents` carrier (`node.proto:430-434`):
+
+```graphql
+type Subscription {
+  employeeUpdates: Employee!
+    @edfs__natsSubscribe(subjects: ["employeeUpdates"], providerId: "my-nats")
+    @edfs__delivery(class: AT_LEAST_ONCE, isolation: PER_SUBSCRIBER)
+}
+```
+
+The directive is **advisory and capped by router YAML**: a field may not request a stronger class than the provider's
+configured ceiling. If omitted, the provider/global default applies. This mirrors how `streamConfiguration` is parsed and
+attached today (`normalization-factory.ts:3076-3081`), and keeps the router YAML as the source of truth for *connection
+and store* details (never in the control plane).
+
+---
+
+## 10. Migration & backward compatibility
+
+- **Opt-in, default off.**
+  `delivery.default.class` defaults to `at-most-once` — byte-for-byte today's behavior, including the existing JetStream
+  flush-gated `msg.Ack()`. Nothing changes for existing deployments until an operator sets a `delivery` block.
+- **The `DurableAdapter` is additive.**
+  Existing `Adapter` callers (publish path, non-durable subscribe) are untouched. An adapter that does not implement
+  `DurableAdapter` simply cannot be configured for `at-least-once` (caught by the §9 startup validation).
+- **Wire changes are negotiated.**
+  A client that doesn't advertise `ack`/`resume` gets the substrate transparently (commit-on-flush) and the *reported*
+  class. No existing client breaks. (Per §4.4, that reported class is realistically `at-least-once-on-flush`.)
+- **Redis durable mode is a coupled producer+consumer flip (MAJOR #11).**
+  Enabling Redis Streams durable mode requires moving publishers to `XADD` *and* consumers to `XREADGROUP` together;
+  mixed deployments deliver zero events. The rollout must coordinate both sides (and the §9 validation gates it).
+- **Rollout sequencing** (matches the dossier's recommended order, with C as substrate):
+  1. Ship the `[]DeliveryResult` plumbing (async channel back-channel) + decoupled commit loop + per-subscriber commit in
+     **shared isolation** — this is also Pattern D's correctness fix. Requires the engine change + release (§12).
+  2. Ship the durable-name fix + `per-subscriber` isolation on JetStream (broker-native checkpoint, no new store);
+     force `experiment_delete_durable_consumers_on_shutdown` off.
+  3. Add Redis Streams durable adapter (producer `XADD` + consumer `XREADGROUP`, coupled flip).
+  4. Add the external `CheckpointStore` (Redis/DynamoDB/Postgres) for Kafka per-client / Kinesis / Event Hubs (prefix-commit,
+     head-of-line documented).
+  5. Layer Pattern A (client ack) on top to move `commit_gate` from `flush` to `client_ack` — gated on patched clients (§4.4).
+- **Reversibility.** Flipping a provider back to `at-most-once` is safe: durable consumers are GC'd on `inactive_ttl`,
+  checkpoints are released, and behavior reverts to fire-and-forget.
+
+---
+
+## 11. Appendix: new/changed Go types
+
+```go
+// ─── package datasource (new / changed) ────────────────────────────────────
+
+// SubscriptionKey: durable identity, survives reconnect + failover.
+// ClientID is server-validated (NOT client-asserted) — §8.5.
+// DestinationHash is deterministically rendered — §3.6.
+type SubscriptionKey struct {
+    Tenant          string
+    ClientID        string
+    RootFieldName   string
+    DestinationHash string
+}
+func (k SubscriptionKey) String() string
+
+// Checkpoint: opaque, backend-specific position. Always serializable.
+// Granularity differs: per-message (JetStream/Redis Streams) vs prefix (Kafka/Kinesis/Event Hubs).
+type Checkpoint []byte
+
+// DeliveryClass: the achievable / requested delivery semantics.
+type DeliveryClass int
+const (
+    AtMostOnce  DeliveryClass = iota // today's default
+    BWindow                          // at-least-once within a redelivery/replay window
+    AtLeastOnce                      // at-least-once across restart + reconnect
+    ExactlyOnce                      // broker-level EOS (JetStream / Pub/Sub / Kafka-EOS)
+)
+
+// CommitGate: when the checkpoint may advance.
+type CommitGate int
+const (
+    GateFlush     CommitGate = iota // bytes to kernel (no client change)
+    GateClientAck                   // client ack received (needs Pattern A + patched client)
+)
+
+// Isolation: shared trigger vs per-subscriber durable consumer.
+// These have OPPOSITE correctness/backpressure properties — §6.
+type Isolation int
+const (
+    IsolationShared       Isolation = iota // keeps fan-out dedup; one checkpoint; slowest-wins; mid-batch-disconnect drop-loss
+    IsolationPerSubscriber                 // one trigger+consumer per client (defeats trigger dedup, §8.3)
+)
+
+// PositionedEvent: a StreamEvent plus its backend position (read from
+// data ignored today: msg.Metadata(), r.Offset/r.Partition, entry id).
+type PositionedEvent struct {
+    StreamEvent
+    Position Checkpoint
+}
+
+// DeliveryResult: the value that today is discarded (Update returns void).
+// Delivered ASYNCHRONOUSLY over a channel (engine resolves on its own goroutine, §3.2).
+type DeliveryResult struct {
+    Position  Checkpoint
+    Confirmed bool
+    Err       error
+}
+
+// DurableCapabilities: advertised per adapter for non-silent degradation.
+type DurableCapabilities struct {
+    PerConsumerDurable bool
+    PrefixCommitOnly   bool // true for Kafka/Kinesis/Event Hubs (no per-message nak)
+    ReplayWindow       time.Duration
+    NativeDedup        bool
+    Class              DeliveryClass
+}
+
+// DurableUpdater: extends SubscriptionEventUpdater with a delivery back-channel.
+// Channel, not return value, because confirmation crosses the engine event-loop
+// goroutine boundary (resolve.go:1086, AsyncResolveGraphQLSubscription) — §3.2.
+type DurableUpdater interface {
+    SubscriptionEventUpdater // Update/Complete/Done/SetHooks (unchanged)
+    UpdateDurable(events []PositionedEvent) <-chan DeliveryResult
+}
+
+// DurableAdapter: extended adapter contract (additive to Adapter).
+type DurableAdapter interface {
+    Lifecycle
+    SubscribeDurable(
+        ctx context.Context,
+        key SubscriptionKey,
+        start Checkpoint, // nil => StartPolicy
+        cfg SubscriptionEventConfiguration,
+        updater DurableUpdater,
+    ) error
+    Publish(ctx context.Context, cfg PublishEventConfiguration, events []StreamEvent) error
+    DurableCapabilities() DurableCapabilities
+}
+
+// CheckpointStore: persists the committed position per subscription.
+// Broker-native impls delegate to the broker; external impls use Redis/DynamoDB/Postgres.
+// Load ERROR => caller MUST refuse to start (never "now") — §6/§7.
+type CheckpointStore interface {
+    Load(ctx context.Context, key SubscriptionKey) (Checkpoint, bool, error)
+    Commit(ctx context.Context, key SubscriptionKey, cp Checkpoint) error // monotonic + idempotent
+    Release(ctx context.Context, key SubscriptionKey) error
+}
+
+// ─── package config (config.go:773-782, new) ───────────────────────────────
+
+type DeliveryConfiguration struct {
+    Default   DeliveryClassConfig                   `yaml:"default"`
+    Providers map[string]ProviderDeliveryConfig     `yaml:"providers"`
+}
+
+type DeliveryClassConfig struct {
+    Class string `yaml:"class"` // at-most-once | at-least-once | exactly-once
+}
+
+type ProviderDeliveryConfig struct {
+    Class         string           `yaml:"class"`
+    Isolation     string           `yaml:"isolation"`     // per-subscriber | shared
+    CommitGate    string           `yaml:"commit_gate"`   // flush | client_ack
+    Checkpoint    CheckpointConfig `yaml:"checkpoint"`
+    ResumeWindow  time.Duration    `yaml:"resume_window"`
+    InactiveTTL   time.Duration    `yaml:"inactive_ttl"`    // consumer GC
+    CheckpointTTL time.Duration    `yaml:"checkpoint_ttl"`  // position GC; MUST be >= resume_window (§7 #5)
+    MaxInFlight   int              `yaml:"max_in_flight"`
+}
+
+type CheckpointConfig struct {
+    Store    string                    `yaml:"store"` // broker | redis | dynamodb | postgres
+    Redis    *RedisCheckpointConfig    `yaml:"redis,omitempty"`
+    DynamoDB *DynamoCheckpointConfig   `yaml:"dynamodb,omitempty"`
+    Postgres *PostgresCheckpointConfig `yaml:"postgres,omitempty"`
+}
+
+// ─── wire (wsproto/proto.go:88-94, new) ────────────────────────────────────
+
+const (
+    MessageTypePing      MessageType = iota + 1
+    MessageTypePong
+    MessageTypeSubscribe
+    MessageTypeComplete
+    MessageTypeTerminate
+    MessageTypeAck // NEW: client ack {id, payload:{cp}} — NON-STANDARD graphql-ws extension, patched clients only (§4.4)
+)
+```
+
+---
+
+## 12. Risks, open questions, and complexity/effort estimate
+
+### Where this pattern is weakest (vs the other six)
+
+1. **Flush ≠ receipt, on its own.**
+   The honest headline weakness. Pattern C alone advances the checkpoint on a flush attempt — the *exact* bug the dossier
+   identifies (§2.1 #1). It narrows it (per-subscriber, restart-survivable, replayable) but does **not** eliminate it.
+   Only Pattern A closes it, and Pattern A needs a patched client (§4.4). For the simplest *correct-relative-to-receipt*
+   win, A or D is closer to the bone.
+2. **The strong guarantee is conditional, the default is weaker.**
+   The headline "at-least-once across restart + reconnect to receipt" holds only with `per-subscriber` + a patched client
+   doing `ack`. The realistic default (stock client, `shared` isolation) is `at-least-once-on-flush-shared` with
+   head-of-line blocking and a mid-batch-disconnect drop-loss hole (§6.1). This is documented, not hidden.
+3. **It breaks the shared-trigger optimization at the *engine* level (§8.3).**
+   Per-subscriber turns one trigger into N triggers (a `prepareTrigger` keying change) and N broker consumers. For
+   high-fan-out subjects this is an engine + broker resource explosion. Patterns B and E preserve sharing better. This is
+   the single biggest scaling risk and the reason `shared` is the default.
+4. **The engine change is L–XL, cross-repo, and version-pinned (§3.2).**
+   The `Update`-returns-void / discard-all-results / deliver-on-own-goroutine reality means a real async back-channel,
+   not a signature tweak. It must be cut as a `graphql-go-tools` release and the `router/go.mod` pin bumped.
+5. **It introduces a new stateful dependency** (the external `CheckpointStore`) for Kafka per-client / Kinesis / Event
+   Hubs, with its own HA, consistency, and operational burden. Patterns B and F have near-zero router-side state.
+6. **Consumer lifecycle / GC is genuinely fiddly** — two separate lifetimes (`inactive_ttl` for consumers,
+   `checkpoint_ttl` ≥ `resume_window` for positions). Get it wrong and resume silently breaks (§7 #5).
+7. **Degradation surface is large.** Several backends degrade to a window, prefix-commit head-of-line, or fail-closed; the
+   §9.1 validation matrix is the largest of any pattern. Done wrong, this is the "confusing matrix of what you actually
+   get" risk the dossier raises for Pattern G.
+
+### Open questions
+
+- **Contiguous-prefix commit vs. throughput / poison messages.**
+  Strict prefix commit means one stuck position holds the whole prefix (and on prefix-commit backends, the whole
+  partition). Do we need a per-subscriber dead-letter for a position that fails N times, to avoid a poison message
+  wedging a subscription forever? What does the client see when a position is dead-lettered (a gap notification)?
+- **Authz-revoke vs transform-drop hook signaling (§8.5).**
+  We require the `StreamBatchEventHook` to *distinguish* these two drop reasons, with opposite checkpoint behavior. Is the
+  v1 hook contract (empty slice = drop, error = abort) expressive enough, or do we need a third signal (`authz-revoke`)?
+  Confirm with the Streams team — this is load-bearing for the no-silent-loss promise and is currently the most likely
+  place for the guarantee to regress.
+- **Lease/fencing for external-checkpoint single-active enforcement (§8.1).**
+  The lease TTL vs. broker single-active-consumer trade-off needs a concrete design. Split-brain → transient duplicates
+  (acceptable) but must be bounded; what is the worst-case duplicate window during a network partition?
+- **`shared`-mode mid-batch-disconnect loss (§6.1) — is it acceptable as the default?**
+  The default isolation has a documented at-most-once-for-that-client hole on mid-batch disconnect. Is that the right
+  default, or should the default be "shared, but drop-on-disconnect surfaces a warning to the operator"?
+
+### Complexity / effort estimate: **XL**
+
+| Workstream | Size | Notes |
+|---|---|---|
+| graphql-go-tools async back-channel (`Update`/`handleTriggerUpdate`/`executeSubscriptionUpdate`) | **L–XL** | Not "M shared with D": result must cross the engine event-loop goroutine boundary via a channel; `resolve.go:1086,616,1479`. |
+| graphql-go-tools `prepareTrigger` keying change (per-subscriber defeats dedup) | **L** | `resolve.go:1277-1289`; folds `SubscriptionKey` into the trigger hash; deletes shared-trigger for marked fields. |
+| graphql-go-tools release + `router/go.mod` pin bump coordination | **M** | Cross-repo release; re-verify line numbers vs the targeted engine snapshot (dossier line-drift caution). |
+| Decoupled commit loop (outside the `s.mu` serialization gate) | **M** | Keyed by position; consumes the result channel; must not block the engine gate (MAJOR #7). |
+| Hook-timeout cancellation (not abandon) of in-flight resolve | **M** | Requires resolve cancellable mid-`LoadGraphQLResponseData` (MAJOR #15). |
+| JetStream durable-name fix + per-subscriber + ack/nak + force-experiment-off | **M** | Broker-native checkpoint, no new store. |
+| Redis Streams durable adapter (producer `XADD` + consumer `XREADGROUP`, coupled flip) | **M–L** | Publisher change + mixed-deployment gate (MAJOR #11). |
+| External `CheckpointStore` (Redis/DynamoDB/Postgres) + leasing | **L** | New stateful dependency + HA + lease/fencing. |
+| Kafka (external cp, prefix-commit) / Kinesis / Event Hubs adapters | **L** | Seek by offset/sequence; head-of-line semantics; NO per-client consumer groups. |
+| `DestinationHash` determinism + sealed resume-token-carries-key | **M** | Correctness-critical (BLOCKER #5). |
+| Wire: `MessageTypeAck`, resume payload, SSE `id:`, `/ack` + client-patch reality | **M** | Pattern A's surface; non-standard extension, patched clients only (§4.4). |
+| Config + directive + startup validation matrix | **M** | Non-silent degradation is the load-bearing part. |
+| Consumer GC / two-lifetime checkpoint vs resume window | **M** | Fiddly; correctness-adjacent (§7 #5). |
+
+**Sequencing recommendation:** ship the async `[]DeliveryResult` seam + decoupled commit loop + JetStream broker-native
+per-subscriber path first (highest guarantee for least new infrastructure, no external store), then Redis Streams, then the
+external `CheckpointStore` for Kafka/Kinesis/Event Hubs, and finally layer Pattern A (gated on patched clients) to move the
+commit gate from flush to client ack. Treat Pattern C as the durable substrate that A and B ride on, **not** as a
+standalone end-to-end guarantee — and ship it knowing the *default* class is `at-least-once-on-flush-shared`, with the
+strong class earned only by `per-subscriber` + a patched, acking client.

--- a/rfc/at-least-once/rfc-D-broker-ack-timing.md
+++ b/rfc/at-least-once/rfc-D-broker-ack-timing.md
@@ -1,0 +1,767 @@
+# RFC: At-Least-Once for GraphQL Subscriptions — Broker-Native Ack Mapped to Client Delivery Confirmation (Pattern D)
+
+**Status:** Draft
+
+**TL;DR.**
+Today EDFS is fire-and-forget by construction.
+The one adapter that even tries durability — NATS JetStream — acks the broker message *unconditionally* after a delivery *attempt*,
+so a message is acked even when the resolve failed, even when the client was mid-disconnect, and even when only some of the shared subscribers actually received it (Section 2.1, bugs #1–#4 in the dossier).
+This RFC proposes the **minimal, surgical correctness fix**:
+make the delivery pipeline *return a per-subscriber result* — `executeSubscriptionUpdate` → `handleTriggerUpdate` → the engine `SubscriptionUpdater.Update` → `datasource.SubscriptionEventUpdater.Update` → the broker adapter — so the adapter can `Ack` only when every (or a policy-quorum of) subscriber's **flush succeeded**, and `Nak`/redeliver otherwise.
+The guarantee delivered is **at-least-once relative to flush success** (bytes handed to the kernel), *not* client receipt.
+It requires **no wire-protocol or client change at all**.
+
+The v1 scope is deliberately narrow: **NATS JetStream, no-hooks path only.**
+It closes bug #2 and (under `policy: all`) bug #3 for the subscriber set present across a redelivery; it narrows bug #1.
+Bug #4 (hooks abandonment) and Kafka are **explicitly deferred** — both require their own redesign (Sections 8.6, 6) and folding them into v1 would silently reintroduce the duplicate/reorder this RFC claims to fix.
+Pattern D is the server-side substrate that Patterns A (client ack), B (cursor resume), and C (durable per-subscription) all build on.
+Complexity for the JetStream-only / no-hooks slice: **M.** Full pattern (with hooks rework + Kafka cursor): **L.**
+
+---
+
+## 1. Title & Status
+
+See heading above.
+Pattern ID: **D**.
+Pattern name: **Broker-Native Ack Mapped to Client Delivery Confirmation (Fix the Ack Timing)**.
+Status: **Draft**.
+
+**Engine version pin.** All `resolve.go` line numbers in this RFC are against **`github.com/wundergraph/graphql-go-tools/v2 v2.4.1`**, which is what `router/go.mod:34` pins (`go list -m` confirms `v2.4.1`).
+An earlier draft cited `v2.1.1-0.20260504064838-5a00844995b5`; that was the wrong tag and every line number was off by a few — all re-derived below against `v2.4.1`.
+
+---
+
+## 2. Problem & Context
+
+### 2.1 The gap, restated
+
+An application can already have at-least-once *in its backend*.
+Kafka has committed offsets, JetStream has durable consumers with explicit ack, Redis Streams has the Pending Entries List, SQS has visibility-timeout redelivery, RabbitMQ has manual `basic.ack`.
+The broker will faithfully redeliver an un-acked message.
+But Cosmo's EDFS pushes that event to the GraphQL client *fire-and-forget* and then tells the broker "done" regardless of what actually happened downstream.
+So a client disconnect, a router restart, or a slow co-subscriber silently drops events that the broker was perfectly willing to redeliver.
+
+The framework abstraction is fire-and-forget *by construction*.
+The engine's `SubscriptionUpdater.Update(data []byte)` returns nothing (`resolve.go:1586`), and the `datasource.Adapter` boundary has no ack hook and no error channel back to the broker (dossier §2, `router/pkg/pubsub/datasource/provider.go:22-28`).
+Durability is therefore a per-adapter property, not a property of EDFS — and only NATS JetStream attempts it.
+
+### 2.2 The concrete current behavior (file:line anchors, v2.4.1)
+
+The entire chain from broker callback to socket write is **one synchronous call stack** (dossier §1.3).
+The NATS JetStream reader goroutine does this, verbatim, in `router/pkg/pubsub/nats/adapter.go:145-157`:
+
+```go
+updater.Update([]datasource.StreamEvent{
+    &Event{evt: &MutableEvent{
+        Data:    msg.Data(),
+        Headers: map[string][]string(msg.Headers()),
+    }},
+})
+
+// Acknowledge the message after it has been processed
+ackErr := msg.Ack()
+if ackErr != nil {
+    log.Error("error acknowledging message", ...)
+    return
+}
+```
+
+`updater.Update(...)` returns **void**.
+It blocks (synchronously, via `wg.Wait()`) until resolve + flush completes for every subscriber, then control returns and `msg.Ack()` runs *unconditionally*.
+
+Two layers below, the engine `SubscriptionUpdater` contract is (`pkg/engine/resolve/resolve.go:1586`):
+
+```go
+type SubscriptionUpdater interface {
+    // Update sends an update to the client. It is not guaranteed that the update is sent immediately.
+    Update(data []byte)
+    UpdateSubscription(id SubscriptionIdentifier, data []byte)
+    Complete()
+    Error(data []byte)
+    Done()
+    CloseSubscription(id SubscriptionIdentifier)
+    Subscriptions() map[context.Context]SubscriptionIdentifier
+}
+```
+
+`Update` returns nothing.
+The concrete impl `subscriptionUpdater.Update` (`resolve.go:1479-1489`) is where the **serialization gate** lives, and it matters for this whole design (Section 4.6):
+
+```go
+// mu serves two roles:
+//   1. Event serialization gate -- held across the entire Update() call including
+//      wg.Wait(), ensuring event A fully completes before event B begins.
+//   2. Lifecycle guard -- the done flag prevents callbacks after Done() ...
+func (s *subscriptionUpdater) Update(data []byte) {
+    s.mu.Lock()
+    defer s.mu.Unlock()
+    if s.done || s.ctx.Err() != nil { return }
+    s.resolver.handleTriggerUpdate(s.triggerID, data)
+}
+```
+
+Inside, `handleTriggerUpdate` (`resolve.go:1086`) fans out under a `sync.WaitGroup` and `wg.Wait()`s for all subscribers — a *perfect* place to collect per-subscriber results, except the result is currently discarded:
+
+```go
+subs, filterErrors := trig.filterSubscriptions(data)        // resolve.go:1095
+for _, fe := range filterErrors {
+    fe.sub.writeError(r.errorFormatter, fe.ctx, fe.err, fe.response)
+}
+var wg sync.WaitGroup
+for _, sub := range subs {
+    if sub.removed.Load() { continue }
+    wg.Go(func() {
+        r.executeSubscriptionUpdate(sub.ctx, sub, data)  // returns void today
+    })
+}
+wg.Wait()
+```
+
+And `executeSubscriptionUpdate` (`resolve.go:616`) has the following terminal branches — **this is the crux of bug #1's misclassification, so read it carefully**:
+
+| # | Branch | What it does to the writer | Does it `Flush()`? |
+|---|---|---|---|
+| 1 | `InitSubscription` fails (`:632-642`) | `sub.writeError(...)` → buffers a GraphQL error into `sub.writer` | **No** — `return` without flush |
+| 2 | `LoadGraphQLResponseData` fails (`:645-655`) | `sub.writeError(...)` → buffers a GraphQL error | **No** — `return` without flush |
+| 3 | `sub.removed` mid-flight (`:657-661`) | nothing | n/a (skipped) |
+| 4 | `resolvable.Resolve` fails (`:663-674`) | `r.errorFormatter.WriteError(...)` → buffers a GraphQL error | **No** — `return` without flush |
+| 5 | **Success path** (`:676-690`) | resolve OK, then `sub.writer.Flush()` (`:678`) | **Yes** — the one place a flush occurs |
+
+The decisive fact (verified in `core/websocket.go:699-736` and `core/graphql_handler.go:378`): **`WriteError` / `writeError` write the error bytes into the writer's in-memory buffer (`rw.buf.Write`) — they do *not* flush to the socket.**
+On WebSocket, the buffered payload only reaches the client when `websocketResponseWriter.Flush()` later calls `protocol.WriteGraphQLData`.
+Branches 1/2/4 buffer an error and then `return` *without flushing* — so under the current code those buffered errors are **not actually delivered to the client** (they are overwritten/reset on the next event or dropped on teardown).
+
+The single real delivery signal is therefore: **did `Flush()` get called and return `nil`?**
+A successful flush means **bytes handed to the kernel/TCP buffer**, *not* an application ack from the client — this is the ceiling of Pattern D, and we state it loudly below.
+
+### 2.3 The four bugs this RFC closes (dossier §2.1, Hop B)
+
+1. **Ack gated on flush *attempt*, not client receipt.** Flush = bytes to kernel, not client receipt. *Narrowed, not fully closed — that is Pattern A's job.*
+2. **Ack fires even when delivery failed.** A flush that errors (client mid-disconnect) tears down the subscription, yet `msg.Ack()` still runs. **Closed.**
+3. **Multi-subscriber fan-out is acked-anyway.** One JetStream message fans to N shared subscribers; some flush, some fail; the single `msg.Ack()` acks the whole trigger. **Closed under `policy: all`, for the subscriber set present across the redelivery** — see the honest scope in Section 4.6 / Section 7. Not "closed unconditionally"; the trigger set is mutable and identity-free, which bounds the claim.
+4. **Hooks path abandons and acks.** With `on_receive_events` hooks, on timeout the updater abandons in-flight deliveries (detached goroutines) and proceeds (`subscription_event_updater.go:65-78`), while JetStream still acks. **Deferred to a follow-up (Section 8.6)** — the abandonment is a detached-goroutine `select`, so it cannot synchronously produce a failure report, and naïvely mapping "timeout → Nak" reintroduces a duplicate+reorder. v1 **disallows** `mode: at_least_once` together with `on_receive_events` hooks.
+
+### 2.4 What this builds on
+
+This is the foundation pattern.
+It is intentionally the smallest change that makes the ack *mean something*.
+It does not touch the wire protocol, the client, the schema, or the proto.
+Patterns A/B/C in the dossier all assume a delivery result exists at the adapter boundary; Pattern D is what creates it.
+
+---
+
+## 3. Goals & Non-Goals
+
+### Goals
+
+- Make broker ack/commit reflect **actual flush success per subscriber**, not a blind attempt.
+- Close bug #2 outright; close bug #3 **under `policy: all`, scoped to the subscribers present across the redelivery** (Section 7); narrow bug #1.
+- Introduce a **per-subscriber delivery result** that propagates engine → `SubscriptionEventUpdater` → `Adapter`, so each adapter can ack/nak correctly for *its* backend.
+- Make the ack policy on a shared trigger explicit and configurable (`all` vs `quorum` vs `any`), because one broker message maps to N heterogeneous client outcomes — and make any silent minority loss under `quorum`/`any` **observable** (Section 8.8 metrics).
+- Keep the change **opt-in** and **default-off** so existing deployments are byte-for-byte unchanged until they ask for it.
+
+### The honest guarantee statement (replaces "strict upgrade / never worse")
+
+We do **not** claim "never worse than today for everyone." That is false at the per-client level, and pretending otherwise is exactly the kind of mush this RFC must avoid. The precise claim is:
+
+> **No event that is acked today is *lost* under Pattern D that today's code would deliver.**
+> In exchange, on the enabled provider:
+> - a **healthy, fast co-subscriber** sharing a trigger with a slow/dead subscriber may receive **duplicate events** (Section 4.6) and may be **stalled** for up to `nak_backoff × max_redeliveries` behind the serialization gate (Section 4.6) — this is observably *worse* for that client than today's silent drop of the slow client's event;
+> - under `quorum`/`any`, the failed minority **still silently misses** the event (bug #3 for the minority), now made visible via a metric (Section 8.8).
+
+"Strict upgrade" is true only at the *system* level under a specific value judgment: *a redelivered duplicate (and some added latency) is preferable to a silent drop.* Operators who do not share that judgment should leave `mode: off`.
+
+### Non-Goals
+
+- **Client receipt.** Flush ≠ receipt. End-to-end client-ack is Pattern A; this RFC does not add a client ack and is honest that a client crashing between TCP-buffer and processing still loses the message.
+- **Replay / resume across reconnect.** No cursor, no `Last-Event-ID`. That is Pattern B.
+- **Cross-router-restart durability per subscriber.** No per-subscriber durable consumer or external checkpoint store. That is Pattern C.
+- **Wire-protocol / client changes.** None. Explicitly (Section 5).
+- **Kafka in v1.** Kafka is **deferred**: it is groupless with no offset commit at all (`kafka/adapter.go:142-153`), so "commit a floor" is unimplementable without pulling in a consumer group — i.e. Pattern C territory. See Section 6.
+- **The hooks (`on_receive_events`) path in v1.** Deferred; see Sections 2.3 #4 and 8.6.
+- **Fixing the durable publish path.** The Cosmo NATS *publish* path uses **core NATS** even for stream-backed subjects (`nats/adapter.go:254`) and can drop a message before it ever reaches the stream. Pattern D only fixes the *consume* ack and assumes the event is durably in the stream. See Non-Goal note in Section 5.
+- **Fixing the per-instance JetStream durable naming** (`nats/adapter.go:69-83`). That is HA-scope (Pattern C); we only *correctly ack* what the current consumer actually reads.
+- **Exactly-once / dedup.** At-least-once means duplicates on redelivery; idempotency stays the client's responsibility (dossier §6.2).
+
+---
+
+## 4. Design — the mechanism in depth
+
+### 4.1 The one idea
+
+Today the call stack returns void at every layer.
+Pattern D threads a **`DeliveryResult`** back up through exactly the layers it falls down through, so the broker reader that holds the message handle (JetStream `msg`) can make a real ack/nak decision.
+
+```
+                       (today: void)                         (Pattern D: returns DeliveryReport)
+broker msg ──▶ adapter.Subscribe reader goroutine (one msg per loop iteration)
+                  │  report := updater.Update([]StreamEvent{oneEvent})  ───────────────────────┐
+                  ▼                                                                             │
+            datasource.SubscriptionEventUpdater.Update(events)  ────────────────────────────┐  │
+                  │  (no-hooks v1: events is length 1 → s.eventUpdater.Update)              │  │
+                  ▼                                                                          │  │
+            engine resolve.SubscriptionUpdater.Update(data)  ──────────────────────────┐   │  │
+                  │  (holds subscriptionUpdater.mu across the whole call — §4.6)        │   │  │
+                  ▼                                                                      │   │  │
+            resolver.handleTriggerUpdate(id, data)                                      │   │  │
+                  │  wg.Go( executeSubscriptionUpdate ) ; wg.Wait()                      │   │  │
+                  ▼                                                                      │   │  │
+            executeSubscriptionUpdate(sub) ─▶ Init / Load / Resolve / Flush             │   │  │
+                  │  outcome keyed on WHETHER THE FLUSH SUCCEEDED, not on resolve        │   │  │
+                  └── per-sub: Flushed | DeliveredError | DeliveryFailed | Skipped ──────┘   │  │
+                      aggregated across all subs on the trigger ─────────────────────────────┘  │
+                          one decision for this one broker message ──────────────────────────────┘
+                              ▼
+                  adapter decides: Ack | Nak(redeliver) | Term(poison)
+```
+
+The synchronization point already exists: `handleTriggerUpdate` already does `wg.Wait()`.
+We are not making the *fan-out* more synchronous; we capture the result of work that already completes synchronously and return it.
+The one genuinely new interaction — that this return value is consumed *after* the `subscriptionUpdater.mu` gate is released, and a Nak then stalls the per-trigger reader — is analyzed honestly in Section 4.6.
+
+### 4.2 The delivery result type — corrected per critique #1
+
+The critical fix versus the prior draft: the outcome is keyed on **whether `Flush()` succeeded**, not on whether resolve succeeded. A subgraph GraphQL error that is written *and flushed* to the client is a **successful delivery of an error payload** — it must be ack-able, not redelivered. Redelivering it would loop forever (the same subgraph error recurs) and poison a message that *was* delivered.
+
+```go
+// resolve package (graphql-go-tools)
+
+type DeliveryOutcome uint8
+
+const (
+    // DeliveryFlushed: a data payload was written and Flush() returned nil. (success path, :676-690)
+    DeliveryFlushed DeliveryOutcome = iota
+    // DeliveredError: a GraphQL error payload was written AND flushed to the client without a
+    // transport error. This is a *successful delivery of an error response* — it MUST be ack-able.
+    // (Reserved for the future where branches 1/2/4 flush their buffered error; see note below.)
+    DeliveredError
+    // DeliveryFailed: the FLUSH ITSELF errored — bytes could not be handed to the socket
+    // (client gone / write deadline). This is the ONLY true non-delivery. (:678 error return)
+    DeliveryFailed
+    // DeliverySkipped: sub was removed or filtered out before any write — not a failure, ack-able.
+    DeliverySkipped
+)
+
+// SubscriberDelivery is the outcome for one subscriber of one update.
+type SubscriberDelivery struct {
+    Outcome DeliveryOutcome
+    // Err carries the *transport* error for DeliveryFailed (flush error). It is NOT a GraphQL/resolve
+    // error — a resolve error that was written to the buffer is not a transport failure.
+    Err error
+}
+
+type DeliveryReport struct {
+    Flushed   int
+    Delivered int // DeliveredError count
+    Failed    int
+    Skipped   int
+}
+```
+
+**Why `DeliveredError` and `DeliveryFailed` are split (the bug-#1 fix).**
+The prior draft lumped "branch 4: `Resolve` failed" into `DeliveryFailed` → Nak. That is wrong: a subgraph returning a GraphQL error (nullability violation, auth error surfaced as a GraphQL error) is a *normal outcome*. Under `policy: all` the prior design would Nak, redeliver, hit the *same* error, and loop until `MaxDeliver` → Term/DLQ of a message that, in a corrected implementation, was delivered to every client as an error exactly once. The corrected rule:
+
+> The question is **"did the flush succeed?"**, not **"did resolve succeed?"**
+> A buffered-and-flushed error response = `DeliveredError` = **ack-able**.
+> Only a `Flush()` that *itself errors* = `DeliveryFailed` = Nak.
+
+**Important implementation honesty:** in the *current* `v2.4.1` engine, branches 1/2/4 buffer the error and `return` **without flushing** (Section 2.2). So today the client does not actually receive those errors at all. Pattern D must therefore make a deliberate engine choice, stated here as an open question (Section 12): either (a) **flush the buffered error before returning** on branches 1/2/4 (then classify the flush result as `DeliveredError` on success / `DeliveryFailed` on flush error) — which *also fixes the latent "buffered error never delivered" bug* — or (b) leave branches 1/2/4 as non-flushing and classify them as `DeliveryFailed` (no bytes ever left the router → genuinely not delivered → Nak is correct). Option (b) is simpler and is the v1 default; option (a) is the cleaner long-term behavior and is called out as the recommended follow-up. Either way, **branch 4 is no longer unconditionally `DeliveryFailed`-then-looped**: under (a) it acks; under (b) it Naks but because *nothing was delivered*, which is legitimate.
+
+The corresponding contract crossing the `datasource` boundary (the adapter never imports the engine):
+
+```go
+// router/pkg/pubsub/datasource
+
+type DeliveryReport struct {
+    Flushed   int // includes DeliveredError under option (a)
+    Failed    int
+    Skipped   int
+}
+
+type Decision uint8
+
+const (
+    DecisionAck  Decision = iota // all good per policy → broker Ack
+    DecisionNak                  // at least one required subscriber's FLUSH failed → redeliver
+    DecisionTerm                 // redelivery budget exhausted → terminate/DLQ
+)
+```
+
+Per critique #14, identity (`SubscriptionIdentifier`) is **not** carried across the `datasource` boundary, because the adapter makes exactly one ack decision for the whole trigger and never needs per-subscriber identity. The counts suffice for the decision; the *metric* that needs per-subscriber visibility (`delivery_subscriber_dropped_total`, Section 8.8) is incremented inside the engine where identity is still in scope, before collapsing to counts. We therefore deliberately drop `ID` from the boundary type (and from `SubscriberDelivery`, which never leaves the engine).
+
+### 4.3 The engine changes (graphql-go-tools)
+
+Three surgical changes, all additive:
+
+1. `executeSubscriptionUpdate` (`resolve.go:616`) returns its outcome instead of void. The branch table from Section 2.2 maps to outcomes as:
+
+```go
+func (r *Resolver) executeSubscriptionUpdate(resolveCtx *Context, sub *subscriptionState, sharedInput []byte) SubscriberDelivery {
+    // branch 1 InitSubscription fail / branch 2 Load fail / branch 4 Resolve fail:
+    //   v1 (option b): buffered error, NOT flushed → return {Outcome: DeliveryFailed} (nothing delivered)
+    //   follow-up (option a): flush the buffered error; on flush nil → DeliveredError, on flush err → DeliveryFailed
+    // branch 3 sub.removed: return {Outcome: DeliverySkipped}
+    // branch 5 success: sub.writer.Flush()
+    //   flush nil → return {Outcome: DeliveryFlushed}
+    //   flush err → _ = r.UnsubscribeSubscription(sub.id); return {Outcome: DeliveryFailed, Err: err}
+}
+```
+
+2. `handleTriggerUpdate` (`resolve.go:1086`) collects the per-sub results its `wg.Wait()` already gates on and returns a `DeliveryReport`. Filter drops (`trig.filterSubscriptions`, `resolve.go:1095`) count as `DeliverySkipped` (the engine *correctly chose* not to deliver — not a broker failure, dossier §6.8).
+
+```go
+func (r *Resolver) handleTriggerUpdate(id uint64, data []byte) DeliveryReport {
+    trig, ok := r.getTrigger(id)
+    if !ok { return DeliveryReport{} } // trigger gone: nothing to ack against
+    subs, filterErrors := trig.filterSubscriptions(data)
+    var rep DeliveryReport
+    var mu sync.Mutex
+    for _, fe := range filterErrors {
+        fe.sub.writeError(r.errorFormatter, fe.ctx, fe.err, fe.response)
+        rep.Skipped++
+    }
+    var wg sync.WaitGroup
+    for _, sub := range subs {
+        if sub.removed.Load() { rep.Skipped++; continue }
+        wg.Go(func() {
+            d := r.executeSubscriptionUpdate(sub.ctx, sub, data)
+            mu.Lock(); rep.add(d); mu.Unlock()
+        })
+    }
+    wg.Wait()
+    return rep
+}
+```
+
+3. `SubscriptionUpdater.Update` (`resolve.go:1586`) returns a `DeliveryReport`. This is the one signature change to the engine's public interface — additive in meaning (callers that ignore the return are unchanged in behavior). The concrete `subscriptionUpdater.Update` (`resolve.go:1479`) returns what `handleTriggerUpdate` now returns; the `s.mu`-guarded body is otherwise unchanged.
+
+```go
+type SubscriptionUpdater interface {
+    // Update fans an event out to a trigger's subscribers and reports per-subscriber
+    // delivery outcomes. The report reflects FLUSH success, not client receipt.
+    Update(data []byte) DeliveryReport
+    Complete()
+    Error(data []byte)
+    Done()
+    CloseSubscription(id SubscriptionIdentifier)
+    Subscriptions() map[context.Context]SubscriptionIdentifier
+}
+```
+
+Note `UpdateSubscription` is **not** changed to return a result in v1, because the only caller of `UpdateSubscription` is the hooks path (`subscription_event_updater.go:117`), which is deferred (Section 8.6). Leaving it void avoids dead plumbing.
+
+### 4.4 The router `datasource` changes — one decision per broker message
+
+This is the seam correction from critique #9. Both real adapters call `updater.Update` with a **single-element** event slice and ack **per message**:
+- NATS: `FetchNoWait(300)` returns a batch, but the reader loops `for msg := range msgBatch.Messages()` and calls `updater.Update([oneEvent])` then `msg.Ack()` **per `msg`** (`nats/adapter.go:145-157`).
+- Kafka (deferred): `PollRecords(10_000)` then `updater.Update([oneRecord])` **per record** (`kafka/adapter.go:110-118`).
+
+So `events` is **always length 1** at the `Update` boundary. There is no multi-event batch to "ack the lowest contiguous prefix" of at this seam. The prior draft's `DeliveryReport.Merge` / batch-prefix machinery was solving a problem that does not exist here. **It is removed.** Each `Update` call corresponds to exactly one broker message and produces exactly one `Decision`.
+
+The real batching (300 JetStream msgs per `FetchNoWait`, 10k Kafka records per poll) happens in the *reader loop*, and there each message already gets its own ack decision in loop order — which is already ordering-safe. The only ordering constraint that lives at the reader-loop level is documented in Section 7 (a Nak'd message redelivers later, after subsequent messages in the same fetch may have acked — an inherent at-least-once reorder, not something `Merge` could fix).
+
+```go
+type SubscriptionEventUpdater interface {
+    // Update delivers a single broker message's event(s) and returns the delivery report.
+    Update(events []StreamEvent) DeliveryReport
+    Complete()
+    Done()
+    SetHooks(hooks Hooks)
+}
+
+// no-hooks path (v1): events is length 1 in both adapters today, but we keep the loop and
+// take the conservative report (a failure in any element fails the message).
+func (s *subscriptionEventUpdater) Update(events []StreamEvent) DeliveryReport {
+    if len(s.hooks.OnReceiveEvents.Handlers) != 0 {
+        // v1: at_least_once + hooks is rejected at startup validation (Section 8.6, 9.2).
+        // This path therefore runs only in mode:off and its return is ignored.
+        ... // existing behavior, return zero report
+    }
+    var rep DeliveryReport
+    for _, event := range events {
+        r := s.eventUpdater.Update(event.GetData()) // engine DeliveryReport
+        rep.Flushed += r.Flushed; rep.Failed += r.Failed; rep.Skipped += r.Skipped
+    }
+    return rep
+}
+```
+
+### 4.5 The adapter changes — `datasource.Adapter` keeps its signature, the reader loop changes
+
+The `Adapter` *interface* (`provider.go:22-28`) does **not** change — `Subscribe` still takes a `SubscriptionEventUpdater`.
+The NATS reader goroutine now reads the return value of `updater.Update` and maps the `DeliveryReport` to a broker decision via a small shared helper:
+
+```go
+// shared policy evaluation, datasource package
+func (p DeliveryPolicy) Decide(r DeliveryReport) Decision {
+    switch {
+    case r.Failed == 0:
+        // includes the all-skipped case (0 flushed, 0 failed, N skipped) → Ack, for EVERY policy.
+        return DecisionAck
+    case p == PolicyAny && r.Flushed > 0:
+        return DecisionAck
+    case p == PolicyQuorum && r.Flushed*2 > (r.Flushed+r.Failed):
+        return DecisionAck
+    default:
+        return DecisionNak
+    }
+}
+```
+
+Per critique #11, the `Failed == 0` case is evaluated *first*, so an all-skipped event (every subscriber filtered/dropped — `Flushed==0, Failed==0, Skipped==N`) Acks under all three policies. Section 8.8 mandates a table-driven test row for this for each policy.
+
+NATS JetStream reader, after the change (`nats/adapter.go:145-157`):
+
+```go
+report := updater.Update([]datasource.StreamEvent{ /* one event */ })
+
+switch p.deliveryPolicy.Decide(report) {
+case datasource.DecisionAck:
+    if err := msg.Ack(); err != nil { log.Error("error acknowledging message", ...); return }
+case datasource.DecisionNak:
+    // redeliver after backoff; co-subscribers that DID flush will see a duplicate (§4.6).
+    // JetStream's MaxDeliver (set finite in §4.7 / §8.7) bounds this; on exhaustion it Terms.
+    if err := msg.NakWithDelay(p.nakBackoff); err != nil { log.Error("error nak'ing message", ...) }
+case datasource.DecisionTerm:
+    _ = msg.Term() // poison / budget exhausted; out of redelivery rotation
+}
+```
+
+### 4.6 Lifecycle, the mutable trigger set, and the serialization-gate stall (critique #2 + #3)
+
+A single JetStream message, two shared subscribers A (fast) and B (slow/dead), `policy: all`:
+
+```
+JetStream delivers msg (stream seq 42), reader holds `msg`
+        ▼
+reader: report := updater.Update([Event{seq42}])
+        │   subscriptionUpdater.mu HELD for the whole call (the "event serialization gate")
+        │   handleTriggerUpdate → wg.Go × {A,B} ; wg.Wait()
+        │     sub A: Init→Load→Resolve→Flush ✔  → Flushed
+        │     sub B: Flush ✖ (client gone)       → Failed ; UnsubscribeSubscription(B)
+        │   returns DeliveryReport{Flushed:1, Failed:1}     ← mu RELEASED here
+        ▼
+   Decide(all) = Nak  →  msg.NakWithDelay(nak_backoff)
+        │
+        │  *** the reader goroutine for this trigger does not fetch the next message
+        │      until after the backoff; meanwhile any NEW live event for this trigger
+        │      arrives through the SAME subscriptionUpdater.mu and queues behind it. ***
+        ▼  (after nak_backoff) JetStream redelivers seq 42 — a NEW Update() call, fanned to
+           WHATEVER subscribers exist NOW (the trigger is keyed by data, not client identity):
+        ├── sub A still present → Flush ✔  (DUPLICATE — A must be idempotent)
+        ├── sub B gone forever  → not in the set; can NEVER be satisfied by redelivery
+        └── a NEW sub C that joined after seq 42 → receives seq 42, an event that PREDATES its
+            subscription (a pre-join, possibly-stale event). Re-authz'd against C (§8.5).
+        ▼  DeliveryReport now depends on the CURRENT set, not the original one.
+```
+
+Three structural truths this RFC states plainly rather than hand-waving:
+
+**(a) Redelivery targets the *trigger*, not the failed subscriber.** The engine re-runs `filterSubscriptions` over the *current* subscriber set on every `Update` (`resolve.go:1095`). The trigger is keyed by data, never by client identity (dossier §1.4). Consequences:
+- Healthy co-subscribers (A) get **duplicates**.
+- A **newly-joined** subscriber (C) can receive an event that predates its subscription — out-of-order/stale relative to C. Whether exposing a pre-join event to a fully-authorized new subscriber is acceptable is a **product decision** (Section 8.5, 12).
+- A **permanently-departed** subscriber (B) is gone from the trigger, so the message can *never* satisfy `policy: all` for B. It will redeliver to A/C until `max_redeliveries`, then `Term`. The framing "redeliver until the slowest *required* subscriber flushes" is therefore **not literally true** — there is no stable "required set" across a redelivery. The honest claim is in Section 7.
+
+**(b) The serialization-gate head-of-line stall (critique #3 — strictly worse than today for healthy clients).** `subscriptionUpdater.mu` is "held across the entire Update() call including wg.Wait()" (`resolve.go:1463-1466`). Our ack/nak decision runs in the *reader goroutine* after `Update` returns and `mu` is released. But on Nak, `NakWithDelay(nak_backoff)` stalls the reader for the backoff before it fetches the next message, and the redelivery comes back through the **same** `subscriptionUpdater.mu`. While a Nak→backoff→redelivery cycle is in flight, **new live events for that trigger queue behind the gate.** With `policy: all` and one permanently-stuck subscriber, the entire shared trigger (all N clients) is frozen for up to:
+
+> **worst-case stall ≈ `nak_backoff × max_redeliveries`** (blast radius: every co-subscriber on the trigger).
+
+This is *strictly worse than today* for the healthy clients on that trigger (today they keep getting fresh events; the slow client's event is silently dropped and never blocks anyone). This is the core cost of mapping one ack onto N clients, and it is the strongest argument for a finite `max_redeliveries` (Section 4.7) and for Pattern C when per-client isolation matters. We surface the stall via `delivery_trigger_stall_seconds` (Section 8.8).
+
+**(c) Duplicates are the at-least-once tax.** Inherent and unavoidable; clients must be idempotent (dossier §6.2).
+
+### 4.7 Bounded redelivery is mandatory (critique #7)
+
+Today the JetStream consumer config (`nats/adapter.go:422-431`) sets only `Durable` and `FilterSubjects` — it does **not** set `MaxDeliver`, so the server default (**unlimited**) applies, along with default `AckExplicit` and 30s `AckWait` (dossier §3.1). Combined with truth (a) above (a departed subscriber can never satisfy `all`), **unlimited `MaxDeliver` + `policy: all` is a denial-of-service**: one client that disconnects uncleanly during an event causes that stream sequence to redeliver *forever*, the consumer's ack floor never advances, and its pending count grows unbounded — freezing the whole trigger per truth (b).
+
+**Therefore, when `mode: at_least_once`:**
+- Pattern D **sets `MaxDeliver` on the consumer config** to a finite `max_redeliveries` (default below), so a never-satisfiable message is `Term`'d (→ advisory / DLQ) rather than redelivered forever. `Term` is defined as the **normal** termination for "a required subscriber never came back."
+- Startup validation **rejects** `mode: at_least_once` with `policy: all` and an effectively-unlimited `max_redeliveries` (`0` meaning "backend default = unlimited"). This combination is unsafe and must not start.
+- Default `max_redeliveries` is **5** when `mode: at_least_once` (finite, bounded stall), overridable.
+
+### 4.8 Components touched (precise, v2.4.1)
+
+- **graphql-go-tools `pkg/engine/resolve/resolve.go`**: `executeSubscriptionUpdate` return value (`:616`); `handleTriggerUpdate` return value (`:1086`); the `SubscriptionUpdater` interface (`:1586`); the concrete `subscriptionUpdater.Update` (`:1479`). New types `DeliveryOutcome`, `SubscriberDelivery`, `DeliveryReport`. `UpdateSubscription` (`:1500`) is **unchanged** (hooks deferred). `handleUpdateSubscription` (`:1114`) **unchanged**.
+- **router `datasource`**: `SubscriptionEventUpdater.Update` return value (`subscription_event_updater.go:19-24, 36-42`); `DeliveryPolicy.Decide`; mirror `DeliveryReport`. The `Adapter` interface (`provider.go:22-28`) is **unchanged**. No `Merge`/batch-prefix machinery.
+- **router NATS adapter** `nats/adapter.go`: read `updater.Update`'s return and branch to `Ack`/`Nak`/`Term` (`:145-157`); set finite `MaxDeliver` on the consumer config (`:422-431`).
+- **router config**: a new `delivery` block under the NATS provider (Section 9), plus startup validation (Section 4.7, 8.6).
+- **router metrics**: extend `metric.StreamsEvent` taxonomy with delivery counters (Section 8.8).
+- **`websocket.go` / `flushwriter.go`**: **no changes.** The flush they already do *is* the success signal; we only read its error, which the engine already has.
+- **`wsproto/proto.go`**, **composition / proto / schema directives**: **no changes.**
+- **Kafka / Redis adapters, hooks path**: **no changes in v1** (deferred — Section 6, 8.6).
+
+---
+
+## 5. Wire protocol & client changes
+
+**None. Justified.**
+
+Pattern D is a pure server-side correctness fix.
+It changes *when the router tells the broker "done,"* nothing the client can observe except that — on the failure-then-redelivery path — a client that *was* connected and *did* receive an event may receive it **again** after a co-subscriber's failure triggered a Nak (Section 4.6).
+That is at-least-once's defining property and requires no protocol affordance: duplicates are delivered over the existing `Next`/`next` frames on the existing `graphql-transport-ws`, `graphql-ws`, and `graphql-sse` transports.
+
+We deliberately do **not** add an `ack` inbound message (`wsproto/proto.go:88-94` untouched), do **not** add an SSE `id:` field (`flushwriter.go` untouched), and do **not** negotiate a capability in `connection_init`.
+Those are the surface of Patterns A/B/G.
+
+**Fallback when a client/transport cannot participate:** not applicable — there is nothing for the client to participate in.
+Every client benefits automatically with zero changes.
+
+The only client-facing guidance is documentation: *because at-least-once now actually redelivers, your resolvers/clients must tolerate duplicates* (the standard idempotency caveat, dossier §6.2).
+
+**Non-Goal note — the produce side caps the end-to-end guarantee (critique #12).**
+"At-least-once relative to flush" is only meaningful if the event reached the stream in the first place. The Cosmo NATS *publish* path uses **core NATS** `p.client.Publish` even for stream-backed subjects (`nats/adapter.go:254`) and is itself fire-and-forget — it can drop a message before the stream. Pattern D assumes the event is durably in the broker and does **not** fix this; an at-least-once *publish* story (idempotent ingest with `Nats-Msg-Id`, JetStream `js.Publish`) is out of scope here but is a real ceiling on end-to-end guarantees and should be its own RFC.
+
+---
+
+## 6. Per-backend adaptability & degradation matrix
+
+**v1 ships exactly one backend: NATS JetStream.** Everything else is either trivially unaffected (no-ack backends), explicitly deferred (Kafka), or not-yet-a-Cosmo-backend (forward-compatible only). The matrix below is honest about which row is in scope.
+
+| Backend | In v1? | Guarantee achieved by Pattern D | Degradation / fallback (non-silent) |
+|---|---|---|---|
+| **NATS JetStream** | **Yes** | **At-least-once relative to flush**, per policy, for the subscriber set present across a redelivery (Section 7). Redelivery after `nak_backoff`; finite `MaxDeliver` bounds retries (Section 4.7). Closes bug #2; closes #3 under `all` for the present set. | The serialization-gate stall and duplicate-to-healthy-co-subscriber (Section 4.6); surfaced via `delivery_trigger_stall_seconds`, `delivery_nak_total`. After `MaxDeliver` exhaustion → `Term` + `delivery_exhausted_total`. |
+| **NATS core** | n/a (no-op) | **Unchanged** — at-most-once | No ack primitive (`ChanSubscribe`, `nats/adapter.go:186`). If `delivery.mode: at_least_once` is set on a core-NATS subject, `on_unsupported` governs: `warn` (log once, run fire-and-forget) or `error` (refuse to start). **Never silent.** |
+| **Redis Pub/Sub** | n/a (no-op) | **Unchanged** — at-most-once | Same as NATS core: no ack primitive (`PSubscribe`/`PUBLISH`, `redis/adapter.go:88-152`). `on_unsupported` warn/error. |
+| **Kafka** | **No — deferred** | — | See note ‡ below. Requires a committed cursor → consumer group → Pattern C territory. **Rejected at startup** if `delivery.mode: at_least_once` is set on a Kafka provider in v1. |
+| **Redis Streams** | No (not a Cosmo backend) | Would be at-least-once via `XACK`/PEL — result-plumbing identical to NATS | Forward-compatible only. |
+| **SQS / Google Pub/Sub / Kinesis / Event Hubs / RabbitMQ** | No (not Cosmo backends) | delete-on-ack / ack-nack / checkpoint families map cleanly when added | Forward-compatible only; offset/checkpoint families inherit the head-of-line shape. |
+
+**‡ Kafka note — why it is deferred, not "M" (critique #5).**
+The Kafka poller (`kafka/adapter.go:51-122`) does `PollRecords(10_000)`, iterates **all records across all partitions in one `RecordIter`**, calls `updater.Update` **per record**, and is **groupless** with `ConsumeResetOffset(AfterMilli(now))` and a brand-new client per `Subscribe` (`:142`). A groupless client **has no offset commit mechanism at all.** To honor a `DeliveryReport` you would need *all* of:
+1. per-`(topic, partition)` floor tracking (the current single-`RecordIter` loop has no per-partition offset state);
+2. pause/resume of partitions whose floor is stuck — otherwise re-fetching from the floor re-delivers everything above it to *all* subscribers every poll (a duplicate storm);
+3. a **committed cursor**, which means introducing a `kgo.ConsumerGroup` or manual `CommitOffsets` — which drags in rebalance, `group.instance.id`, and the per-instance naming problem the RFC otherwise defers to Pattern C.
+
+With the *current* groupless client, an in-memory floor buys **nothing across restart**: on restart the consumer resets to `AfterMilli(now)` and re-reads from "now" anyway — the exact gap listed as out-of-scope. So Kafka either grows a consumer group (Pattern C, contradicting this RFC's scope boundary) or its "floor" is a lie across restart. **Kafka is therefore L-shaped and deferred**; v1 rejects `at_least_once` on Kafka at startup rather than pretending.
+
+**Two families (dossier §3.3), restated for what *would* happen when these land:**
+- *Per-message ack* (JetStream — v1; Redis Streams, SQS, Pub/Sub, Rabbit — future): Pattern D is exact — failed subscribers' messages are individually redelivered, succeeded ones are not held back.
+- *Offset/sequence commit* (Kafka, Kinesis, Event Hubs — future): Pattern D can only advance a *floor*, so one slow subscriber blocks the head of the line for everyone sharing that partition, and a restart re-reads above the floor. This is the explicit, documented degradation of the log-offset family with the shared-trigger model — and the reason those backends are a better fit for Pattern B.
+
+---
+
+## 7. Delivery semantics achieved
+
+**Headline:** **at-least-once relative to flush success** (bytes accepted by the writer's `Flush()` without error), per the configured shared-trigger policy, on NATS JetStream, **for the subscriber set present across a redelivery.**
+
+- **At-most-once?** No longer — a flush failure now triggers redelivery instead of a silent drop.
+- **At-least-once?** Yes, *bounded by* (i) the broker's redelivery + finite `MaxDeliver`, (ii) the flush definition, and (iii) the **mutable, identity-free trigger set** (Section 4.6): a subscriber present at original delivery *and still present at redelivery* is guaranteed to be retried until it flushes or the budget is exhausted. A subscriber that departs permanently is **not** retried (it is gone from the trigger); the message burns its redelivery budget then `Term`s. This is the precise, honest scope of "closes bug #3."
+- **Exactly-once?** No. Redelivery produces duplicates (Section 4.6). Clients/resolvers must be idempotent.
+
+**Duplicates.** Guaranteed possible on the Nak/redelivery path, especially with shared triggers: when subscriber B fails, the Nak redelivers to A who already had it, and to any new C that joined since.
+
+**Ordering.** Per-subscriber ordering is **preserved on JetStream with `policy: all` and serial redelivery**, *within one event*. It can be **violated** by:
+- a Nak'd message redelivering *after* later messages from the same `FetchNoWait(300)` batch already acked (an inherent at-least-once reorder; see Section 4.4 — this is *not* fixable by a prefix-floor at the `Update` seam, because each message is acked independently in loop order);
+- `policy: any/quorum`, which acks before the slowest subscriber, so the slow subscriber's redelivery (if it comes back) interleaves.
+We do **not** claim global ordering — Cosmo never had it (ordering is partition/stream-scoped, dossier §6.1).
+
+**Exact failure windows that remain (be precise):**
+
+1. **Flush ≠ receipt (bug #1, narrowed not closed).** A client that crashes after the router's `Flush()` buffered bytes into the kernel/TCP but before the client app processed them: acked, lost. Closing this requires a client ack (Pattern A).
+2. **Router crash between flush and ack.** The router flushes successfully, then dies before `msg.Ack()`. The broker redelivers → a **duplicate**, not a loss (acceptable).
+3. **Permanently-departed required subscriber.** Under `policy: all`, a subscriber that leaves uncleanly mid-event can never satisfy the policy; the message redelivers (duplicating to healthy co-subscribers) until `MaxDeliver`, then `Term`s. The departed subscriber's event is lost to it — but it is *gone*, so this is delivery to a set that no longer includes it. Made visible via `delivery_exhausted_total`.
+4. **Minority loss under `quorum`/`any`.** A `Failed` subscriber when the policy still Acks silently misses the event (Section 8.3). Made visible via `delivery_subscriber_dropped_total` (Section 8.8).
+5. **Cross-instance / cross-restart of in-flight handles.** A different router instance after failover does not inherit in-flight handles; with JetStream's per-instance durable naming (`nats/adapter.go:69-83`), cross-instance failover still drops in-flight events. **Pattern C territory**, out of scope.
+
+---
+
+## 8. Cross-cutting concerns
+
+### 8.1 Router HA / horizontal scaling & sticky sessions
+
+Pattern D does **not** add HA durability. In-flight (held, un-acked) broker handles live in the reader goroutine of the process that read them; a crash before ack → broker redelivers to whichever instance next consumes (JetStream redelivers to the same per-instance durable, dossier §2.3). Sticky sessions are **not required** — the redelivery target is decided by the broker, not by client affinity. The known limitation: JetStream's per-instance durable naming means failover to a *new* instance doesn't resume the old instance's un-acked set (failure window #5). Documented; Pattern C fixes it.
+
+### 8.2 Per-subscription state / memory cost
+
+Near-zero new persistent state. The `DeliveryReport` is a transient, stack-scoped value (counts + per-sub outcome during fan-out) that exists only for the duration of one `Update` call. No per-subscriber durable map, no external store. This is the cheapest of the durable-ish patterns (dossier §6.7).
+
+### 8.3 Multi-tenant shared-trigger fan-out (the central tension)
+
+One broker subscription fans to N subscribers (dossier §1.4, §6.5); one broker ack must now reflect N heterogeneous outcomes. We make the coupling **explicit and configurable** via `delivery.policy`:
+
+- **`all`** (default when durability is requested): ack only when no subscriber's flush failed. The only policy giving a real per-subscriber at-least-once guarantee — at the cost of duplicates and the serialization-gate stall to co-subscribers (Section 4.6).
+- **`quorum`**: ack when a majority flushed. Bounds blast radius; **the failed minority silently misses the event — this is bug #3 for the minority** and is made observable by `delivery_subscriber_dropped_total`.
+- **`any`**: ack if *anyone* flushed. Closes bug #2 (no longer ack on total failure) but **explicitly re-creates bug #3** (a single success acks for all). The cheapest upgrade; same metric makes the loss visible.
+
+We are blunt: `quorum` and `any` **reintroduce silent per-subscriber loss under a config flag.** They are offered because some operators rationally prefer bounded blast radius over universal redelivery, but the RFC's non-silence mandate (dossier) requires the dropped-subscriber metric (Section 8.8) so the loss is *observable*, never invisible.
+
+Pattern D **does not break trigger dedup** (unlike C): the shared trigger and single broker subscription are preserved.
+
+### 8.4 Backpressure
+
+Unchanged in shape, improved in correctness, with one new *worse* case made explicit. The reader goroutine already blocks on `updater.Update` until all subscribers flush (dossier §2.2). Pattern D adds the ack-decision branch after that point — and, on Nak, the `nak_backoff` stall (Section 4.6 (b)) which *is* new backpressure with teeth: a slow subscriber now correctly stalls the consumer and triggers redelivery rather than silently dropping, but the stall propagates to healthy co-subscribers on the trigger. `MaxSubscriptionFetchTimeout` (30s, `config.go:454`) remains the per-update liveness guard; a subscriber whose flush times out is `DeliveryFailed`.
+
+### 8.5 Security / authz
+
+- **Replay re-runs authz per event — but against the *current* subscriber set (critique #10).** Redelivery flows through the same `handleTriggerUpdate` → `filterSubscriptions` → resolve path, so per-event authorization (declarative filters, dossier §6.8) runs again on the redelivered event. Because the trigger set is mutable (Section 4.6), the re-authz runs against whatever subscribers exist *now* — which can *expose a pre-join event to a newly-joined, fully-authorized subscriber C*. The authz itself is correct (C is authorized); the **product question** is whether C should logically see an event that predates its subscription. This RFC flags it as a decision to make, not a bug to hide: for most event streams a recently-redelivered event is acceptable; for strictly time-windowed/entitlement-scoped streams it may not be. Default v1 behavior is the engine's existing semantics (no special suppression), documented.
+- **No new tokens, no cursors, no replay window.** Pattern D introduces no client-presented position, so Pattern B's cursor-forgery surface **does not exist** here.
+- **Drop ≠ failure.** A filter/authz decision *not* to deliver is `DeliverySkipped`, not `DeliveryFailed` (Section 4.3) — a correctly-filtered event still Acks, not an endless Nak. This is the reconciliation dossier §6.8 demands.
+
+### 8.6 Interaction with existing Cosmo Streams hooks — DEFERRED in v1 (critique #4)
+
+The prior draft sketched mapping hook abandonment-on-timeout to `DeliveryFailed` → Nak. **That is unimplementable as sketched and would reintroduce the very duplicate+reorder it claims to fix.** The actual hooks path (`subscription_event_updater.go:36-78`):
+
+```
+go func() { for sub { semaphore.Acquire; go updateSubscription(...) }; wg.Wait(); close(done) }()
+select {
+case <-done:            // all finished
+case <-updaterCtx.Done(): // TIMEOUT: return immediately, goroutines still running detached
+    log.Warn("...Events may arrive out of order.")
+}
+```
+
+On timeout, the updater **returns while the per-subscription goroutines are still running detached** (the code comment is explicit: "we will also not wait for them, basically abandoning them"). At the moment of timeout there are **no results to aggregate** — you cannot synchronously produce a report that says "these subs failed" when the determination is "we stopped waiting." Worse: those abandoned goroutines later call `s.eventUpdater.UpdateSubscription(...)` → `subscriptionUpdater.UpdateSubscription` → `s.mu.Lock()` (`resolve.go:1500`), racing the *next* event's `Update` for the serialization mutex and flushing **late**. If Pattern D had already Nak'd based on "timeout = failed" and *then* an abandoned goroutine flushes successfully, you get a Nak-redelivery duplicate **plus** the late original — two copies and a reorder.
+
+**Therefore, v1:**
+- **Rejects `mode: at_least_once` together with any `on_receive_events` hook at startup validation.** A clear error: "at_least_once delivery is not supported with on_receive_events hooks in this release; the hook timeout-abandonment path must be reworked to be synchronous first."
+- The reconciliation is a **follow-up**: rework the hooks path to be *synchronous* (no detached goroutines; bound each subscription's hook execution and wait for or hard-cancel it deterministically) so it can produce a real per-subscriber report. Only then can abandonment-on-timeout map to a Nak, and a hook that *intentionally drops* an event map to `DeliverySkipped` (ack-able). This is its own design problem and is graded separately (Section 12).
+
+This is the most important honesty correction versus the prior draft, which advertised bug #4 as "Closed."
+
+### 8.7 JetStream consumer config
+
+`mode: at_least_once` sets `MaxDeliver = max_redeliveries` (finite, default 5) on the consumer config (`nats/adapter.go:422-431`). It does **not** change `AckPolicy` (already `AckExplicit` by default) or `AckWait` (server default 30s). `nak_backoff` is applied via `msg.NakWithDelay`, independent of `AckWait`. Startup validation rejects `policy: all` with effectively-unlimited `MaxDeliver` (Section 4.7).
+
+### 8.8 Observability — first-class, because the guarantee depends on it (critique #8, #13)
+
+The metrics are load-bearing: under `quorum`/`any` they are the *only* thing that makes silent minority loss visible, and under `all` they expose the stall blast radius. They extend `metric.StreamsEvent` (`pkg/metric/stream_metric_store.go:25`).
+
+| Metric | Type | Labels | Meaning |
+|---|---|---|---|
+| `router_streams_delivery_nak_total` | counter | `provider_id`, `destination` | Messages Nak'd (redelivery triggered). |
+| `router_streams_delivery_redelivered_total` | counter | `provider_id`, `destination` | Redelivered messages observed (duplicates emitted). |
+| `router_streams_delivery_exhausted_total` | counter | `provider_id`, `destination` | Messages `Term`'d after `MaxDeliver` (a never-satisfiable required subscriber). |
+| `router_streams_delivery_subscriber_dropped_total` | counter | `provider_id`, `destination`, `policy` | A subscriber was `Failed` but the policy still Acked → that subscriber **silently missed the event**. Incremented in the engine where per-subscriber identity is still in scope. The non-silence guarantee for `quorum`/`any`. |
+| `router_streams_delivery_trigger_stall_seconds` | histogram | `provider_id`, `destination` | Time a trigger's reader was stalled in a Nak/backoff/redelivery cycle (Section 4.6 (b)). |
+| `router_streams_delivery_policy_unsupported_total` | counter | `provider_id` | `at_least_once` requested on a no-ack backend; emitted once with the startup warning. |
+
+**Cardinality.** Labels are bounded: `provider_id` is operator-defined (small), `destination` is the subject/topic (bounded by config), `policy` is one of three. We deliberately **do not** label per-trigger or per-subscriber (unbounded — per-trigger is a hash of input+headers, effectively unbounded under high-cardinality variables). Per-subscriber detail, when needed for debugging, goes to a debug log line gated behind a sampling flag, not a metric label.
+
+---
+
+## 9. Configuration surface
+
+All new config is **router-local YAML**, opt-in, default-off. No schema directives, no proto, no composition changes.
+
+### 9.1 Per-provider default
+
+```yaml
+version: "1"
+
+events:
+  providers:
+    nats:
+      - id: my-nats
+        url: "nats://localhost:4222"
+        # NEW: default delivery behavior for all JetStream-backed subscribes on this provider.
+        delivery:
+          # off (default): today's behavior exactly — ack after attempt, byte-for-byte unchanged.
+          # at_least_once: map DeliveryReport → Ack/Nak.  (JetStream only in v1.)
+          mode: at_least_once
+          # all | quorum | any  — how a shared trigger's N outcomes collapse to one ack.
+          # NOTE: quorum/any silently drop the failed minority (see delivery_subscriber_dropped_total).
+          policy: all
+          # what to do when the backend can't honor `mode` (NATS core):
+          #   warn  (default): log once at startup, run fire-and-forget.
+          #   error: refuse to start.
+          on_unsupported: warn
+          # Nak backoff before redelivery. Worst-case trigger stall ≈ nak_backoff × max_redeliveries.
+          nak_backoff: 5s
+          # MaxDeliver budget. MUST be finite when policy: all (0 = unlimited is REJECTED at startup).
+          max_redeliveries: 5
+```
+
+### 9.2 Defaults, invariants & startup validation
+
+- `delivery.mode` defaults to **`off`** everywhere → zero behavioral change until explicitly enabled.
+- `policy` defaults to `all` when `mode: at_least_once`.
+- `max_redeliveries` defaults to **5** when `mode: at_least_once`. **Startup rejects** `policy: all` + `max_redeliveries: 0` (unlimited) — unsafe (Section 4.7).
+- `mode: at_least_once` on a **Kafka** provider is **rejected at startup** in v1 (Section 6 ‡): "at_least_once is not supported on Kafka in this release."
+- `mode: at_least_once` together with any **`on_receive_events`** hook is **rejected at startup** (Section 8.6).
+- `mode: at_least_once` on a **no-ack backend** (NATS core, Redis Pub/Sub): `on_unsupported` governs (`warn` runs fire-and-forget + logs once; `error` refuses to start). **Never silent** (dossier mandate).
+- No per-field/per-operation knob in v1 — delivery policy is per-provider, keeping the schema/proto clean.
+
+### 9.3 What is *not* added
+
+- No `wsproto` capability, no `connection_init` payload field (Section 5).
+- No `@edfs__*` directive argument, no `DataSourceCustomEvents` proto field (`node.proto:430-434` untouched).
+- No external state store config (Pattern C).
+
+---
+
+## 10. Migration, backward compatibility & live recovery
+
+- **Opt-in, default-off.** With no `delivery` block, every code path is behaviorally identical to today: the engine computes a `DeliveryReport`, the adapter ignores it and acks unconditionally as before. The engine interface change (`Update` now returns `DeliveryReport`) is source-compatible for the router (its only consumer); existing tests that call `Update` and ignore the return compile unchanged.
+- **Rollout.**
+  1. Land the engine signature change (graphql-go-tools `v2.4.x+1`) — additive return, no behavior change when ignored.
+  2. Land the router `datasource` plumbing + NATS adapter branch behind `delivery.mode: off` default.
+  3. Enable `at_least_once` per-provider in staging on JetStream, validate redelivery + idempotency + the stall metric, then opt-in production.
+- **Backward compatibility with clients:** total — no wire change (Section 5). The only observable difference for an enabled provider is *duplicate events on redelivery*.
+- **Downgrade:** set `mode: off` (or remove the block). New events revert to today's behavior immediately.
+- **Live recovery from a stuck trigger (runbook — critique #13).** `mode: off` does **not** drain messages already Nak'd and in JetStream's redelivery rotation; those keep redelivering on their `AckWait`/`nak_backoff` schedule until `MaxDeliver` `Term`s them. To recover a trigger stuck in a Nak loop *live*:
+  1. Confirm via `delivery_nak_total` rate + `delivery_trigger_stall_seconds` which `destination` is stuck.
+  2. Set `mode: off` for the provider and reload — this stops *new* Naks; in-flight Nak'd messages still drain.
+  3. To drain immediately rather than waiting out `MaxDeliver`: lower `max_redeliveries` (forces faster `Term`) or, operationally, purge/age-out the affected stream sequences on the broker side (a NATS admin action, outside the router). Because `MaxDeliver` is now finite (Section 4.7), the worst case is bounded at `nak_backoff × max_redeliveries` even without intervention.
+  4. The departed-subscriber root cause is visible in `delivery_exhausted_total`; chronic exhaustion on a `destination` is the signal to move that trigger to Pattern C (per-subscriber isolation) or `policy: quorum`.
+- **Engine-version coupling:** requires the `SubscriptionUpdater` change to land in the pinned `graphql-go-tools/v2` version (currently `v2.4.1`); re-verify the `executeSubscriptionUpdate`/`handleTriggerUpdate` lines against the exact target tag at implementation time.
+
+---
+
+## 11. Testing strategy (critique #13)
+
+These behaviors are not unit-testable in isolation — they require **deterministic broker integration tests** (a real or embedded JetStream) plus engine-level unit tests for the report plumbing.
+
+**Engine unit tests (graphql-go-tools, no broker):**
+- `executeSubscriptionUpdate` returns the correct `DeliveryOutcome` for each of the five branches — including the **bug-#1 regression test**: a `Resolve` error that produces a flushed error response classifies as `DeliveredError`/ack-able (option a) or `DeliveryFailed`-but-nothing-delivered (option b), and is asserted explicitly so no future change silently reverts to "Nak a delivered error."
+- `handleTriggerUpdate` aggregates N subscriber outcomes into the right counts, including the all-skipped case.
+- `DeliveryPolicy.Decide`: a table test with one row per `(flushed, failed, skipped) × {all, quorum, any}` cell, **including the `0 flushed / 0 failed / N skipped` row → Ack for all three policies** (critique #11), asserting the full `Decision` value with `assert.Equal`.
+
+**JetStream integration tests (deterministic redelivery):**
+- *Bug #2*: single subscriber whose flush fails → `msg` is Nak'd, redelivered, then acked once the subscriber recovers. Assert exact ack/nak call sequence.
+- *Bug #3 under `all`*: two shared subscribers, one fails → Nak; healthy subscriber receives a **duplicate** on redelivery (assert the duplicate). Then a third subscriber joins before redelivery → assert it receives the pre-join event (documents Section 4.6 (a) as tested behavior, not accident).
+- *Permanently-departed subscriber*: subscriber leaves uncleanly → message redelivers exactly `max_redeliveries` times then `Term`s; `delivery_exhausted_total` increments. Assert the stall is bounded by `nak_backoff × max_redeliveries`.
+- *Quorum/any minority loss*: under `any`, one of two flushes → Ack; `delivery_subscriber_dropped_total` increments for the failed subscriber. Assert the metric (the non-silence contract).
+- *Serialization-gate stall*: with one stuck subscriber under `all`, assert a *new* live event for the same trigger is delayed by the in-flight Nak cycle (Section 4.6 (b)).
+
+**Startup-validation tests:**
+- `at_least_once` + Kafka provider → startup error.
+- `at_least_once` + `on_receive_events` hook → startup error.
+- `at_least_once` + `policy: all` + `max_redeliveries: 0` → startup error.
+- `at_least_once` + NATS core + `on_unsupported: error` → startup error; `: warn` → starts + single warning.
+
+All response/metric/decision assertions use full-value `assert.Equal` (not `Contains`), per house testing rules.
+
+---
+
+## 12. Risks, open questions, and a complexity/effort estimate
+
+### Where this pattern is weakest (be honest)
+
+1. **Flush ≠ receipt — the hard ceiling.** A client that crashes after the kernel buffered the bytes but before the app processed them is *acked and lost*. Pattern D narrows bug #1 but cannot close it without a client ack (Pattern A). If true end-to-end at-least-once is the requirement, Pattern D is *necessary but not sufficient*.
+2. **Shared-trigger coupling is genuinely worse for healthy co-subscribers.** `policy: all` makes the slowest/dead subscriber inflict duplicates *and* a `nak_backoff × max_redeliveries` stall on everyone on the trigger (Section 4.6 (b)). This is not hidden: it is the inherent cost of one ack covering N clients, and the strongest argument for Pattern C (per-subscriber durability, at the cost of N broker consumers + broken dedup).
+3. **The mutable, identity-free trigger set bounds the guarantee.** "Closes bug #3" is only true for subscribers present *across* a redelivery; departed subscribers can never be satisfied, and newly-joined ones may see pre-join events (Section 4.6 (a), 8.5). The guarantee is scoped, not absolute.
+4. **Hooks and Kafka are deferred for real reasons, not convenience.** The hooks abandonment path cannot synchronously report failure (Section 8.6) and Kafka has no offset commit at all (Section 6 ‡). v1 rejects both at startup rather than ship a guarantee it can't keep.
+5. **No cross-instance / cross-restart durability of in-flight handles** (failure window #5). Pattern C.
+
+### Open questions
+
+- **Branch 1/2/4 flush behavior (option a vs b — Section 4.2).** Should the engine *flush* the buffered error on init/load/resolve failure (option a: makes them `DeliveredError`/ack-able and incidentally fixes the latent "buffered error never delivered to client" bug) or leave them non-flushing (option b: classify as `DeliveryFailed`, Nak because nothing was delivered)? Option (b) is the simpler v1 default; option (a) is the recommended follow-up but is a behavior change to error delivery that deserves its own review. **This is the single most consequential open question.**
+- **Pre-join event exposure (Section 4.6 (a), 8.5).** Is it acceptable for a newly-joined, authorized subscriber to receive a redelivered event that predates its subscription? Default v1: yes (engine's existing semantics). Some entitlement-scoped streams may want suppression — needs a product call before adding a knob.
+- **`policy` granularity.** Per-provider in v1. Per-subscribe-config (per subject) likely eventually; deferred to stay surgical.
+- **Hooks synchronous rework (Section 8.6).** What is the right deterministic timeout semantics for a synchronous hooks path — hard-cancel the hook goroutine (risky if it holds resources) vs. bound it and treat overrun as `DeliveryFailed`? This is the gating design for re-enabling hooks under `at_least_once`.
+
+### Complexity / effort estimate (re-graded — critique #15)
+
+**JetStream-only, no-hooks v1 slice: M.** **Full pattern (with hooks rework + Kafka cursor): L.**
+
+| Area | Effort | Notes |
+|---|---|---|
+| Engine: thread `DeliveryReport` through `executeSubscriptionUpdate` / `handleTriggerUpdate` / `Update` | **S–M** | Mechanical; the `wg.Wait()` sync point exists. The bug-#1 fix (split `DeliveredError`/`DeliveryFailed` on *flush* result, not resolve result) is the subtle part. |
+| NATS adapter: branch on report → `Ack`/`Nak`/`Term`; set finite `MaxDeliver` | **S** | Ack site exists (`nats/adapter.go:145-157`); consumer config edit (`:422-431`). |
+| Config + startup validation + metrics + docs | **M** | New `DeliveryConfiguration`; the validation matrix (Section 9.2) and six metrics (Section 8.8) are real work; "duplicates expected" docs. |
+| Serialization-gate stall analysis + bounded-stall tests | **S–M** | Analysis done (Section 4.6); deterministic integration tests are the cost. |
+| **— v1 subtotal —** | **M** | JetStream + no-hooks only. |
+| Hooks path: synchronous rework so abandonment can report (Section 8.6) | **L (follow-up)** | Its own design problem; v1 rejects the combination at startup instead. |
+| Kafka: groupless → committed cursor / consumer group (Section 6 ‡) | **L (follow-up)** | Pattern C territory; v1 rejects at startup instead. |
+
+The cost in v1 is concentrated in the bug-#1-correct outcome classification and the validation/observability surface; everything else is plumbing a return value through layers that already synchronize. Carving out hooks and Kafka is what keeps v1 honest at **M**; pretending they were "M" too is what made the prior draft's grade not credible. This remains the **highest correctness-per-effort** of the seven patterns and the prerequisite substrate for A, B, and C — which is why the dossier's sequencing recommends shipping it first.

--- a/rfc/at-least-once/rfc-E-router-replay-buffer.md
+++ b/rfc/at-least-once/rfc-E-router-replay-buffer.md
@@ -1,0 +1,790 @@
+# RFC: At-Least-Once for GraphQL Subscriptions — Hybrid Buffered-with-Redelivery / Router-Side Replay Buffer (Pattern E)
+
+**Status:** Draft (revised after adversarial review)
+
+**TL;DR.**
+Cosmo's EDFS subscription path is fire-and-forget end-to-end (broker → resolve → socket write),
+so any disconnect, router restart, or slow consumer silently drops events —
+and only NATS JetStream has *any* durability, and even that is broken (it acks on flush attempt, not client receipt).
+This RFC proposes a **router-side replay buffer**:
+a bounded, ordered, in-memory log of **already-resolved response frames**, keyed by a **router-assigned monotonic sequence**,
+that lets a reconnecting client replay the tail it missed before resuming live.
+The whole point is that it is **backend-agnostic**:
+it manufactures a replay window even for backends that have none (NATS core, Redis Pub/Sub),
+turning at-most-once into at-least-once *for disconnects shorter than the window*.
+Beyond the window it degrades — explicitly, never silently — to at-most-once.
+
+The first revision of this RFC placed the buffer between the broker adapter and the engine and claimed "no engine change."
+That was **wrong**, and the adversarial review was right to reject it:
+the events flowing there are *raw broker bytes*, the channel is *all-subscribers*, and the wire `id` must be stamped on
+the *resolved* payload on the far side of the engine boundary.
+This revision corrects the layering, **admits the required graphql-go-tools engine change**, re-derives the effort estimate (now **L** for the in-process variant alone),
+and tightens every guarantee claim. Where a weakness is inherent to the pattern, it is documented in §12, not hidden.
+
+---
+
+## 1. Problem & Context
+
+The research dossier (`rfc/at-least-once/00-research-dossier.md`) establishes the gap precisely,
+so I will only restate the parts this pattern attacks.
+
+An application very often *already has* at-least-once in its backend:
+Kafka offsets, JetStream durable consumers, Redis Streams consumer groups.
+The durability is sitting right there in the broker.
+But Cosmo's EDFS layer throws it away on the last hop.
+The entire chain from broker callback to client socket write is **one synchronous call stack with no buffer**:
+the broker-reader goroutine calls `updater.Update([]datasource.StreamEvent{...})`
+(`router/pkg/pubsub/nats/adapter.go:146`, `router/pkg/pubsub/kafka/adapter.go:110`, `router/pkg/pubsub/redis/adapter.go:132`),
+which drives `subscriptionEventUpdater.Update` (`router/pkg/pubsub/datasource/subscription_event_updater.go:36-129`),
+which drives the engine's `handleTriggerUpdate`, the full GraphQL resolve (including federated subgraph fetches), and finally `sub.writer.Flush()` —
+a single socket write under a write deadline
+(`router/core/websocket.go:704-736` for WS, `router/core/flushwriter.go:116-167` for SSE/multipart).
+
+The consequences, from the dossier's §2.1:
+
+- **Ack is gated on flush *attempt*, not client receipt.**
+  JetStream `msg.Ack()` (`router/pkg/pubsub/nats/adapter.go:154`) runs *after* `updater.Update()` returns.
+  A successful `Flush()` only means bytes were handed to the kernel/TCP buffer,
+  not that the client processed them.
+  A client that crashes after TCP-buffering but before processing loses the message, yet it is acked → **lost**.
+- **No resume / replay anywhere.**
+  A reconnecting client always starts a brand-new subscription from "now".
+  There is no `Last-Event-ID` handling
+  (a grep of `router/core/` + `router/internal/wsproto/` for `Last-Event-ID`/`resume`/`cursor`/`resumeToken` returns nothing),
+  the SSE writer never emits an `id:` field (`router/core/flushwriter.go:116-167`),
+  the recognized inbound WS message set is only `Ping`, `Pong`, `Subscribe`, `Complete`, `Terminate`
+  (`router/internal/wsproto/proto.go:88-94`),
+  and a reconnecting client gets a fresh `ConnectionID` (`resolve.NewConnectionID()`, `router/core/websocket.go:367`)
+  plus a brand-new subscription id (`router/core/websocket.go:1160-1185`).
+- **Slow consumers drop events at the broker client layer.**
+  NATS core uses an unbuffered channel (`make(chan *nats.Msg)`, `router/pkg/pubsub/nats/adapter.go:168`);
+  on overflow the nats.go client drops events and logs `nats.ErrSlowConsumer`
+  ("NATS slow consumer detected. Events are being dropped.", `router/pkg/pubsub/nats/provider_builder.go:96-105`).
+  Redis Pub/Sub drops on go-redis channel overflow.
+- **The backends that hurt most have no native replay at all.**
+  From the dossier's §3.3,
+  NATS core and Redis Pub/Sub are "delete-on-ack queues" with no cursor and no historical replay.
+  Pattern B (cursor/resume) is **impossible** on those backends —
+  there is no durable position to seek to.
+- **WS half-open connections are not detected.**
+  The WS heartbeat is an explicit **no-op** (dossier §1.6, `router/core/websocket.go:659-662`);
+  the router never proactively pings downstream WS clients.
+  A client that vanishes without a TCP FIN stays attached to its trigger until the *next write to it fails*.
+  This is load-bearing for §3.5 below and is a hard prerequisite this RFC must address.
+
+This is exactly the gap Pattern E exists to bridge.
+
+If the backend is a log (Kafka, Redis Streams, Kinesis, Event Hubs, JetStream),
+Pattern B (broker-cursor resume) is the right tool and Pattern E is redundant.
+But the moment the chosen backend is a queue or a core pub/sub system,
+the *only* way to give a reconnecting client the events it missed is for the **router itself** to have remembered them.
+Pattern E is that memory:
+a small, bounded, router-side log placed in front of backends that lack one.
+
+This RFC builds directly on the **Cosmo Streams v1 hooks** (`rfc/cosmo-streams-v1.md`).
+The replay buffer captures events *after* resolve, downstream of the inbound `OnStreamEvents` hook chain,
+so the events it stores have already passed through data-mapping and filtering — but note carefully (§3.4) that what it stores
+is the **resolved response frame**, not the raw broker event, which is what makes the layering work.
+
+---
+
+## 2. Goals & Non-Goals
+
+### Goals
+
+1. Deliver **at-least-once** to a reconnecting GraphQL subscription client
+   for any disconnect **shorter than a configured buffer window**,
+   on **any** EDFS backend — including the ones with no native replay.
+2. Be **backend-agnostic** for the replay window itself.
+   No new broker feature is required for the in-process window; broker ack-hold integration is per-backend and optional.
+3. Make degradation **explicit and non-silent.**
+   When the gap exceeds the window, the client learns via a typed gap signal,
+   not by silently missing events.
+4. Preserve the **shared-trigger broker fan-out optimization** (`rfc/at-least-once/00-research-dossier.md` §1.4) for the *broker read*:
+   one broker subscription, N subscribers. (The *replay* ring is per-subscriber — see §3.4 for why this is forced, and §12 for the honest cost.)
+5. Keep the memory cost an **explicit, tunable knob**, with a hard cap and a documented eviction policy.
+6. Provide a clean **upgrade path** to cross-restart durability via a pluggable external buffer store,
+   without changing the wire protocol — while being honest (§12) that this path largely re-implements a log backend.
+
+### Non-Goals
+
+1. **True end-to-end client-receipt acknowledgement.**
+   That is Pattern A.
+   Pattern E gives at-least-once *across reconnect within a window*, not per-message client confirmation.
+   A client that stays connected but silently fails to process a flushed message is still not covered —
+   the buffer can only help a client that *reconnects and asks*.
+2. **Durability beyond the window.**
+   We do not attempt to reconstruct arbitrarily old history.
+   That is what a log backend (Pattern B) or a durable per-subscriber consumer (Pattern C) is for.
+3. **Exactly-once.**
+   Replay can deliver duplicates. Clients must be idempotent (dossier §6.2).
+4. **Cross-router cursor portability without a shared store.**
+   The router-assigned sequence is scoped to a router instance + trigger generation.
+   A reconnect that lands on a different router instance (without the shared external store) cannot replay; it degrades.
+5. **Changing the publish path.**
+   This RFC is about the subscribe/deliver side only.
+6. **Replaying *byte-identical* federated data.**
+   See §3.4 and §8.5: a replayed frame is the *captured resolved output* from when the event was delivered,
+   not a re-resolution. This is a deliberate design choice that avoids the thundering-herd re-fetch problem — at the cost of storing resolved bytes.
+
+---
+
+## 3. Design — the mechanism in depth
+
+### 3.1 The core idea in one paragraph
+
+Capture the **resolved response frame** that the engine produces for each subscriber, *as it is flushed*, into a bounded ring keyed by a **router-assigned monotonic sequence** (`uint64`).
+Each subscriber's ring retains the last N frames (and/or the last T seconds).
+On the first `Subscribe`, the subscriber starts at the live head.
+On a `Subscribe` carrying a **resume token** whose `(triggerEpoch, seq)` is still inside that subscriber's ring lineage,
+the router replays the stored frames from `seq+1` to the head — *without re-resolving* — then attaches the subscriber to live.
+The broker ack for an event is held until the event has aged out of a short in-flight retention zone,
+so the broker remains the durability backstop while the event is still "fresh".
+
+### 3.2 The layering decision (the thing the first revision got wrong)
+
+The first revision placed the ring between the adapter and the engine, storing the **raw broker event** and claiming the engine was untouched.
+The adversarial review correctly demolished this. The two facts that force a different layering:
+
+- **What flows pre-engine is raw broker bytes, fanned to *all* subscribers.**
+  `SubscriptionUpdater.Update(data []byte)` (graphql-go-tools `resolve.go:1598`) takes the raw event payload
+  (NATS `msg.Data`, Redis `msg.Payload`, Kafka record value) and fans it to *every* subscriber on the trigger.
+  Resolution — `InitSubscription` + `LoadGraphQLResponseData` + `Resolve`, **including federated subgraph fetches for nested/`@requires` fields** — happens *per subscriber, per event, inside the engine* (`resolve.go:579-606`).
+  A ring of raw events would therefore have to **re-run the full federated resolve on every replayed event**: a 1024-event replay on one reconnect = up to 1024× subgraph fan-out (a thundering herd), and worse, the replay would resolve against **current** subgraph state, not the state at buffer time — silently delivering *different data* under the banner of "replay". That is a correctness hole, not just a cost.
+
+- **The wire `id` must be stamped on the *resolved* payload, downstream of resolve.**
+  The resolved JSON is assembled inside the engine and written by `sub.writer.Flush()` (`resolve.go:604`, `flushwriter.go:116`).
+  The seq is a router concept. There is no way to inject `extensions.cosmo.seq` into a payload the router never assembles
+  unless the router sits **downstream of resolve, at the writer**.
+
+**Conclusion: the ring stores post-resolve response frames, captured at the writer in `router/core`, per subscriber.**
+This is what makes replay cheap and correct (no re-fetch, byte-stable), and it is what lets the seq be stamped at the same point it is captured.
+It costs us the "one ring per trigger" memory story — resolved output is inherently per-subscriber. We accept and document that (§8.2, §12-#5).
+
+The broker-read fan-out optimization (one broker subscription, N subscribers) is **untouched** — that lives upstream of resolve and we do not move it. Only the *replay memory* is per-subscriber.
+
+### 3.3 Where it sits in the pipeline
+
+```
+                 ┌──────────────────────── one trigger: ONE broker subscription, N subscribers ───────────────────────┐
+                 │                                                                                                      │
+ broker ──msg──▶ adapter reader goroutine                                                                               │
+ (nats/kafka/    │                                                                                                      │
+  redis/...)     ▼                                                                                                      │
+            updater.Update(rawData)   ── unchanged shared fan-out (raw bytes to all subs) ──┐                           │
+                 │                                                                           │                          │
+                 ▼                                                                           ▼                          │
+        ┌──────────────────┐   (Cosmo Streams v1)                                  (engine fans the SAME raw event     │
+        │ OnStreamEvents    │   inbound hook chain: data-map, filter, drop          to every subscriber on the trigger) │
+        └──────────────────┘                                                                                            │
+                 │  mapped+filtered raw event                                                                           │
+                 ▼                                                                                                       │
+   engine handleTriggerUpdate ──▶ executeSubscriptionUpdate ──▶ resolve (incl. subgraph fetches) ──▶ writer            │
+                 │                                                                       │                              │
+                 │            ┌────────── ENGINE CHANGE (graphql-go-tools) ──────────────┤                              │
+                 │            │ per-subscriber writer is wrapped; engine threads an       │                              │
+                 │            │ opaque per-event seq token to the writer (§3.6).          │                              │
+                 │            │ New SubscriptionUpdater.Replay(id, fromSeq) entry point   │                              │
+                 │            │ addresses ONE subscriber for replay (§3.6).               │                              │
+                 │            └───────────────────────────────────────────────────────────────────────────────────────┘
+                 ▼
+        ┌────────────────────────────────────────────────────────────────────────────┐
+        │ REPLAY RING (NEW, per subscriber, in router/core)                             │
+        │  - on flush: capture resolved frame bytes, assign/stamp seq, store in ring    │
+        │  - stamp extensions.cosmo.seq (WS/multipart) / id: line (SSE) at this point    │
+        │  - on reconnect: serve stored frames seq+1..head, THEN attach to live          │
+        └────────────────────────────────────────────────────────────────────────────┘
+                                                                  │
+                                                                  ▼
+                                                       client socket (WS / SSE / multipart)
+```
+
+### 3.4 What the ring stores, and why replay is cheap
+
+Each ring slot stores the **already-resolved, already-stamped response frame** (the exact bytes that were flushed), plus its seq and timestamp.
+On replay the router writes those stored bytes back out verbatim, in seq order, then attaches the subscriber to live.
+
+Consequences, stated honestly:
+
+- **No re-resolve on replay, no subgraph re-fetch.** This is now *true* (the first revision's §8.6 claimed it falsely while storing raw events). Because we store post-resolve bytes, replay is a memcpy-and-write, not a federated query. The thundering-herd problem the review identified is eliminated by construction.
+- **Replay is byte-stable.** The client receives exactly what it would have received live, not a re-resolution against drifted subgraph state.
+- **Authorization on replay is *not* re-run by default** (changed from the prior revision; see §8.5 for the security trade-off and the opt-in re-check).
+- **Memory cost is per-subscriber.** Resolved frames are subscriber-specific (different subscribers may have different `@skip`/`@include`, variables, or hook-filtered fields), so they cannot be shared across a trigger. This is the real cost of correct replay and is the dominant term in §8.2.
+
+### 3.5 The sequence and the resume token
+
+The router-assigned sequence is a `uint64` that monotonically increases per (trigger-epoch, subscriber-lineage).
+It is **not** the broker's position; it is the router's own counter.
+
+A resume token must survive a reconnect and be tamper-evident. It encodes:
+
+```go
+// ResumeToken is what the client echoes back on reconnect. Opaque + signed on the wire.
+type ResumeToken struct {
+    RouterID     string `json:"r"` // mints the token; detects cross-instance reconnect
+    TriggerEpoch uint64 `json:"e"` // bumped on (re)create; detects restart / trigger rebuild
+    TriggerKey   string `json:"k"` // hash of (tenant ∥ namespace ∥ rendered input ∥ headers); re-binds to authorized trigger
+    Seq          uint64 `json:"s"` // last router seq the client confirms it received
+}
+```
+
+On the wire the token is an opaque base64url string: the JSON above, signed (HMAC) with a router secret,
+so a client cannot forge a `Seq`/`TriggerKey` to seek into another tenant's buffer (dossier §6.8).
+
+**Token issuance is throttled, not per-event (addresses review #5).**
+HMAC + JSON-marshal on *every* delivered frame at subscription fan-out rate is unbudgeted CPU and a per-event payload tax.
+Instead the router stamps a full resume token at most every `token_interval` (default 1s) or every `token_every_n` frames (default 32), whichever comes first, and **always** on the last frame before a heartbeat.
+Between token boundaries, frames carry only a cheap bare `seq` integer (no HMAC) under `extensions.cosmo.seq`; the signed token (`extensions.cosmo.resumeToken`) is what the client persists and echoes back.
+This bounds HMAC cost to O(token_interval) regardless of event rate, and the client always has a recent signed token to resume from. The cost of throttling is a slightly larger duplicate window on reconnect (the client resumes from the last *token* boundary, replaying a few already-seen frames — safe, idempotent). This trade-off is budgeted in §12.
+
+**TriggerKey includes a tenant/namespace discriminator (addresses review #14).**
+`TriggerKey = hash(tenantID ∥ namespace ∥ providerId ∥ renderedInput ∥ subgraphHeaderSubset)`.
+The tenant/namespace prefix guarantees two tenants that happen to render identical input + headers do **not** collide on the same key, closing the cross-tenant token-replay hole.
+
+### 3.6 Components touched — including the graphql-go-tools engine change (corrects the prior "no engine change" claim)
+
+This RFC **does** require a graphql-go-tools change. The first revision's "Cosmo-repo-only, no engine change" framing was wrong:
+replay to a *single* reconnecting subscriber while co-subscribers stay live, and stamping a per-event seq onto the *resolved* frame, both live on the engine side of the boundary.
+
+| Component | File:line anchor | Change |
+|---|---|---|
+| **Engine: `SubscriptionUpdater`** | graphql-go-tools `pkg/engine/resolve/resolve.go:1598` | **NEW.** Add `Replay(id SubscriptionIdentifier, frames [][]byte)` (write pre-rendered frames to one subscriber, bypassing resolve) and a way for the router to obtain the engine-minted `SubscriptionIdentifier` for a freshly (re)attached subscription. New `subscriptionEventKind` for replay frames so `handleTriggerUpdate` routes them to a single sub, not the trigger fan-out. |
+| **Engine: writer seq threading** | graphql-go-tools `resolve.go:579-606`, writer interface | **NEW.** Thread an opaque per-event token from `Update`/resolve to the `SubscriptionResponseWriter`, so the router's wrapping writer (below) can stamp the correct seq onto *this* flush. |
+| **Router: subscriber writer wrapper** | `router/core/websocket.go:704-736`, `router/core/flushwriter.go:116-167` | **NEW.** Wrap the per-subscriber `SubscriptionResponseWriter`. On `Flush`: assign/read the seq for this frame, stamp `extensions.cosmo.seq` (+ throttled `resumeToken`) for WS/multipart or prepend an `id:` line for SSE, capture the (post-stamp) frame into the subscriber's ring, then write to the socket. |
+| **Router: WS server keepalive** | `router/core/websocket.go:659-662` | **NEW (hard prerequisite, addresses review #2/#4).** Replace the no-op WS heartbeat with a real server→client ping on `ws_keepalive_interval`; a missed pong within `ws_keepalive_timeout` tears the subscription down, marking the subscriber detached so the ack-release predicate is not pinned by a dead-but-attached client. |
+| **Router: reconnect / token plumbing** | `router/core/websocket.go:1141-1185`, `router/internal/wsproto/proto.go:88-94` | Read `resumeToken` from `Subscribe` payload `extensions`; on a valid token, call the engine `Replay` path for this subscription's identifier before attaching live. No new inbound WS message type. |
+| **Router: SSE/multipart** | `router/core/flushwriter.go:116-167,252-299`, `router/core/graphql_handler.go:265-293` | Emit `id:` line per SSE event; read `Last-Event-ID` request header on reconnect; map it to a resume token; replay then go live. |
+| **Router: ack-hold integration** | `router/pkg/pubsub/nats/adapter.go:146,154`, `kafka/adapter.go:110`, `redis/adapter.go:132,191` | Optional, per backend. Move `msg.Ack()` out of the reader loop; register the ack handle; release on the §3.5 predicate. Groupless Kafka / Redis Pub/Sub → no-op (nothing to hold). |
+| **Router: config** | `router/pkg/config/config.go:773-782` (`EventsConfiguration`) | New `delivery.replay_buffer` block (§9). |
+| **Composition / proto** | `proto/wg/cosmo/node/v1/node.proto:430-434` | **No change.** Delivery semantics are router-local. |
+
+The honest summary: **engine change + router change + new wire stamping.** This is why §12 re-estimates the in-process variant as **L**, not M, and adds a graphql-go-tools PR as an explicit work item.
+
+### 3.7 Lifecycle — happy path and reconnect
+
+```
+T0  Client subscribes (no resume token)
+       router: resolve trigger T (shared broker sub). engine mints SubscriptionIdentifier for subscriber S.
+       router: per-subscriber ring created for S at head H=seq 0.
+       seq 1 ─▶ resolve ─▶ stamp+capture ─▶ flush to S   (ring[S] = {1})
+       seq 2 ─▶ resolve ─▶ stamp+capture ─▶ flush to S   (ring[S] = {1,2})
+       seq 3 ─▶ ...                                         (ring[S] = {1,2,3}; token stamped at boundary)
+
+T1  ── client network drops between seq 3 and seq 4 ──
+       WS keepalive (§3.6) detects the dead socket within ws_keepalive_timeout and marks S detached.
+       seq 4,5,6 still resolve+fan-out to OTHER live subs; for S there is no live socket.
+       S's ring is held warm for warm_keep (§6 failure #3). S's seq cursor stays at 3.
+       (Note: events 4..6 are NOT in S's ring unless S was the one resolving them; see §6 / §12-#6.)
+
+T2  Client reconnects, sends Subscribe { extensions:{ cosmo:{ resume: token(epoch,T,seq=3) } } }
+       router: verify signature + epoch + triggerKey == hash(tenant∥ns∥input∥headers) → OK.
+       router: re-attach to trigger T; engine mints a NEW SubscriptionIdentifier S'.
+       router: re-associate S' with S's warm ring via TriggerKey (§8.3).
+       router: REPLAY stored frames 4,5,6 (if present) via engine Replay(S', frames) — verbatim bytes, no re-resolve.
+       router: attach S' to live at head.
+       seq 7 ─▶ S'   (live again)
+
+T2' Alternate: gap too large / warm ring expired / different tenant-keyed trigger.
+       seq 3 not in ring (evicted, or warm_keep elapsed, or TriggerKey differs).
+       router emits typed GAP signal (extensions.cosmo.delivery.gap = {from:3,to:<head-1>, reason}) then goes live.
+       NON-SILENT degradation.
+```
+
+A subtlety the review surfaced and §6 / §12-#6 make explicit: for a *single* dropped subscriber, frames 4..6 only exist in its ring if the router kept resolving them for that detached subscriber during the gap. Doing so would mean resolving (and paying subgraph cost) for a client that is gone. The design therefore offers two warm-keep modes (§6 failure #3): **frame-capture warm-keep** (keep resolving for the absent subscriber, capturing frames — costs subgraph fetches for a gone client) and **cursor-only warm-keep** (cheaper; only replays what was already in the ring at drop time, which for a sole subscriber on a trigger is just the pre-drop tail). This is an inherent tension and is documented, not hidden.
+
+### 3.8 When does the broker ack fire? (reconciled with backpressure, addresses review #4)
+
+The first revision's predicate ("delivered to all current subscribers AND aged past grace") deadlocks against undetectable half-open WS clients and re-couples ack to the slowest consumer — contradicting the backpressure claim in §8.4. Both are fixed here.
+
+We define a per-event **ack-release predicate that does *not* depend on per-subscriber delivery**:
+
+```
+release broker ack for event e  ⟺  (now - e.firstSeenAt) >= AckHoldGrace
+```
+
+That is the whole predicate. Rationale and the honest trade-off:
+
+- **Why drop the "delivered to all subscribers" clause.** The review showed two fatal interactions with it:
+  (a) a half-open WS client that is dead-but-attached (no proactive ping, dossier §1.6) is never observed to "fail to deliver",
+  so "delivered to all" never becomes true and the ack is pinned forever (until grace anyway);
+  (b) a slow subscriber on a shared trigger pins the broker ack for the *whole* trigger, re-introducing the head-of-line coupling §8.4 claims to remove.
+  Releasing purely on age decouples the broker ack from any individual subscriber's fate — the broker reader writes the raw event to the engine and the ack timer starts; it is never blocked by a slow or dead consumer. **This is what makes the §8.4 backpressure improvement real.**
+- **The cost of dropping it.** The ack no longer reflects "everyone got it"; it reflects "this event has had its grace window". Recovery within grace relies on (i) the router ring for clients that reconnect, and (ii) broker redelivery for backends that have it. A subscriber that drops *just before* an event arrives, on a no-redelivery backend, past grace, gets a gap signal. That is the inherent ceiling of this pattern and is stated in §6.
+- **WS keepalive is a hard prerequisite** (§3.6). Without proactive server pings, a half-open WS client is never detached and keeps consuming a ring slot and (under frame-capture warm-keep) keeps triggering resolves. The keepalive bounds half-open detection to `ws_keepalive_timeout` rather than "next failed write, possibly never".
+
+`AckHoldGrace` is bounded by the backend's ack-wait budget to avoid the broker *also* redelivering (a duplicate source):
+default `min(ack_hold_grace_config, backendAckWait/2)`. **Caveat (review #16):** EDFS does not surface JetStream `AckWait` today (dossier §3.1), so `backendAckWait` is read from `msg.Metadata()`/consumer info if available (a new read) and otherwise falls back to a static `30s` assumption — documented as a guess, with the `duplicates_suspected` metric (§10) as the canary.
+
+Slow-consumer / backpressure interaction:
+because the broker ack releases on age (not on subscriber delivery), **a slow subscriber no longer head-of-line-blocks the broker reader or pins the ack**.
+A subscriber whose ring fills (it cannot keep up) falls off its own ring tail → typed gap signal, then jump to live.
+This converts today's *silent* slow-consumer drop (NATS core / Redis) into an *explicit, observable* one — without coupling co-subscribers.
+
+---
+
+## 4. Wire protocol & client changes
+
+The router hands the client a stable, monotonic `seq` per delivered frame (cheap integer) and a periodically-refreshed signed `resumeToken` (§3.5); the client echoes the last token on reconnect.
+
+### 4.1 graphql-transport-ws (modern graphql-ws) and graphql-ws (legacy subscriptions-transport-ws)
+
+No new message types (`Ping/Pong/Subscribe/Complete/Terminate` at `proto.go:88-94` unchanged). Two existing extension points:
+
+**Server → client: stamp inside `Next` (at the writer, post-resolve — §3.6).**
+
+```jsonc
+{
+  "id": "sub-1", "type": "next",
+  "payload": {
+    "data": { "employeeUpdates": { "id": 100 } },
+    "extensions": {
+      "cosmo": {
+        "seq": 42,                                 // cheap per-frame integer
+        "resumeToken": "AAAB...signed"             // present only at token boundaries (§3.5)
+      }
+    }
+  }
+}
+```
+
+**Client → server: carry the resume token on (re)`Subscribe`.**
+
+```jsonc
+{
+  "id": "sub-1", "type": "subscribe",
+  "payload": {
+    "query": "subscription { employeeUpdates { id } }",
+    "variables": {},
+    "extensions": { "cosmo": { "resume": "AAAB...signed" } }   // last token the client persisted
+  }
+}
+```
+
+Backward-compatible: a stock graphql-ws client that ignores `extensions.cosmo` and never sends `resume` behaves exactly as today (at-most-once). A Cosmo-aware client (or the Cosmo TS SDK helper) persists the latest `resumeToken` and echoes it.
+
+**Legacy `subscriptions-transport-ws` and `absinthe` (addresses review #15).** The dossier (§1.6) lists three WS subprotocols. The `extensions.cosmo` stamping is harmless on the legacy `graphql-ws` and `absinthe` subprotocols, but those client libraries do not persist/echo a resume token. **Behavior on those two subprotocols: no resume, always at-most-once**, negotiation reports `class: "at-most-once"`. We do not invest in resume for the deprecated subprotocols.
+
+**Client token-persistence durability (addresses review #5).** Resume across a *hard* client crash requires the client to have persisted the latest `resumeToken` to durable storage (localStorage/IndexedDB/disk). Browsers and mobile frequently lose in-memory state on crash. The SDK helper persists tokens to durable storage on a debounce; clients that do not persist simply resume from wherever they last durably recorded, replaying a slightly larger (idempotent) duplicate tail. This is documented as a client responsibility, not a router guarantee.
+
+### 4.2 graphql-sse and plain SSE
+
+SSE is the happy case: the resume primitive is native (dossier §4.1). Today `flushwriter.go:116-167` writes only `event:`/`data:`. We add the `id:` line (the value is the signed resume token, emitted at every token boundary; bare frames between boundaries reuse the last id, which browsers tolerate):
+
+```
+id: AAAB...signed
+event: next
+data: {"data":{"employeeUpdates":{"id":100}}}
+
+```
+
+The browser's `EventSource` tracks the last `id:` and sends it as `Last-Event-ID` on auto-reconnect. The router reads it (new path in the SSE handler), maps it to a `ResumeToken`, replays, then goes live. **Stock browsers get reconnect-replay for free** once the server emits `id:` and honors the header.
+`multipart/mixed` has no native id; the token rides in the body `extensions.cosmo` (same as WS) and the SDK echoes it on resubscribe.
+
+### 4.3 Capability negotiation (corrected: connection-level vs operation-level — addresses review #6)
+
+The first revision reported the concrete `class`/`windowSeconds` in `connection_ack`. That is an **ordering bug**: `connection_init`/`connection_ack` is a *connection-level* handshake that completes *before* any `Subscribe`, so before the operation is parsed and the trigger/provider (and thus the class/window) is known. A single connection can also multiplex subscriptions hitting different providers with different classes.
+
+The corrected split:
+
+- **`connection_ack` advertises only the capability**, not the concrete class:
+
+  ```jsonc
+  // connection_ack (server → client) — connection level
+  { "type": "connection_ack", "payload": { "cosmo": { "delivery": { "supportsResume": true } } } }
+  ```
+
+- **The concrete class/window is reported *per subscription*, on the first `Next` of that operation** (after the trigger is resolved):
+
+  ```jsonc
+  // first Next for sub-1 (server → client) — operation level
+  { "id": "sub-1", "type": "next",
+    "payload": { "data": { ... },
+      "extensions": { "cosmo": { "delivery": { "class": "at-least-once-window", "windowSeconds": 60, "windowEvents": 1024 }, "seq": 1, "resumeToken": "..." } } } }
+  ```
+
+For SSE, the per-operation class is emitted as a leading comment frame (`: cosmo-delivery {...}`) before the first data event. The client thus learns the *actual* per-operation guarantee once the backend is known — and can decide whether to also run an app-level catch-up (Pattern F) as a backstop for long disconnects.
+
+### 4.4 Fallback when a client/transport cannot participate
+
+Never silent:
+
+- **Stock client / no resume token**: at-most-once exactly as today; per-operation `class: "at-most-once"`.
+- **Legacy `graphql-ws` / `absinthe` / non-SDK multipart**: at-most-once (§4.1).
+- **Buffer disabled in config**: `class: "at-most-once"`; `seq`/`id` still emitted (harmless); resume tokens rejected with a typed `delivery.unsupported` extension.
+
+---
+
+## 5. Per-backend adaptability & degradation matrix
+
+Pattern E's thesis: **you can pick any *currently-supported* backend and still get a window of at-least-once**, with degradation made explicit. The matrix is split (addresses review #9) into backends EDFS supports today and a clearly-labelled *unverified design sketch* for backends EDFS does not yet have. Presenting speculative adapters as "Yes, supported" was misleading; the dossier (§3.1) is explicit that SQS/Pub-Sub/Kinesis/Event Hubs/RabbitMQ are **not supported in EDFS today**.
+
+### 5.1 Supported today
+
+| Backend | How | Guarantee with Pattern E | Degradation / fallback |
+|---|---|---|---|
+| **NATS core** | Buffer is the *only* net. Ack handle = no-op. | **At-least-once within window, *while the trigger and broker read stay continuously alive*** (see qualifier below). Flagship case: today silently drops on slow-consumer (`provider_builder.go:96-105`); Pattern E gives a real reconnect window + explicit overflow. | Beyond window → at-most-once (gap signal). No broker-redelivery backstop. Trigger teardown loses the window (qualifier below). |
+| **NATS JetStream** | Redundant with B/D. Ack handle = `msg.Ack()` under the §3.8 predicate. | At-least-once within window **plus** broker-redelivery backstop within `AckWait`. | **Prefer Pattern B** (true broker cursor) for gaps beyond the window. Pattern E here mainly fixes the ack timing (dossier bugs #1–#4). |
+| **Kafka** | Groupless (today's default): ack handle = no-op; buffer-only. See the hard qualifier below. | At-least-once within window **only while the trigger stays alive and reading**; the broker backlog is *not* recoverable (see below). | **Prefer Pattern B** (native `(partition,offset)` cursor) for long gaps. |
+| **Redis Pub/Sub** | Buffer is the only net. Ack handle = no-op. | **At-least-once within window** (same continuity qualifier as NATS core). Turns silent go-redis overflow drops into explicit window + gap. | Beyond window → at-most-once (gap). No redelivery backstop. |
+| **Redis Streams** (if/when adapter adds Streams mode) | Ack handle = `XACK`. | At-least-once within window + PEL backstop within grace. | **Prefer Pattern B** (entry-id cursor) for long gaps. |
+
+**Hard qualifier for no-replay / reset-to-now backends (addresses review #8).**
+For **NATS core**, **Redis Pub/Sub**, and **groupless Kafka**, the window holds **only while the trigger and its broker read are continuously alive**.
+The router ring can only contain events the broker read *delivered to the engine*. Cross the warm-keep boundary or any trigger rebuild and:
+- NATS core / Redis Pub/Sub: events published during the gap were never read → not in the ring → gone.
+- **Kafka groupless re-subscribes with `ConsumeResetOffset(AfterMilli(now))` (dossier §2.3): on any trigger rebuild or router restart it *skips the entire downtime backlog at the broker* — before the ring can ever see those events.**
+So the matrix's "at-least-once within window" for these backends means: *for a disconnect during which the trigger stayed up and kept reading*. It does **not** survive a trigger teardown or restart. This narrows the real-world guarantee substantially and is restated in §6.
+
+### 5.2 Unverified design sketch (NOT supported in EDFS today)
+
+These backends do **not** exist in EDFS (dossier §3.1). The rows below are *design sketches*, not validated behavior, and must not be read as "supported".
+
+| Backend | Sketched ack handle | Sketched guarantee | Known concern |
+|---|---|---|---|
+| **AWS SQS (Std/FIFO)** | `DeleteMessage`, grace ≤ visibility timeout | window + SQS redelivery backstop | Unverified; no adapter exists. |
+| **Google Pub/Sub** | `ack`, grace ≤ ack deadline | window + redelivery backstop | Has native `seek`/snapshots → prefer B. Unverified. |
+| **AWS Kinesis** | checkpoint on release | window only | **Coarse checkpointing:** KCL checkpoints are sequence-number high-water marks, *not* per-message. "Release ack for event e" cannot be expressed: advancing the checkpoint past e abandons any unreleased e' < e. Per-event ack-hold does **not** map. Sketch is likely unworkable as drawn. |
+| **Azure Event Hubs** | checkpoint on release | window only | Same coarse-checkpoint problem as Kinesis. |
+| **RabbitMQ / AMQP** | `basic.ack`, requeue-on-channel-loss backstop | window + requeue backstop | Requeue may reorder (dossier §6.1). Unverified. |
+
+**The decision rule, stated plainly:**
+on **no-cursor / delete-on-ack backends (NATS core, Redis Pub/Sub)**, Pattern E is the *primary and only* in-router mechanism for reconnect-replay — use it, subject to the continuity qualifier.
+On **log/cursor backends (Kafka, Redis Streams, JetStream)**, Pattern E is *redundant* with Pattern B and B is strictly better for long gaps — use E there only for a single uniform short-window code path or to fix JetStream's ack timing.
+
+---
+
+## 6. Delivery semantics achieved
+
+Stated precisely, with the failure windows that remain.
+
+**Within the buffer window** (disconnect duration < `windowSeconds`, missed events < `windowEvents`, reconnect lands on the same router instance with the trigger epoch intact, **and the trigger/broker read stayed continuously alive throughout the gap** — see §5.1 qualifier):
+
+- **At-least-once.** Every event the client missed during the gap that the router captured into the ring is replayed verbatim.
+- **Duplicates are possible** → at-least-once, not exactly-once. Sources:
+  (a) a frame flushed to the client's TCP buffer right before the drop, that the client *did* process, but whose seq it had not yet durably recorded → replayed again;
+  (b) token throttling (§3.5) means the client resumes from the last *token boundary*, replaying a few already-seen frames;
+  (c) on redelivery-capable backends, a misconfigured `AckHoldGrace` above the broker ack-wait makes the broker also redeliver.
+  **Clients must be idempotent** (dossier §6.2). The router surfaces a stable idempotency key (the router `seq`, and where available the broker key/`Nats-Msg-Id`) for client dedup.
+- **Ordering** is preserved **within a trigger**: the router assigns `seq` in arrival order and replay walks stored frames in `seq` order before attaching to live. **Strict serialization point (addresses review #11):** because the engine dispatches each event to a per-subscriber `workChan` and resolve is async per subscriber (`resolve.go:1037`), the router must serialize at the *writer*: the wrapping writer holds a per-subscriber gate that flushes all replay frames (already resolved, just bytes) before releasing the first live frame for that subscriber. Replay frames are pre-resolved bytes, so they cannot race subgraph fetches against live frames — but the gate is still required so a live frame that finishes resolving first does not jump ahead of a not-yet-written replay frame. This gate is specified as part of the §3.6 writer wrapper.
+- Ordering is *not* global across triggers (it never was — dossier §6.1) and is only as good as the order the backend delivered to the adapter (partition/subject-scoped).
+
+**Beyond the buffer window** (gap too long, too many events, fell off the ring tail, trigger torn down, or backend reset-to-now skipped the backlog):
+
+- **At-most-once**, *explicitly signalled*. The router emits a typed `extensions.cosmo.delivery.gap = { from, to, reason }` (or SSE `: gap {...}`) then attaches to live. The client knows it has a hole and can run an app-level catch-up query (Pattern F). This is the deliberate, non-silent degradation that satisfies Goal 3.
+
+**Across router restart (in-process buffer):**
+
+- The in-process ring is **lost**; the `TriggerEpoch` in every minted token no longer matches → epoch mismatch → gap → at-most-once. This is the headline limitation; the durable store variant (§9, §12) fixes it at the cost of an external dependency and hot-path write amplification.
+
+**Across router HA / multi-instance:**
+
+- A reconnect landing on a *different* instance than the one that minted the token cannot replay (`RouterID` mismatch) → gap. Mitigations: sticky sessions, or the durable shared store.
+
+**Failure windows that remain even within the window:**
+
+1. **Client processes a flushed frame but never durably records its seq** — gets a *duplicate* on reconnect (safe, idempotent), not a loss. Pattern E has no per-message client ack (that is Pattern A).
+2. **Event arrives during the exact instant of disconnect** — captured if the router was still resolving for that subscriber; otherwise subject to the warm-keep mode (failure #3).
+3. **Trigger torn down between disconnect and reconnect** (last subscriber left → trigger context cancelled → adapter goroutine stopped → broker subscription dropped) — the ring is freed, epoch gone on rebuild → gap. To hold the window open we keep a subscriber's ring **warm** for `warm_keep` after it detaches, in one of two modes:
+   - **cursor-only warm-keep (default, cheap):** keep the already-captured ring tail; do *not* keep resolving for the absent subscriber. For a *sole* subscriber on a trigger this means only the pre-drop tail is replayable; events published during the gap are not captured. Honest and cheap.
+   - **frame-capture warm-keep (opt-in, costly):** keep resolving and capturing frames for the absent subscriber during the gap, so the gap tail is replayable — at the cost of running subgraph fetches for a client that is gone, and pinning the trigger to one instance.
+   This is an inherent tension (you cannot capture resolved frames for an absent subscriber without resolving for it) and is documented, not papered over.
+4. **Half-open WS not detected** before keepalive timeout (§3.6) — the subscriber holds a ring slot (and, under frame-capture mode, triggers resolves) until `ws_keepalive_timeout`. The keepalive bounds this; without it (the prior revision's assumption) it would be unbounded.
+
+---
+
+## 7. (folded into §6)
+
+*Delivery semantics are covered in §6; §8 is Cross-cutting concerns. This stub preserves the required template numbering; §6 is the authoritative semantics section.*
+
+---
+
+## 8. Cross-cutting concerns
+
+### 8.1 Router HA / horizontal scaling & sticky sessions
+
+The single biggest design axis (dossier §6.6) and Pattern E's softest spot. The in-process ring is bound to one instance. Three modes:
+
+1. **Single instance / sticky sessions (recommended default for in-process).** Reconnects of a given connection route back to the same instance (cookie/consistent-hash at the LB). Ring is in RAM; replay is local and fast. Restart still loses the ring (epoch bump → gap).
+2. **Multi-instance, no stickiness, in-process buffer.** Reconnect may land anywhere; `RouterID` mismatch → gap → at-most-once. Honest but weak. Negotiation reports a shorter effective window (or `at-most-once`) when the deployment advertises >1 instance without stickiness.
+3. **Durable shared buffer store (the +L variant, §12).** Ring persisted to an external store (Redis sorted set keyed by `(routerFleetId, triggerKey, epoch)`, score = `seq`) shared by the fleet. Any instance can replay; survives restart. Cost: external dependency on the hot path, write amplification of *resolved frames* (larger than raw events), and the store becomes the ordering authority. **Warm-keep tension (addresses review #19):** keeping a trigger warm pins its broker subscription and ring to one instance, which conflicts with mode 2's no-stickiness; warm-keep is only meaningful under stickiness (mode 1) or when the ring lives in the shared store (mode 3). Stated explicitly so operators do not enable warm-keep expecting it to help under mode 2.
+
+### 8.2 Per-subscription state / memory cost
+
+The explicit cost knob (Goal 5) — and, post-layering-correction, larger than the prior revision implied because the ring is **per subscriber** and stores **resolved frames** (typically bigger than raw events):
+`Memory ≈ Σ_subscribers (windowEvents × avgResolvedFrameSize)`.
+There is no per-trigger sharing of replay memory (resolved output is subscriber-specific, §3.4). This is the honest cost of correct, no-re-resolve replay.
+Hard caps: `windowEvents` (count) and `windowBytes` (per subscriber), whichever binds first, plus a global ceiling `maxTotalBytes` across all subscribers (LRU-evict whole subscriber rings under global pressure, downgrading those subscribers to at-most-once with a gap on next reconnect). The buffer never grows unbounded; backpressure on a slow consumer is "fall off the tail", never "grow the ring".
+
+### 8.3 Multi-tenant shared-trigger fan-out and reconnect re-association (addresses review #7)
+
+Cosmo's shared trigger (one broker subscription per input+headers hash, fanned to N clients — dossier §1.4) is **preserved for the broker read** (§3.2). What is *not* shared is replay memory (§8.2).
+
+On reconnect, the engine mints a **new** `ConnectionID` + `SubscriptionIdentifier` (dossier §1.4, `websocket.go:367,1168`). The router must re-associate the new subscription with the prior warm ring. The mechanism:
+
+- The resume token carries `TriggerKey = hash(tenant ∥ namespace ∥ providerId ∥ renderedInput ∥ headerSubset)`.
+- On reconnect, the router computes the *current* subscription's `TriggerKey` from its (freshly authenticated) operation and headers, and looks up a warm ring under `(RouterID, TriggerKey, TriggerEpoch)`.
+- If found and seq is in range → replay; else → gap signal.
+
+**Header-sensitive keying is an inherent limitation (documented, not hidden).** Because `TriggerKey` includes the subgraph header subset, a client that reconnects with a *rotated* auth token or a changed locale header computes a *different* `TriggerKey` → no warm ring match → gap signal. For deployments where per-request headers vary across a connection's lifetime (auth token rotation is common), this materially narrows same-trigger resume. Two responses:
+- Configure the `headerSubset` to exclude volatile headers (auth tokens) from the key where the operation's *data* does not depend on them — operator's call, with the security caveat that the ring then spans header values.
+- Accept the gap and pair with Pattern F for those deployments.
+This is called out so nobody discovers it in production.
+
+The one wrinkle on **subscriber-specific inbound filtering**: if an `OnStreamEvents` hook filters events differently per subscriber, the per-subscriber resolved-frame ring is *already* correct by construction — each subscriber's ring holds only the frames that subscriber actually received. (This is a side benefit of per-subscriber resolved-frame storage over the prior shared-raw-ring design.)
+
+### 8.4 Backpressure
+
+Pattern E **improves** backpressure relative to today, and this is now consistent with the §3.8 ack predicate (the prior revision contradicted itself here). Currently a slow client blocks the broker reader for the whole shared trigger (per-trigger-serial backpressure, dossier §2.2). With the per-subscriber ring **and an age-based (not delivery-based) ack release**, the broker reader fans the raw event to the engine and the ack timer starts immediately — it is never blocked by a slow or dead subscriber. Each subscriber's flush proceeds at its own pace; a subscriber that cannot keep up falls off its own ring tail → explicit gap, not a stall and not a silent drop, and not a pinned broker ack. The bounded cost is held broker acks (capped by `AckHoldGrace` and a `max_in_flight_acks` per trigger); when the in-flight cap is reached the broker reader pauses (restoring backpressure to the broker, the safe direction).
+
+### 8.5 Security / authz
+
+- **Resume tokens are opaque + HMAC-signed + tenant/namespace-scoped** (§3.5, dossier §6.8). `TriggerKey` includes a tenant∥namespace discriminator (review #14), closing the cross-tenant collision hole. The token only selects a position *within* a trigger the *current, freshly-authenticated* subscription resolves to; a mismatch is "no resume", never a cross-trigger seek.
+- **Replay serves *captured resolved frames*, not a re-resolution (changed from the prior revision; addresses review #18).** Because the ring stores the bytes that were already authorized and resolved at delivery time, replay re-emits *exactly* those bytes. The security trade-off, stated honestly: an event that was authorized when captured but whose authz has since been **revoked** would, on naive replay, be re-emitted to the (re-authenticated) client. Two mitigations:
+  - **Short window by design** bounds the staleness exposure (seconds-to-minutes, vs Pattern B over multi-day retention).
+  - **Opt-in `revalidate_on_replay`** (config, default off): on replay the router re-runs the subscription's authz hook (`SubscriptionOnStart` / claim check) once per reconnect, and if the *current* auth no longer satisfies the subscription, it suppresses replay and emits a gap. This does **not** re-resolve field data (no subgraph re-fetch); it only re-gates the whole replay. Operators who need per-field revocation precision must use Pattern B/C with current-authz re-resolution and accept its cost.
+  The prior revision claimed replay "re-runs authz per event with current authentication"; that was only true if replay re-resolved, which it must not (review #2). This revision is precise about the trade-off instead.
+
+### 8.6 Interaction with existing Cosmo Streams hooks
+
+- The ring is populated **at the writer, after resolve**, so it holds fully-resolved per-subscriber frames. Data-mapping and resolve are **never** re-run on replay (now *true*, because we store resolved bytes — the prior revision claimed this while storing raw events, which was false).
+- `SubscriptionOnStart` runs on every (re)subscribe, including reconnects, before any replay — so the initial-message hook and authz hook fire as normal, and the replay tail follows the initial message. A reconnect that wants to suppress a duplicate initial message can inspect the resume token via the hook context.
+- **The abandon-on-timeout reorder path (`subscription_event_updater.go:69-79`) is *upstream* of the ring and is NOT resolved by Pattern E (corrects the prior revision's false claim, review #11).** That path runs before resolve, in the inbound hooks fan-out; a hook that abandons in-flight delivery still produces out-of-order or dropped events *into* the resolve stage, and the ring faithfully captures whatever order it was flushed in. Pattern E removes the *post-resolve* slow-subscriber stall (that subscriber just falls behind its own cursor), but it does not touch the hooks-path reorder warning. Honest scope.
+
+---
+
+## 9. Configuration surface
+
+Router YAML, under the existing `events` block (`router/pkg/config/config.go:773-782`). A new `delivery` sub-block, off by default:
+
+```yaml
+version: "1"
+
+events:
+  providers:
+    nats:
+      - id: my-nats
+        url: "nats://localhost:4222"
+
+  # NEW: router-side replay buffer (Pattern E). Off by default.
+  delivery:
+    replay_buffer:
+      enabled: true                 # default false → today's at-most-once behavior, unchanged
+
+      # The window — guarantee holds for gaps smaller than BOTH limits. Per subscriber.
+      window_events: 1024           # max resolved frames retained per subscriber ring
+      window_seconds: 60            # max age retained per subscriber ring
+      window_bytes: 8MiB            # hard byte cap per subscriber ring (whichever binds first)
+
+      # Resume-token issuance throttle (§3.5) — bounds HMAC cost on the hot path.
+      token_interval: 1s
+      token_every_n: 32
+
+      # Warm-keep after a subscriber detaches (§6 failure #3).
+      warm_keep: 60s
+      warm_keep_mode: cursor_only   # cursor_only (cheap, default) | frame_capture (costly)
+
+      # WS server keepalive (§3.6) — hard prerequisite for half-open detection.
+      ws_keepalive_interval: 15s
+      ws_keepalive_timeout: 30s
+
+      # Ack-hold (§3.8). Clamped to backendAckWait/2 when readable, else static guess.
+      ack_hold_grace: 30s
+      max_in_flight_acks: 4096      # per trigger; broker reader pauses when reached
+
+      # Security (§8.5).
+      revalidate_on_replay: false   # re-gate the whole replay against current authz on reconnect
+
+      # Global safety ceiling across all subscriber rings; LRU-evict whole rings under pressure.
+      max_total_bytes: 1GiB
+
+      # Cross-restart / HA durability. Default in_process (lost on restart).
+      store:
+        type: in_process           # in_process | redis
+        # redis:
+        #   provider_id: my-redis
+        #   key_prefix: cosmo:replay:
+        #   ttl: 120s
+```
+
+**Per-provider override** (a backend with a native log may want the buffer off, deferring to Pattern B):
+
+```yaml
+events:
+  providers:
+    kafka:
+      - id: my-kafka
+        brokers: ["localhost:9092"]
+        delivery:
+          replay_buffer:
+            enabled: false         # prefer Pattern B (native offset cursor) here
+```
+
+**Schema-directive / proto additions: none required.** Delivery semantics are a router-local operational concern; the same composed graph should be deployable with or without a buffer. *Future extension (out of scope for v1):* a per-field `@edfs__delivery(class: ...)` directive — that is Pattern G territory and would require the proto/composition changes this RFC avoids.
+
+---
+
+## 10. Migration & backward compatibility
+
+- **Opt-in.** `events.delivery.replay_buffer.enabled` defaults to `false`. Off → byte-for-byte today's behavior: no `seq`/`id` stamping, no token reading, at-most-once, shared trigger as-is.
+- **Default behavior unchanged.** Existing graphs/clients/brokers continue exactly as before.
+- **Stock clients keep working when enabled.** A client that ignores `extensions.cosmo` / `Last-Event-ID` gets at-most-once (negotiation reports it). The stamping is additive and ignored by spec-compliant clients.
+- **Rollout sequence.**
+  1. Land the graphql-go-tools change (`Replay` entry point + writer seq threading) and the router WS keepalive — these are prerequisites and the keepalive is independently valuable.
+  2. Ship the writer wrapper + ring + token plumbing behind the flag (in-process), targeting **NATS core / Redis Pub/Sub first** where it delivers the most net-new value.
+  3. Ship the SSE `Last-Event-ID` path (free reconnect-replay for browsers).
+  4. Ship the JetStream ack-timing fix (move `msg.Ack()` under the §3.8 predicate) — a correctness win even without resume.
+  5. Ship the `redis` durable store for cross-restart/HA, gated separately (see §12 for the "why not just use a log backend" argument before building this).
+- **Interop with other patterns.** On log backends, recommend Pattern B over E (per-provider `enabled: false`). Pattern E is the substrate that makes the *non-log* backends reach parity, composing cleanly under a future Pattern G negotiation layer.
+- **Observability for migration.** Emit metrics from day one (§10 list below). The gap-signal and duplicates counters are the canaries.
+
+---
+
+## 11. Appendix: new/changed Go types
+
+Sketches, in the style of `rfc/cosmo-streams-v1.md` Appendix 1. Partial, illustrative.
+
+```go
+package replay
+
+import (
+    "sync"
+    "time"
+)
+
+// SeqNum is the router-assigned monotonic sequence, scoped per (triggerEpoch, subscriber lineage).
+type SeqNum uint64
+
+// CapturedFrame is one slot in a subscriber's ring: the EXACT post-resolve, post-stamp bytes
+// that were flushed to the client. Replay re-emits these verbatim — no re-resolve, no subgraph fetch.
+type CapturedFrame struct {
+    Seq      SeqNum
+    Bytes    []byte    // resolved + stamped response frame
+    StoredAt time.Time
+}
+
+// SubscriberRing is per subscriber (NOT per trigger): resolved frames are subscriber-specific.
+type SubscriberRing struct {
+    mu         sync.Mutex
+    epoch      uint64
+    triggerKey string            // hash(tenant ∥ ns ∥ provider ∥ input ∥ headerSubset)
+    head       SeqNum
+    frames     []CapturedFrame   // bounded by window_events / window_bytes
+    oldestSeq  SeqNum
+    bytes      int
+    detachedAt time.Time         // warm-keep clock; zero while live
+    cfg        ReplayBufferConfig
+}
+
+// Capture stamps seq onto the frame (caller did the JSON/SSE stamping), stores it, evicts the tail.
+func (r *SubscriberRing) Capture(seq SeqNum, stamped []byte, now time.Time)
+
+// Replay returns stored frames (seq+1..head) for verbatim re-emit via the engine Replay entry point.
+// ok=false means fromSeq fell off the tail / warm-keep expired → caller emits a Gap signal.
+func (r *SubscriberRing) Replay(fromSeq SeqNum) (frames []CapturedFrame, ok bool)
+```
+
+```go
+// ResumeToken — base64url(JSON)+HMAC on the wire. Issued at throttled boundaries (§3.5), not per event.
+type ResumeToken struct {
+    RouterID     string `json:"r"`
+    TriggerEpoch uint64 `json:"e"`
+    TriggerKey   string `json:"k"` // tenant/namespace-scoped (§8.5)
+    Seq          SeqNum `json:"s"`
+}
+
+func Encode(t ResumeToken, secret []byte) string
+func Decode(s string, secret []byte) (ResumeToken, error) // verifies HMAC
+
+type GapSignal struct {
+    From   SeqNum `json:"from"`
+    To     SeqNum `json:"to"`
+    Reason string `json:"reason"` // "window_exceeded"|"epoch_mismatch"|"tail_eviction"|"cross_instance"|"warm_keep_expired"|"trigger_rebuilt"|"trigger_key_changed"|"authz_revoked"
+}
+```
+
+```go
+// ENGINE-SIDE (graphql-go-tools) — the change the prior revision wrongly denied.
+// Added to resolve.SubscriptionUpdater (pkg/engine/resolve/resolve.go:1598).
+type SubscriptionUpdater interface {
+    Update(data []byte)                                   // existing: raw event → resolve → fan-out
+    UpdateSubscription(id SubscriptionIdentifier, data []byte) // existing
+    // NEW: write pre-rendered frames to ONE subscriber, bypassing resolve entirely.
+    Replay(id SubscriptionIdentifier, frames [][]byte)
+}
+```
+
+The honest delta vs the prior revision: this is **not** an additive Cosmo-only change. It adds an engine method (`Replay`), a new `subscriptionEventKind` so `handleTriggerUpdate` routes replay frames to a single subscriber, engine→writer seq threading, and a router-side writer wrapper. The engine's existing `Update(data)` is unchanged for the live path.
+
+```go
+type ReplayBufferConfig struct {
+    Enabled            bool          `yaml:"enabled"`
+    WindowEvents       int           `yaml:"window_events"`
+    WindowSeconds      time.Duration `yaml:"window_seconds"`
+    WindowBytes        int64         `yaml:"window_bytes"`
+    TokenInterval      time.Duration `yaml:"token_interval"`
+    TokenEveryN        int           `yaml:"token_every_n"`
+    WarmKeep           time.Duration `yaml:"warm_keep"`
+    WarmKeepMode       string        `yaml:"warm_keep_mode"` // cursor_only | frame_capture
+    WSKeepaliveInterval time.Duration `yaml:"ws_keepalive_interval"`
+    WSKeepaliveTimeout  time.Duration `yaml:"ws_keepalive_timeout"`
+    AckHoldGrace       time.Duration `yaml:"ack_hold_grace"`
+    MaxInFlightAcks    int           `yaml:"max_in_flight_acks"`
+    RevalidateOnReplay bool          `yaml:"revalidate_on_replay"`
+    MaxTotalBytes      int64         `yaml:"max_total_bytes"`
+    Store              BufferStoreConfig `yaml:"store"`
+}
+```
+
+---
+
+## 12. Risks, open questions, and complexity/effort estimate
+
+### Where this pattern is weakest (be honest)
+
+1. **The required engine change kills the "M, no-engine-change" framing.** Replay to a single subscriber and post-resolve seq stamping live in graphql-go-tools (§3.6). This is a graphql-go-tools PR + a router bump + a writer wrapper + WS keepalive, on top of the ring/token/eviction/concurrency test surface. **Re-estimated as L for the in-process variant alone** (see below).
+
+2. **Cross-restart durability is the headline weakness.** An in-process ring is lost on every restart/deploy; in a rolling-deploy world the window resets to zero each rollout, so clients reconnecting right after a deploy get at-most-once-with-gap. **Versus B/C, strictly weaker on restart.**
+
+3. **Why durable-store Pattern E instead of just switching to a log backend? (addresses review #10).** The durable variant writes *every resolved frame* to Redis on the hot path — write amplification on a backend the customer chose *because it is non-durable*. If you are willing to run a durable store, the honest question is "why not run a log backend (Redis Streams / JetStream) and use Pattern B?" The only defensible answers: (a) the customer **cannot** change the backend (org constraint, existing NATS-core infrastructure), and wants a router-side window without touching the broker; (b) a heterogeneous fleet wants one uniform replay code path. If neither holds, **recommend Pattern B and scope the durable store out of v1.** The durable store is therefore deferred, not part of the v1 recommendation.
+
+4. **The window is short and the failure mode is a cliff.** Below the window: at-least-once. One second beyond: at-most-once for the *entire* tail (gap signal, jump to live). No graceful "degraded but partial" middle. For long-disconnect profiles (mobile backgrounding for minutes/hours), Pattern F (app-level backfill) is the better fit; use E *with* it, not instead.
+
+5. **Memory under fan-out is now per-subscriber and stores resolved frames (review acknowledged).** The layering correction (§3.4) means replay memory does **not** share across a trigger and stores resolved frames (bigger than raw events): `Σ_subscribers (windowEvents × frameSize)`. This is materially more memory than the prior revision implied. The global ceiling protects the process but downgrades whole subscriber rings to at-most-once on next reconnect under pressure — an operational surprise if not watched.
+
+6. **The reset-to-now / no-replay backends only hold the window while the trigger stays alive (review #8).** NATS core, Redis Pub/Sub, and groupless Kafka lose the backlog *at the broker* across any trigger teardown or restart, before the ring can see it. The real-world guarantee on exactly the backends this pattern targets is narrower than "at-least-once within window": it is "at-least-once within window, for a disconnect during which the trigger kept reading".
+
+7. **Sole-subscriber gaps need frame-capture warm-keep, which resolves for an absent client (§3.7, §6 failure #3).** Capturing the gap tail for a lone subscriber means running subgraph fetches for a client that is gone. The cheap default (cursor-only) cannot capture gap events for a sole subscriber. Inherent tension.
+
+### Open questions
+
+1. **Warm-keep mode default & broker subscription lifecycle.** Is `cursor_only` the right default for all backends, or should redelivery-capable backends (JetStream) default to relying on broker redelivery + cursor-only, while no-redelivery backends offer `frame_capture` more prominently? Needs validation against real reconnect timing.
+
+2. **Engine `Replay` API shape and ownership of `SubscriptionIdentifier`.** The router must obtain the engine-minted identifier for a freshly re-attached subscription to call `Replay(id, frames)`. Exact API (return the id from attach? a callback?) must be designed with the graphql-go-tools maintainers — this is the load-bearing engine-side design decision and gates the whole effort.
+
+3. **Confirmation model & token throttling interaction.** With throttled tokens (§3.5), the client resumes from the last token boundary, not the last frame. Is the resulting duplicate tail (≤ `token_every_n` frames) acceptable for all use cases, or do we need an optional explicit per-token client confirm to tighten it? Keeping E confirm-free is simpler and duplicates are idempotent-safe.
+
+4. **Durable store consistency / epoch fencing.** The Redis-backed ring makes the store the ordering authority; a trigger migrating instances mid-stream needs an epoch fencing token to prevent two instances appending to the same `(triggerKey, epoch)`. Spec before building the (deferred) L variant.
+
+5. **`revalidate_on_replay` granularity.** Re-gating the *whole* replay on current authz (§8.5) is coarse — it cannot redact individual stale fields without re-resolving (which we refuse, review #2). Is whole-replay suppression the right behavior, or do some customers need field-level precision (→ Pattern B/C)? Document loudly either way.
+
+### Complexity / effort estimate (re-derived after admitting the engine change)
+
+- **In-process, no proto change, *with* the graphql-go-tools engine change: L.**
+  - graphql-go-tools: `Replay(id, frames)` entry point + new replay `subscriptionEventKind` + engine→writer seq threading. A non-trivial engine PR with its own review cycle and a router bump.
+  - Router: writer wrapper (stamp + capture + replay-then-live serialization gate), per-subscriber ring, token codec with throttling, reconnect re-association, **WS server keepalive** (independently valuable), ack-hold integration (NATS/JetStream), config, metrics.
+  - Biggest test surface: reconnect/replay/eviction/fan-out concurrency, the replay-then-live serialization gate, and half-open-WS detection.
+  - Estimate: **~6–8 weeks** for one engineer including the engine PR, to a shippable, flagged, tested state.
+
+- **Durable buffer store (redis) for cross-restart/HA: +L/XL, deferred.** `BufferStore` redis impl, epoch fencing, key lifecycle/TTL, hot-path write amplification of *resolved frames* + its perf work, HA reconnect routing. Estimate: **+4–6 weeks**, and per §12-#3 it should not ship unless the "can't switch backends" justification holds.
+
+### Metrics (§10, expanded — addresses review #17)
+
+`cosmo_replay_buffer_events_buffered`, `_replayed`, `_evicted`, `_gap_signals_total{reason}`, `_ring_bytes`, `_ack_hold_seconds`, `_in_flight_acks`,
+**`_duplicates_suspected_total`** (canary for `AckHoldGrace` > broker ack-wait, the duplicate source in §6),
+**`_ack_pin_age_seconds` (per-trigger gauge)** (canary for the half-open-WS / slow-consumer ack pinning in §3.8),
+**`_ws_keepalive_timeouts_total`** (half-open detections),
+**`_replay_serialization_wait_seconds`** (replay-then-live gate health).
+
+### One-line honest placement (vs. the other six patterns)
+
+Pattern E is the *only* pattern that gives any reconnect-replay guarantee on at-most-once backends (NATS core, Redis Pub/Sub) without changing the backend or the client beyond a resume token — but it **requires a graphql-go-tools engine change** (single-subscriber replay + post-resolve seq stamping), stores **per-subscriber resolved frames** (not a cheap shared per-trigger ring), holds the window **only while the trigger stays alive** on the very backends it targets, and is the *weakest* on restart/HA. It is *redundant* on log backends where Pattern B is simpler and durable for far longer. Ship it for the no-cursor backends with sticky sessions; defer the durable store; defer to B/C/D elsewhere.

--- a/rfc/at-least-once/rfc-F-outbox-client-dedup.md
+++ b/rfc/at-least-once/rfc-F-outbox-client-dedup.md
@@ -1,0 +1,525 @@
+# RFC: At-Least-Once for GraphQL Subscriptions — Outbox / Dedup-on-Client, Reconnect-Backfill (Pattern F)
+
+**Status:** Draft
+
+**TL;DR.**
+Cosmo's EDFS pushes broker events to clients fire-and-forget,
+so a disconnect, a router restart, or a slow consumer silently drops events.
+This pattern does **not** try to make the stream itself durable.
+Instead, for subscriptions whose events are **also rows in a queryable backing store** (an outbox / changelog / entity table),
+it pairs the subscription with a normal **catch-up query** the client runs on (re)connect,
+queues live deltas that arrive while the query is in flight,
+merges them in `since`-order, and **dedups by an application-owned idempotency key**.
+The guarantee is *state convergence on reconnect* for state-convergent, outbox-backed subscriptions:
+you may miss intermediate transitions, but the final state converges and no persisted state is lost
+as long as the outbox is queryable and retains the backfill window.
+
+**Two hard scope gates, stated up front (see §2, §6):**
+1. **F recovers nothing for subscriptions whose events are not also rows in a queryable store.**
+   Pure notification / transient / presence streams ("a message was posted", "user is typing", presence pings)
+   have no current-state to converge to. For those, F is **at-most-once with extra steps** — exactly today's behavior.
+2. **F is for state-convergent payloads only** (the event carries the *current* state of an entity, not a delta-op like "increment by 3").
+   For delta/CRDT payloads the merge produces wrong results; use Pattern A or B.
+
+The idempotency key and the `since` cursor are **owned and surfaced by the application's own schema**
+(on the subscription type and the catch-up query), *not* stamped by the router into a side-channel —
+because, as the revised design explains (§3, §4), no router-only side-channel to the client exists in the current engine.
+The router's contribution is **documentation, observability config, an optional composition lint, and an SDK helper** for the backfill-merge-dedup loop.
+A fully router-stamped key (the original proposal) is possible only with an engine change and is re-scoped as an **L-effort alternative** in §3.5 and §11.
+There are **no changes to the subscription wire protocol**.
+Router-side complexity is **S** for the documented/SDK path, **L** for the engine-stamped alternative;
+the real cost is the application outbox and the client.
+
+---
+
+## 1. Problem & Context
+
+Cosmo's EDFS gives an application *at-least-once into the broker* but *at-most-once out to the client*.
+A team that has carefully configured Kafka offset commits or a JetStream durable consumer on the producer side
+discovers that none of that durability survives the last hop:
+the router reads an event and pushes it down the socket fire-and-forget,
+and any disconnect, restart, or slow consumer drops it on the floor.
+
+The dossier (`00-research-dossier.md` §2) traces exactly where the guarantee evaporates.
+The framework abstraction is fire-and-forget *by construction*:
+the engine's `SubscriptionUpdater.Update(data)` returns no error and has no ack hook back to the broker
+(`router/pkg/pubsub/datasource/provider.go:22-28`),
+so durability is a per-adapter property, not a property of EDFS.
+
+Four concrete behaviors make the gap real:
+
+1. **No client ack, no resume, anywhere.**
+   The recognized inbound WebSocket message set is exactly `Ping`, `Pong`, `Subscribe`, `Complete`, `Terminate`
+   (`router/internal/wsproto/proto.go:88-94`) — there is no "ack received next" concept and no cursor.
+   `connection_init` / `connection_ack` is a one-time *connection* handshake, not a per-message data ack.
+   A reconnecting client always gets a brand-new `ConnectionID` (`resolve.NewConnectionID()`, `websocket.go:367`)
+   and a brand-new subscription id (`websocket.go:1160-1185`),
+   and the new trigger starts from "now."
+
+2. **Acks (where they exist) are gated on flush attempt, not receipt.**
+   On the one durable path, JetStream, the adapter calls `msg.Ack()` *after* `updater.Update()` returns
+   (`router/pkg/pubsub/nats/adapter.go:146` then the `msg.Ack()` immediately following).
+   But `Update` only ran a single socket write under a deadline — a successful flush means bytes handed to the kernel,
+   not an application ack from the client.
+   A client that crashes after TCP-buffering but before processing loses the message, yet it is acked → **lost**.
+
+3. **The non-log backends drop silently under load.**
+   NATS core uses an unbuffered Go channel (`nats/adapter.go:168`) and the nats.go client drops on overflow with `nats.ErrSlowConsumer`
+   (`provider_builder.go:96-105`);
+   Redis Pub/Sub drops on go-redis channel overflow.
+   Kafka re-subscribes with `ConsumeResetOffset(AfterMilli(now))`, so a router restart **skips everything produced during downtime**
+   (`kafka/adapter.go:32-34, 51-122`).
+
+4. **No cursor is ever surfaced to the client.**
+   The delivered event structs carry only `Data`, `Headers`, and (Kafka) `Key`
+   (`nats/engine_datasource.go:39-42`, `kafka/engine_datasource.go:59-63`);
+   JetStream `msg.Metadata()` (stream/consumer sequence) is never read,
+   and the SSE writer never emits an `id:` field (`flushwriter.go:307-312`).
+
+The other six patterns in this series close this gap by adding durability *to the stream*:
+client acks (A), backend cursors (B), per-subscription durable consumers (C), ack-timing fixes (D), a router replay buffer (E),
+or a negotiation layer over all of them (G).
+
+Pattern F takes the opposite stance.
+It accepts that the *stream* is lossy and instead makes the *application state* the source of truth.
+This is not a workaround invented for this RFC —
+it is the pattern Cosmo already recommends to clients today (dossier §4.2):
+> on reconnect, run a catch-up query, queue incoming live deltas while it's in flight, then merge (query first, then deltas), deduping with idempotency keys.
+
+What Pattern F adds is **the scaffolding to make that recommendation safe and turnkey, without lying about what the router can do**:
+a documented contract for an application-owned idempotency key that is identical across the live stream and the backfill query,
+a `since`-cursor convention backed by an outbox,
+a composition-time lint that catches the most common misuses,
+and an SDK helper that implements the backfill-merge-dedup loop so application teams do not each reinvent it (and get it subtly wrong).
+
+**What changed since the prior draft (and why).**
+The earlier draft claimed the router could stamp a per-event idempotency key into `extensions.cosmo` via a `DeliveryMeta` side-channel that "travels with the event to the writer," with a universal content-hash fallback.
+Verification against the pinned engine (`graphql-go-tools v2.4.1`) and the router shows that mechanism **does not work as described**:
+
+- The adapter hands the engine only `event.GetData()` — raw `[]byte` — and `GetData()` returns *only* `e.Data`; `Key`/`Headers`/any added field are dropped at this boundary (`subscription_event_updater.go:39, 122`; `nats/engine_datasource.go:21-26, 44-49`; `kafka/engine_datasource.go:22-27, 65-67`).
+- The engine interface is literally `Update(data []byte)` / `UpdateSubscription(id, data []byte)` with **no metadata parameter** (`resolve.go:1586-1590`).
+- `executeSubscriptionUpdate(resolveCtx, sub, sharedInput []byte)` runs `InitSubscription` → `LoadGraphQLResponseData` (federated/nested fetches) → `Resolve` into `sub.writer` (`resolve.go:616-675`). The writer receives the **resolved** GraphQL payload, not the broker event body.
+- `websocketResponseWriter.Flush()` builds `extensions` *solely* from `rw.header` (response headers); it has **zero** access to the originating broker event or any key (`websocket.go:704-736`).
+
+So there is no router-only path to attach a per-event key at the writer, and a content hash taken at the adapter cannot match anything the client can recompute (the bytes are different after resolve — see §3.2).
+The honest, shippable design therefore moves key/`since` ownership into the **application schema** (§3), where it already has to live for the backfill query to align anyway, and re-scopes the "router stamps it for you" variant as an explicit engine-change alternative (§3.5).
+
+This pattern composes cleanly with the existing Cosmo Streams v1 hooks (`cosmo-streams-v1.md`):
+the catch-up query is an ordinary federated query that needs no streams machinery,
+and where a hook transforms event bodies, it is also the right place for the application to (re)assert its key into the resolved shape (§7).
+
+---
+
+## 2. Goals & Non-Goals
+
+**Goals.**
+
+- For **state-convergent, outbox-backed** subscriptions, guarantee that no persisted application **state** is permanently lost
+  across a disconnect, router restart, or slow-consumer drop — provided the outbox is queryable and retains the backfill window.
+- Work on **every** EDFS backend for that class of subscription, including NATS core and Redis Pub/Sub, with no backend feature dependency,
+  *because the durability that matters lives in the application's datastore, not in the stream.*
+- Require **zero** changes to the graphql-ws / graphql-transport-ws / graphql-sse wire protocols.
+- Make client-side dedup *correct* by defining a precise, testable contract for an **application-owned** idempotency key
+  that is identical across the live subscription payload and the backfill query result — and by **proving the contract end-to-end with a test** (§12).
+- Provide a documented, opinionated client recipe (and an SDK helper) for the backfill-merge-dedup loop.
+- Keep router state at exactly O(1) per subscription — no per-subscriber durable consumers, no held broker acks, no replay buffer.
+- Add a composition-time **lint** that flags the two footguns (non-state-convergent payload; missing key/since on a field that opts into F).
+
+**Non-Goals.**
+
+- **Recovering anything for non-outbox subscriptions.** If the event is not also a row in a queryable store, F recovers nothing.
+  Pure notification / transient / presence streams get **at-most-once** under F — identical to today. (This is the dominant applicability gate, not a footnote; see §6.)
+- **True at-least-once delivery of every discrete event.** F does not promise every intermediate transition is delivered.
+  If an entity goes `A → B → C` during a disconnect and the backfill returns the current state, the client sees `A → C` and never observes `B`.
+  Teams that need every transition want Pattern A, B, or E.
+- **Delta/CRDT payloads.** If the event is an operation (`"increment by 3"`) rather than current state, F's merge is wrong. Out of scope.
+- **A router-stamped, content-hash idempotency key.** The prior draft's router-stamps-`extensions` mechanism is **withdrawn** as the primary design (it cannot work without an engine change; see §1, §3.2). It survives only as the §3.5 alternative.
+- **Replacing the broker ack-timing fix (Pattern D).** F does not fix the `msg.Ack()`-on-flush-attempt bug; it routes around the consequence. D and F are complementary.
+- **A generic event store inside the router.** The router does not persist events. The outbox is the application's responsibility.
+- **Exactly-once delivery.** With idempotent client merge the *effective* result is exactly-once *state convergence*, but discrete-event exactly-once is out of scope (see §6).
+- **Changing the publish path.** Publish-side idempotency (idempotent ingest with `Nats-Msg-Id`) is orthogonal and out of scope here.
+
+---
+
+## 3. Design — the mechanism in depth
+
+The mechanism has one client-side loop and a small amount of application-schema convention.
+The router's role is documentation, an optional lint, observability config, and an SDK helper.
+Crucially, none of it touches the synchronous fire-and-forget data path (dossier §1.3) — that path keeps working exactly as today; F decorates it from the application schema outward.
+
+### 3.1 The contract: an application-owned idempotency key, surfaced in the typed schema
+
+The dedup join key and the `since` cursor are **fields of the application's GraphQL types**, present in *both* the subscription payload and the backfill query result.
+They are part of the typed `data`, not a router side-channel — because (a) that is the only place the client can reliably read them without an engine change (§3.2), and (b) the backfill query has to expose them anyway for the merge to work.
+
+```graphql
+type Subscription {
+  employeeUpdated(id: ID!): EmployeeUpdate!
+    @edfs__natsSubscribe(subjects: ["employee.{{ args.id }}.updated"], providerId: "my-nats")
+}
+
+type Query {
+  # Backfill: everything that changed for this entity since the client's high-water mark,
+  # in the SAME shape and key space as the subscription. Backed by an outbox / changelog table.
+  employeeUpdatesSince(id: ID!, since: String): [EmployeeUpdate!]!
+}
+
+type EmployeeUpdate {
+  # The dedup join key. Application-owned, opaque, stable, identical across
+  # the live subscription and the backfill query for the SAME logical event.
+  idempotencyKey: ID!
+  # The high-water mark cursor. Monotonic per (entity, stream). See §3.4.
+  since: String!
+  employee: Employee!
+}
+```
+
+**The contract, stated precisely (this is the whole correctness mechanism):**
+
+1. For one logical state transition, the `idempotencyKey` value emitted on the live subscription **equals** the `idempotencyKey` value the backfill query returns for that same transition.
+   Because both are typed fields the application populates from the *same* source (the outbox row's id, the `Nats-Msg-Id`, the Kafka key — whatever the application chose), the application controls this directly. The router does not synthesize it.
+2. The key is **opaque and non-enumerable** when surfaced to the client (§7 security). Do not expose a raw primary-key sequence: it leaks row counts/ordering, and on a shared trigger (dossier §6.5) a co-subscriber sees its shape.
+3. The payload is **state-convergent**: `employee` is the current entity state, not a delta.
+4. `since` is **per (entity, stream) monotonic** and is the event's own position label — **not** a shared resume cursor (see §3.3).
+
+There is no content-hash fallback. As §3.2 proves, a content hash cannot be made to match across the resolve boundary, so it would silently break dedup. **If the application cannot supply a stable, schema-surfaced key for a subscription, that subscription is not a candidate for F.**
+
+### 3.2 Why the router cannot synthesize the key (and why content-hash is withdrawn)
+
+Two independent code facts, verified against the router and `graphql-go-tools v2.4.1`:
+
+- **There is no side-channel from the adapter to the writer.** The adapter calls `updater.Update(event.GetData())` (`subscription_event_updater.go:39`) or `UpdateSubscription(subID, event.GetData())` (`:122`). `GetData()` returns *only* `e.Data` (`nats/engine_datasource.go:21-26`, `:44-49`; `kafka/engine_datasource.go:22-27`, `:65-67`) — `Key`, `Headers`, and any new struct field are dropped here. The engine interface is `Update(data []byte)` / `UpdateSubscription(id, data []byte)` with no metadata parameter (`resolve.go:1586-1590`). `executeSubscriptionUpdate(ctx, sub, sharedInput []byte)` (`:616`) hands `sub.writer` the *resolved* response only; `websocketResponseWriter.Flush()` constructs `extensions` purely from `rw.header` (`websocket.go:704-736`). The writer therefore has no access to the broker event or any per-event key. Attaching `extensions.cosmo.idempotencyKey` at the writer is **impossible without modifying the engine** (see §3.5).
+- **A content hash cannot match across resolve.** Even if the router hashed `event.Data` at the adapter, the client never sees those bytes. The broker `input` flows through `InitSubscription` → `LoadGraphQLResponseData` (federated / nested subgraph fetches) → `Resolve` into the writer (`resolve.go:627-664`). The final GraphQL payload has a different field set, ordering, enrichment, and federation joins. `hash(adapter Data) ≠ hash(resolved payload)`, so a client-side or outbox-side content hash would *never* equal the router's — every event would look unique, and on the deliberate reconnect overlap (§3.3) **every overlapped event would leak as a duplicate**. That is worse than no dedup. Content-hash dedup is therefore **withdrawn**.
+
+Consequence for the guarantee: **F does not "guarantee a key always exists."** A stable key exists only when the application supplies one (an explicit app-set id: outbox row id, `Nats-Msg-Id`, Kafka key, `x-idempotency-key`) and surfaces it through the schema per §3.1. For any backend/subscription lacking an app-set id, F provides no dedup and therefore no safe backfill — it degrades to at-most-once.
+
+### 3.3 `since` is a per-event position label, not a shared resume cursor — and the client owns resume state
+
+`since` is the event's **own** position label (a monotonic per-(entity, stream) value: an outbox sequence, a ULID, a timestamp — §3.4). It is the same for all N fan-out recipients of one event, which is correct *because it labels the event, not a client's progress.*
+
+The **resume cursor is the client's responsibility, and the client's alone.** Each client tracks its own *last-successfully-applied* `since` locally. On reconnect, the client passes *its own* last-applied `since` to the backfill query. One event fanned to N clients carries one `since`, but client A may have durably applied up to `since=50` and client B only up to `since=10`; each resumes from its own watermark. The router holds none of this. (This corrects the prior draft, which described `since` as a shared per-event "high-water mark the client should resume from" — meaningless across fan-out.)
+
+This is also why the SSE `Last-Event-ID` "free resume" story from the prior draft does not hold: a per-event `id:` line is the wrong thing to echo for a per-client resume cursor, and graphql-sse does not implement `Last-Event-ID` resumption anyway (dossier §4.1). See §4 — that claim is withdrawn.
+
+### 3.4 `since` ordering and the lower-boundary gap (the commit-ordering contract)
+
+The merge is **"apply in `since` order, dedup by key"** — *not* "backfill-first, then live" (the prior draft's rule applied stale-over-fresh when state changed again between the outbox snapshot and the query; see §15-equivalent in §6). For that to be correct, `since` must be a **total order per (entity, stream)**:
+
+- **Required: monotonic sequence or ULID, not bare timestamps.** A monotonic outbox sequence (or a ULID) gives an unambiguous total order. Wall-clock timestamps are clock-skew-prone and ambiguous at equal resolution; the SDK helper (§10) **requires** monotonic `since` and rejects timestamp cursors unless the application explicitly opts into the escape hatch and accepts the ambiguity.
+- **Required: the live event's `since` and the outbox row's `since` are assigned by the *same authority* (publish-side).** If the live stream and the outbox can disagree on an event's position, backfill is unsound. Concretely: the publisher assigns `since` once, writes it to the outbox row, and stamps it on the published event body. The router never assigns `since`.
+
+**The lower-boundary gap (a real lost-event window, added to §6).** If the client's `lastSeen` advanced from a *live* event whose outbox row had not yet committed (async/lagging outbox write), then `WHERE since > lastSeen` would *skip* in-flight events that landed in the outbox with `since ≤ lastSeen`. Mitigations, both required by the contract:
+
+1. **Commit-then-publish (or same-transaction outbox).** The outbox row must be durably committed *before* the event is published to the broker, or written transactionally with the producing mutation (a true transactional outbox). Then any `since` a client could have seen live is already present in the outbox.
+2. **Resume with a safety margin.** The SDK helper resumes from `lastSeen − margin` (a small number of sequence steps, or a short time window for the timestamp escape hatch), accepting extra duplicates (which dedup collapses) to close the gap. The application documents its outbox write-ordering guarantee so the margin can be sized to zero where commit-then-publish is strict.
+
+### 3.5 Alternative: router-stamped key via an engine change (re-scoped to L)
+
+For teams that want the router to surface the key so unmodified clients get dedup metadata without schema changes, the only correct implementation is an **engine modification**, scoped honestly here as a separate, larger effort:
+
+- Extend the engine `SubscriptionUpdater` interface (`resolve.go:1586-1590`) and `Update`/`UpdateSubscription`/`executeSubscriptionUpdate`/`subscriptionState`/the `SubscriptionResponseWriter` to carry a **per-event metadata struct** alongside `data []byte`, so the originating key/`since` survive to `Flush()` and can be merged into `extensions.cosmo`.
+- Propagate that struct through `subscription_event_updater.go` (a real `Update` signature change, not the additive-struct-field trick the prior draft assumed — `GetData()` would also need a sibling `GetDelivery()` that the adapter populates and the engine forwards).
+- This is **multi-repo** (it modifies the pinned `graphql-go-tools` and the router) and is therefore an **L** effort. It is listed under "Hidden engine changes" in §11. Even then, the *content-hash fallback stays withdrawn* (§3.2): the key must still be an app-set id assigned pre-resolve, because the engine cannot hash the post-resolve payload back into the matching adapter-side value either. The engine change only changes *who carries the app-set key to the wire*, not whether a key can be synthesized.
+
+The RFC recommends the §3.1 schema-surfaced approach as the default and treats §3.5 as opt-in for a later milestone.
+
+### 3.6 Lifecycle diagram
+
+```
+                         ┌──────────────────── application owns ────────────────────┐
+   publisher ──► broker  │   outbox / changelog table  (durable, queryable)          │
+       │   (commit-then- │        ▲   assigns `since` + idempotencyKey ONCE           │
+       │    publish, §3.4)└────────┼──────────────────────────────────────────────────┘
+       ▼                          │
+   ┌─────────┐   live event        │  Query.employeeUpdatesSince(since)
+   │ adapter │  (body carries      │            ▲
+   └────┬────┘   idempotencyKey    │            │ (HTTP query on (re)connect)
+        │        + since in data)  │            │
+        ▼                          │            │
+   engine resolve ─► writer ─► Next (typed data incl. idempotencyKey, since)
+        │                          │            │
+   ─────┼──────────────────────────┼────────────┼───────────────────────────────────
+        │     C L I E N T          │            │
+        ▼                          │            │
+   steady state:  receive Next ─► apply, dedup by key ─► advance OWN lastSeen=since
+                                   │
+   ─── DISCONNECT ─────────────────┘
+                                   │
+   reconnect (client owns resume): │
+     1. Subscribe (fresh, from "now")  ─────►  live deltas start flowing
+        └─ buffer live deltas in a queue
+     2. run Query.employeeUpdatesSince(since = OWN lastSeen − margin)  ◄── backfill
+     3. merge ALL (backfill ∪ buffered live) and apply in `since` order, dedup by key
+     4. resume steady state
+```
+
+The reconnect window is deliberately overlapped (lower margin in step 2, plus live buffering) so the union covers the gap; dedup-by-key collapses the overlap. Apply order is decided by `since`, never by arrival order or "backfill-first."
+
+---
+
+## 4. Wire protocol & client changes
+
+**Subscription protocol changes: none.**
+This is the defining property of Pattern F and the reason it pairs with stock clients on any transport.
+
+Justification, point by point against dossier §4.4:
+
+- We do **not** add an `ack` inbound message (option 1) — no `wsproto` change (`proto.go:88-94`).
+- We do **not** require a resume token in the `Subscribe` payload (option 2) — the router still subscribes from "now."
+- We take option 3 (client-side dedup/backfill) explicitly, and accept its ceiling: *state-convergent on reconnect, for outbox-backed subscriptions only.*
+
+What rides on existing fields:
+
+- **graphql-ws / graphql-transport-ws / graphql-sse.** The `idempotencyKey` and `since` ride as **ordinary typed fields in the `data`** (§3.1). Any spec-compliant client reads them with no transport change. A client that ignores them behaves exactly as today (at-most-once). This is the fallback for non-participating clients: silent, safe, no negotiation.
+- **No `extensions.cosmo` block, no SSE `id:` line.** The prior draft proposed both; both are **withdrawn**. The `extensions` route requires the engine change (§3.5). The SSE `id:` "free resume" claim is incorrect: `flushwriter.go:307-312` hardcodes `event: next\ndata: ` (adding `id:` is a real writer change, not free), the echoed `Last-Event-ID` would carry the wrong value for a per-client cursor (§3.3), and graphql-sse does not implement `Last-Event-ID` resumption (dossier §4.1). **SSE clients run the catch-up query like everyone else.**
+- **Capability negotiation.** None. A client opts in purely by *reading the two typed fields* and *running the catch-up query*.
+
+The companion catch-up query is **not** a protocol change — it is an ordinary GraphQL query over the existing HTTP path (`graphql_handler.go`), defined in the application's schema. The "client change" is application code (or the SDK helper, §10), not a transport change.
+
+This remains the cheapest client-integration story of the seven patterns, and the only one fully transparent to unmodified Apollo / Relay / urql clients — at the cost that the application must surface the two fields itself.
+
+---
+
+## 5. Per-backend adaptability & degradation matrix
+
+The headline, corrected: **the durability that matters lives in the application outbox, not the stream — so "state-convergent on reconnect" is a property of the application's outbox, not of the backend.** The backend's only contributions are (a) whether a *native stable id* exists that the application can copy into its key, and (b) whether the live stream can suggest a `since` (the outbox always provides the authoritative one).
+
+The columns are split to stop the prior draft's misattribution:
+
+| Backend | Supported by F? | Backend's contribution (key id quality) | Guarantee **given a complete, queryable outbox** | What is **lost if the outbox does NOT contain the event** |
+|---|---|---|---|---|
+| **NATS core** | Yes | `Nats-Msg-Id` if publisher set it; else **none** (no usable key from the stream) | State-convergent on reconnect | **Everything** — live event dropped, no replay, no row → permanent loss |
+| **NATS JetStream** | Yes | `Nats-Msg-Id` (publisher dedup id); stream seq available | State-convergent on reconnect | The event survives in the *stream* (JetStream is a log) → prefer Pattern B if you want it without an outbox; under F, lost unless in outbox |
+| **Kafka** | Yes | record `Key` (already surfaced) or app header | State-convergent on reconnect | Survives in the *topic* within retention → Pattern B recovers it; under F, lost unless in outbox |
+| **Redis Pub/Sub** | Yes | app header key if present; else none | State-convergent on reconnect | **Everything** — drop on overflow, no replay, no row → permanent loss |
+| **Redis Streams** | Yes | stream entry ID (stable, sortable) | State-convergent on reconnect | Survives in the *stream* (PEL/entry IDs) → Pattern B works; under F, lost unless in outbox |
+| **AWS SQS (Standard)** | Yes (when wired) | FIFO → `MessageDeduplicationId`; Standard → none | State-convergent on reconnect | **Everything** — delete-on-ack, no replay → permanent loss. NB: F is *not* using SQS for durability; it relies entirely on the outbox, and would work identically with **no broker at all** |
+| **Google Pub/Sub** | Yes | `messageId` (stable) | State-convergent on reconnect | Possibly recoverable via snapshot/seek (B); under F, lost unless in outbox |
+| **AWS Kinesis** | Yes | partition key + sequence number | State-convergent on reconnect | Survives in shard within retention (iterator expiry 5 min makes B fragile); under F, lost unless in outbox |
+| **Azure Event Hubs** | Yes | partition key + offset | State-convergent on reconnect | Survives in partition within retention; under F, lost unless in outbox |
+| **RabbitMQ / AMQP** | Yes | `message-id` property if set; else none | State-convergent on reconnect | **Everything** — delete-on-ack, no replay → permanent loss |
+
+Read the table honestly: for the at-most-once backends F is *sold* as the answer for (**NATS core, Redis Pub/Sub, SQS Standard, RabbitMQ**), the "guarantee achieved" column is *entirely* an application-outbox property. If the application does not independently write the event to the queryable store, **F recovers nothing** on those rows — they are at-most-once. The "F is the only viable durable-feel pattern on SQS Standard" framing from the prior draft was misleading and is removed: F isn't using SQS for durability at all.
+
+Degradation is surfaced non-silently in two ways: the composition lint (§8) flags fields that opt into F without a schema-surfaced key/since or with a delta-shaped payload, and the application's own observability reports key-source and outbox hit/miss. The router cannot stamp `keySource` (no side-channel; §3.2), so this observability lives in the application resolver / SDK helper, not the router.
+
+---
+
+## 6. Delivery semantics achieved
+
+Be precise about what F does and does not promise.
+
+**Applicability gate (the dominant one).** F applies only to subscriptions that are **(a) state-convergent** and **(b) backed by a queryable outbox/changelog/entity store**. For everything else — pure notification, presence, "typed", "new message arrived" event streams that are never persisted as current state — **F is at-most-once, identical to today.** A large fraction of real GraphQL subscriptions are exactly this kind of transient stream; for them F adds nothing. Do not present F as a universal floor for them.
+
+**For discrete events (the live stream): at-most-once.**
+F changes nothing about the live push path. A disconnect, restart, or slow-consumer overflow still drops live events exactly as today (dossier §2). F does not redeliver them.
+
+**For application state (across a reconnect, in-scope subscriptions): state-convergent.**
+After the client completes the backfill-merge-dedup loop (§3.6), its view of every entity in scope of the catch-up query equals the authoritative store. No state is permanently lost as long as the outbox is queryable and retains the window the client must backfill.
+
+**Duplicates: expected and required to be tolerated.**
+The reconnect window deliberately overlaps the live stream, so the same logical update arrives twice. The application-owned key collapses them. The client *must* be idempotent; this is the contract, not a bug (dossier §6.2).
+
+**Ordering: not guaranteed for intermediates; final state converges.**
+The merge rule is "apply in `since` order, dedup by key" (§3.4). For state-convergent payloads, last-writer-by-`since` is correct by construction. For delta/CRDT payloads F is the **wrong** pattern — use A or B. This must be loud in the docs and is enforced by the lint (§8).
+
+**Exact failure windows that remain:**
+
+1. **Non-outbox events.** Any event not persisted as a queryable row is unrecoverable. (The applicability gate, restated as a failure mode.)
+2. **Intermediate-transition loss.** `A → B → C` during a disconnect; backfill returns `C` → `B` never observed. Acceptable for last-writer-wins state; unacceptable for event-sourced / audit consumers.
+3. **Outbox retention gap.** If the disconnect outlasts outbox retention for the `since` window, the backfill returns a truncated set. The application must either retain long enough or signal **"snapshot reset"** (return full current state, drop `since`) as a *defined* error, not a silent short read (analogue of "cursor expired", dossier §5b).
+4. **Lower-boundary gap.** In-flight live events whose outbox row committed late can be skipped by `WHERE since > lastSeen`. Closed by commit-then-publish + safety-margin resume (§3.4).
+5. **Key misalignment.** If the subscription's `idempotencyKey` and the backfill's `idempotencyKey` for the same transition differ, dedup silently fails (duplicates leak, or — worse — distinct events collapse). Caught only by the end-to-end test (§12); this is why that test is mandatory.
+6. **Backfill-vs-live merge bug in client code.** Applying live deltas before backfill, or out of `since` order, can apply stale over fresh. The SDK helper (§10) makes apply-in-`since`-order a library invariant.
+
+**Net: at-least-once redelivery via the outbox + idempotent, `since`-ordered client merge = effective exactly-once *state convergence* for in-scope subscriptions, never exactly-once *event delivery*, and nothing at all for out-of-scope subscriptions.**
+
+---
+
+## 7. Cross-cutting concerns
+
+**Router HA / horizontal scaling & sticky sessions.**
+This is F's quiet superpower (dossier §6.6). The router holds **no per-subscription durable state** and durability lives in the application outbox, so a reconnect can land on *any* router instance. No sticky sessions, no consumer-name coordination, no external checkpoint store. The per-instance JetStream durable-naming tension (`nats/adapter.go:69-83`) is irrelevant to F. Cheapest pattern to operate at scale and under churn.
+
+**Per-subscription state / memory cost.**
+Router-side: **exactly O(1)** — F adds *nothing* to the router data path (no key derivation, no hash, since the router does not synthesize the key; §3.2). No buffer, no held ack, no per-subscriber consumer. Lowest-memory pattern of the seven (dossier §6.7).
+
+**Multi-tenant shared-trigger fan-out.**
+F **preserves** the shared-trigger optimization (dossier §1.4, §6.5): one broker subscription still fans out to N subscribers, each receiving the same typed payload (including the same `idempotencyKey`/`since`, which the *application* put in the body — correct, since the key labels the event). F does not force per-subscriber consumers (C) or per-subscriber ack (A). The catch-up query is per-client and stateless on the router, scaling as ordinary query traffic. **Caveat (security):** because the same key value is visible to every co-subscriber on a shared trigger, the application must keep keys opaque/non-enumerable (§3.1) — a key derived from a primary-key sequence would leak one tenant's row counts/ordering to co-subscribers.
+
+**Where the key is asserted vs. the hooks pipeline.**
+Correcting the prior draft: the `OnReceiveEvents` hook runs **per subscription, after fan-out** (`subscription_event_updater.go:52` iterates `subscriptions`, then `:95-129` runs per `subID`), not "once at the adapter before fan-out." Because F's key lives in the *application schema body*, hook transforms are simply part of producing that body: if a hook rewrites the payload, the application must ensure the rewritten body still carries the agreed `idempotencyKey`/`since`. The **post-hook re-derivation rule** (was OQ#5): if a hook *splits* one event into N output events, each output event must carry its **own** key (the application assigns one per output row in the outbox too) — never one shared key across the three (that would collapse them on dedup). A hook that **drops** an event is fine: the dropped event is simply not delivered live and, if it was real state, is recovered via backfill. Drop ≠ loss under F. Since there is no content hash anywhere (§3.2), there is no "pre- vs post-hook hashing" question to resolve.
+
+**Backpressure.**
+Unchanged. F adds no buffer and holds no ack, so no new backpressure coupling. The existing per-trigger-serial backpressure and silent-drop behavior (dossier §2.2) still apply to the *live* stream — but for in-scope subscriptions a drop is no longer permanent loss, because the next reconnect's backfill recovers the state. This is the conceptual shift: F makes the existing lossy backpressure *tolerable* for in-scope subscriptions, not fixed.
+
+**Reconnect thundering herd (new).**
+Because every reconnect fires a backfill query, a synchronized reconnect storm (router restart, LB failover, a mobile-network flap across thousands of clients) becomes a **thundering herd of `*Since` queries** hitting the outbox/DB precisely when the system is already stressed. Worse, the backfill re-runs full per-event authz (the security feature below) — for a wide `since` window that is N× the per-event authz cost of normal delivery, per reconnecting client. Mitigations the RFC requires the SDK helper and docs to implement:
+- **Jittered backfill** — randomized delay before the catch-up query on reconnect, to de-synchronize the herd.
+- **Bounded / paginated `*Since`** — the catch-up query must paginate and the application should rate-limit / cost-bound it; an unbounded `since` window must page rather than return an unbounded set.
+- **Snapshot-reset short-circuit** — if a client's window exceeds retention, return current state once (§6 failure #3) instead of replaying a huge span per event.
+
+**Security / authz.**
+- The catch-up query runs through the **normal** query authz path — same resolver, field-level auth, tenant scoping as any federated query. No new "replay" surface bypassing authz, unlike raw cursor-replay (Pattern B). Backfill *is* a query, so it re-runs *current* authz per event by construction (dossier §6.8) — at the cost amplification noted above.
+- `since` is opaque to the router; the application's `*Since` resolver validates it and enforces tenant scope. The router never seeks a broker by it.
+- **Key opacity is mandatory, not advisory.** The key is in the client-visible body and (shared trigger) visible to co-subscribers. It **must** be opaque/non-enumerable and must not encode sensitive data or enumerable ordering. The lint (§8) cannot prove opacity, so this is a documented requirement plus a review checklist item.
+
+---
+
+## 8. Configuration & composition surface
+
+F's primary path needs **no router YAML and no proto change** — the key and `since` are application schema fields (§3.1), and the router does not read them. This is a deliberate simplification over the prior draft's `delivery` block and `DataSourceCustomEvents` additions, which existed only to feed the withdrawn router-stamping mechanism.
+
+What the router *does* add is **optional and additive**:
+
+**A composition-time lint / advisory directive `@edfs__backfill` (optional).**
+Purely a marker that lets composition validate the contract and emit a warning — it does **not** change runtime behavior and is **not** required to use F.
+
+```graphql
+type Subscription {
+  employeeUpdated(id: ID!): EmployeeUpdate!
+    @edfs__natsSubscribe(subjects: ["employee.{{ args.id }}.updated"], providerId: "my-nats")
+    @edfs__backfill(query: "employeeUpdatesSince", keyField: "idempotencyKey", sinceField: "since")
+}
+```
+
+Composition (parsed alongside the other `@edfs__*` directives in `normalization-factory.ts:2804-3169`) then lints:
+- the named backfill query exists and returns a list of the **same** object type as the subscription;
+- both the subscription payload type and the backfill element type expose `keyField` and `sinceField`;
+- a best-effort heuristic flag when the payload looks delta-shaped (e.g. field names like `delta`, `increment`, `op`) — advisory, since the router cannot know payload semantics.
+
+If `@edfs__backfill` is absent, F still works (it is pure application + client convention); the lint simply does not run. This keeps the composition footprint to *one optional directive definition* and a validation pass — no proto field, no config plumbing across the three planes.
+
+**Engine-stamped variant config (§3.5, deferred).** Only the L-effort alternative would need a `delivery` block and proto fields; it is out of scope for the first milestone and not specified here.
+
+---
+
+## 9. Migration & backward compatibility
+
+**Opt-in, additive, and safe by default.**
+
+- **Nothing is always-on, and nothing changes for existing clients.** Because the primary path is application-schema convention, the router behaves identically until an application adds the key/since fields and a `*Since` query. Apollo/Relay/urql clients that do not read the new fields behave exactly as today (at-most-once). No client breaks.
+- **No router schema/proto/YAML change required** for the primary path. `@edfs__backfill` is an optional lint marker (§8).
+- **Rollout in three stages:**
+  1. **Application adds the outbox + the two schema fields + the catch-up query** (`Query.*Since(since:)`), assigning `since`/`idempotencyKey` publish-side with commit-then-publish (§3.4). No Cosmo change required (optionally add `@edfs__backfill` for the lint).
+  2. **Add the end-to-end alignment test (§12)** to CI before any client ships dedup — this is the gate that catches key misalignment (§6 failure #5).
+  3. **Clients adopt the SDK helper** (§10) or hand-roll the backfill-merge-dedup loop. Stock clients keep working throughout.
+- **Reversible.** Removing the fields/query reverts to today's behavior with no residual state (F is stateless on the router).
+- **Composes forward.** F is the right baseline to ship first for state-convergent, outbox-backed subscriptions because it is cheap and backend-agnostic; teams that later need intermediate-event delivery can layer Pattern B (cursor resume) on log backends or Pattern A (client ack) on any backend, without removing F.
+
+---
+
+## 10. Appendix: SDK helper contract and (optional) engine-change types
+
+The primary deliverable on Cosmo's side is the **client SDK helper**, not router Go types — the router does not synthesize anything.
+
+```ts
+// ── client SDK helper (TypeScript) ──
+// Encapsulates the backfill-merge-dedup invariant so applications don't get
+// step ordering wrong (§6 failure #6) or the lower-boundary margin wrong (§3.4).
+//
+// Invariants the helper enforces:
+//  - apply in `since` order (NOT arrival order, NOT backfill-first)         (§3.4)
+//  - dedup by application-owned idempotencyKey                              (§3.1)
+//  - resume from (own lastSeen − margin), with jitter before the query     (§3.4, §7)
+//  - require monotonic `since`; reject timestamp cursors unless opted in    (§3.4)
+//  - bounded LRU `seen` set sized to cover the overlap window
+//
+// onReconnect:
+//   liveBuf = []                         // buffer live deltas during backfill
+//   subscribe(); route each Next -> liveBuf.push(next)   // each Next is typed: { idempotencyKey, since, ...data }
+//   await jitter()                       // de-synchronize the herd (§7)
+//   backfill = await paginate(SinceQuery, { since: max(lastSeen - margin, floor) })  // (§7 pagination)
+//   merged = mergeBySinceOrder(backfill, drain(liveBuf))   // total order by `since`
+//   for ev of merged:
+//     if seen.has(ev.idempotencyKey) continue              // DEDUP
+//     apply(ev); seen.add(ev.idempotencyKey); lastSeen = max(lastSeen, ev.since)
+//   // steady state: apply live in `since` order, dedup by key, advance lastSeen
+interface BackfillMerger<T> {
+  // returns false for a duplicate (skip); advances lastSeen on apply
+  onEvent(ev: { idempotencyKey: string; since: string; data: T }): boolean;
+  // returns the `since` argument to query with (lastSeen − margin)
+  onReconnect(): { sinceArg: string; jitterMs: number };
+}
+```
+
+```graphql
+# ── composition: the one OPTIONAL lint directive (§8) ──
+directive @edfs__backfill(
+  query: String!        # the catch-up Query field name, e.g. "employeeUpdatesSince"
+  keyField: String!     # the idempotency key field on the payload, e.g. "idempotencyKey"
+  sinceField: String!   # the since cursor field on the payload, e.g. "since"
+) on FIELD_DEFINITION
+```
+
+```go
+// ── DEFERRED (§3.5): engine-change types, only for the L-effort router-stamped variant ──
+// Shown to scope the alternative honestly; NOT part of the primary milestone.
+//
+// Would require modifying graphql-go-tools (multi-repo):
+//   type SubscriptionUpdater interface {
+//       Update(data []byte, meta *DeliveryMeta)                          // signature change
+//       UpdateSubscription(id SubscriptionIdentifier, data []byte, meta *DeliveryMeta)
+//   }
+// plus threading *DeliveryMeta through executeSubscriptionUpdate / subscriptionState /
+// the SubscriptionResponseWriter so Flush() can merge it into extensions.cosmo.
+// Even then, IdempotencyKey MUST be an app-set id assigned pre-resolve (no content hash; §3.2).
+type DeliveryMeta struct {
+    IdempotencyKey string // app-set id forwarded from the broker event body/header
+    Since          string // app-set monotonic position label
+}
+```
+
+---
+
+## 11. Risks, open questions, and a complexity/effort estimate
+
+**Where this pattern is weakest (be honest):**
+
+- **It only helps state-convergent, outbox-backed subscriptions.** This is the single biggest limitation, now stated as a gate (§2, §6), not a footnote. For pure notification/event streams F is at-most-once. Quantify against your own EDFS usage before calling F a "floor."
+- **It is not at-least-once for events.** F delivers *state convergence*, not *every transition*. Audit-trail / event-sourcing consumers must use A, B, or E.
+- **It pushes real cost to the application.** Outbox table, the `*Since` query, commit-then-publish `since` assignment, and — critically — keeping the subscription key field and the query key field in the *same key space*. A misaligned key silently breaks dedup (§6 #5). This is why the end-to-end test (§12) is mandatory, not optional.
+- **No content-hash safety net.** The universal fallback is withdrawn (§3.2). A subscription with no app-set stable key is simply not a candidate for F.
+- **Reconnect thundering herd.** Backfill-on-reconnect amplifies load and authz cost at the worst moment (§7); mitigations are required, not nice-to-have.
+
+**Alternatives considered:**
+
+- **Router-stamped `extensions.cosmo` key (prior draft's primary design).** Rejected as primary: requires an engine change (§3.2, §3.5); content-hash variant cannot match across resolve. Retained as the §3.5 L-effort alternative.
+- **Content-hash universal key.** Rejected outright: cannot match across the resolve boundary (§3.2).
+- **SSE `Last-Event-ID` free resume.** Rejected: wrong value to echo for a per-client cursor (§3.3), graphql-sse does not implement it, and emitting `id:` is a real writer change (§4).
+- **Other patterns (A/B/C/D/E/G).** Cross-referenced in the dossier §5; F is deliberately the weakest-but-cheapest, chosen for at-most-once backends and state-convergent use cases. D is the recommended correctness-first companion.
+
+**Open questions:**
+
+1. **Should the router ship a reference outbox?** Stance: stay out (the application owns durability). A `wgc` template + a Postgres transactional-outbox pattern + a generated `*Since` resolver would lower adoption cost dramatically. Follow-up, not core.
+2. **Ship the §3.5 engine-stamped variant at all?** It buys dedup metadata for clients that won't change their schema, at L effort and a pinned-engine modification. Lean: defer until the schema-surfaced path has adoption data.
+
+(The prior draft's OQ on `since` timestamp-vs-sequence is now *resolved* in §3.4 — monotonic required, timestamps as an explicit escape hatch. The OQ on `OnStreamEvents` split/grow is now *specified* in §7 — per-output-event key. The OQ on SSE `Last-Event-ID` wiring is *withdrawn* with the SSE claim, §4.)
+
+**Complexity / effort estimate.**
+
+- **Router-side, primary path: S.** No engine change, no proto change, no YAML change, no router data-path change. Deliverables are: one optional composition lint directive + validation pass (`composition/`), an SDK helper (client repo), and documentation. The router itself is essentially untouched. This is *smaller* than the prior draft claimed — because the parts that made it M (the `delivery` block, `DataSourceCustomEvents` fields, writer touch-points) were feeding the withdrawn stamping mechanism and are gone.
+- **Router-side, §3.5 engine-stamped alternative: L (deferred).** Multi-repo: a `SubscriptionUpdater`/`Update` signature change in pinned `graphql-go-tools`, threading `*DeliveryMeta` through `executeSubscriptionUpdate`/`subscriptionState`/the writer, plus the SSE writer change and `delivery` config/proto plumbing across the three planes. Listed here as "Hidden engine changes" so it is not under-estimated.
+- **Application-side: M (recurring, per app).** Transactional outbox + `*Since` query + commit-then-publish + key/since alignment. Not Cosmo's code, but it is the gate to the guarantee and where teams will get it wrong.
+- **Client-side: S–M.** Hand-rolled it is the pattern teams already use (dossier §4.2); the SDK helper turns it into S.
+
+**Honest positioning vs the other six:**
+F is the cheapest, most portable, lowest-risk pattern to *operate*, and the best (often only) answer for at-most-once backends (NATS core, Redis Pub/Sub, SQS Standard) — **but only for state-convergent, outbox-backed subscriptions, and only because the durability lives in the app's datastore.** It is the *weakest* on the actual problem statement — restoring at-least-once delivery of every event — because it deliberately does not try, and it provides nothing for transient/notification streams. The right framing: **F is the floor for state-convergent, outbox-backed subscriptions, and irrelevant for everything else.** Ship the S-effort schema-surfaced path first as that baseline; layer B/A where intermediate-event fidelity is required; consider the §3.5 engine variant later if client-transparent metadata proves worth the L.
+
+---
+
+## 12. Testing & verification plan
+
+The correctness of F lives entirely in the **key-alignment contract across the resolve boundary** (§3.1, §3.2) and the **`since`-ordered merge** (§3.4). The test plan exists to catch exactly the failure (§6 #5) that the prior draft's design hid.
+
+**Mandatory gate (blocks Draft → Proposed):**
+
+1. **End-to-end key equality through resolve.** A test that drives a real subscription event through the engine (`InitSubscription` → `LoadGraphQLResponseData` → `Resolve`) to the writer, captures the `idempotencyKey` the client receives on the live `Next`, then runs the companion `*Since` query for the same logical transition and asserts the two `idempotencyKey` values are **byte-for-byte equal**. Assert the *full* typed payload of both (per house style: `assert.Equal` on the entire object, never `Contains`), so a renamed/added field is caught. This is the test whose absence let the resolve-boundary mismatch (§3.2) go unnoticed.
+2. **`since`-ordered merge correctness.** Given a backfill set and a buffered live set that overlap, assert the merged applied sequence equals the expected `since`-ordered, key-deduped sequence — including the case where the same entity changed again server-side (different key, higher `since`) between snapshot and query (assert newest-by-`since` wins, not backfill-first).
+3. **Lower-boundary gap.** Simulate a late outbox commit; assert that commit-then-publish + `lastSeen − margin` resume recovers the in-flight event and that, without the margin, it would be skipped (negative control).
+4. **Non-state-convergent / delta payload.** Assert the lint (§8) flags a delta-shaped payload field opting into `@edfs__backfill`.
+5. **Duplicate tolerance.** Assert that replaying the overlap window applies each transition exactly once (dedup by key).
+
+**Observability / rollback:**
+- Application-side metrics (in the resolver / SDK helper, since the router has no side-channel): backfill query rate, `*Since` window size distribution, outbox hit/miss, dedup-collapse count.
+- Rollback is removal of the schema fields + query; no router state to clean up.

--- a/rfc/at-least-once/rfc-G-tiered-capability-negotiation.md
+++ b/rfc/at-least-once/rfc-G-tiered-capability-negotiation.md
@@ -1,0 +1,885 @@
+# RFC: At-Least-Once for GraphQL Subscriptions — Tiered Capability Negotiation (Pattern G)
+
+**Status:** Draft
+
+**TL;DR.**
+Today EDFS delivery is fire-and-forget by construction:
+the broker reader goroutine drives resolve + socket flush in one synchronous call stack,
+and only NATS JetStream attempts any durability — and even that acks on flush *attempt*, not client receipt
+(`router/pkg/pubsub/nats/adapter.go:154`).
+Different backends can offer wildly different guarantees,
+and customers reasonably want to keep the broker they already run.
+Pattern G is the policy/routing layer that turns this into an *honest* system:
+a subscription declares a *desired* delivery class (`at-most-once`, `at-least-once`, `exactly-once`),
+the client advertises what it can do (`supports: [ack, resume]`) in `connection_init`,
+and the router selects the **strongest mechanism the chosen backend and client can jointly satisfy**,
+degrades transparently, and reports the **actual class achieved** in `extensions.delivery`.
+It does not invent durability — it composes Patterns A/B/C/D/E/F per backend and refuses to *silently* pretend.
+This is the direct answer to "let me pick my backend even if that means a weaker guarantee — just tell me the truth about what I get."
+
+---
+
+## 1. Problem & Context
+
+The research dossier states the gap precisely:
+
+> Today, **only NATS JetStream achieves any durability, and only because its adapter independently calls `msg.Ack()`** after a *flush attempt*.
+> There is no client acknowledgement, no resume token, no replay, and no per-subscriber delivery accounting anywhere in EDFS.
+> Everywhere else delivery is at-most-once by construction.
+
+An application frequently *already has* at-least-once in its backend:
+Kafka with committed offsets, JetStream with durable consumers, Redis Streams with consumer groups and a Pending Entries List.
+But the moment those events cross the EDFS boundary into Cosmo,
+the guarantee evaporates,
+because the framework abstraction itself is fire-and-forget:
+`datasource.Adapter` (`router/pkg/pubsub/datasource/provider.go:22-28`)
+and the engine's `SubscriptionUpdater.Update(data)` return **no error and expose no ack hook back to the broker**.
+Durability is therefore a per-adapter property, not a property of EDFS,
+and only one adapter even tries.
+
+Concretely, the loss windows are:
+
+- **Hop A — Broker → router read.**
+  Only JetStream consumes durably (durable pull consumer, explicit ack).
+  Kafka is groupless and resets to "now" (`ConsumeResetOffset(AfterMilli(now))`, `router/pkg/pubsub/kafka/adapter.go:32-34, 51-122`),
+  NATS core uses an unbuffered channel that drops on slow-consumer overflow (`router/pkg/pubsub/nats/adapter.go:168`),
+  and Redis uses **Pub/Sub, not Streams** (`router/pkg/pubsub/redis/adapter.go:88-152, 191`) — no ack primitive at all.
+
+- **Hop B — Router resolve → client flush.**
+  Even on JetStream, ack timing is wrong:
+  `msg.Ack()` (`nats/adapter.go:154`) runs *after* `updater.Update()` returns,
+  but `updater.Update()` only ran resolve + `writer.Flush()`,
+  and `Flush()` is a single socket write under a write deadline — bytes handed to the kernel, not an application ack from the client
+  (`router/core/websocket.go:704-736`, `router/core/flushwriter.go:116-167`).
+  A client that crashes after TCP-buffering but before processing loses the message, yet it is acked → **lost-but-acked**.
+  The no-hooks path also ignores the result of delivery entirely (`router/pkg/pubsub/datasource/subscription_event_updater.go:36-129`),
+  and the hooks path can *abandon* in-flight deliveries on timeout while the JetStream loop still proceeds to `msg.Ack()`
+  ("Events may arrive out of order," `subscription_event_updater.go:69-79`).
+
+- **Hop C — No client ack anywhere.**
+  The recognized inbound WS message set is `Ping`, `Pong`, `Subscribe`, `Complete`, `Terminate`
+  (`router/internal/wsproto/proto.go:88-94`) — there is no "ack received next" concept.
+  `connection_init`/`connection_ack` is a one-time *connection* handshake, not a data ack.
+
+- **Hop D — No resume / replay.**
+  A reconnecting client always starts a brand-new subscription from "now":
+  it gets a new `ConnectionID` (`router/core/websocket.go:367`) and a brand-new subscription id (`websocket.go:1160-1185`).
+  The SSE writer never emits an `id:` field (`flushwriter.go:116-167`),
+  so even native browser SSE auto-resume cannot work,
+  and the delivered event structs carry only `Data`/`Headers`/`Key` — **no sequence/offset cursor is ever surfaced**
+  (`nats/engine_datasource.go:39-42`, `kafka/engine_datasource.go:58-63`); JetStream `msg.Metadata()` is never read.
+
+The dossier enumerates six concrete patterns to close these hops (A–F),
+each with a different cost, a different backend footprint, and a different protocol requirement.
+The trouble is that **no single pattern is right for every backend**:
+B (cursor replay) is excellent on Kafka but *impossible* on NATS core;
+A (client ack) is natural on SQS but degrades to a cursor-advance on Kafka;
+E (router buffer) is the only thing that works on Redis Pub/Sub.
+A customer who runs three different brokers behind one router should not have to pick one guarantee for all of them,
+nor should they be silently downgraded without knowing it.
+
+**Pattern G is the layer that resolves this.**
+It does not add a new durability mechanism.
+It adds the *negotiation, selection, and honesty* layer that sits atop whichever of A–F have shipped,
+chooses the best feasible mechanism per `(backend, client, requested class)` triple,
+and reports the truth back to the client.
+
+This builds directly on the existing Cosmo Streams v1 hooks where relevant:
+the v1 `SubscriptionOnStart` hook (`cosmo-streams-v1.md`) is the natural place to surface and override a negotiated class,
+and the v1 `StreamBatchEventHook` / `OnStreamEvents` batch contract is where per-event idempotency keys and replay-time authz re-checks must run.
+Pattern G does not replace those hooks; it threads a delivery policy through them.
+
+---
+
+## 2. Goals & Non-Goals
+
+### Goals
+
+1. **Honest delivery.**
+   The router must never report or imply a guarantee it cannot meet for a given subscription.
+   The *actual* achieved class is always reported back to the client (`extensions.delivery`), and observable in logs/metrics/traces.
+2. **Backend choice without lock-in to a guarantee.**
+   A user can keep any supported backend and still get the *strongest feasible* class on it, with explicit, non-silent degradation when the backend cannot reach the requested class.
+3. **Composition, not reinvention.**
+   G selects among already-implemented mechanisms (A/B/C/D/E/F).
+   It is a pure routing/policy layer; it adds no new broker integration of its own.
+4. **Graceful client fallback.**
+   Stock clients (Apollo, urql, Relay, plain SSE) that cannot ack or resume must still work, degrading to a clearly reported `at-most-once` (or whatever floor is feasible without their participation).
+5. **Per-field and per-client control.**
+   The desired class can be expressed per subscription field (schema directive at composition time) and/or per client (capability handshake at connection time), with a deterministic precedence rule.
+6. **Opt-in and backward compatible.**
+   With no configuration and no client capabilities advertised, behavior is byte-for-byte identical to today.
+
+### Non-Goals
+
+1. **Implementing A–F.**
+   This RFC specifies the negotiation contract and the selection algorithm,
+   plus the minimal hooks each underlying pattern must expose to be selectable.
+   It assumes A–F (or a subset) are delivered by their own RFCs.
+   Where a pattern is absent, G simply has fewer rungs on the ladder and degrades accordingly.
+2. **A new wire protocol.**
+   G reuses graphql-ws / graphql-transport-ws / graphql-sse and adds only the minimal handshake fields and an `ack`/`resume` extension. It does not invent a fourth subprotocol.
+3. **Guaranteeing ordering as a side effect.**
+   Ordering remains a separate, per-mechanism property (§7). G reports it but does not strengthen it.
+4. **Cross-backend global ordering or cross-backend exactly-once.**
+   Out of scope — exactly-once is per-backend, per-stream, and only where the backend supports it.
+5. **Solving HA durable state on its own.**
+   G's selection depends on the HA story of the pattern it selects (e.g. C's checkpoint store). G surfaces the constraint; it does not fix it.
+
+---
+
+## 3. Design — the mechanism in depth
+
+### 3.1 The core idea: a delivery class is the *output* of a negotiation, not an input
+
+There are three delivery classes, ordered:
+
+```
+at-most-once  <  at-least-once  <  exactly-once
+```
+
+A subscription has a **requested class** (a ceiling the user asks for) and an **achieved class** (the floor the system can prove it will meet).
+The router computes:
+
+```
+achieved = min( requested,
+                backendCeiling(provider, backendStreamConfig),
+                clientCeiling(negotiatedClientCapabilities),
+                transportCeiling(transport),
+                routerCeiling(enabledPatterns, haTopology) )
+```
+
+`min` over the partial order. Each term is the strongest class that *that dimension* can support:
+
+- **`backendCeiling`** — the strongest class the chosen broker primitive supports given how it is consumed
+  (e.g. JetStream durable consumer → up to `exactly-once`; Kafka → `at-least-once` via cursor; NATS core → `at-most-once`).
+- **`clientCeiling`** — derived from the capabilities the client advertised: `supports:[ack]` enables A; `supports:[resume]` enables B; neither → `at-most-once` unless a router-side mechanism (E) can carry it without client help, in which case it is `at-least-once`-within-window.
+- **`transportCeiling`** — WS full-duplex can carry `ack`; SSE/multipart are one-directional and need the out-of-band ack channel (§5) or resume-only.
+- **`routerCeiling`** — which of A–F are actually compiled/enabled, plus whether the HA topology supports the state the chosen mechanism needs (sticky routing, external checkpoint store).
+
+The achieved class then **selects the concrete mechanism** to wire up (the "selection table," §3.4),
+and that selection is reported in `extensions.delivery` (§5.3).
+
+This is the whole pattern: a `min` over capability ceilings, a deterministic mechanism selection, and an honest report.
+
+### 3.2 Components touched
+
+Pattern G is deliberately thin. It introduces one new package and threads a small amount of state through existing seams.
+
+- **New: `router/pkg/pubsub/delivery/` (the policy engine).**
+  - `Negotiator` — pure function `(Request) → Decision` computing `achieved` and the selected mechanism.
+  - `CapabilityRegistry` — per-provider declared ceilings, populated at provider build time.
+  - `Decision` — the negotiated outcome (class, mechanism, idempotency-key source, replay window, ordering guarantee) carried for the life of the subscription.
+
+- **Provider adapters (`router/pkg/pubsub/{nats,kafka,redis}`).**
+  Each adapter gains a `Capabilities()` method declaring what classes/mechanisms it can support for a given resolved stream config
+  (e.g. NATS reports `exactly-once` only when a JetStream `streamConfiguration` is present *and* double-ack + dedup are enabled;
+  it reports `at-most-once` for core NATS subjects).
+  Each adapter's `Subscribe`/`Update` path is parameterized by the selected mechanism so the *same* adapter can run fire-and-forget (today) or ack-gated / cursor-bearing.
+
+- **`datasource.SubscriptionEventUpdater` (`router/pkg/pubsub/datasource/subscription_event_updater.go:19-24`).**
+  This is the central seam. Today it is fire-and-forget.
+  G requires it to carry a `Decision` and to return a per-event/per-subscriber `DeliveryOutcome` upward,
+  so the adapter can ack/commit/`XACK` correctly (this is exactly the Pattern D contract change — D is the substrate G stands on).
+  When the decision is `at-most-once`, this collapses to today's void-returning behavior with zero overhead.
+
+- **graphql-go-tools `resolve.SubscriptionUpdater` contract.**
+  For any class above `at-most-once`, the engine must surface a delivery result rather than `void`,
+  and must attach the router-assigned (or backend-derived) sequence/cursor to each `Next` so the writers can emit it.
+  This is the single change that lives outside the Cosmo repo;
+  if the engine cannot be changed in a given release, G caps `routerCeiling` at `at-most-once` and says so — honestly.
+
+- **`router/core/websocket.go` + `router/internal/wsproto/proto.go`.**
+  Parse the capability payload in `connection_init`; add the `ack` inbound message and the `resume` field on `Subscribe`;
+  emit `id` (sequence/cursor) on each `Next`; emit the negotiated `extensions.delivery` on the first frame.
+
+- **`router/core/flushwriter.go` (SSE/multipart).**
+  Emit `id:` on SSE so native `Last-Event-ID` auto-resume works;
+  honor `Last-Event-ID` on (re)connect;
+  wire the out-of-band `POST /graphql/ack` back-channel for ack-class subscriptions on one-directional transports.
+
+- **Config (`router/pkg/config/config.go`).**
+  A new `events.delivery` block (defaults, per-provider caps, enabled mechanisms, replay window, ack window). See §9.
+
+- **Composition / proto (optional).**
+  An optional `@edfs__delivery(class: AT_LEAST_ONCE)` directive on subscription fields, serialized into `DataSourceCustomEvents` so the per-field *requested* class travels in the execution config.
+  Without it, the requested class comes from config/handshake only.
+
+### 3.3 Lifecycle diagram
+
+```
+                         CONNECTION (once per socket)
+ client ── connection_init { payload.cosmo.delivery.supports:[ack,resume] } ──▶ router
+ client ◀── connection_ack { payload.cosmo.delivery.accepted:[ack,resume] } ──── router
+                         (router stores negotiatedClientCapabilities on the connection)
+
+                         SUBSCRIPTION (once per operation)
+ client ── Subscribe { id, payload:{query,...}, extensions.delivery.request: at-least-once,
+                                              extensions.delivery.resume: <cursor?> } ──▶ router
+                                                          │
+                                  ┌───────────────────────┴───────────────────────┐
+                                  ▼                                                 │
+                    delivery.Negotiator.Negotiate(Request{                         │
+                        requested  = field-directive ∧ Subscribe.request ∧ cfg     │
+                        client     = negotiatedClientCapabilities                  │
+                        transport  = WS | SSE | multipart                          │
+                        backend    = adapter.Capabilities(resolvedStreamConfig)    │
+                        router     = enabledPatterns ∧ haTopology })               │
+                                  │                                                 │
+                                  ▼                                                 │
+                    Decision{ achieved=at-least-once,                              │
+                              mechanism=CURSOR (Pattern B),                        │
+                              idempotencyKeySource=Nats-Msg-Id,                    │
+                              replayWindow=stream-retention,                       │
+                              ordering=per-stream }                                │
+                                  │                                                 │
+ client ◀── Next #0 (first frame) extensions.delivery = Decision (reported) ───────┘
+                                  │
+            adapter.Subscribe(ctx, updater[Decision], resume=<cursor>)
+                                  │  (B: seek backend to cursor, replay missed, then live)
+                                  ▼
+            broker ── event ──▶ adapter ──▶ updater.Update([]StreamEvent, Decision)
+                                  │            │ (D substrate: returns DeliveryOutcome)
+                                  │            ▼
+                                  │      engine resolve + Flush, sequence/cursor attached
+                                  │            │
+ client ◀── Next #n { ..., id:<cursor_n> } ───┘
+                                  │
+   (A only) client ── ack { id:<cursor_n> } ──▶ router ──▶ adapter.Confirm(cursor_n)
+                                  │                          │ JetStream Ack / Kafka commit / XACK / SQS delete
+                                  ▼
+                          broker ack / commit / checkpoint advances
+```
+
+The two negotiation points are the **connection handshake** (capabilities, once)
+and the **subscription start** (requested class ∧ resume cursor, per operation).
+Everything after that is the selected mechanism running with the `Decision` as its policy object.
+
+### 3.4 The selection algorithm
+
+`Negotiate` is a pure, deterministic function. In prose:
+
+1. **Compute the requested class.**
+   `requested = min(fieldDirectiveClass, subscribeRequestClass, configDefaultClass)`.
+   If none is set, `requested = at-most-once` (today's behavior — no change unless asked).
+   *Precedence note:* we take the `min`, not "most specific wins."
+   A field annotated `at-least-once` cannot be forced down by a client asking for `at-most-once` unless the client genuinely cannot do better — but a client *can* voluntarily ask for less.
+   Conversely a field annotated `at-most-once` is a hard ceiling the client cannot exceed.
+   This makes the directive a *guarantee floor authored by the schema owner* and the handshake a *capability statement by the client*; the achieved class is their intersection with the backend.
+
+2. **Compute each ceiling** (`backendCeiling`, `clientCeiling`, `transportCeiling`, `routerCeiling`) as in §3.1.
+
+3. **`achieved = min(requested, all ceilings)`.**
+
+4. **Select the mechanism for `achieved` on this backend** via the selection table:
+
+   | achieved | backend family | mechanism selected |
+   |---|---|---|
+   | `at-most-once` | any | fire-and-forget (today) |
+   | `at-least-once` | log/cursor store (Kafka, Redis Streams, Kinesis, Event Hubs, JetStream, Pub/Sub) + client `resume` | **B** (cursor replay) |
+   | `at-least-once` | ack/redelivery queue (SQS, RabbitMQ, JetStream) + client `ack` | **A** (client-ack, broker redelivery) |
+   | `at-least-once` | no native durability (NATS core, Redis Pub/Sub) + any client | **E** (router replay buffer, window-bounded) |
+   | `at-least-once` | any, no client participation, but D enabled | **D** (correct broker ack on flush — "at-least-once relative to flush") |
+   | `exactly-once` | JetStream (double-ack + `Nats-Msg-Id` dedup) / Pub/Sub EOS / Kafka EOS + client `ack` + idempotent client | **A + C** + dedup |
+   | cross-restart `at-least-once` | durable per-sub state available | **C** (durable consumer per subscription) under A or B |
+
+   When more than one mechanism qualifies (e.g. Kafka with both `ack` and `resume` clients), prefer the one with the lower router cost: B (≈O(1) router state) over A (per-in-flight state) over C/E (per-subscriber state). This preference is configurable per provider.
+
+5. **Fill in the rest of the `Decision`:** idempotency-key source (§8.2), replay window, ordering guarantee, and a human-readable `reason` string explaining any degradation (e.g. `"requested exactly-once, backend redis(pubsub) ceiling at-most-once: no durable position"`).
+
+6. **Report.** The `Decision` is emitted to the client (§5.3) and recorded on the span.
+
+Because every term is a `min` over a fixed partial order and the selection table is total,
+the algorithm is deterministic and explainable — for any subscription you can answer
+"why did I get this class?" by printing the four ceilings and the winning table row.
+
+### 3.5 Where the `at-most-once` fast path stays free
+
+If `achieved == at-most-once` (no directive, no capabilities, no config, or an at-most-once backend),
+the `Decision` carries `mechanism = FireAndForget` and the updater path is the *existing* void path
+(`subscription_event_updater.go:36-129`) with no sequence attachment, no ack channel, no buffer.
+The negotiation is a few comparisons at subscription start and nothing per event.
+This is the property that makes G safe to ship as on-by-default-but-inert.
+
+---
+
+## 4. (folded into §3) — design depth lives in §3; see §5 for the wire.
+
+---
+
+## 5. Wire protocol & client changes
+
+G adds the minimum to existing protocols. Three pieces: a capability handshake, a per-message id + resume token, and a reported-class field. Plus an out-of-band ack channel for one-directional transports.
+
+### 5.1 Capability handshake (connection scope)
+
+**graphql-ws / graphql-transport-ws.** The client adds a namespaced object to the `connection_init` payload (the payload is already free-form and ignored by stock servers, so this is backward compatible):
+
+```jsonc
+// client → server
+{ "type": "connection_init",
+  "payload": { "cosmo": { "delivery": { "supports": ["ack", "resume"] } } } }
+```
+
+The server replies in `connection_ack` with the subset it accepts (intersection of client capabilities and enabled router mechanisms):
+
+```jsonc
+// server → client
+{ "type": "connection_ack",
+  "payload": { "cosmo": { "delivery": { "accepted": ["resume"] } } } }
+```
+
+If the client sends no `cosmo.delivery` block, `negotiatedClientCapabilities = {}` and every subscription on the connection is capped at the no-client-participation rung (D if enabled, else at-most-once). This is the **stock-client fallback** and requires zero client changes.
+
+**graphql-sse.** SSE has no init frame; capabilities are advertised via a request header on the subscription request:
+
+```
+X-Cosmo-Delivery-Supports: resume
+```
+
+A browser using the native `EventSource` cannot set headers and cannot ack; it advertises nothing and relies purely on native `Last-Event-ID` resume (see §5.2) — which works *for free* once the server emits `id:`.
+
+### 5.2 Per-message id and resume token (subscription scope)
+
+**WS.** On `Subscribe`, the client may request a class and present a resume cursor:
+
+```jsonc
+{ "type": "subscribe", "id": "1",
+  "payload": { "query": "subscription { employeeUpdates { id } }" },
+  "extensions": { "delivery": { "request": "at-least-once", "resume": "<opaque-cursor>" } } }
+```
+
+Each `Next` carries the cursor as the message `id` extension so the client can store it and present it on reconnect:
+
+```jsonc
+{ "type": "next", "id": "1",
+  "payload": { "data": { "employeeUpdates": { "id": "100" } },
+               "extensions": { "delivery": { "id": "<opaque-cursor-n>" } } } }
+```
+
+**SSE.** The writer emits the cursor as the SSE `id:` field (today it emits only `event:`/`data:`, `flushwriter.go:116-167`):
+
+```
+id: <opaque-cursor-n>
+event: next
+data: {"data":{"employeeUpdates":{"id":"100"}}}
+```
+
+The browser stores it and sends `Last-Event-ID: <opaque-cursor-n>` automatically on auto-reconnect; the router treats that header exactly like the WS `resume` field. This is the cheapest at-least-once on the planet for SSE clients: emit `id:`, honor `Last-Event-ID`, replay, done.
+
+The cursor is **always opaque and signed** (§8.5): it encodes `(providerId, streamConfigHash, backendPosition, tenantClaimHash)` in a router-signed token. A client cannot forge a position to read data it is not entitled to; the router rejects a cursor whose signature or tenant scope does not match the reconnecting principal and replies with a `delivery.resumeRejected` error, restarting the subscription from live.
+
+### 5.3 Reported class (`extensions.delivery`)
+
+The first frame of every subscription (whether `Next #0` carries data or the router synthesizes an empty leading frame) reports the negotiated `Decision`:
+
+```jsonc
+"extensions": {
+  "delivery": {
+    "requested": "exactly-once",
+    "achieved":  "at-least-once",
+    "mechanism": "cursor",
+    "ordering":  "per-stream",
+    "replayWindow": "retention",
+    "idempotencyKey": "Nats-Msg-Id",
+    "reason": "requested exactly-once; backend nats(jetstream) without double-ack/dedup ceiling at-least-once"
+  }
+}
+```
+
+`requested != achieved` is the honesty contract made visible.
+The same object is attached to the OpenTelemetry span (`cosmo.delivery.achieved`, `cosmo.delivery.mechanism`, `cosmo.delivery.degraded=true`) and incremented on a Prometheus counter `router_delivery_negotiations_total{achieved,mechanism,degraded}` so operators can alert on silent-looking degradation.
+
+### 5.4 Out-of-band ack for one-directional transports
+
+SSE and multipart are write-only; an `ack`-class subscription on them cannot use an inline ack message. For these, G exposes a back-channel:
+
+```
+POST /graphql/ack
+Content-Type: application/json
+{ "subscription": "<server-issued-subscription-token>", "id": "<opaque-cursor-n>" }
+```
+
+The subscription token is minted at subscription start and returned in `extensions.delivery.ackEndpoint`/`extensions.delivery.ackToken`. The router maps it to the in-flight broker ack handle. This is only offered when the backend supports per-message ack (A) and the client advertised `ack`; otherwise SSE/multipart fall back to **resume-only** (B) which needs no back-channel. Most SSE deployments will use resume-only; the ack endpoint exists for SQS/RabbitMQ-over-SSE corner cases where there is no durable position to resume from.
+
+### 5.5 Fallback when a client/transport cannot participate
+
+This is the heart of the pattern, so it is explicit:
+
+| client/transport situation | what G does |
+|---|---|
+| stock graphql-ws client, no `cosmo.delivery` block | cap at D (if enabled) else at-most-once; report it |
+| client advertises `resume` only | select B on log backends; A is unavailable; report achieved |
+| client advertises `ack` only | select A on ack backends; on log backends, map ack→cursor-advance (still B-shaped); report it |
+| native browser `EventSource` (no headers, no ack) | resume-only via `Last-Event-ID`; works automatically once server emits `id:` |
+| multipart `subscriptionSpec=1.0` client | same as SSE: resume-only or at-most-once; no inline ack |
+| legacy `subscriptions-transport-ws` | no capabilities possible; at-most-once; report via `extensions` if the client surfaces them, else silent floor |
+| absinthe (Phoenix) | at-most-once unless extended; not a priority |
+
+In every row the rule is identical: **degrade to the strongest feasible class and report it.** The router never pretends.
+
+---
+
+## 6. Per-backend adaptability & degradation matrix
+
+This is the pattern's reason to exist: it lets a user **pick any backend** and get the strongest honest guarantee on it, with explicit, non-silent degradation. Columns: how G supports it, the best class achievable, and what the degradation/fallback is when the request exceeds it.
+
+| Backend | Supported? How | Best achievable class | Mechanism G selects | Degradation / fallback (non-silent) |
+|---|---|---|---|---|
+| **NATS core** | Yes (today, fire-and-forget) | `at-most-once` | FireAndForget; **E** if router buffer enabled | Request `at-least-once`/`exactly-once` → `reason: "nats(core) has no durable position or ack"`; with E enabled → `at-least-once`-within-buffer-window; else reported `at-most-once` |
+| **NATS JetStream** | Yes; durable pull consumer, `msg.Metadata()` cursor, double-ack + `Nats-Msg-Id` dedup | `exactly-once` (with double-ack + dedup + idempotent client) | **A** (ack) or **B** (stream-seq cursor); **C** for cross-restart; **A+C+dedup** for EOS | Without double-ack/dedup → caps at `at-least-once`; without durable name fix (`nats/adapter.go:69-83`) cross-restart caps at in-instance only; all reported |
+| **Kafka** | Yes; surface `(partition,offset)` cursor; `seek`/`offsetsForTimes` | `at-least-once` | **B** (cursor) | No per-message ack → A unavailable, ack maps to in-order cursor-advance; cursor evicted by `offsets.retention.minutes` (7d) or `retention.ms` → `reason: "cursor expired"`, restart from live; EOS only with read-committed (LSO stall risk surfaced) |
+| **Redis Pub/Sub** | Yes (today, fire-and-forget) | `at-most-once` | FireAndForget; **E** if router buffer enabled | Same as NATS core: no durable position/ack. Request higher → reported degrade; recommend migrating to Redis Streams |
+| **Redis Streams** | Requires a Streams adapter (not the current Pub/Sub one) | `at-least-once` | **A** (PEL + `XACK`/`XCLAIM`) or **B** (entry-id cursor) | Entry trimmed by `MAXLEN`/`MINID` → cursor expired, restart from live; no native dedup → client must be idempotent |
+| **SQS (Standard)** | Requires an SQS adapter | `at-least-once` (with dupes) | **A** (visibility timeout + `DeleteMessage`) or **E** | No cursor → B unavailable; resume-only clients get **E** (router buffer) or at-most-once; dupes inherent → idempotent client required |
+| **SQS (FIFO)** | Requires an SQS adapter | `exactly-once`-processing | **A** + native 5-min dedup | No cursor → B unavailable; replay beyond visibility window not possible |
+| **Google Pub/Sub** | Requires a Pub/Sub adapter | `exactly-once` (EOS subscription) or `at-least-once` | **A** (`ack`/`modifyAckDeadline`) or **B** (snapshot/seek-by-time) | Without EOS subscription → `at-least-once`; snapshot retention 7d / message retention 31d bound replay |
+| **Kinesis** | Requires a Kinesis adapter | `at-least-once` | **B** (shard iterator + sequence number, KCL/external checkpoint) | Iterator expires 5 min → re-derive from sequence; retention 24h→7d→365d bounds replay; no native dedup |
+| **Event Hubs** | Requires an Event Hubs adapter | `at-least-once` | **B** (offset + sequence, external checkpoint store) | Checkpoint store is external (HA dependency); retention 7d (std) / 90d (premium) bounds replay; no native dedup |
+| **RabbitMQ / AMQP** | Requires an AMQP adapter | `at-least-once` | **A** (`basic.ack`/`nack`, requeue) | No durable position → B unavailable; requeue breaks FIFO → `ordering: best-effort`; no replay beyond unacked |
+
+Two structural facts drive every row (from the dossier):
+
+- **Delete-on-ack queues** (SQS, RabbitMQ, NATS core) have **no cursor** → B is impossible; they get A (if the client can ack) or E (router buffer) or honest at-most-once.
+- **Log/cursor stores** (Kafka, Redis Streams, Kinesis, Event Hubs, JetStream, Pub/Sub) have a position primitive → B is the cheap default; A/C layer on for stronger guarantees.
+
+The non-EDFS backends (SQS, Pub/Sub, Kinesis, Event Hubs, RabbitMQ, Redis Streams) are **listed for completeness of the policy table** — G can route to them the day their adapters exist; until then `adapter.Capabilities()` simply does not register them and `backendCeiling` is "unsupported," which G reports as a config error at startup rather than a silent runtime surprise.
+
+---
+
+## 7. Delivery semantics achieved
+
+Pattern G's own guarantee is **honesty**: the achieved class is always `≤ requested`, always correct, and always reported. The concrete semantics are inherited from the selected mechanism:
+
+- **`at-most-once` (FireAndForget).**
+  Exactly today's behavior. No duplicates, no replay. Loss windows: client disconnect, slow-consumer drop (NATS core unbuffered channel `nats/adapter.go:168`, Redis Pub/Sub overflow), router restart, broker gap. This is the honest floor, not a failure.
+
+- **`at-least-once` via D (correct broker ack).**
+  Closes the §2 bugs (ack-on-failure, fan-out-all-acked, abandon-but-acked) by acking only on flush success.
+  **Ceiling: flush ≠ receipt** — bytes-to-kernel, not client-processed. A client crashing between TCP-buffer and processing still loses that event (and it is *not* acked, so a durable backend redelivers on reconnect — which is the point). No client change needed.
+
+- **`at-least-once` via B (cursor replay).**
+  At-least-once across disconnect gaps **within the backend replay window**. Duplicates on reconnect (the event in flight when the socket dropped is replayed) → **client must be idempotent**. Ordering: per-stream/per-partition (the cursor *is* the order; gaps are contiguous). Remaining failure window: gap longer than retention → `cursor expired` → restart from live (events in the gap are lost, reported).
+
+- **`at-least-once` via A (client ack + broker redelivery).**
+  True at-least-once to client *receipt* (the client acked it). Duplicates on redelivery → idempotent client required. Ordering: preserved only with `MaxAckPending=1` (throughput cost) or in-order ack processing; otherwise reordering on redelivery (RabbitMQ requeue is worst — reinserts near head). Remaining window: router restart loses in-flight unacked-to-client ack handles unless the backend redelivers (JetStream/SQS/Rabbit do; Kafka-by-offset does not per-message).
+
+- **`at-least-once` via E (router buffer).**
+  At-least-once for disconnects **shorter than the buffer window**; beyond it → at-most-once (reported). The only option that gives *any* guarantee on NATS core / Redis Pub/Sub / SQS-standard. In-process buffer is lost on router restart unless an external buffer store is configured. Ordering: router-assigned, preserved within the buffer.
+
+- **`exactly-once`.**
+  Only a *composition*: publisher dedup (`Nats-Msg-Id` / Kafka idempotent producer) + confirmed consumer ack (JetStream double-ack / Pub/Sub EOS / store-cursor-with-data) + client ack (A) + idempotent client.
+  G will report `exactly-once` only when every link is present; otherwise it reports `at-least-once` with a `reason`. Realistically, **at-least-once + idempotent client = effective exactly-once**, and G says so in the `reason` when it cannot prove true broker EOS. Read-committed consumption can stall the cursor at the LSO on an open upstream transaction — a head-of-line failure mode G surfaces as a metric, not a hang.
+
+**Cross-cutting semantic note (ordering vs at-least-once).**
+These conflict on every backend. Redelivery (Nak, AckWait, requeue) can reorder. G never claims global ordering; `Decision.ordering` is one of `per-stream`, `per-partition`, `per-group`, or `best-effort`, and it is reported. If a subscriber needs strict order *and* at-least-once, the only honest answer on most backends is `MaxAckPending=1` (B/C with single in-flight), which G will select only when the field is annotated `ordering: STRICT` — and it will report the throughput implication.
+
+---
+
+## 8. Cross-cutting concerns
+
+### 8.1 Router HA / horizontal scaling & sticky sessions
+
+This is the single biggest design axis, and G's honesty contract makes it *visible* rather than fixing it:
+
+- **B (cursor)** needs reconnect **stickiness** to a replica/partition holding the position, *or* a shared external cursor view. The cursor is backend-scoped, so any replica that can `seek` the backend can resume — B is the most HA-friendly because durability lives in the broker. `routerCeiling` for B is `at-least-once` even across instances *if* the backend is seekable from any replica (Kafka, JetStream by stream-seq).
+- **A (client ack)** holds ack handles per-process. A router restart loses unacked-to-client handles unless the backend redelivers. `routerCeiling` for A is therefore "as good as the backend's redelivery," and G caps it accordingly.
+- **C (durable per-sub)** needs the durable consumer name keyed on the *subscription* identity, not the router instance — the current JetStream naming (`hostname-listenAddr` hash, `nats/adapter.go:69-83`) must be fixed, and then coordinated (queue group / `WorkQueuePolicy` / Kafka static membership) so two instances don't double-consume. G will only offer C's cross-restart guarantee when the HA topology declares it can satisfy this (`events.delivery.ha.durableState: true` in config); otherwise it degrades and reports.
+
+The negotiator takes `haTopology` as an input precisely so the `routerCeiling` reflects reality. A single-instance dev router and a 5-replica HA deployment will *honestly* report different achieved classes for the same subscription.
+
+### 8.2 Per-subscription state / memory cost
+
+G itself adds ~O(1) per subscription (the `Decision` struct, a few pointers). The cost is whatever the selected mechanism carries:
+
+- B: ≈O(1) router (durability in broker) — cheapest.
+- A: O(in-flight per client) ack handles + a map, capped by `MaxAckPending`.
+- E: O(window × subscribers) RAM — the explicit tunable knob.
+- C: O(active subscriptions) broker consumers + external checkpoint store — most expensive, and it **breaks shared-trigger dedup** (§8.3).
+
+The negotiator's cost-preference tie-break (§3.4 step 4) exists so G defaults to the cheapest mechanism that meets the class.
+
+### 8.3 Multi-tenant shared-trigger fan-out
+
+Cosmo shares one broker subscription per unique input+headers hash across N clients (`kafka/adapter.go:124-125`, the engine dedups identical triggers).
+This is the central tension:
+
+- **B and E preserve sharing well.** B is stateless per client (each client carries its own cursor; the *shared* broker read continues; a reconnecting client replays from its own cursor against the same shared stream — or a short-lived per-client seek). E's buffer is per-trigger and fanned out.
+- **A and C fight sharing.** Per-subscriber ack (A) means one broker message has N heterogeneous client outcomes; the single `msg.Ack()` can't represent "3 of 5 acked." C needs a consumer per subscription → N broker consumers, killing dedup.
+
+G's policy: when `achieved` selects A or C on a *shared* trigger, the negotiator must decide between two honest options, controlled by config:
+(a) **split the trigger** into per-subscriber consumption (correct, expensive — `events.delivery.fanout: isolate`), or
+(b) **ack-on-slowest** / **ack-on-quorum** within the shared trigger (cheap, couples subscribers — Pattern D's policy) and report `ordering`/`mechanism` accordingly.
+The chosen fan-out policy is reflected in `Decision` and reported. There is no silent third option.
+
+### 8.4 Backpressure
+
+Today backpressure is synchronous and per-trigger-serial (the broker reader blocks until all subscribers flush). G keeps this for at-most-once and D. For A/E it adds explicit caps (`MaxAckPending`, buffer size) that become the memory/guarantee knob. A slow client either backpressures the shared trigger (penalizing co-subscribers) or is isolated (C, at consumer-count cost) — the negotiator's fan-out policy (§8.3) decides which, and reports it. The per-update timeout (`MaxSubscriptionFetchTimeout`, 30s, `config.go:454`) and write deadlines remain the liveness guards.
+
+### 8.5 Security / authz
+
+- **Cursors/resume tokens are opaque, signed, and tenant-scoped.** A raw `(partition, offset)` or stream-seq would let a client seek to data it shouldn't see, especially with replay. The cursor embeds a tenant-claim hash; on reconnect the router verifies the reconnecting principal's claims hash against the cursor and rejects mismatches (`delivery.resumeRejected`).
+- **Replay re-runs authz per event.** Replayed events pass through the *same* authorization as live delivery — and critically, with the **current** authorization, not the authorization at original publish time. A revoked tenant/user must not receive replayed history. This is enforced by running replay through the existing Cosmo Streams `StreamBatchEventHook` / `OnStreamEvents` path (which is where filtering/authz already lives, `cosmo-streams-v1.md`) for every replayed batch, exactly as for live batches.
+- **Ack endpoint authz.** The out-of-band `POST /graphql/ack` (§5.4) requires the server-issued subscription token, which is bound to the connection's authentication; a stolen token cannot ack another tenant's subscription.
+
+### 8.6 Interaction with existing Cosmo Streams hooks
+
+G is designed to *thread through* v1 hooks, not bypass them:
+
+- **`SubscriptionOnStart`** is the natural override point: a module can inspect `ctx.Delivery()` (new accessor exposing the `Decision`) and *lower* the requested class for a given principal (e.g. force `at-most-once` for an untrusted client) — it must not be able to raise above the computed ceilings (that would be dishonest).
+- **`StreamBatchEventHook` / `OnStreamEvents`** is where idempotency keys are assigned/validated and where replayed batches are re-authorized. A hook that **drops** an event (returns a shorter slice) must result in a correct broker ack — drop ≠ delivery failure. G makes this explicit: the `DeliveryOutcome` distinguishes `Dropped` (ack/commit — intentional filter) from `Failed` (nak/redeliver — transient). This reconciles the §2.1 "abandon-on-timeout" hazard: a hook-dropped event is *acked*, a hook-errored or flush-failed event is *redelivered*.
+- **`StreamPublishEventHook`** is unaffected, but G suggests an *idempotent ingest* companion (publish with `Nats-Msg-Id` / Kafka idempotent producer) so the publish side can also be at-least-once — currently publish errors are swallowed (`redis/engine_datasource.go:205-209`). That is a separate publish-durability concern noted here for completeness.
+
+---
+
+## 9. Configuration surface
+
+### 9.1 Router YAML — new `events.delivery` block
+
+```yaml
+version: "1"
+
+events:
+  # NEW: global delivery policy. Absent → behaves exactly as today (at-most-once everywhere).
+  delivery:
+    enabled: true
+    default_class: at-most-once        # requested class when neither directive nor handshake sets one
+    enabled_mechanisms: [ack, cursor, buffer, durable]   # which of A/B/E/C are compiled in & allowed
+    report_extensions: true            # emit extensions.delivery to clients
+    fanout: ack-on-slowest             # ack-on-slowest | ack-on-quorum | isolate (see §8.3)
+    ack:
+      window: 30s                      # client-ack timeout before nak/redeliver (Pattern A)
+      max_ack_pending: 1024            # backpressure cap; 1 => strict ordering, low throughput
+    buffer:                            # Pattern E
+      window: 30s
+      max_events_per_trigger: 1000
+      store: memory                    # memory | redis://... (external => survives restart)
+    ha:
+      durable_state: false             # true only if durable consumer/checkpoint coordination is configured (enables C cross-restart)
+
+  providers:
+    nats:
+      - id: my-jetstream
+        url: "nats://localhost:4222"
+        # NEW: per-provider cap & JetStream durability knobs
+        delivery:
+          max_class: exactly-once      # ceiling for this provider; negotiator never exceeds it
+          jetstream:
+            ack_policy: explicit
+            ack_wait: 30s
+            max_deliver: -1
+            double_ack: true           # required to reach exactly-once
+            dedup_window: 2m           # Nats-Msg-Id duplicate window
+    kafka:
+      - id: my-kafka
+        brokers: ["localhost:9092"]
+        delivery:
+          max_class: at-least-once     # log store; B
+          group_instance_id_prefix: cosmo-router   # static membership for stable cursors under churn
+    redis:
+      - id: my-redis
+        urls: ["redis://localhost:6379"]
+        delivery:
+          max_class: at-most-once      # Pub/Sub; raise only after a Streams adapter exists
+```
+
+Validation at startup: if `default_class` or any field directive exceeds a provider's `max_class` and no degradation path exists, the router logs a warning per field (not an error — degradation is allowed and is the whole point), unless `events.delivery.strict: true`, in which case the router refuses to start so misconfiguration is caught loudly.
+
+### 9.2 Schema directive (optional, composition + proto)
+
+A new directive lets the schema owner author a *requested* class per subscription field:
+
+```graphql
+directive @edfs__delivery(
+  class: edfs__DeliveryClass! = AT_LEAST_ONCE
+  ordering: edfs__Ordering = BEST_EFFORT
+) on FIELD_DEFINITION
+
+enum edfs__DeliveryClass { AT_MOST_ONCE AT_LEAST_ONCE EXACTLY_ONCE }
+enum edfs__Ordering { BEST_EFFORT STRICT }
+
+type Subscription {
+  employeeUpdates: Employee!
+    @edfs__natsSubscribe(subjects: ["employeeUpdates"], providerId: "my-jetstream")
+    @edfs__delivery(class: EXACTLY_ONCE, ordering: STRICT)
+}
+```
+
+Composition parses `@edfs__delivery` alongside the existing `@edfs__*` directives (`composition/src/v1/normalization/normalization-factory.ts:2804-3169`) and serializes the requested class + ordering into `DataSourceCustomEvents` (`proto/wg/cosmo/node/v1/node.proto:430-434`), so the per-field request travels in the execution config. The directive is optional; without it the request comes from config default and/or the client handshake.
+
+---
+
+## 10. Migration & backward compatibility
+
+- **Default off / inert.**
+  With no `events.delivery` block, no `@edfs__delivery` directive, and no client capability handshake, every subscription negotiates to `at-most-once` / `FireAndForget` and the code path is byte-for-byte today's. No behavior change, no overhead beyond a few comparisons at subscription start.
+- **Server-first rollout.**
+  Ship the negotiator + reporting first (it can report `at-most-once` honestly before any of A–F land). Operators immediately gain `extensions.delivery` visibility and the `router_delivery_negotiations_total` metric — they learn what they *would* get if mechanisms were enabled.
+- **Incremental mechanism enablement.**
+  As each underlying pattern ships (the dossier's suggested order: D → B → A → C/E), add it to `enabled_mechanisms`. The negotiator automatically starts selecting it where feasible. No client change is forced — a stock client simply stays on the no-participation rung.
+- **Client adoption is opt-in and gradual.**
+  A client that adds `supports:[resume]` immediately gets B on log backends; one that adds `supports:[ack]` gets A on ack backends. Clients that never change keep working at the honest floor.
+- **Directive adoption is additive.**
+  `@edfs__delivery` is a new optional directive; existing schemas compose unchanged. Adding it raises the *requested* ceiling for a field but never breaks composition.
+- **Strict mode for safety-critical deployments.**
+  `events.delivery.strict: true` flips degradation from "warn and proceed" to "refuse to start," for shops that would rather fail closed than silently run at a lower class.
+
+---
+
+## 11. Appendix: new/changed Go types
+
+```go
+// Package router/pkg/pubsub/delivery
+
+// DeliveryClass is a totally ordered guarantee level.
+// AtMostOnce < AtLeastOnce < ExactlyOnce.
+type DeliveryClass uint8
+
+const (
+    AtMostOnce DeliveryClass = iota
+    AtLeastOnce
+    ExactlyOnce
+)
+
+func (c DeliveryClass) String() string { /* "at-most-once" | ... */ return "" }
+
+// Min returns the weaker of two classes (the partial-order meet).
+func Min(a, b DeliveryClass) DeliveryClass { if a < b { return a }; return b }
+
+// Mechanism is the concrete pattern selected to realize a class on a backend.
+type Mechanism uint8
+
+const (
+    FireAndForget Mechanism = iota // today's path (Pattern none / D-off)
+    BrokerAck                      // Pattern D: ack on flush success
+    ClientAck                      // Pattern A: client ack + broker redelivery
+    Cursor                         // Pattern B: cursor replay on reconnect
+    DurableConsumer               // Pattern C: per-subscription durable state
+    RouterBuffer                  // Pattern E: bounded router-side replay buffer
+)
+
+// Ordering is the order guarantee G will report (never global).
+type Ordering uint8
+
+const (
+    BestEffort Ordering = iota
+    PerStream
+    PerPartition
+    PerGroup
+    Strict // only with single in-flight; throughput cost
+)
+
+// Capabilities is what a provider adapter can offer for a resolved stream config.
+// Each adapter implements Capabilities(); the registry aggregates them.
+type Capabilities struct {
+    MaxClass          DeliveryClass     // ceiling this backend+config can reach
+    HasCursor         bool              // log/cursor store => Pattern B feasible
+    HasPerMessageAck  bool              // ack/redelivery queue => Pattern A feasible
+    HasNativeDedup    bool              // SQS FIFO, Pub/Sub EOS, JetStream Nats-Msg-Id
+    DurablePerSub     bool              // can host a durable consumer per subscription (C)
+    ReplayWindow      ReplayWindow      // retention-bound | none | buffer
+    IdempotencyKey    IdempotencyKeySource // where the dedup key comes from
+    DefaultOrdering   Ordering
+}
+
+type IdempotencyKeySource uint8
+
+const (
+    KeyNone IdempotencyKeySource = iota
+    KeyNatsMsgID      // Nats-Msg-Id header
+    KeyKafkaKey       // record key
+    KeyEntryID        // Redis Streams entry id
+    KeyContentHash    // fallback: hash of payload
+)
+
+type ReplayWindow struct {
+    Kind  string        // "retention" | "buffer" | "none"
+    Bound time.Duration // best-effort bound for reporting (0 = unbounded/unknown)
+}
+
+// CapabilityProvider is implemented by each pubsub adapter (nats, kafka, redis, …).
+// It is the only new method adapters must add for G to route to them.
+type CapabilityProvider interface {
+    // Capabilities reports what this adapter can guarantee for the given resolved
+    // stream configuration (e.g. JetStream-backed subject vs core NATS subject).
+    Capabilities(cfg datasource.SubscriptionEventConfiguration) Capabilities
+}
+
+// Request is the full input to negotiation, assembled at subscription start.
+type Request struct {
+    Requested   DeliveryClass     // min(field directive, Subscribe.request, config default)
+    OrderingReq Ordering          // from @edfs__delivery(ordering:)
+    Client      ClientCapabilities
+    Transport   Transport         // WS | SSE | Multipart
+    Backend     Capabilities
+    Router      RouterCapabilities
+}
+
+type ClientCapabilities struct {
+    Ack    bool // advertised supports:[ack]
+    Resume bool // advertised supports:[resume]
+}
+
+type Transport uint8
+
+const (
+    TransportWS Transport = iota
+    TransportSSE
+    TransportMultipart
+)
+
+// RouterCapabilities reflects which mechanisms are enabled AND whether the HA
+// topology can satisfy the state a mechanism needs.
+type RouterCapabilities struct {
+    Enabled       map[Mechanism]bool
+    DurableState  bool          // events.delivery.ha.durable_state (enables C cross-restart)
+    BufferStore   string        // "" | "memory" | external => E restart-survival
+    Fanout        FanoutPolicy
+}
+
+type FanoutPolicy uint8
+
+const (
+    AckOnSlowest FanoutPolicy = iota
+    AckOnQuorum
+    Isolate // split shared trigger into per-subscriber consumption (breaks dedup)
+)
+
+// Decision is the negotiated outcome, carried for the life of the subscription
+// and reported to the client via extensions.delivery.
+type Decision struct {
+    Requested      DeliveryClass
+    Achieved       DeliveryClass // <= Requested, always
+    Mechanism      Mechanism
+    Ordering       Ordering
+    IdempotencyKey IdempotencyKeySource
+    ReplayWindow   ReplayWindow
+    Fanout         FanoutPolicy
+    Degraded       bool   // Achieved < Requested
+    Reason         string // human-readable explanation of any degradation
+}
+
+// Negotiator is a pure function: same input => same Decision. No I/O.
+type Negotiator interface {
+    Negotiate(req Request) Decision
+}
+
+// --- Substrate contract changes (Pattern D), required for any class > at-most-once ---
+
+// DeliveryOutcome is returned per delivered event/subscriber so the adapter can
+// ack/commit correctly. Distinguishes intentional drop (ack) from failure (redeliver).
+type DeliveryOutcome uint8
+
+const (
+    Delivered DeliveryOutcome = iota // flushed successfully => ack/commit/XACK
+    Dropped                          // hook filtered it out  => ack/commit (NOT a failure)
+    Failed                           // flush/resolve failed  => nak/redeliver
+)
+
+// SubscriptionEventUpdater changes from fire-and-forget to outcome-returning.
+// When Decision.Mechanism == FireAndForget the return is ignored and the path
+// is identical to today (zero overhead).
+//
+// CHANGED from: Update(events []datasource.StreamEvent)
+type SubscriptionEventUpdater interface {
+    UpdateWithDecision(
+        events []datasource.StreamEvent,
+        d Decision,
+    ) []DeliveryOutcome // one per event; len == len(events)
+
+    // Confirm is invoked by the transport when a client ack arrives (Pattern A)
+    // or when a cursor is durably advanced (Pattern B/C).
+    Confirm(cursor Cursor) error
+}
+
+// Cursor is the opaque, signed, tenant-scoped resume token on the wire.
+type Cursor struct {
+    ProviderID      string
+    StreamConfigHash string
+    Position        []byte // backend-specific: stream-seq | (partition,offset) | entry-id | …
+    TenantClaimHash string // bound to the principal; verified on resume
+    Sig             []byte // router HMAC over the above
+}
+
+func (c Cursor) Encode() string { /* base64url(signed) */ return "" }
+func DecodeCursor(s string, key []byte) (Cursor, error) { return Cursor{}, nil }
+```
+
+```go
+// Package router/core — hook accessor so v1 modules can read/lower the Decision.
+
+// Added to SubscriptionOnStartHookContext (v1).
+type SubscriptionOnStartHookContext interface {
+    RequestContext() RequestContext
+    SubscriptionEventConfiguration() SubscriptionEventConfiguration
+    WriteEvent(event StreamEvent)
+
+    // NEW: read the negotiated decision; LowerDelivery may only weaken it.
+    Delivery() delivery.Decision
+    LowerDelivery(to delivery.DeliveryClass) // ignored if `to` >= achieved
+}
+```
+
+```go
+// Engine contract delta (graphql-go-tools resolve), conditional on class > at-most-once.
+//
+// CHANGED: Update must surface a result and attach a cursor/sequence to each Next.
+// If the engine version in a release cannot provide this, the router caps
+// routerCeiling at at-most-once and reports it (honesty preserved).
+type SubscriptionUpdater interface {
+    Update(data []byte) // existing, at-most-once path
+
+    // NEW (optional capability, feature-detected at startup):
+    UpdateSeq(data []byte, cursor delivery.Cursor) delivery.DeliveryOutcome
+}
+```
+
+---
+
+## 12. Risks, open questions, and complexity/effort estimate
+
+### Where this pattern is weakest (honest self-assessment)
+
+1. **It is only as good as the patterns beneath it.**
+   G adds no durability of its own. If D/B/A/E/C are not shipped, G is a very elaborate way to report `at-most-once`. Its value is *entirely* derivative — it is the meta-pattern, not a mechanism. Compared to B (which directly buys at-least-once on log backends with minimal state) or D (which fixes the actual ack bugs with no client change), G ships *no guarantee on its own*. **This is its single biggest weakness:** it cannot be the first thing built, and on its own it changes nothing about delivery.
+
+2. **The negotiation matrix is a comprehension and support burden.**
+   "What do I actually get?" becomes a function of five inputs (requested, backend, client, transport, router HA). Even with `extensions.delivery.reason`, customers will be surprised by degradations, and support will field "why is this at-most-once?" tickets. The matrix in §6 must be documented exhaustively and the `reason` strings must be excellent, or the honesty becomes noise.
+
+3. **Reporting honesty depends on every mechanism reporting honestly.**
+   A bug in B's "cursor expired" detection, or in A's "router restart lost the handle" accounting, makes G *confidently report a guarantee it isn't meeting* — which is worse than today's silent at-most-once, because customers will trust the label. G's correctness is the union of all its mechanisms' correctness.
+
+4. **Shared-trigger fan-out forces an uncomfortable choice (§8.3).**
+   For A/C on a shared trigger, G must either split the trigger (expensive, kills dedup) or couple subscribers (ack-on-slowest). Neither is great; G just makes the choice explicit and configurable. It does not dissolve the tension.
+
+5. **HA-dependent ceilings are hard to compute correctly.**
+   `routerCeiling` must reflect whether the *deployment* can satisfy a mechanism's state needs. Getting this wrong in either direction is bad: too optimistic → dishonest report; too pessimistic → needless degradation. This requires the deployment to declare its topology truthfully (`events.delivery.ha.*`), which is itself error-prone.
+
+### Open questions
+
+- **Precedence semantics.** §3.4 takes `min(directive, handshake, config)`. Is "schema author sets a floor, client states capability, achieved = intersection" the right mental model, or should a field directive be a *hard* requirement that *fails* the subscription if unmet (fail-closed per field) rather than degrading? Probably configurable per field (`@edfs__delivery(class:, required: true)`), but that adds matrix surface.
+- **Should `at-most-once` ever auto-upgrade?** If a backend+client *could* do at-least-once for free (e.g. SSE client + Kafka, just emit `id:`), should G silently give the stronger guarantee, or only when requested? Leaning: report the *capability* but only *activate* the stronger mechanism when requested, to keep behavior predictable and costs opt-in.
+- **Cursor format stability across router versions.** A signed cursor minted by v1 must be decodable by v2 (rolling deploys). Needs a version byte and a key-rotation story.
+- **Per-event vs per-batch outcomes with v1 hooks.** `OnStreamEvents` operates on batches and may grow/shrink/reorder; mapping `[]DeliveryOutcome` back to original broker messages after a hook reshapes the batch needs a stable per-source-message identity (the idempotency key) — confirm this round-trips for all providers.
+- **Multipart and the ack back-channel.** Is the out-of-band `POST /graphql/ack` worth building, or should multipart/SSE be resume-only forever (and ack-class simply unavailable on them)? Leaning resume-only; build the ack endpoint only if an ack-only backend (SQS) + SSE combo is a real customer need.
+
+### Complexity / effort estimate
+
+**Overall: L** — a thin policy layer, but it sits atop and must integrate with every one of A–F, and its honesty contract demands rigorous per-mechanism reporting.
+
+| Component | Effort | Notes |
+|---|---|---|
+| `delivery` package: `Negotiator`, `Decision`, registry | S | Pure functions; heavily unit-testable (the selection table is the spec). |
+| Adapter `Capabilities()` for nats/kafka/redis | S–M | Mostly declarative; the logic is "what does this resolved config support." |
+| Capability handshake in `connection_init` + `wsproto` ack/resume + SSE `id:`/`Last-Event-ID` | M | Wire changes; backward-compatible by construction (free-form payload). |
+| `extensions.delivery` reporting + OTel + Prometheus | S | High value, low cost; ship first. |
+| Threading `Decision` through `SubscriptionEventUpdater` + engine `UpdateSeq` | M–L | Depends on the engine change landing; feature-detected fallback if not. |
+| Signed cursor mint/verify + tenant scoping + key rotation | M | Security-sensitive; needs careful review. |
+| Shared-trigger fanout policy (ack-on-slowest/quorum/isolate) | M | Couples with Pattern D/C decisions. |
+| Strict-mode startup validation + docs of the full matrix | M | The matrix docs are real work and gate adoption. |
+| **Underlying mechanisms A/B/C/D/E** | *(separate RFCs)* | **Not counted here** — G's L assumes these exist; without them G is L-of-reporting only. |
+
+**Recommended sequencing (matches the dossier):**
+ship the negotiator + reporting against an at-most-once-only world first (instant observability win),
+then enable mechanisms as their RFCs land — **D** (correctness, no client change) → **B** (cursor, emit `id:`) → **A** (client ack) → **C/E** (backend reinforcements).
+G is the product framing that ties them together; it should be *designed* now and *fully valuable* last.


### PR DESCRIPTION
## Summary

Adds an RFC bundle exploring how to bring **end-to-end at-least-once delivery** to GraphQL Subscriptions built on Cosmo's EDFS / Cosmo Streams.

The problem: an application may already have at-least-once in its event-driven backend (Kafka offsets, NATS JetStream durable consumers), but the moment a GraphQL Subscription is layered on top via EDFS, that guarantee is lost — the router consumes the event and pushes it to the client fire-and-forget, so a client disconnect, router restart, or slow consumer silently drops events.

This is a **docs-only** change (no code). It captures the investigation, seven competing designs, independent review, and a recommended direction for discussion.

## What's included (`rfc/at-least-once/`)

- **`README.md`** — entry point / index.
- **`CONCLUSION.md`** — the decision write-up: combined scorecard, recommended pick, independent pick, the reconciliation, and the final layered sequence with honest per-piece guarantees. **Start here.**
- **`00-research-dossier.md`** — grounded research: current EDFS data path with `file:line` anchors, where the guarantee is lost, and a per-backend capability matrix (NATS core/JetStream, Kafka, Redis Pub/Sub vs Streams, SQS, Google Pub/Sub, Kinesis, Event Hubs, RabbitMQ).
- **`rfc-A … rfc-G`** — seven competing RFCs, each authored, adversarially critiqued, and revised.
- **`codex/`** — independent review of each RFC plus the independent pick and discussion.

## Recommended direction (from `CONCLUSION.md`)

The seven approaches collapse into one layered architecture rather than seven alternatives:

- **Foundation — D (server-only):** fix broker ack timing via a per-subscriber delivery-result back-channel; ack/commit only after a successful flush. No client changes. Boundary: socket-write.
- **Flagship — B (cursor/resume):** opaque per-event cursor; on reconnect the client resumes and the router replays the gap then goes live. Leans on the broker's retained log instead of making the router a database.
- **B + batched cursor-ack:** client advances a high-water mark only after processing → reaches the client-processed boundary on log backends, cheaply.
- **Thin delivery-class core (ships with D+B):** `required_` vs `preferred_` delivery class + an honest `extensions.delivery { class, boundary, mechanism, degraded_reason }` so picking a weaker backend degrades explicitly, never silently.
- **A** (per-message client ack) is a selective premium add-on (delete-on-ack queues like SQS/RabbitMQ); **G** (tiered negotiation) comes last; **C/E/F** are folded in as components (durable checkpoint substrate / degraded replay window / SDK state-convergence).
- One coordinated `graphql-go-tools` engine change serves both D and B — paid once.

## Notes

- Draft, for review/discussion — not an accepted decision.
- Doc-only; no runtime/engine changes in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added research dossier and architectural decision documents outlining patterns for implementing at-least-once message delivery for GraphQL subscriptions, including cursor-based replay on reconnect, client acknowledgment protocols, durable checkpoints, and capability negotiation mechanisms across different message broker backends.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wundergraph/cosmo/pull/2904?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->