### PR TITLE
fix: dedupe and exclude disabled feature flags in schema page dropdown

### DIFF
--- a/controlplane/src/core/bufservices/feature-flag/getFeatureFlagsInLatestCompositionByFederatedGraph.ts
+++ b/controlplane/src/core/bufservices/feature-flag/getFeatureFlagsInLatestCompositionByFederatedGraph.ts
@@ -81,7 +81,9 @@ export function getFeatureFlagsInLatestCompositionByFederatedGraph(
             namespaceId: namespace.id,
             includeSubgraphs: false,
           });
-          if (flag) {
+          // A disabled feature flag is no longer served in the latest composition (its router config is
+          // removed without recomposing), so exclude it even though its schema version rows still exist.
+          if (flag && flag.isEnabled) {
             featureFlags.push(flag);
           }
         }

--- a/controlplane/src/core/repositories/FeatureFlagRepository.ts
+++ b/controlplane/src/core/repositories/FeatureFlagRepository.ts
@@ -1307,13 +1307,21 @@ export class FeatureFlagRepository {
   }: {
     baseSchemaVersionId: string;
   }) {
+    // A feature flag can have multiple composed schema versions against the same base schema version
+    // (e.g. recomposing the feature flag recomposes it against the unchanged base, so rows accumulate).
+    // Deduplicate by feature flag, keeping the latest composed version, so callers get one entry per flag.
     const ffSchemaVersions = await this.db
-      .select({
+      .selectDistinctOn([federatedGraphsToFeatureFlagSchemaVersions.featureFlagId], {
         id: federatedGraphsToFeatureFlagSchemaVersions.composedSchemaVersionId,
         featureFlagId: federatedGraphsToFeatureFlagSchemaVersions.featureFlagId,
       })
       .from(federatedGraphsToFeatureFlagSchemaVersions)
+      .innerJoin(
+        schemaVersion,
+        eq(schemaVersion.id, federatedGraphsToFeatureFlagSchemaVersions.composedSchemaVersionId),
+      )
       .where(eq(federatedGraphsToFeatureFlagSchemaVersions.baseCompositionSchemaVersionId, baseSchemaVersionId))
+      .orderBy(federatedGraphsToFeatureFlagSchemaVersions.featureFlagId, desc(schemaVersion.createdAt))
       .execute();
 
     if (ffSchemaVersions.length === 0) {

--- a/controlplane/test/feature-flag/get-feature-flags-in-latest-composition-by-federated-graph.test.ts
+++ b/controlplane/test/feature-flag/get-feature-flags-in-latest-composition-by-federated-graph.test.ts
@@ -144,7 +144,9 @@ describe('GetFeatureFlagsInLatestCompositionByFederatedGraph', () => {
     });
     expect(afterDisable.response?.code).toBe(EnumStatusCode.OK);
     expect(afterDisable.featureFlags).toHaveLength(1);
-    expect(afterDisable.featureFlags).toStrictEqual(expect.arrayContaining([expect.objectContaining({ name: flagName })]));
+    expect(afterDisable.featureFlags).toStrictEqual(
+      expect.arrayContaining([expect.objectContaining({ name: flagName })]),
+    );
   });
 
   test('Should return empty list when no feature flags exist', async (testContext) => {

--- a/controlplane/test/feature-flag/get-feature-flags-in-latest-composition-by-federated-graph.test.ts
+++ b/controlplane/test/feature-flag/get-feature-flags-in-latest-composition-by-federated-graph.test.ts
@@ -101,7 +101,7 @@ describe('GetFeatureFlagsInLatestCompositionByFederatedGraph', () => {
     await createFeatureFlag(client, flagName, labels, ['users-feature'], 'default', true);
 
     // recomposeFeatureFlag recomposes only the feature flag against the existing base composition (the base
-    // schema version is unchanged). Each call creates another feature flag composition for the same
+    // schema version is unchanged). Each call creates another feature flag composition for the same\
     // (base composition, feature flag) pair, which is the source of the duplicates in the dropdown.
     const recomposeResp1 = await client.recomposeFeatureFlag({ name: flagName, namespace: 'default' });
     expect(recomposeResp1.response?.code).toBe(EnumStatusCode.OK);
@@ -116,7 +116,7 @@ describe('GetFeatureFlagsInLatestCompositionByFederatedGraph', () => {
 
     expect(resp.response?.code).toBe(EnumStatusCode.OK);
     // Despite multiple accumulated composition rows, the flag must appear exactly once.
-    expect(resp.featureFlags).toEqual([flagName]);
+    expect(resp.featureFlags).toStrictEqual(expect.arrayContaining([expect.objectContaining({ name: flagName })]));
     expect(resp.featureFlags).toHaveLength(1);
 
     // Create a second, enabled feature flag. It is composed into the latest composition, so it shows up too.
@@ -128,7 +128,12 @@ describe('GetFeatureFlagsInLatestCompositionByFederatedGraph', () => {
       namespace: 'default',
     });
     expect(withSecondFlag.response?.code).toBe(EnumStatusCode.OK);
-    expect(withSecondFlag.featureFlags.map((f) => f.name).sort()).toEqual([flagName, secondFlagName].sort());
+    expect(withSecondFlag.featureFlags).toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: flagName }),
+        expect.objectContaining({ name: secondFlagName }),
+      ]),
+    );
     expect(withSecondFlag.featureFlags).toHaveLength(2);
 
     await toggleFeatureFlag(client, secondFlagName, false, 'default');
@@ -139,7 +144,7 @@ describe('GetFeatureFlagsInLatestCompositionByFederatedGraph', () => {
     });
     expect(afterDisable.response?.code).toBe(EnumStatusCode.OK);
     expect(afterDisable.featureFlags).toHaveLength(1);
-    expect(afterDisable.featureFlags).toEqual([flagName]);
+    expect(afterDisable.featureFlags).toStrictEqual(expect.arrayContaining([expect.objectContaining({ name: flagName })]));
   });
 
   test('Should return empty list when no feature flags exist', async (testContext) => {

--- a/controlplane/test/feature-flag/get-feature-flags-in-latest-composition-by-federated-graph.test.ts
+++ b/controlplane/test/feature-flag/get-feature-flags-in-latest-composition-by-federated-graph.test.ts
@@ -12,7 +12,7 @@ import {
   DEFAULT_ROUTER_URL,
   DEFAULT_SUBGRAPH_URL_ONE,
   SetupTest,
-  toggleFeatureFlag
+  toggleFeatureFlag,
 } from '../test-util.js';
 
 let dbname = '';
@@ -103,10 +103,11 @@ describe('GetFeatureFlagsInLatestCompositionByFederatedGraph', () => {
     // recomposeFeatureFlag recomposes only the feature flag against the existing base composition (the base
     // schema version is unchanged). Each call creates another feature flag composition for the same
     // (base composition, feature flag) pair, which is the source of the duplicates in the dropdown.
-    for (let i = 0; i < 2; i++) {
-      const recomposeResp = await client.recomposeFeatureFlag({ name: flagName, namespace: 'default' });
-      expect(recomposeResp.response?.code).toBe(EnumStatusCode.OK);
-    }
+    const recomposeResp1 = await client.recomposeFeatureFlag({ name: flagName, namespace: 'default' });
+    expect(recomposeResp1.response?.code).toBe(EnumStatusCode.OK);
+
+    const recomposeResp2 = await client.recomposeFeatureFlag({ name: flagName, namespace: 'default' });
+    expect(recomposeResp2.response?.code).toBe(EnumStatusCode.OK);
 
     const resp = await client.getFeatureFlagsInLatestCompositionByFederatedGraph({
       federatedGraphName,
@@ -115,7 +116,7 @@ describe('GetFeatureFlagsInLatestCompositionByFederatedGraph', () => {
 
     expect(resp.response?.code).toBe(EnumStatusCode.OK);
     // Despite multiple accumulated composition rows, the flag must appear exactly once.
-    expect(resp.featureFlags.filter((f) => f.name === flagName)).toHaveLength(1);
+    expect(resp.featureFlags).toEqual([flagName]);
     expect(resp.featureFlags).toHaveLength(1);
 
     // Create a second, enabled feature flag. It is composed into the latest composition, so it shows up too.
@@ -128,6 +129,7 @@ describe('GetFeatureFlagsInLatestCompositionByFederatedGraph', () => {
     });
     expect(withSecondFlag.response?.code).toBe(EnumStatusCode.OK);
     expect(withSecondFlag.featureFlags.map((f) => f.name).sort()).toEqual([flagName, secondFlagName].sort());
+    expect(withSecondFlag.featureFlags).toHaveLength(2);
 
     await toggleFeatureFlag(client, secondFlagName, false, 'default');
 
@@ -137,7 +139,7 @@ describe('GetFeatureFlagsInLatestCompositionByFederatedGraph', () => {
     });
     expect(afterDisable.response?.code).toBe(EnumStatusCode.OK);
     expect(afterDisable.featureFlags).toHaveLength(1);
-    expect(afterDisable.featureFlags[0].name).toBe(flagName);
+    expect(afterDisable.featureFlags).toEqual([flagName]);
   });
 
   test('Should return empty list when no feature flags exist', async (testContext) => {

--- a/controlplane/test/feature-flag/get-feature-flags-in-latest-composition-by-federated-graph.test.ts
+++ b/controlplane/test/feature-flag/get-feature-flags-in-latest-composition-by-federated-graph.test.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import { join } from 'node:path';
 import { EnumStatusCode } from '@wundergraph/cosmo-connect/dist/common/common_pb';
+import { formatISO } from 'date-fns';
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 import { afterAllSetup, beforeAllSetup, genID, genUniqueLabel } from '../../src/core/test-util.js';
 import {
@@ -11,6 +12,7 @@ import {
   DEFAULT_ROUTER_URL,
   DEFAULT_SUBGRAPH_URL_ONE,
   SetupTest,
+  toggleFeatureFlag
 } from '../test-util.js';
 
 let dbname = '';
@@ -64,6 +66,78 @@ describe('GetFeatureFlagsInLatestCompositionByFederatedGraph', () => {
     expect(resp.response?.code).toBe(EnumStatusCode.OK);
     expect(resp.featureFlags.length).toBeGreaterThanOrEqual(1);
     expect(resp.featureFlags.some((f) => f.name === flagName)).toBe(true);
+  });
+
+  test('Should return each feature flag only once when it has multiple compositions against the same base', async (testContext) => {
+    const { client, server } = await SetupTest({ dbname, enabledFeatures: ['split-config-loading'] });
+    testContext.onTestFinished(() => server.close());
+
+    const labels = [genUniqueLabel()];
+    const federatedGraphName = genID('fedGraph');
+
+    await createAndPublishSubgraph(
+      client,
+      'users',
+      'default',
+      fs.readFileSync(join(process.cwd(), 'test/test-data/feature-flags/users.graphql')).toString(),
+      labels,
+      DEFAULT_SUBGRAPH_URL_ONE,
+    );
+
+    await createThenPublishFeatureSubgraph(
+      client,
+      'users-feature',
+      'users',
+      'default',
+      fs.readFileSync(join(process.cwd(), 'test/test-data/feature-flags/users-feature.graphql')).toString(),
+      labels,
+      'http://localhost:4101',
+    );
+
+    const federatedGraphLabels = labels.map(({ key, value }) => `${key}=${value}`);
+    await createFederatedGraph(client, federatedGraphName, 'default', federatedGraphLabels, DEFAULT_ROUTER_URL);
+
+    const flagName = genID('flag');
+    await createFeatureFlag(client, flagName, labels, ['users-feature'], 'default', true);
+
+    // recomposeFeatureFlag recomposes only the feature flag against the existing base composition (the base
+    // schema version is unchanged). Each call creates another feature flag composition for the same
+    // (base composition, feature flag) pair, which is the source of the duplicates in the dropdown.
+    for (let i = 0; i < 2; i++) {
+      const recomposeResp = await client.recomposeFeatureFlag({ name: flagName, namespace: 'default' });
+      expect(recomposeResp.response?.code).toBe(EnumStatusCode.OK);
+    }
+
+    const resp = await client.getFeatureFlagsInLatestCompositionByFederatedGraph({
+      federatedGraphName,
+      namespace: 'default',
+    });
+
+    expect(resp.response?.code).toBe(EnumStatusCode.OK);
+    // Despite multiple accumulated composition rows, the flag must appear exactly once.
+    expect(resp.featureFlags.filter((f) => f.name === flagName)).toHaveLength(1);
+    expect(resp.featureFlags).toHaveLength(1);
+
+    // Create a second, enabled feature flag. It is composed into the latest composition, so it shows up too.
+    const secondFlagName = genID('flag');
+    await createFeatureFlag(client, secondFlagName, labels, ['users-feature'], 'default', true);
+
+    const withSecondFlag = await client.getFeatureFlagsInLatestCompositionByFederatedGraph({
+      federatedGraphName,
+      namespace: 'default',
+    });
+    expect(withSecondFlag.response?.code).toBe(EnumStatusCode.OK);
+    expect(withSecondFlag.featureFlags.map((f) => f.name).sort()).toEqual([flagName, secondFlagName].sort());
+
+    await toggleFeatureFlag(client, secondFlagName, false, 'default');
+
+    const afterDisable = await client.getFeatureFlagsInLatestCompositionByFederatedGraph({
+      federatedGraphName,
+      namespace: 'default',
+    });
+    expect(afterDisable.response?.code).toBe(EnumStatusCode.OK);
+    expect(afterDisable.featureFlags).toHaveLength(1);
+    expect(afterDisable.featureFlags[0].name).toBe(flagName);
   });
 
   test('Should return empty list when no feature flags exist', async (testContext) => {


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled feature flags are now excluded from API responses and router configuration.
  * Duplicate feature-flag entries are deduplicated so each flag appears only once when multiple composed versions exist.
  * Improved consistency when retrieving feature flags from the latest composition.

* **Tests**
  * Added tests validating deduplication and disabled-flag filtering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [x] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [x] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).
