### PR TITLE
feat: implement early stop for feature flag updates with no changes

### DIFF
--- a/cli/src/commands/feature-flag/commands/update.ts
+++ b/cli/src/commands/feature-flag/commands/update.ts
@@ -71,7 +71,10 @@ export default (opts: BaseCommandOptions) => {
         compositionWarnings: resp.compositionWarnings,
         deploymentErrors: resp.deploymentErrors,
         spinner,
-        successMessage: `The feature flag "${name}" was updated successfully.`,
+        successMessage:
+          resp.hasChanged === false
+            ? `The feature flag "${name}" has no new changes.`
+            : `The feature flag "${name}" was updated successfully.`,
         subgraphCompositionBaseErrorMessage: `The feature flag "${name}" was updated but with composition errors.`,
         subgraphCompositionDetailedErrorMessage:
           `There were composition errors when composing at least one federated graph related to the` +

--- a/connect-go/gen/proto/wg/cosmo/platform/v1/platform.pb.go
+++ b/connect-go/gen/proto/wg/cosmo/platform/v1/platform.pb.go
@@ -22609,6 +22609,7 @@ type UpdateFeatureFlagResponse struct {
 	CompositionErrors   []*CompositionError    `protobuf:"bytes,2,rep,name=composition_errors,json=compositionErrors,proto3" json:"composition_errors,omitempty"`
 	DeploymentErrors    []*DeploymentError     `protobuf:"bytes,3,rep,name=deployment_errors,json=deploymentErrors,proto3" json:"deployment_errors,omitempty"`
 	CompositionWarnings []*CompositionWarning  `protobuf:"bytes,4,rep,name=compositionWarnings,proto3" json:"compositionWarnings,omitempty"`
+	HasChanged          *bool                  `protobuf:"varint,5,opt,name=has_changed,json=hasChanged,proto3,oneof" json:"has_changed,omitempty"`
 	unknownFields       protoimpl.UnknownFields
 	sizeCache           protoimpl.SizeCache
 }
@@ -22669,6 +22670,13 @@ func (x *UpdateFeatureFlagResponse) GetCompositionWarnings() []*CompositionWarni
 		return x.CompositionWarnings
 	}
 	return nil
+}
+
+func (x *UpdateFeatureFlagResponse) GetHasChanged() bool {
+	if x != nil && x.HasChanged != nil {
+		return *x.HasChanged
+	}
+	return false
 }
 
 type EnableFeatureFlagRequest struct {
@@ -34943,12 +34951,15 @@ const file_wg_cosmo_platform_v1_platform_proto_rawDesc = "" +
 	"\x16feature_subgraph_names\x18\x04 \x03(\tR\x14featureSubgraphNames\x12!\n" +
 	"\funset_labels\x18\x05 \x01(\bR\vunsetLabels\x12M\n" +
 	" disable_resolvability_validation\x18\x06 \x01(\bH\x00R\x1edisableResolvabilityValidation\x88\x01\x01B#\n" +
-	"!_disable_resolvability_validation\"\xde\x02\n" +
+	"!_disable_resolvability_validation\"\x94\x03\n" +
 	"\x19UpdateFeatureFlagResponse\x12:\n" +
 	"\bresponse\x18\x01 \x01(\v2\x1e.wg.cosmo.platform.v1.ResponseR\bresponse\x12U\n" +
 	"\x12composition_errors\x18\x02 \x03(\v2&.wg.cosmo.platform.v1.CompositionErrorR\x11compositionErrors\x12R\n" +
 	"\x11deployment_errors\x18\x03 \x03(\v2%.wg.cosmo.platform.v1.DeploymentErrorR\x10deploymentErrors\x12Z\n" +
-	"\x13compositionWarnings\x18\x04 \x03(\v2(.wg.cosmo.platform.v1.CompositionWarningR\x13compositionWarnings\"\xda\x01\n" +
+	"\x13compositionWarnings\x18\x04 \x03(\v2(.wg.cosmo.platform.v1.CompositionWarningR\x13compositionWarnings\x12$\n" +
+	"\vhas_changed\x18\x05 \x01(\bH\x00R\n" +
+	"hasChanged\x88\x01\x01B\x0e\n" +
+	"\f_has_changed\"\xda\x01\n" +
 	"\x18EnableFeatureFlagRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1c\n" +
 	"\tnamespace\x18\x02 \x01(\tR\tnamespace\x12\x18\n" +
@@ -37489,6 +37500,7 @@ func file_wg_cosmo_platform_v1_platform_proto_init() {
 	file_wg_cosmo_platform_v1_platform_proto_msgTypes[333].OneofWrappers = []any{}
 	file_wg_cosmo_platform_v1_platform_proto_msgTypes[339].OneofWrappers = []any{}
 	file_wg_cosmo_platform_v1_platform_proto_msgTypes[341].OneofWrappers = []any{}
+	file_wg_cosmo_platform_v1_platform_proto_msgTypes[342].OneofWrappers = []any{}
 	file_wg_cosmo_platform_v1_platform_proto_msgTypes[343].OneofWrappers = []any{}
 	file_wg_cosmo_platform_v1_platform_proto_msgTypes[344].OneofWrappers = []any{}
 	file_wg_cosmo_platform_v1_platform_proto_msgTypes[345].OneofWrappers = []any{}

--- a/connect/src/wg/cosmo/platform/v1/platform_pb.ts
+++ b/connect/src/wg/cosmo/platform/v1/platform_pb.ts
@@ -19554,6 +19554,11 @@ export class UpdateFeatureFlagResponse extends Message<UpdateFeatureFlagResponse
    */
   compositionWarnings: CompositionWarning[] = [];
 
+  /**
+   * @generated from field: optional bool has_changed = 5;
+   */
+  hasChanged?: boolean;
+
   constructor(data?: PartialMessage<UpdateFeatureFlagResponse>) {
     super();
     proto3.util.initPartial(data, this);
@@ -19566,6 +19571,7 @@ export class UpdateFeatureFlagResponse extends Message<UpdateFeatureFlagResponse
     { no: 2, name: "composition_errors", kind: "message", T: CompositionError, repeated: true },
     { no: 3, name: "deployment_errors", kind: "message", T: DeploymentError, repeated: true },
     { no: 4, name: "compositionWarnings", kind: "message", T: CompositionWarning, repeated: true },
+    { no: 5, name: "has_changed", kind: "scalar", T: 8 /* ScalarType.BOOL */, opt: true },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): UpdateFeatureFlagResponse {

--- a/controlplane/src/core/bufservices/feature-flag/updateFeatureFlag.ts
+++ b/controlplane/src/core/bufservices/feature-flag/updateFeatureFlag.ts
@@ -5,11 +5,12 @@ import {
   UpdateFeatureFlagRequest,
   UpdateFeatureFlagResponse,
 } from '@wundergraph/cosmo-connect/dist/platform/v1/platform_pb';
+import { joinLabel } from '@wundergraph/cosmo-shared';
 import { AuditLogRepository } from '../../repositories/AuditLogRepository.js';
 import { FeatureFlagRepository } from '../../repositories/FeatureFlagRepository.js';
 import { DefaultNamespace, NamespaceRepository } from '../../repositories/NamespaceRepository.js';
 import type { RouterOptions } from '../../routes.js';
-import { enrichLogger, getLogger, handleError, isValidLabels } from '../../util.js';
+import { enrichLogger, getLogger, handleError, isValidLabels, normalizeLabels } from '../../util.js';
 import { UnauthorizedError } from '../../errors/errors.js';
 import { CompositionService } from '../../services/CompositionService.js';
 
@@ -93,6 +94,59 @@ export function updateFeatureFlag(
         compositionErrors: [],
         deploymentErrors: [],
         compositionWarnings: [],
+      };
+    }
+
+    // Determine whether the request actually changes anything. The update only touches the labels
+    // (when labels are provided or unsetLabels is set) and the feature subgraph set (when feature
+    // subgraph names are provided). If neither differs from what is currently stored, there is
+    // nothing to recompose, so we skip the write and composition entirely.
+    let labelsChanged = false;
+    const currentLabels = normalizeLabels(featureFlagDTO.labels).map((l) => joinLabel(l));
+    if (req.unsetLabels) {
+      labelsChanged = currentLabels.length > 0;
+    } else if (req.labels.length > 0) {
+      const newLabels = normalizeLabels(req.labels).map((l) => joinLabel(l));
+      // Both arrays are normalized (sorted + deduped) joined labels. The length check catches
+      // additions/removals; `includes` then compares by membership rather than position, so it does
+      // not rely on both arrays being in the same order.
+      labelsChanged =
+        currentLabels.length !== newLabels.length || currentLabels.some((label) => !newLabels.includes(label));
+    }
+
+    let featureSubgraphsChanged = false;
+    if (featureSubgraphIds.length > 0) {
+      const currentFeatureSubgraphIds = new Set(featureFlagDTO.featureSubgraphs.map((fs) => fs.id));
+      featureSubgraphsChanged =
+        featureSubgraphIds.length !== currentFeatureSubgraphIds.size ||
+        featureSubgraphIds.some((id) => !currentFeatureSubgraphIds.has(id));
+    }
+
+    if (!labelsChanged && !featureSubgraphsChanged) {
+      const auditLogRepo = new AuditLogRepository(opts.db);
+      await auditLogRepo.addAuditLog({
+        organizationId: authContext.organizationId,
+        organizationSlug: authContext.organizationSlug,
+        auditAction: 'feature_flag.updated',
+        action: 'updated',
+        actorId: authContext.userId,
+        auditableType: 'feature_flag',
+        auditableDisplayName: featureFlagDTO.name,
+        apiKeyName: authContext.apiKeyName,
+        actorDisplayName: authContext.userDisplayName,
+        actorType: authContext.auth === 'api_key' ? 'api_key' : 'user',
+        targetNamespaceId: namespace.id,
+        targetNamespaceDisplayName: namespace.name,
+      });
+
+      return {
+        response: {
+          code: EnumStatusCode.OK,
+        },
+        compositionErrors: [],
+        deploymentErrors: [],
+        compositionWarnings: [],
+        hasChanged: false,
       };
     }
 
@@ -192,6 +246,7 @@ export function updateFeatureFlag(
       compositionErrors,
       deploymentErrors,
       compositionWarnings,
+      hasChanged: true,
     };
   });
 }

--- a/controlplane/src/core/bufservices/feature-flag/updateFeatureFlag.ts
+++ b/controlplane/src/core/bufservices/feature-flag/updateFeatureFlag.ts
@@ -107,9 +107,6 @@ export function updateFeatureFlag(
       labelsChanged = currentLabels.length > 0;
     } else if (req.labels.length > 0) {
       const newLabels = normalizeLabels(req.labels).map((l) => joinLabel(l));
-      // Both arrays are normalized (sorted + deduped) joined labels. The length check catches
-      // additions/removals; `includes` then compares by membership rather than position, so it does
-      // not rely on both arrays being in the same order.
       labelsChanged =
         currentLabels.length !== newLabels.length || currentLabels.some((label) => !newLabels.includes(label));
     }

--- a/controlplane/test/feature-flag/update-feature-flag.test.ts
+++ b/controlplane/test/feature-flag/update-feature-flag.test.ts
@@ -18,6 +18,43 @@ import {
 
 let dbname = '';
 
+// Feature-subgraph change detection compares the new id set against the stored set (length +
+// membership), so it is order-independent. `hasChanged` is the same early-no-op signal as above.
+const createFeatureSubgraph = async (client: Parameters<typeof createFeatureFlag>[0]) => {
+  const subgraphName = genID('subgraph');
+  const featureSubgraphName = genID('featureSubgraph');
+  await createBaseAndFeatureSubgraph(
+    client,
+    subgraphName,
+    featureSubgraphName,
+    DEFAULT_SUBGRAPH_URL_ONE,
+    DEFAULT_SUBGRAPH_URL_TWO,
+  );
+  return featureSubgraphName;
+};
+
+// The update handler skips the write + recomposition when nothing actually changes. For labels
+  // this is decided by `currentLabels.some((label, i) => label !== newLabels[i])` over two arrays
+  // that `normalizeLabels` has already sorted and deduped, guarded by a length check. `hasChanged`
+  // is `false` only when that early no-op return is taken, so it is the precise signal to assert.
+  const createFlagWithLabels = async (
+    client: Parameters<typeof createFeatureFlag>[0],
+    labels: { key: string; value: string }[],
+  ) => {
+    const subgraphName = genID('subgraph');
+    const featureSubgraphName = genID('featureSubgraph');
+    await createBaseAndFeatureSubgraph(
+      client,
+      subgraphName,
+      featureSubgraphName,
+      DEFAULT_SUBGRAPH_URL_ONE,
+      DEFAULT_SUBGRAPH_URL_TWO,
+    );
+    const featureFlagName = genID('flag');
+    await createFeatureFlag(client, featureFlagName, labels, [featureSubgraphName]);
+    return featureFlagName;
+  };
+
 describe('Update feature flag tests', () => {
   beforeAll(async () => {
     dbname = await beforeAllSetup();
@@ -431,5 +468,165 @@ describe('Update feature flag tests', () => {
       featureSubgraphNames: [featureSubgraphName],
     });
     expect(updateFeatureFlagResponse.response?.code).toBe(EnumStatusCode.ERROR_NOT_AUTHORIZED);
+  });
+
+  test('that updating a feature flag with the same labels in a different order is a no-op (hasChanged is false)', async (testContext) => {
+    const { client, server } = await SetupTest({ dbname });
+    testContext.onTestFinished(() => server.close());
+
+    const featureFlagName = await createFlagWithLabels(client, [
+      { key: 'team', value: 'A' },
+      { key: 'env', value: 'prod' },
+    ]);
+
+    // Same set of labels, reversed order.
+    const res = await client.updateFeatureFlag({
+      name: featureFlagName,
+      labels: [
+        { key: 'env', value: 'prod' },
+        { key: 'team', value: 'A' },
+      ],
+    });
+    expect(res.response?.code).toBe(EnumStatusCode.OK);
+    expect(res.hasChanged).toBe(false);
+  });
+
+  test('that updating a feature flag with the identical labels is a no-op (hasChanged is false)', async (testContext) => {
+    const { client, server } = await SetupTest({ dbname });
+    testContext.onTestFinished(() => server.close());
+
+    const labels = [
+      { key: 'team', value: 'A' },
+      { key: 'env', value: 'prod' },
+    ];
+    const featureFlagName = await createFlagWithLabels(client, labels);
+
+    const res = await client.updateFeatureFlag({ name: featureFlagName, labels });
+    expect(res.response?.code).toBe(EnumStatusCode.OK);
+    expect(res.hasChanged).toBe(false);
+  });
+
+  test('that updating a feature flag with the same labels plus a duplicate is a no-op (hasChanged is false)', async (testContext) => {
+    const { client, server } = await SetupTest({ dbname });
+    testContext.onTestFinished(() => server.close());
+
+    const featureFlagName = await createFlagWithLabels(client, [{ key: 'team', value: 'A' }]);
+
+    // Duplicate of the existing label — `normalizeLabels` dedupes, so this is not a change.
+    const res = await client.updateFeatureFlag({
+      name: featureFlagName,
+      labels: [
+        { key: 'team', value: 'A' },
+        { key: 'team', value: 'A' },
+      ],
+    });
+    expect(res.response?.code).toBe(EnumStatusCode.OK);
+    expect(res.hasChanged).toBe(false);
+  });
+
+  test('that updating a feature flag with a changed label value triggers a change (hasChanged is true)', async (testContext) => {
+    const { client, server } = await SetupTest({ dbname });
+    testContext.onTestFinished(() => server.close());
+
+    const featureFlagName = await createFlagWithLabels(client, [
+      { key: 'team', value: 'A' },
+      { key: 'env', value: 'prod' },
+    ]);
+
+    const res = await client.updateFeatureFlag({
+      name: featureFlagName,
+      labels: [
+        { key: 'team', value: 'B' }, // value changed A -> B
+        { key: 'env', value: 'prod' },
+      ],
+    });
+    expect(res.response?.code).toBe(EnumStatusCode.OK);
+    expect(res.hasChanged).toBe(true);
+  });
+
+  test('that updating a feature flag with an added label triggers a change (hasChanged is true)', async (testContext) => {
+    const { client, server } = await SetupTest({ dbname });
+    testContext.onTestFinished(() => server.close());
+
+    const featureFlagName = await createFlagWithLabels(client, [{ key: 'team', value: 'A' }]);
+
+    const res = await client.updateFeatureFlag({
+      name: featureFlagName,
+      labels: [
+        { key: 'team', value: 'A' },
+        { key: 'env', value: 'prod' }, // added
+      ],
+    });
+    expect(res.response?.code).toBe(EnumStatusCode.OK);
+    expect(res.hasChanged).toBe(true);
+  });
+
+  test('that updating a feature flag with the same feature subgraphs is a no-op (hasChanged is false)', async (testContext) => {
+    const { client, server } = await SetupTest({ dbname });
+    testContext.onTestFinished(() => server.close());
+
+    const featureSubgraphName = await createFeatureSubgraph(client);
+    const featureFlagName = genID('flag');
+    await createFeatureFlag(client, featureFlagName, [], [featureSubgraphName]);
+
+    const res = await client.updateFeatureFlag({
+      name: featureFlagName,
+      featureSubgraphNames: [featureSubgraphName],
+    });
+    expect(res.response?.code).toBe(EnumStatusCode.OK);
+    expect(res.hasChanged).toBe(false);
+  });
+
+  test('that updating a feature flag with the same feature subgraphs in a different order is a no-op (hasChanged is false)', async (testContext) => {
+    const { client, server } = await SetupTest({ dbname });
+    testContext.onTestFinished(() => server.close());
+
+    const featureSubgraphOne = await createFeatureSubgraph(client);
+    const featureSubgraphTwo = await createFeatureSubgraph(client);
+    const featureFlagName = genID('flag');
+    await createFeatureFlag(client, featureFlagName, [], [featureSubgraphOne, featureSubgraphTwo]);
+
+    // Same set of feature subgraphs, reversed order.
+    const res = await client.updateFeatureFlag({
+      name: featureFlagName,
+      featureSubgraphNames: [featureSubgraphTwo, featureSubgraphOne],
+    });
+    expect(res.response?.code).toBe(EnumStatusCode.OK);
+    expect(res.hasChanged).toBe(false);
+  });
+
+  test('that updating a feature flag with an added feature subgraph triggers a change (hasChanged is true)', async (testContext) => {
+    const { client, server } = await SetupTest({ dbname });
+    testContext.onTestFinished(() => server.close());
+
+    const featureSubgraphOne = await createFeatureSubgraph(client);
+    const featureSubgraphTwo = await createFeatureSubgraph(client);
+    const featureFlagName = genID('flag');
+    await createFeatureFlag(client, featureFlagName, [], [featureSubgraphOne]);
+
+    const res = await client.updateFeatureFlag({
+      name: featureFlagName,
+      featureSubgraphNames: [featureSubgraphOne, featureSubgraphTwo], // added featureSubgraphTwo
+    });
+    expect(res.response?.code).toBe(EnumStatusCode.OK);
+    expect(res.hasChanged).toBe(true);
+  });
+
+  test('that updating a feature flag with a swapped feature subgraph triggers a change (hasChanged is true)', async (testContext) => {
+    const { client, server } = await SetupTest({ dbname });
+    testContext.onTestFinished(() => server.close());
+
+    const featureSubgraphOne = await createFeatureSubgraph(client);
+    const featureSubgraphTwo = await createFeatureSubgraph(client);
+    const featureFlagName = genID('flag');
+    await createFeatureFlag(client, featureFlagName, [], [featureSubgraphOne]);
+
+    // Same count, different member.
+    const res = await client.updateFeatureFlag({
+      name: featureFlagName,
+      featureSubgraphNames: [featureSubgraphTwo],
+    });
+    expect(res.response?.code).toBe(EnumStatusCode.OK);
+    expect(res.hasChanged).toBe(true);
   });
 });

--- a/controlplane/test/feature-flag/update-feature-flag.test.ts
+++ b/controlplane/test/feature-flag/update-feature-flag.test.ts
@@ -33,27 +33,29 @@ const createFeatureSubgraph = async (client: Parameters<typeof createFeatureFlag
   return featureSubgraphName;
 };
 
-// The update handler skips the write + recomposition when nothing actually changes. For labels
-  // this is decided by `currentLabels.some((label, i) => label !== newLabels[i])` over two arrays
-  // that `normalizeLabels` has already sorted and deduped, guarded by a length check. `hasChanged`
-  // is `false` only when that early no-op return is taken, so it is the precise signal to assert.
-  const createFlagWithLabels = async (
-    client: Parameters<typeof createFeatureFlag>[0],
-    labels: { key: string; value: string }[],
-  ) => {
-    const subgraphName = genID('subgraph');
-    const featureSubgraphName = genID('featureSubgraph');
-    await createBaseAndFeatureSubgraph(
-      client,
-      subgraphName,
-      featureSubgraphName,
-      DEFAULT_SUBGRAPH_URL_ONE,
-      DEFAULT_SUBGRAPH_URL_TWO,
-    );
-    const featureFlagName = genID('flag');
-    await createFeatureFlag(client, featureFlagName, labels, [featureSubgraphName]);
-    return featureFlagName;
-  };
+/**
+ * The update handler skips the write + recomposition when nothing actually changes. For labels
+ * this is decided by `currentLabels.some((label, i) => label !== newLabels[i])` over two arrays
+ * that `normalizeLabels` has already sorted and deduped, guarded by a length check. `hasChanged`
+ * is `false` only when that early no-op return is taken, so it is the precise signal to assert.
+ */
+const createFlagWithLabels = async (
+  client: Parameters<typeof createFeatureFlag>[0],
+  labels: { key: string; value: string }[],
+) => {
+  const subgraphName = genID('subgraph');
+  const featureSubgraphName = genID('featureSubgraph');
+  await createBaseAndFeatureSubgraph(
+    client,
+    subgraphName,
+    featureSubgraphName,
+    DEFAULT_SUBGRAPH_URL_ONE,
+    DEFAULT_SUBGRAPH_URL_TWO,
+  );
+  const featureFlagName = genID('flag');
+  await createFeatureFlag(client, featureFlagName, labels, [featureSubgraphName]);
+  return featureFlagName;
+};
 
 describe('Update feature flag tests', () => {
   beforeAll(async () => {

--- a/proto/wg/cosmo/platform/v1/platform.proto
+++ b/proto/wg/cosmo/platform/v1/platform.proto
@@ -2507,6 +2507,7 @@ message UpdateFeatureFlagResponse {
   repeated CompositionError composition_errors = 2;
   repeated DeploymentError deployment_errors = 3;
   repeated CompositionWarning compositionWarnings = 4;
+  optional bool has_changed = 5;
 }
 
 message EnableFeatureFlagRequest {


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Update operations now indicate whether they made changes — responses show either "has no new changes" or "was updated successfully".

* **Tests**
  * Added tests verifying change-detection for labels (order, duplicates, value changes) and for feature-subgraph updates (order, additions, swaps).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [x] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [x] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).
