### PR TITLE
fix(router): connection leak with redis pub/sub

### DIFF
--- a/router/pkg/pubsub/redis/adapter.go
+++ b/router/pkg/pubsub/redis/adapter.go
@@ -99,17 +99,21 @@ func (p *ProviderAdapter) Subscribe(ctx context.Context, conf datasource.Subscri
 	sub := p.conn.PSubscribe(ctx, subConf.Channels...)
 	msgChan := sub.Channel()
 
-	cleanup := func() {
-		err := sub.PUnsubscribe(ctx, subConf.Channels...)
-		if err != nil {
-			log.Error(fmt.Sprintf("error unsubscribing from redis for topics %v", subConf.Channels), zap.Error(err))
-		}
-	}
-
 	p.closeWg.Add(1)
 
 	go func() {
 		defer p.closeWg.Done()
+
+		// Always release the dedicated pub/sub connection on every exit path,
+		// otherwise each subscription leaks a connection. Closing the PubSub
+		// also unsubscribes from all channels server-side, so an explicit
+		// PUnsubscribe is unnecessary (and would fail anyway once the context
+		// driving teardown is cancelled).
+		defer func() {
+			if err := sub.Close(); err != nil {
+				log.Error(fmt.Sprintf("error closing redis subscription for topics %v", subConf.Channels), zap.Error(err))
+			}
+		}()
 
 		for {
 			select {
@@ -137,12 +141,10 @@ func (p *ProviderAdapter) Subscribe(ctx context.Context, conf datasource.Subscri
 			case <-p.ctx.Done():
 				// When the application context is done, we stop the subscription if it is not already done
 				log.Debug("application context done, stopping subscription")
-				cleanup()
 				return
 			case <-ctx.Done():
 				// When the subscription context is done, we stop the subscription if it is not already done
 				log.Debug("subscription context done, stopping subscription")
-				cleanup()
 				return
 			}
 		}

--- a/router/pkg/pubsub/redis/adapter_test.go
+++ b/router/pkg/pubsub/redis/adapter_test.go
@@ -1,0 +1,70 @@
+package redis
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/stretchr/testify/require"
+	"github.com/wundergraph/cosmo/router/pkg/pubsub/datasource"
+	"go.uber.org/zap/zaptest"
+)
+
+// noopUpdater satisfies datasource.SubscriptionEventUpdater for tests.
+type noopUpdater struct{}
+
+func (noopUpdater) Update(events []datasource.StreamEvent) {}
+func (noopUpdater) Complete()                              {}
+func (noopUpdater) Done()                                  {}
+func (noopUpdater) SetHooks(hooks datasource.Hooks)        {}
+
+func newTestAdapter(t *testing.T) (*ProviderAdapter, *miniredis.Miniredis) {
+	t.Helper()
+
+	mr := miniredis.RunT(t)
+
+	adapter := NewProviderAdapter(
+		context.Background(),
+		zaptest.NewLogger(t),
+		[]string{fmt.Sprintf("redis://%s", mr.Addr())},
+		false,
+		datasource.ProviderOpts{},
+	)
+	require.NoError(t, adapter.Startup(context.Background()))
+	t.Cleanup(func() { _ = adapter.Shutdown(context.Background()) })
+
+	return adapter.(*ProviderAdapter), mr
+}
+
+// TestProviderAdapter_Subscribe_ReleasesConnectionOnCancel guards against the
+// connection leak where each subscription's dedicated pub/sub connection was
+// never closed (only PUnsubscribe was called, with an already-cancelled
+// context). After every subscription context is cancelled, the pool's total
+// connection count must return to its pre-subscribe baseline.
+func TestProviderAdapter_Subscribe_ReleasesConnectionOnCancel(t *testing.T) {
+	p, _ := newTestAdapter(t)
+
+	baseline := p.conn.PoolStats().TotalConns
+
+	const subscriptions = 10
+	for i := 0; i < subscriptions; i++ {
+		subCtx, cancel := context.WithCancel(context.Background())
+		err := p.Subscribe(subCtx, &SubscriptionEventConfiguration{
+			Provider: "test-provider",
+			Channels: []string{fmt.Sprintf("channel-%d", i)},
+		}, noopUpdater{})
+		require.NoError(t, err)
+
+		// Cancelling the subscription context must tear the subscription down
+		// and release its dedicated connection.
+		cancel()
+	}
+
+	require.Eventually(t, func() bool {
+		return p.conn.PoolStats().TotalConns <= baseline
+	}, 5*time.Second, 10*time.Millisecond,
+		"redis pub/sub connections leaked: have %d, baseline %d",
+		p.conn.PoolStats().TotalConns, baseline)
+}


### PR DESCRIPTION
Fix for: #2915

<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Redis subscription connection cleanup to ensure resources are properly released and prevent connection leaks.

* **Tests**
  * Added test to verify Redis connections are released when subscriptions are canceled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [x] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

<!--
Please add any additional information or context regarding your changes here.
-->