### PR TITLE
chore: ignore .claude/worktrees/ directory

### DIFF
--- a/.github/workflows/dummy-ci.yaml
+++ b/.github/workflows/dummy-ci.yaml
@@ -15,6 +15,7 @@ on:
       - 'LICENSE'
       - '.github/PULL_REQUEST_TEMPLATE.md'
       - '.github/CODEOWNERS'
+      - '.gitignore'
 jobs:
   build_test:
     timeout-minutes: 5

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ go.work.sum
 
 # Serena
 .serena/
+
+# Claude Code
+.claude/worktrees/


### PR DESCRIPTION
## Summary

- Adds `.claude/worktrees/` to `.gitignore` to avoid tracking Claude Code's temporary worktree directories, consistent with the existing `.serena/` entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated development config to ignore local workspace data created by the code editor.
  * CI workflow updated to also trigger when the repository's ignore-list is modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->