### PR TITLE
chore: add hostname tag to Sentry config

### DIFF
--- a/controlplane/src/core/composition/composeGraphs.worker.ts
+++ b/controlplane/src/core/composition/composeGraphs.worker.ts
@@ -11,6 +11,7 @@
  * is safe for local modules. Value imports from npm packages are fine.
  */
 import { randomUUID } from 'node:crypto';
+import os from 'node:os';
 import { printSchemaWithDirectives } from '@graphql-tools/utils';
 import {
   federateSubgraphsContract,
@@ -87,6 +88,8 @@ if (SENTRY_ENABLED && SENTRY_DSN) {
     enableLogs: SENTRY_ENABLE_LOGS,
     spotlight: process.env.NODE_ENV !== 'production',
   });
+
+  Sentry.setTag('hostname', os.hostname());
 }
 
 function parseGRPCMapping(mappings: string): GRPCMapping {

--- a/controlplane/src/core/sentry.config.ts
+++ b/controlplane/src/core/sentry.config.ts
@@ -1,3 +1,4 @@
+import os from 'node:os';
 import process from 'node:process';
 import * as Sentry from '@sentry/node';
 import { nodeProfilingIntegration } from '@sentry/profiling-node';
@@ -32,6 +33,8 @@ if (SENTRY_ENABLED && SENTRY_DSN) {
     enableLogs: SENTRY_ENABLE_LOGS,
     spotlight: process.env.NODE_ENV !== 'production',
   });
+
+  Sentry.setTag('hostname', os.hostname());
 
   if (process.env.NODE_ENV !== 'production') {
     console.log('Sentry is initialized.');


### PR DESCRIPTION
Tags each Sentry event with the hostname of the machine generating the telemetry, making it easier to filter and correlate events by server instance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Telemetry now adds the machine hostname as a tag for error reporting across core and worker processes.
  * This improves traceability of reports to specific hosts without changing external behavior or public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->