### PR TITLE
fix(router/connectrpc): map GraphQL enum values to proto names on response path

### DIFF
--- a/router/pkg/connectrpc/handler.go
+++ b/router/pkg/connectrpc/handler.go
@@ -188,7 +188,17 @@ func (h *RPCHandler) HandleRPC(ctx context.Context, serviceName, methodName stri
 		return nil, fmt.Errorf("failed to execute GraphQL query: %w", err)
 	}
 
-	return responseJSON, nil
+	// Convert the GraphQL response back to proto JSON. This is the inverse of the request-path
+	// transform: the subgraph emits bare GraphQL enum values (e.g. "HAPPY"), but the Vanguard
+	// transcoder parses this JSON against the method's output descriptor, which only knows the
+	// proto-prefixed value names (e.g. "MOOD_HAPPY"). Without re-adding the prefix the enum is
+	// dropped on the binary/gRPC wire and falls back to *_UNSPECIFIED on the JSON wire.
+	protoResponseJSON, err := h.convertGraphQLResponseToProtoJSON(serviceName, methodName, responseJSON)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert GraphQL response to proto JSON: %w", err)
+	}
+
+	return protoResponseJSON, nil
 }
 
 // convertProtoJSONToGraphQLVariables processes proto JSON for GraphQL compatibility.
@@ -410,6 +420,157 @@ func toUpperSnakeCase(s string) string {
 		result.WriteRune(r)
 	}
 	return strings.ToUpper(result.String())
+}
+
+// convertGraphQLResponseToProtoJSON is the inverse of convertProtoJSONToGraphQLVariables on the
+// response path. It walks the GraphQL response data tree using the method's OUTPUT message
+// descriptor and re-adds the proto enum type prefix to every bare GraphQL enum value so the
+// downstream Vanguard transcoder can map it to the correct proto enum value
+// (e.g. "HAPPY" -> "MOOD_HAPPY").
+//
+// Why only enums: every other GraphQL scalar already round-trips as valid proto3-JSON. Enums are
+// the only type whose GraphQL representation (bare name) differs from the proto3-JSON canonical
+// form (prefixed name) AND which the parser strictly rejects on mismatch.
+//
+// Like the request path, this is a no-op when the proto schema isn't available (e.g. in tests
+// without a loaded descriptor) so behavior degrades gracefully to passthrough.
+func (h *RPCHandler) convertGraphQLResponseToProtoJSON(serviceName, methodName string, responseJSON json.RawMessage) (json.RawMessage, error) {
+	if len(responseJSON) == 0 {
+		return json.RawMessage("{}"), nil
+	}
+
+	var responseData any
+	if err := json.Unmarshal(responseJSON, &responseData); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal GraphQL response JSON: %w", err)
+	}
+
+	// Without a proto schema we can't know which fields are enums, so return as-is.
+	if h.protoLoader == nil {
+		return responseJSON, nil
+	}
+
+	method, err := h.protoLoader.GetMethod(serviceName, methodName)
+	if err != nil {
+		h.logger.Debug("method not found in proto loader, skipping response transformations",
+			zap.String("service", serviceName),
+			zap.String("method", methodName),
+			zap.Error(err))
+		return responseJSON, nil
+	}
+
+	messageDesc := method.OutputMessageDescriptor
+	if messageDesc == nil {
+		h.logger.Warn("output message descriptor is nil, skipping response transformations",
+			zap.String("service", serviceName),
+			zap.String("method", methodName))
+		return responseJSON, nil
+	}
+
+	converted := h.addProtoEnumPrefixesRecursive(responseData, messageDesc)
+
+	protoJSON, err := json.Marshal(converted)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal proto JSON response: %w", err)
+	}
+
+	return protoJSON, nil
+}
+
+// addProtoEnumPrefixesRecursive walks a decoded JSON value against a message descriptor and
+// rewrites enum fields to their proto-prefixed value names. Field names are preserved as-is:
+// protographic emits proto3-JSON camelCase that already matches the descriptor's JSON names.
+func (h *RPCHandler) addProtoEnumPrefixesRecursive(data any, messageDesc protoreflect.MessageDescriptor) any {
+	switch v := data.(type) {
+	case map[string]any:
+		result := make(map[string]any, len(v))
+		for key, value := range v {
+			var fieldDesc protoreflect.FieldDescriptor
+			if messageDesc != nil {
+				fieldDesc = getFieldByJSONName(messageDesc, key)
+			}
+			result[key] = h.addProtoEnumPrefixToValue(value, fieldDesc)
+		}
+		return result
+	case []any:
+		result := make([]any, len(v))
+		for i, item := range v {
+			result[i] = h.addProtoEnumPrefixesRecursive(item, messageDesc)
+		}
+		return result
+	default:
+		return data
+	}
+}
+
+// addProtoEnumPrefixToValue handles a single field value: enums get the prefix re-added (handling
+// both scalar and repeated enums), nested messages recurse with their own descriptor, and any other
+// value passes through unchanged.
+func (h *RPCHandler) addProtoEnumPrefixToValue(value any, fieldDesc protoreflect.FieldDescriptor) any {
+	if fieldDesc != nil {
+		if enumDesc := getEnumType(fieldDesc); enumDesc != nil {
+			switch v := value.(type) {
+			case []any: // repeated enum
+				result := make([]any, len(v))
+				for i, item := range v {
+					result[i] = h.addProtoEnumPrefixToValue(item, fieldDesc)
+				}
+				return result
+			case string:
+				return h.mapGraphQLEnumToProtoValue(v, enumDesc)
+			case nil:
+				// A null/absent enum maps to the proto zero value (*_UNSPECIFIED), the inverse
+				// of the request path stripping *_UNSPECIFIED to "".
+				return h.unspecifiedEnumValueName(enumDesc)
+			default:
+				return value
+			}
+		}
+
+		if msgDesc := getMessageType(fieldDesc); msgDesc != nil {
+			return h.addProtoEnumPrefixesRecursive(value, msgDesc)
+		}
+	}
+
+	return value
+}
+
+// mapGraphQLEnumToProtoValue re-adds the proto enum type prefix to a bare GraphQL enum value.
+//
+// It is descriptor-driven: it iterates the enum's declared values and strips each one's prefix
+// with the same stripEnumPrefixWithType used on the request path, then matches against the GraphQL
+// value. Driving the match off the descriptor (rather than recomputing the prefix from the value)
+// keeps request and response paths symmetric and sidesteps any case-conversion mismatch between
+// protographic's value naming and the router's toUpperSnakeCase.
+//
+// On a lookup miss the value is returned unchanged. The downstream proto3-JSON parse then rejects
+// the unknown enum name with a hard error, which is the desired outcome - far better than silently
+// substituting a wrong value or dropping the field.
+func (h *RPCHandler) mapGraphQLEnumToProtoValue(graphqlValue string, enumDesc protoreflect.EnumDescriptor) string {
+	if graphqlValue == "" {
+		return h.unspecifiedEnumValueName(enumDesc)
+	}
+
+	enumTypeName := string(enumDesc.Name())
+	values := enumDesc.Values()
+	for i := 0; i < values.Len(); i++ {
+		protoName := string(values.Get(i).Name())
+		if stripEnumPrefixWithType(protoName, enumTypeName) == graphqlValue {
+			return protoName
+		}
+	}
+
+	h.logger.Warn("no proto enum value matched GraphQL response enum value",
+		zap.String("enum", enumTypeName),
+		zap.String("graphql_value", graphqlValue))
+	return graphqlValue
+}
+
+// unspecifiedEnumValueName returns the name of the enum's zero value (proto convention: *_UNSPECIFIED).
+func (h *RPCHandler) unspecifiedEnumValueName(enumDesc protoreflect.EnumDescriptor) string {
+	if zero := enumDesc.Values().ByNumber(0); zero != nil {
+		return string(zero.Name())
+	}
+	return ""
 }
 
 // makeCriticalGraphQLError creates a Connect error for GraphQL errors with no data (complete failure).

--- a/router/pkg/connectrpc/handler.go
+++ b/router/pkg/connectrpc/handler.go
@@ -506,29 +506,31 @@ func (h *RPCHandler) addProtoEnumPrefixesRecursive(data any, messageDesc protore
 // both scalar and repeated enums), nested messages recurse with their own descriptor, and any other
 // value passes through unchanged.
 func (h *RPCHandler) addProtoEnumPrefixToValue(value any, fieldDesc protoreflect.FieldDescriptor) any {
-	if fieldDesc != nil {
-		if enumDesc := getEnumType(fieldDesc); enumDesc != nil {
-			switch v := value.(type) {
-			case []any: // repeated enum
-				result := make([]any, len(v))
-				for i, item := range v {
-					result[i] = h.addProtoEnumPrefixToValue(item, fieldDesc)
-				}
-				return result
-			case string:
-				return h.mapGraphQLEnumToProtoValue(v, enumDesc)
-			case nil:
-				// A null/absent enum maps to the proto zero value (*_UNSPECIFIED), the inverse
-				// of the request path stripping *_UNSPECIFIED to "".
-				return h.unspecifiedEnumValueName(enumDesc)
-			default:
-				return value
-			}
-		}
+	if fieldDesc == nil {
+		return value
+	}
 
-		if msgDesc := getMessageType(fieldDesc); msgDesc != nil {
-			return h.addProtoEnumPrefixesRecursive(value, msgDesc)
+	if enumDesc := getEnumType(fieldDesc); enumDesc != nil {
+		switch v := value.(type) {
+		case []any: // repeated enum
+			result := make([]any, len(v))
+			for i, item := range v {
+				result[i] = h.addProtoEnumPrefixToValue(item, fieldDesc)
+			}
+			return result
+		case string:
+			return h.mapGraphQLEnumToProtoValue(v, enumDesc)
+		case nil:
+			// A null/absent enum maps to the proto zero value (*_UNSPECIFIED), the inverse
+			// of the request path stripping *_UNSPECIFIED to "".
+			return h.unspecifiedEnumValueName(enumDesc)
+		default:
+			return value
 		}
+	}
+
+	if msgDesc := getMessageType(fieldDesc); msgDesc != nil {
+		return h.addProtoEnumPrefixesRecursive(value, msgDesc)
 	}
 
 	return value

--- a/router/pkg/connectrpc/handler_test.go
+++ b/router/pkg/connectrpc/handler_test.go
@@ -200,4 +200,79 @@ func TestConvertGraphQLResponseToProtoJSON(t *testing.T) {
 			"mood": "MOOD_HAPPY"
 		}`, string(result))
 	})
+
+	t.Run("maps null enum to the proto zero value (_UNSPECIFIED)", func(t *testing.T) {
+		handler := setupHandlerWithSchema(t)
+
+		// A nullable GraphQL enum that resolved to null must become the proto zero value,
+		// the inverse of the request path stripping *_UNSPECIFIED to "".
+		graphqlJSON := []byte(`{"name": "John", "mood": null}`)
+		result, err := handler.convertGraphQLResponseToProtoJSON("test.EmployeeService", "GetEmployee", graphqlJSON)
+		require.NoError(t, err)
+
+		assert.JSONEq(t, `{
+			"name": "John",
+			"mood": "MOOD_UNSPECIFIED"
+		}`, string(result))
+	})
+
+	t.Run("re-adds prefix to repeated enum values", func(t *testing.T) {
+		handler := setupHandlerWithSchema(t)
+
+		// GetDocumentResponse.moods is `repeated Mood`.
+		graphqlJSON := []byte(`{"name": "doc", "moods": ["HAPPY", "SAD"]}`)
+		result, err := handler.convertGraphQLResponseToProtoJSON("test.EmployeeService", "GetDocument", graphqlJSON)
+		require.NoError(t, err)
+
+		assert.JSONEq(t, `{
+			"name": "doc",
+			"moods": ["MOOD_HAPPY", "MOOD_SAD"]
+		}`, string(result))
+	})
+
+	t.Run("re-adds prefix to enum nested in a message", func(t *testing.T) {
+		handler := setupHandlerWithSchema(t)
+
+		// GetDocumentResponse.document is a nested Document message holding a DocumentStatus enum.
+		graphqlJSON := []byte(`{"document": {"title": "spec", "status": "archived"}}`)
+		result, err := handler.convertGraphQLResponseToProtoJSON("test.EmployeeService", "GetDocument", graphqlJSON)
+		require.NoError(t, err)
+
+		assert.JSONEq(t, `{
+			"document": {
+				"title": "spec",
+				"status": "DOCUMENT_STATUS_archived"
+			}
+		}`, string(result))
+	})
+
+	t.Run("preserves original case of the enum value segment", func(t *testing.T) {
+		handler := setupHandlerWithSchema(t)
+
+		// protographic keeps the value's original case: DOCUMENT_STATUS_active, NOT
+		// DOCUMENT_STATUS_ACTIVE. The descriptor-driven match must round-trip "active" exactly.
+		graphqlJSON := []byte(`{"document": {"status": "active"}}`)
+		result, err := handler.convertGraphQLResponseToProtoJSON("test.EmployeeService", "GetDocument", graphqlJSON)
+		require.NoError(t, err)
+
+		assert.JSONEq(t, `{
+			"document": {
+				"status": "DOCUMENT_STATUS_active"
+			}
+		}`, string(result))
+	})
+
+	t.Run("returns unknown enum value unchanged so the transcoder surfaces the error", func(t *testing.T) {
+		handler := setupHandlerWithSchema(t)
+
+		// A value with no matching proto enum is left as-is; the downstream proto3-JSON parse
+		// then rejects it rather than this layer silently substituting a wrong value.
+		graphqlJSON := []byte(`{"mood": "ECSTATIC"}`)
+		result, err := handler.convertGraphQLResponseToProtoJSON("test.EmployeeService", "GetEmployee", graphqlJSON)
+		require.NoError(t, err)
+
+		assert.JSONEq(t, `{
+			"mood": "ECSTATIC"
+		}`, string(result))
+	})
 }

--- a/router/pkg/connectrpc/handler_test.go
+++ b/router/pkg/connectrpc/handler_test.go
@@ -176,3 +176,28 @@ func TestConvertProtoJSONToGraphQLVariables(t *testing.T) {
 		}`, string(result))
 	})
 }
+
+// TestConvertGraphQLResponseToProtoJSON covers the response direction (GraphQL -> proto),
+// the inverse of convertProtoJSONToGraphQLVariables. The GraphQL subgraph emits bare enum
+// values (e.g. "HAPPY"), but the proto descriptor only knows the prefixed value names
+// (e.g. "MOOD_HAPPY"). Without re-adding the prefix, the Vanguard transcoder cannot map the
+// value and silently drops the enum field on the binary wire / falls back to *_UNSPECIFIED on
+// the JSON wire. Regression test for https://github.com/wundergraph/cosmo/issues/2924.
+func TestConvertGraphQLResponseToProtoJSON(t *testing.T) {
+	t.Run("re-adds proto enum prefix to response enum value", func(t *testing.T) {
+		handler := setupHandlerWithSchema(t)
+
+		// GetEmployeeResponse has fields { string name; Mood mood; } where Mood.MOOD_HAPPY = 1.
+		// The subgraph returns the bare GraphQL enum name "HAPPY".
+		graphqlJSON := []byte(`{"name": "John", "mood": "HAPPY"}`)
+		result, err := handler.convertGraphQLResponseToProtoJSON("test.EmployeeService", "GetEmployee", graphqlJSON)
+		require.NoError(t, err)
+
+		// The enum must be rewritten to the proto-prefixed value name so proto3-JSON parsing
+		// (done by the Vanguard transcoder) maps it to the correct integer instead of dropping it.
+		assert.JSONEq(t, `{
+			"name": "John",
+			"mood": "MOOD_HAPPY"
+		}`, string(result))
+	})
+}

--- a/router/pkg/connectrpc/handler_test.go
+++ b/router/pkg/connectrpc/handler_test.go
@@ -184,7 +184,11 @@ func TestConvertProtoJSONToGraphQLVariables(t *testing.T) {
 // value and silently drops the enum field on the binary wire / falls back to *_UNSPECIFIED on
 // the JSON wire. Regression test for https://github.com/wundergraph/cosmo/issues/2924.
 func TestConvertGraphQLResponseToProtoJSON(t *testing.T) {
+	t.Parallel()
+
 	t.Run("re-adds proto enum prefix to response enum value", func(t *testing.T) {
+		t.Parallel()
+
 		handler := setupHandlerWithSchema(t)
 
 		// GetEmployeeResponse has fields { string name; Mood mood; } where Mood.MOOD_HAPPY = 1.
@@ -202,6 +206,8 @@ func TestConvertGraphQLResponseToProtoJSON(t *testing.T) {
 	})
 
 	t.Run("maps null enum to the proto zero value (_UNSPECIFIED)", func(t *testing.T) {
+		t.Parallel()
+
 		handler := setupHandlerWithSchema(t)
 
 		// A nullable GraphQL enum that resolved to null must become the proto zero value,
@@ -217,6 +223,8 @@ func TestConvertGraphQLResponseToProtoJSON(t *testing.T) {
 	})
 
 	t.Run("re-adds prefix to repeated enum values", func(t *testing.T) {
+		t.Parallel()
+
 		handler := setupHandlerWithSchema(t)
 
 		// GetDocumentResponse.moods is `repeated Mood`.
@@ -231,6 +239,8 @@ func TestConvertGraphQLResponseToProtoJSON(t *testing.T) {
 	})
 
 	t.Run("re-adds prefix to enum nested in a message", func(t *testing.T) {
+		t.Parallel()
+
 		handler := setupHandlerWithSchema(t)
 
 		// GetDocumentResponse.document is a nested Document message holding a DocumentStatus enum.
@@ -247,6 +257,8 @@ func TestConvertGraphQLResponseToProtoJSON(t *testing.T) {
 	})
 
 	t.Run("preserves original case of the enum value segment", func(t *testing.T) {
+		t.Parallel()
+
 		handler := setupHandlerWithSchema(t)
 
 		// protographic keeps the value's original case: DOCUMENT_STATUS_active, NOT
@@ -263,6 +275,8 @@ func TestConvertGraphQLResponseToProtoJSON(t *testing.T) {
 	})
 
 	t.Run("returns unknown enum value unchanged so the transcoder surfaces the error", func(t *testing.T) {
+		t.Parallel()
+
 		handler := setupHandlerWithSchema(t)
 
 		// A value with no matching proto enum is left as-is; the downstream proto3-JSON parse

--- a/router/pkg/connectrpc/testdata/test.proto
+++ b/router/pkg/connectrpc/testdata/test.proto
@@ -31,7 +31,37 @@ message GetEmployeeResponse {
   Mood mood = 2;
 }
 
+// DocumentStatus exercises protographic's case-preserving enum value naming:
+// the value segment keeps its original GraphQL case (active, not ACTIVE), so the
+// response transform must NOT uppercase the value when re-adding the prefix.
+enum DocumentStatus {
+  DOCUMENT_STATUS_UNSPECIFIED = 0;
+  DOCUMENT_STATUS_active = 1;
+  DOCUMENT_STATUS_archived = 2;
+}
+
+// Document is a nested message holding an enum, used to exercise the recursive
+// response transform.
+message Document {
+  string title = 1;
+  DocumentStatus status = 2;
+}
+
+// GetDocumentRequest is the request message for GetDocument
+message GetDocumentRequest {
+  string id = 1;
+}
+
+// GetDocumentResponse exercises the response transform's repeated-enum and
+// nested-message handling.
+message GetDocumentResponse {
+  string name = 1;
+  repeated Mood moods = 2;
+  Document document = 3;
+}
+
 // EmployeeService provides employee operations
 service EmployeeService {
   rpc GetEmployee(GetEmployeeRequest) returns (GetEmployeeResponse);
+  rpc GetDocument(GetDocumentRequest) returns (GetDocumentResponse);
 }


### PR DESCRIPTION
## Summary

Fixes the ConnectRPC transcoder dropping GraphQL enum values on the response path (community issue #2924, ENG-9687).

The router had asymmetric enum handling: the request path strips proto enum prefixes (`MOOD_HAPPY` -> `HAPPY`) but the response path returned GraphQL data raw. The Vanguard transcoder then parses that JSON against the method's output descriptor, which only knows the prefixed value names (`MOOD_HAPPY`). A bare value like `HAPPY` misses the lookup:

| Wire | Result before this fix |
| -- | -- |
| Connect-JSON | lookup miss -> falls back to index-0 `*_UNSPECIFIED` |
| Connect-binary / gRPC | enum can't be encoded -> field silently omitted -> decodes as `*_UNSPECIFIED` |

## The fix

Adds `convertGraphQLResponseToProtoJSON`, the inverse of `convertProtoJSONToGraphQLVariables`, wired into `HandleRPC` between the GraphQL call and the return. It:

- Re-adds the prefix descriptor-driven: iterates `enumDesc.Values()`, strips each value's prefix via the existing `stripEnumPrefixWithType`, and matches the GraphQL value - symmetric with the request path, avoiding any case-conversion mismatch with protographic's value naming.
- Handles repeated enums and nested messages (incl. abstract types, which protographic emits as `oneof`).
- Maps null/absent enums to `*_UNSPECIFIED` (inverse of the request path's `*_UNSPECIFIED` -> `""`).
- On a lookup miss, leaves the value as-is so the downstream proto3-JSON parse surfaces a hard error rather than silently substituting a wrong value.

No behavior change for non-enum fields: every other GraphQL scalar already round-trips as valid proto3-JSON.

## Scope

Enums only - per protographic's scalar map, every non-enum value is already valid proto3-JSON. This gap existed in both the original `eng-8277` (structpb) branch and merged main (Vanguard) - never a regression.

## Tests

- RED -> GREEN: `TestConvertGraphQLResponseToProtoJSON` (asserts `HAPPY` -> `MOOD_HAPPY` via `test.EmployeeService.GetEmployee`) now passes.
- All existing `TestConvertProtoJSONToGraphQLVariables` request-path cases still pass.

Follow-ups (tracked in ENG-9687): extend test coverage for null->`UNSPECIFIED`, nested/repeated, case-preserving values, and a wire-level regression test.

Closes #2924

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored proto-style enum prefixes in RPC responses so enum values returned from GraphQL are rewritten to expected proto names; handles nullable enums (maps null to proto zero value), repeated enums, nested fields, and preserves case segments.

* **Tests**
  * Added regression test covering enum conversion behavior, nested/repeated cases, null handling, and unknown-value passthrough.

* **Chores**
  * Expanded test schema with document-related enums/messages to exercise conversion logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->