### PR TITLE
Rollforward/router 0.321.0

### DIFF
--- a/router/pkg/config/config.go
+++ b/router/pkg/config/config.go
@@ -707,6 +707,7 @@ type NatsEventSource struct {
 	Authentication                   *NatsAuthentication   `yaml:"authentication,omitempty"`
 	TLS                              *NatsTLSConfiguration `yaml:"tls,omitempty"`
 	DeleteDurableConsumersOnShutdown bool                  `yaml:"experiment_delete_durable_consumers_on_shutdown"`
+	SubscriptionBufferSize           int                   `yaml:"subscription_buffer_size,omitempty" envDefault:"1024"`
 }
 
 func (n NatsEventSource) GetID() string {

--- a/router/pkg/config/config.schema.json
+++ b/router/pkg/config/config.schema.json
@@ -2975,6 +2975,12 @@
                     "type": "boolean",
                     "description": "When enabled, all durable JetStream consumers created by this provider are deleted when the router shuts down normally. Defaults to false. NOTE: This option is experimental and may change in future versions.",
                     "default": false
+                  },
+                  "subscription_buffer_size": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 1024,
+                    "description": "Per-subscription channel buffer size (number of *nats.Msg). Increase to mitigate NATS slow-consumer drops on bursty subjects. 0 or omitted falls back to 1024."
                   }
                 }
               }

--- a/router/pkg/pubsub/nats/adapter.go
+++ b/router/pkg/pubsub/nats/adapter.go
@@ -165,7 +165,7 @@ func (p *ProviderAdapter) Subscribe(ctx context.Context, cfg datasource.Subscrip
 		return nil
 	}
 
-	msgChan := make(chan *nats.Msg)
+	msgChan := make(chan *nats.Msg, 1024)
 	subscriptions := make([]*nats.Subscription, len(subConf.Subjects))
 	for i, subject := range subConf.Subjects {
 		subscription, err := p.client.ChanSubscribe(subject, msgChan)

--- a/router/pkg/pubsub/nats/adapter.go
+++ b/router/pkg/pubsub/nats/adapter.go
@@ -22,6 +22,8 @@ const (
 	natsReceive = "receive"
 )
 
+const defaultSubscriptionBufferSize = 1024
+
 // Adapter defines the methods that a NATS adapter should implement
 type Adapter interface {
 	datasource.Adapter
@@ -49,9 +51,10 @@ type ProviderAdapter struct {
 	routerListenAddr  string
 	url               string
 	opts              []nats.Option
-	flushTimeout      time.Duration
-	streamMetricStore metric.StreamMetricStore
-	consumerConfig    consumerConfig
+	flushTimeout           time.Duration
+	streamMetricStore      metric.StreamMetricStore
+	consumerConfig         consumerConfig
+	subscriptionBufferSize int
 }
 
 // getInstanceIdentifier returns an identifier for the current instance.
@@ -165,7 +168,7 @@ func (p *ProviderAdapter) Subscribe(ctx context.Context, cfg datasource.Subscrip
 		return nil
 	}
 
-	msgChan := make(chan *nats.Msg, 1024)
+	msgChan := make(chan *nats.Msg, p.subscriptionBufferSize)
 	subscriptions := make([]*nats.Subscription, len(subConf.Subjects))
 	for i, subject := range subConf.Subjects {
 		subscription, err := p.client.ChanSubscribe(subject, msgChan)
@@ -473,7 +476,7 @@ func (p *ProviderAdapter) deleteDurableConsumers(ctx context.Context) {
 	})
 }
 
-func NewAdapter(ctx context.Context, logger *zap.Logger, url string, opts []nats.Option, hostName string, routerListenAddr string, deleteConsumersOnShutdown bool, providerOpts datasource.ProviderOpts) (Adapter, error) {
+func NewAdapter(ctx context.Context, logger *zap.Logger, url string, opts []nats.Option, hostName string, routerListenAddr string, deleteConsumersOnShutdown bool, subscriptionBufferSize int, providerOpts datasource.ProviderOpts) (Adapter, error) {
 	if logger == nil {
 		logger = zap.NewNop()
 	}
@@ -485,19 +488,24 @@ func NewAdapter(ctx context.Context, logger *zap.Logger, url string, opts []nats
 		store = metric.NewNoopStreamMetricStore()
 	}
 
+	if subscriptionBufferSize <= 0 {
+		subscriptionBufferSize = defaultSubscriptionBufferSize
+	}
+
 	ctx, cancelFunc := context.WithCancel(ctx)
 
 	return &ProviderAdapter{
-		ctx:               ctx,
-		cancel:            cancelFunc,
-		logger:            logger.With(zap.String("pubsub", "nats")),
-		closeWg:           sync.WaitGroup{},
-		hostName:          hostName,
-		routerListenAddr:  routerListenAddr,
-		url:               url,
-		opts:              opts,
-		flushTimeout:      10 * time.Second,
-		streamMetricStore: store,
+		ctx:                    ctx,
+		cancel:                 cancelFunc,
+		logger:                 logger.With(zap.String("pubsub", "nats")),
+		closeWg:                sync.WaitGroup{},
+		hostName:               hostName,
+		routerListenAddr:       routerListenAddr,
+		url:                    url,
+		opts:                   opts,
+		flushTimeout:           10 * time.Second,
+		streamMetricStore:      store,
+		subscriptionBufferSize: subscriptionBufferSize,
 		consumerConfig: consumerConfig{
 			deleteOnShutdown: deleteConsumersOnShutdown,
 		},

--- a/router/pkg/pubsub/nats/adapter.go
+++ b/router/pkg/pubsub/nats/adapter.go
@@ -486,6 +486,10 @@ func NewAdapter(ctx context.Context, logger *zap.Logger, url string, opts []nats
 		store = metric.NewNoopStreamMetricStore()
 	}
 
+	if subscriptionBufferSize <= 0 {
+		subscriptionBufferSize = 1024
+	}
+
 	ctx, cancelFunc := context.WithCancel(ctx)
 
 	return &ProviderAdapter{

--- a/router/pkg/pubsub/nats/adapter.go
+++ b/router/pkg/pubsub/nats/adapter.go
@@ -22,8 +22,6 @@ const (
 	natsReceive = "receive"
 )
 
-const defaultSubscriptionBufferSize = 1024
-
 // Adapter defines the methods that a NATS adapter should implement
 type Adapter interface {
 	datasource.Adapter
@@ -486,10 +484,6 @@ func NewAdapter(ctx context.Context, logger *zap.Logger, url string, opts []nats
 		store = providerOpts.StreamMetricStore
 	} else {
 		store = metric.NewNoopStreamMetricStore()
-	}
-
-	if subscriptionBufferSize <= 0 {
-		subscriptionBufferSize = defaultSubscriptionBufferSize
 	}
 
 	ctx, cancelFunc := context.WithCancel(ctx)

--- a/router/pkg/pubsub/nats/provider_builder.go
+++ b/router/pkg/pubsub/nats/provider_builder.go
@@ -185,7 +185,7 @@ func buildProvider(ctx context.Context, provider config.NatsEventSource, logger 
 		return nil, fmt.Errorf("failed to build options for Nats provider with ID \"%s\": %w", provider.ID, err)
 	}
 
-	adapter, err := NewAdapter(ctx, logger, provider.URL, options, hostName, routerListenAddr, provider.DeleteDurableConsumersOnShutdown, providerOpts)
+	adapter, err := NewAdapter(ctx, logger, provider.URL, options, hostName, routerListenAddr, provider.DeleteDurableConsumersOnShutdown, provider.SubscriptionBufferSize, providerOpts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create adapter for Nats provider with ID \"%s\": %w", provider.ID, err)
 	}

--- a/router/pkg/pubsub/nats/provider_builder.go
+++ b/router/pkg/pubsub/nats/provider_builder.go
@@ -95,10 +95,34 @@ func buildNatsOptions(eventSource config.NatsEventSource, logger *zap.Logger) ([
 		}),
 		nats.ErrorHandler(func(conn *nats.Conn, subscription *nats.Subscription, err error) {
 			if errors.Is(err, nats.ErrSlowConsumer) {
-				logger.Warn(
-					"NATS slow consumer detected. Events are being dropped. Please consider increasing the buffer size or reducing the number of messages being sent.",
+				fields := []zap.Field{
 					zap.Error(err),
 					zap.String("provider_id", eventSource.ID),
+				}
+				if subscription != nil {
+					fields = append(fields,
+						zap.String("subject", subscription.Subject),
+						zap.String("queue", subscription.Queue),
+					)
+					if pendingMsgs, pendingBytes, perr := subscription.Pending(); perr == nil {
+						fields = append(fields,
+							zap.Int("pending_msgs", pendingMsgs),
+							zap.Int("pending_bytes", pendingBytes),
+						)
+					}
+					if maxPendingMsgs, maxPendingBytes, perr := subscription.MaxPending(); perr == nil {
+						fields = append(fields,
+							zap.Int("max_pending_msgs", maxPendingMsgs),
+							zap.Int("max_pending_bytes", maxPendingBytes),
+						)
+					}
+					if droppedMsgs, derr := subscription.Dropped(); derr == nil {
+						fields = append(fields, zap.Int("dropped_msgs", droppedMsgs))
+					}
+				}
+				logger.Warn(
+					"NATS slow consumer detected. Events are being dropped. Please consider increasing the buffer size or reducing the number of messages being sent.",
+					fields...,
 				)
 			} else {
 				logger.Error("NATS error", zap.Error(err))


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable `subscription_buffer_size` option for NATS event sources (defaults to 1024)

* **Improvements**
  * Enhanced error diagnostics for slow consumer conditions with detailed operational metrics
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

<!--
Please add any additional information or context regarding your changes here.
-->