### PR TITLE
chore: add pool queue size and thread count as Sentry measurements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ go.work.sum
 
 # Serena
 .serena/
+
+# Claude Code
+.claude/worktrees/

--- a/controlplane/src/core/composition/composeGraphs.pool.ts
+++ b/controlplane/src/core/composition/composeGraphs.pool.ts
@@ -155,6 +155,9 @@ export function composeGraphsInWorker(
       const traceData = Sentry.getTraceData();
       const pool = getComposeGraphsPool();
       span.setAttribute('pool.queueSize', pool.queueSize);
+      span.setAttribute('pool.threads', pool.threads.length);
+      Sentry.setMeasurement('pool.queueSize', pool.queueSize, 'none');
+      Sentry.setMeasurement('pool.threads', pool.threads.length, 'none');
 
       return pool.run({
         ...fullTask,


### PR DESCRIPTION
Captures `pool.queueSize` and `pool.threads` as both span attributes and Sentry measurements on `ComposeGraphsPool.composeGraphsInWorker` spans.

- **Span attributes** — visible in the trace explorer on the individual span
- **Sentry measurements** — numeric, aggregatable at the transaction level for use in dashboards (`avg`, `max`, `p95` etc.)

This supports building a Sentry dashboard for composition queue usage, split by hostname/pod.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development configuration files
  * Enhanced monitoring capabilities for worker pool performance tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->