### PR TITLE
feat(helm): add unhealthy pod eviction policy support to pdb

### DIFF
--- a/helm/cosmo/charts/cdn/templates/pdb.yaml
+++ b/helm/cosmo/charts/cdn/templates/pdb.yaml
@@ -13,6 +13,9 @@ spec:
 {{- if .Values.podDisruptionBudget.maxUnavailable }}
   maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
 {{- end }}
+{{- if .Values.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ .Values.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+{{- end }}
   selector:
     matchLabels:
     {{- include "cdn.selectorLabels" . | nindent 6 }}

--- a/helm/cosmo/charts/controlplane/templates/pdb.yaml
+++ b/helm/cosmo/charts/controlplane/templates/pdb.yaml
@@ -13,6 +13,9 @@ spec:
 {{- if .Values.podDisruptionBudget.maxUnavailable }}
   maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
 {{- end }}
+{{- if .Values.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ .Values.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+{{- end }}
   selector:
     matchLabels:
     {{- include "controlplane.selectorLabels" . | nindent 6 }}

--- a/helm/cosmo/charts/graphqlmetrics/templates/pdb.yaml
+++ b/helm/cosmo/charts/graphqlmetrics/templates/pdb.yaml
@@ -13,6 +13,9 @@ spec:
 {{- if .Values.podDisruptionBudget.maxUnavailable }}
   maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
 {{- end }}
+{{- if .Values.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ .Values.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+{{- end }}
   selector:
     matchLabels:
     {{- include "graphqlmetrics.selectorLabels" . | nindent 6 }}

--- a/helm/cosmo/charts/otelcollector/templates/pdb.yaml
+++ b/helm/cosmo/charts/otelcollector/templates/pdb.yaml
@@ -13,6 +13,9 @@ spec:
 {{- if .Values.podDisruptionBudget.maxUnavailable }}
   maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
 {{- end }}
+{{- if .Values.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ .Values.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+{{- end }}
   selector:
     matchLabels:
     {{- include "otelcollector.selectorLabels" . | nindent 6 }}

--- a/helm/cosmo/charts/router/templates/pdb.yaml
+++ b/helm/cosmo/charts/router/templates/pdb.yaml
@@ -13,6 +13,9 @@ spec:
 {{- if .Values.podDisruptionBudget.maxUnavailable }}
   maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
 {{- end }}
+{{- if .Values.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ .Values.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+{{- end }}
   selector:
     matchLabels:
     {{- include "router.selectorLabels" . | nindent 6 }}

--- a/helm/cosmo/charts/studio/templates/pdb.yaml
+++ b/helm/cosmo/charts/studio/templates/pdb.yaml
@@ -13,6 +13,9 @@ spec:
 {{- if .Values.podDisruptionBudget.maxUnavailable }}
   maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
 {{- end }}
+{{- if .Values.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ .Values.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+{{- end }}
   selector:
     matchLabels:
     {{- include "studio.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring an unhealthy pod eviction policy in PodDisruptionBudget settings across all deployment charts, enabling enhanced control over pod disruption behavior during cluster maintenance operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

<!--
Please add any additional information or context regarding your changes here.
-->