### PR TITLE
feat(router): entity cache OTEL/Prometheus metrics (5/6)

### DIFF
--- a/router/core/graph_server.go
+++ b/router/core/graph_server.go
@@ -100,20 +100,22 @@ type (
 		inFlightRequests *atomic.Uint64
 		// graphMuxList contains all graph muxes of this graph server.
 		// It's keyed by mux name (feature flag name or empty string for base graph).
-		graphMuxList               map[string]*graphMux
-		graphMuxListLock           sync.Mutex
-		runtimeMetrics             *rmetric.RuntimeMetrics
-		otlpEngineMetrics          *rmetric.EngineMetrics
-		prometheusEngineMetrics    *rmetric.EngineMetrics
-		connectionMetrics          *rmetric.ConnectionMetrics
-		instanceData               InstanceData
-		pubSubProviders            []datasource.Provider
-		traceDialer                *TraceDialer
-		connector                  *grpcconnector.Connector
-		circuitBreakerManager      *circuit.Manager
-		headerPropagation          *HeaderPropagation
-		entityCacheInstances       map[string]resolve.LoaderCache
-		entityCacheKeyInterceptors []EntityCacheKeyInterceptor
+		graphMuxList                 map[string]*graphMux
+		graphMuxListLock             sync.Mutex
+		runtimeMetrics               *rmetric.RuntimeMetrics
+		otlpEngineMetrics            *rmetric.EngineMetrics
+		prometheusEngineMetrics      *rmetric.EngineMetrics
+		connectionMetrics            *rmetric.ConnectionMetrics
+		otlpEntityCacheMetrics       *rmetric.EntityCacheMetrics
+		prometheusEntityCacheMetrics *rmetric.EntityCacheMetrics
+		instanceData                 InstanceData
+		pubSubProviders              []datasource.Provider
+		traceDialer                  *TraceDialer
+		connector                    *grpcconnector.Connector
+		circuitBreakerManager        *circuit.Manager
+		headerPropagation            *HeaderPropagation
+		entityCacheInstances         map[string]resolve.LoaderCache
+		entityCacheKeyInterceptors   []EntityCacheKeyInterceptor
 	}
 )
 
@@ -301,6 +303,10 @@ func newGraphServer(routerCtx context.Context, r *Router, response *routerconfig
 
 	if err := s.setupEngineStatistics(mappedMetricAttributes); err != nil {
 		return nil, fmt.Errorf("failed to setup engine statistics: %w", err)
+	}
+
+	if err := s.setupEntityCacheMetrics(mappedMetricAttributes); err != nil {
+		return nil, fmt.Errorf("failed to setup entity cache metrics: %w", err)
 	}
 
 	if s.registrationInfo != nil {
@@ -725,6 +731,30 @@ func (s *graphServer) logEntityCacheOverrideIssues(
 			}
 		}
 	}
+}
+
+func (s *graphServer) setupEntityCacheMetrics(baseAttributes []attribute.KeyValue) error {
+	if !s.entityCachingConfig.Enabled {
+		return nil
+	}
+
+	if s.metricConfig.OpenTelemetry.EntityCachingStats {
+		var err error
+		s.otlpEntityCacheMetrics, err = rmetric.NewEntityCacheMetrics(s.logger, baseAttributes, s.otlpMeterProvider)
+		if err != nil {
+			return fmt.Errorf("failed to create entity cache metrics for OTLP: %w", err)
+		}
+	}
+
+	if s.metricConfig.Prometheus.EntityCachingStats {
+		var err error
+		s.prometheusEntityCacheMetrics, err = rmetric.NewEntityCacheMetrics(s.logger, baseAttributes, s.promMeterProvider)
+		if err != nil {
+			return fmt.Errorf("failed to create entity cache metrics for Prometheus: %w", err)
+		}
+	}
+
+	return nil
 }
 
 type graphMux struct {
@@ -1893,6 +1923,12 @@ func (s *graphServer) buildGraphMux(
 			GlobalKeyPrefix: s.entityCachingConfig.GlobalCacheKeyPrefix,
 			KeyInterceptors: s.entityCacheKeyInterceptors,
 		}
+
+		for _, m := range []*rmetric.EntityCacheMetrics{s.otlpEntityCacheMetrics, s.prometheusEntityCacheMetrics} {
+			if m != nil {
+				handlerOpts.EntityCaching.Metrics = append(handlerOpts.EntityCaching.Metrics, m)
+			}
+		}
 		// TODO: Add entity analytics exporter to handler options here once analytics pipeline is implemented (see ENTITY_CACHE_ANALYTICS.md).
 	}
 
@@ -2293,7 +2329,21 @@ func (s *graphServer) Shutdown(ctx context.Context) error {
 		}
 	}
 
+	if s.otlpEntityCacheMetrics != nil {
+		if err := s.otlpEntityCacheMetrics.Shutdown(); err != nil {
+			finalErr = errors.Join(finalErr, err)
+		}
+	}
+
+	if s.prometheusEntityCacheMetrics != nil {
+		if err := s.prometheusEntityCacheMetrics.Shutdown(); err != nil {
+			finalErr = errors.Join(finalErr, err)
+		}
+	}
+
 	// Shutdown graphs muxes, which are not reused by the next graph server, to release resources
+
+	// Shutdown all graphs muxes to release resources
 	// e.g. planner cache
 	s.graphMuxListLock.Lock()
 	defer s.graphMuxListLock.Unlock()

--- a/router/core/graph_server_cache_metrics_test.go
+++ b/router/core/graph_server_cache_metrics_test.go
@@ -1,0 +1,134 @@
+package core
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.uber.org/zap"
+
+	"github.com/wundergraph/cosmo/router/pkg/config"
+	"github.com/wundergraph/cosmo/router/pkg/entitycache"
+	rmetric "github.com/wundergraph/cosmo/router/pkg/metric"
+)
+
+func TestEntityCacheMetricRegistrations_DeduplicatesDefaultAlias(t *testing.T) {
+	t.Parallel()
+
+	cache, err := entitycache.NewMemoryEntityCache(1024)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cache.Close() })
+
+	registrations := entityCacheMetricRegistrations(map[string]cacheMetricSource{
+		"default":  cache,
+		"memory-1": cache,
+	})
+
+	require.Len(t, registrations, 1)
+	require.Equal(t, "entity_memory-1", registrations[0].cacheType)
+	require.EqualValues(t, 1024, registrations[0].maxCost)
+	require.NotNil(t, registrations[0].metrics)
+}
+
+func TestEntityCacheMetricRegistrations_UsesCircuitBreakerWrappedMemoryCache(t *testing.T) {
+	t.Parallel()
+
+	cache, err := entitycache.NewMemoryEntityCache(2048)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cache.Close() })
+
+	wrapped := entitycache.NewCircuitBreakerCache(cache, entitycache.CircuitBreakerConfig{
+		Enabled:          true,
+		FailureThreshold: 3,
+		CooldownPeriod:   time.Second,
+	})
+
+	registrations := entityCacheMetricRegistrations(map[string]cacheMetricSource{
+		"memory-2": wrapped,
+	})
+
+	require.Len(t, registrations, 1)
+	require.Equal(t, "entity_memory-2", registrations[0].cacheType)
+	require.EqualValues(t, 2048, registrations[0].maxCost)
+	require.NotNil(t, registrations[0].metrics)
+}
+
+func TestSetupEntityCacheMetrics_RespectsMetricOptIn(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		metrics  rmetric.Config
+		wantOTLP bool
+		wantProm bool
+	}{
+		{
+			name:     "default off",
+			metrics:  rmetric.Config{},
+			wantOTLP: false,
+			wantProm: false,
+		},
+		{
+			name: "otlp only",
+			metrics: rmetric.Config{
+				OpenTelemetry: rmetric.OpenTelemetry{
+					EntityCachingStats: true,
+				},
+			},
+			wantOTLP: true,
+			wantProm: false,
+		},
+		{
+			name: "prometheus only",
+			metrics: rmetric.Config{
+				Prometheus: rmetric.PrometheusConfig{
+					EntityCachingStats: true,
+				},
+			},
+			wantOTLP: false,
+			wantProm: true,
+		},
+		{
+			name: "both enabled",
+			metrics: rmetric.Config{
+				OpenTelemetry: rmetric.OpenTelemetry{
+					EntityCachingStats: true,
+				},
+				Prometheus: rmetric.PrometheusConfig{
+					EntityCachingStats: true,
+				},
+			},
+			wantOTLP: true,
+			wantProm: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := &graphServer{
+				Config: &Config{
+					logger: zap.NewNop(),
+					entityCachingConfig: config.EntityCachingConfiguration{
+						Enabled: true,
+					},
+					metricConfig:      &tt.metrics,
+					otlpMeterProvider: sdkmetric.NewMeterProvider(sdkmetric.WithReader(sdkmetric.NewManualReader())),
+					promMeterProvider: sdkmetric.NewMeterProvider(sdkmetric.WithReader(sdkmetric.NewManualReader())),
+				},
+			}
+
+			err := s.setupEntityCacheMetrics([]attribute.KeyValue{
+				attribute.String("service.name", "test-router"),
+			})
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantOTLP, s.otlpEntityCacheMetrics != nil)
+			assert.Equal(t, tt.wantProm, s.prometheusEntityCacheMetrics != nil)
+		})
+	}
+}

--- a/router/core/graphql_handler.go
+++ b/router/core/graphql_handler.go
@@ -16,6 +16,7 @@ import (
 
 	rErrors "github.com/wundergraph/cosmo/router/internal/errors"
 	"github.com/wundergraph/cosmo/router/pkg/config"
+	rmetric "github.com/wundergraph/cosmo/router/pkg/metric"
 	rotel "github.com/wundergraph/cosmo/router/pkg/otel"
 	"github.com/wundergraph/cosmo/router/pkg/statistics"
 
@@ -95,6 +96,7 @@ type EntityCachingHandlerOptions struct {
 	L2Enabled       bool
 	GlobalKeyPrefix string
 	KeyInterceptors []EntityCacheKeyInterceptor
+	Metrics         []*rmetric.EntityCacheMetrics
 }
 
 func NewGraphQLHandler(opts HandlerOptions) *GraphQLHandler {
@@ -276,6 +278,7 @@ func (h *GraphQLHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		graphqlExecutionSpan.SetAttributes(rotel.WgAcquireResolverWaitTimeMs.Int64(info.ResolveAcquireWaitTime.Milliseconds()))
 		graphqlExecutionSpan.SetAttributes(rotel.WgResolverDeduplicatedRequest.Bool(info.ResolveDeduplicated))
+		h.recordEntityCacheMetrics(resolveCtx)
 	case *plan.SubscriptionResponsePlan:
 		var (
 			writer resolve.SubscriptionResponseWriter
@@ -601,6 +604,19 @@ func (h *GraphQLHandler) setDebugCacheHeaders(w http.ResponseWriter, opCtx *oper
 	}
 }
 
+// recordEntityCacheMetrics records OTEL metrics from the cache analytics snapshot.
+// TODO: Add entity analytics export here once the analytics pipeline is implemented (see ENTITY_CACHE_ANALYTICS.md).
+func (h *GraphQLHandler) recordEntityCacheMetrics(resolveCtx *resolve.Context) {
+	if len(h.entityCaching.Metrics) == 0 {
+		return
+	}
+	snapshot := resolveCtx.GetCacheStats()
+	ctx := resolveCtx.Context()
+	for _, m := range h.entityCaching.Metrics {
+		m.RecordSnapshot(ctx, snapshot)
+	}
+}
+
 const (
 	disableEntityCacheHeader   = "X-WG-Disable-Entity-Cache"
 	disableEntityCacheL1Header = "X-WG-Disable-Entity-Cache-L1"
@@ -639,7 +655,7 @@ func (h *GraphQLHandler) cachingOptions(reqCtx *requestContext) resolve.CachingO
 	return resolve.CachingOptions{
 		EnableL1Cache:         enableL1,
 		EnableL2Cache:         enableL2,
-		EnableCacheAnalytics:  false,
+		EnableCacheAnalytics:  len(h.entityCaching.Metrics) > 0,
 		GlobalCacheKeyPrefix:  globalKeyPrefix,
 		L2CacheKeyInterceptor: h.buildL2CacheKeyInterceptor(reqCtx),
 	}

--- a/router/core/graphql_handler_caching_options_test.go
+++ b/router/core/graphql_handler_caching_options_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+
+	rmetric "github.com/wundergraph/cosmo/router/pkg/metric"
 )
 
 func newCachingOptionsHandler(entity EntityCachingHandlerOptions) *GraphQLHandler {
@@ -169,4 +171,17 @@ func TestGraphQLHandler_cachingOptions_CacheKeyPrefixReplacesEmptyGlobal(t *test
 		GlobalCacheKeyPrefix:  "standalone",
 		L2CacheKeyInterceptor: nil,
 	}, opts)
+}
+
+func TestGraphQLHandler_cachingOptions_MetricsEnablesAnalytics(t *testing.T) {
+	t.Parallel()
+	h := newCachingOptionsHandler(EntityCachingHandlerOptions{
+		L1Enabled: true,
+		L2Enabled: true,
+		Metrics:   []*rmetric.EntityCacheMetrics{nil}, // just non-empty slice
+	})
+	reqCtx := newCachingOptionsReqCtx(t, false, nil)
+
+	opts := h.cachingOptions(reqCtx)
+	require.True(t, opts.EnableCacheAnalytics)
 }

--- a/router/core/router.go
+++ b/router/core/router.go
@@ -2877,10 +2877,11 @@ func MetricConfigFromTelemetry(cfg *config.Telemetry) *rmetric.Config {
 		ResourceAttributes: buildResourceAttributes(cfg.ResourceAttributes),
 		CardinalityLimit:   cfg.Metrics.CardinalityLimit,
 		OpenTelemetry: rmetric.OpenTelemetry{
-			Enabled:         cfg.Metrics.OTLP.Enabled,
-			RouterRuntime:   cfg.Metrics.OTLP.RouterRuntime,
-			GraphqlCache:    cfg.Metrics.OTLP.GraphqlCache,
-			ConnectionStats: cfg.Metrics.OTLP.ConnectionStats,
+			Enabled:            cfg.Metrics.OTLP.Enabled,
+			RouterRuntime:      cfg.Metrics.OTLP.RouterRuntime,
+			GraphqlCache:       cfg.Metrics.OTLP.GraphqlCache,
+			ConnectionStats:    cfg.Metrics.OTLP.ConnectionStats,
+			EntityCachingStats: cfg.Metrics.OTLP.EntityCachingStats,
 			EngineStats: rmetric.EngineStatsConfig{
 				Subscription: cfg.Metrics.OTLP.EngineStats.Subscriptions,
 			},
@@ -2897,11 +2898,12 @@ func MetricConfigFromTelemetry(cfg *config.Telemetry) *rmetric.Config {
 			},
 		},
 		Prometheus: rmetric.PrometheusConfig{
-			Enabled:         cfg.Metrics.Prometheus.Enabled,
-			ListenAddr:      cfg.Metrics.Prometheus.ListenAddr,
-			Path:            cfg.Metrics.Prometheus.Path,
-			GraphqlCache:    cfg.Metrics.Prometheus.GraphqlCache,
-			ConnectionStats: cfg.Metrics.Prometheus.ConnectionStats,
+			Enabled:            cfg.Metrics.Prometheus.Enabled,
+			ListenAddr:         cfg.Metrics.Prometheus.ListenAddr,
+			Path:               cfg.Metrics.Prometheus.Path,
+			GraphqlCache:       cfg.Metrics.Prometheus.GraphqlCache,
+			ConnectionStats:    cfg.Metrics.Prometheus.ConnectionStats,
+			EntityCachingStats: cfg.Metrics.Prometheus.EntityCachingStats,
 			EngineStats: rmetric.EngineStatsConfig{
 				Subscription: cfg.Metrics.Prometheus.EngineStats.Subscriptions,
 			},

--- a/router/pkg/config/config.go
+++ b/router/pkg/config/config.go
@@ -113,6 +113,7 @@ type Prometheus struct {
 	ListenAddr          string      `yaml:"listen_addr" envDefault:"127.0.0.1:8088" env:"PROMETHEUS_LISTEN_ADDR"`
 	GraphqlCache        bool        `yaml:"graphql_cache" envDefault:"false" env:"PROMETHEUS_GRAPHQL_CACHE"`
 	ConnectionStats     bool        `yaml:"connection_stats" envDefault:"false" env:"PROMETHEUS_CONNECTION_STATS"`
+	EntityCachingStats  bool        `yaml:"entity_caching_stats" envDefault:"false" env:"PROMETHEUS_ENTITY_CACHING_STATS"`
 	Streams             bool        `yaml:"streams" envDefault:"false" env:"PROMETHEUS_STREAM"`
 	EngineStats         EngineStats `yaml:"engine_stats" envPrefix:"PROMETHEUS_"`
 	CostStats           CostStats   `yaml:"cost_stats" envPrefix:"PROMETHEUS_COST_STATS_"`
@@ -164,6 +165,7 @@ type MetricsOTLP struct {
 	RouterRuntime       bool                  `yaml:"router_runtime" envDefault:"true" env:"METRICS_OTLP_ROUTER_RUNTIME"`
 	GraphqlCache        bool                  `yaml:"graphql_cache" envDefault:"false" env:"METRICS_OTLP_GRAPHQL_CACHE"`
 	ConnectionStats     bool                  `yaml:"connection_stats" envDefault:"false" env:"METRICS_OTLP_CONNECTION_STATS"`
+	EntityCachingStats  bool                  `yaml:"entity_caching_stats" envDefault:"false" env:"METRICS_OTLP_ENTITY_CACHING_STATS"`
 	EngineStats         EngineStats           `yaml:"engine_stats" envPrefix:"METRICS_OTLP_"`
 	CostStats           CostStats             `yaml:"cost_stats" envPrefix:"METRICS_OTLP_COST_STATS_"`
 	CircuitBreaker      bool                  `yaml:"circuit_breaker" envDefault:"false" env:"METRICS_OTLP_CIRCUIT_BREAKER"`

--- a/router/pkg/config/config.schema.json
+++ b/router/pkg/config/config.schema.json
@@ -1537,6 +1537,11 @@
                   "default": false,
                   "description": "Enable the collection of connection stats. The default value is false."
                 },
+                "entity_caching_stats": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Enable the collection of entity cache metrics. The default value is false."
+                },
                 "streams": {
                   "type": "boolean",
                   "default": false,
@@ -1692,6 +1697,11 @@
                   "type": "boolean",
                   "default": false,
                   "description": "Enable the collection of connection stats. The default value is false."
+                },
+                "entity_caching_stats": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Enable the collection of entity cache metrics. The default value is false."
                 },
                 "streams": {
                   "type": "boolean",

--- a/router/pkg/config/config_test.go
+++ b/router/pkg/config/config_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/caarlos0/env/v11"
 	"github.com/santhosh-tekuri/jsonschema/v6"
 	"github.com/sebdah/goldie/v2"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1052,6 +1053,26 @@ version: "1"
 
 	require.True(t, c.Config.Telemetry.Metrics.Prometheus.EngineStats.Subscriptions)
 	require.True(t, c.Config.Telemetry.Metrics.OTLP.EngineStats.Subscriptions)
+}
+
+func TestMetricEntityCachingStatsConfig(t *testing.T) {
+	f := createTempFileFromFixture(t, `
+version: "1"
+`)
+	c, err := LoadConfig([]string{f})
+	require.NoError(t, err)
+
+	assert.Equal(t, false, c.Config.Telemetry.Metrics.Prometheus.EntityCachingStats)
+	assert.Equal(t, false, c.Config.Telemetry.Metrics.OTLP.EntityCachingStats)
+
+	t.Setenv("PROMETHEUS_ENTITY_CACHING_STATS", "true")
+	t.Setenv("METRICS_OTLP_ENTITY_CACHING_STATS", "true")
+
+	c, err = LoadConfig([]string{f})
+	require.NoError(t, err)
+
+	assert.Equal(t, true, c.Config.Telemetry.Metrics.Prometheus.EntityCachingStats)
+	assert.Equal(t, true, c.Config.Telemetry.Metrics.OTLP.EntityCachingStats)
 }
 
 func TestMatchAndNegateMatch(t *testing.T) {

--- a/router/pkg/config/fixtures/full.yaml
+++ b/router/pkg/config/fixtures/full.yaml
@@ -179,6 +179,7 @@ telemetry:
       router_runtime: true
       graphql_cache: true
       connection_stats: true
+      entity_caching_stats: true
       engine_stats:
         subscriptions: true
       cost_stats:
@@ -207,6 +208,7 @@ telemetry:
       listen_addr: '127.0.0.1:8088'
       graphql_cache: true
       connection_stats: true
+      entity_caching_stats: true
       engine_stats:
         subscriptions: true
       cost_stats:

--- a/router/pkg/config/testdata/config_defaults.json
+++ b/router/pkg/config/testdata/config_defaults.json
@@ -41,6 +41,7 @@
         "RouterRuntime": true,
         "GraphqlCache": false,
         "ConnectionStats": false,
+        "EntityCachingStats": false,
         "EngineStats": {
           "Subscriptions": false
         },
@@ -65,6 +66,7 @@
         "ListenAddr": "127.0.0.1:8088",
         "GraphqlCache": false,
         "ConnectionStats": false,
+        "EntityCachingStats": false,
         "Streams": false,
         "EngineStats": {
           "Subscriptions": false

--- a/router/pkg/config/testdata/config_full.json
+++ b/router/pkg/config/testdata/config_full.json
@@ -62,6 +62,7 @@
         "RouterRuntime": true,
         "GraphqlCache": true,
         "ConnectionStats": true,
+        "EntityCachingStats": true,
         "EngineStats": {
           "Subscriptions": true
         },
@@ -98,6 +99,7 @@
         "ListenAddr": "127.0.0.1:8088",
         "GraphqlCache": true,
         "ConnectionStats": true,
+        "EntityCachingStats": true,
         "Streams": false,
         "EngineStats": {
           "Subscriptions": true

--- a/router/pkg/metric/config.go
+++ b/router/pkg/metric/config.go
@@ -19,14 +19,15 @@ const DefaultServerName = "cosmo-router"
 const DefaultCardinalityLimit = 2000
 
 type PrometheusConfig struct {
-	Enabled         bool
-	ConnectionStats bool
-	ListenAddr      string
-	Path            string
-	GraphqlCache    bool
-	EngineStats     EngineStatsConfig
-	CircuitBreaker  bool
-	CostStats       config.CostStats
+	Enabled            bool
+	ConnectionStats    bool
+	EntityCachingStats bool
+	ListenAddr         string
+	Path               string
+	GraphqlCache       bool
+	EngineStats        EngineStatsConfig
+	CircuitBreaker     bool
+	CostStats          config.CostStats
 	// Metrics to exclude from Prometheus exporter
 	ExcludeMetrics []*regexp.Regexp
 	// Metric labels to exclude from Prometheus exporter
@@ -86,14 +87,15 @@ type LogExporterConfig struct {
 }
 
 type OpenTelemetry struct {
-	Enabled         bool
-	ConnectionStats bool
-	RouterRuntime   bool
-	GraphqlCache    bool
-	CircuitBreaker  bool
-	CostStats       config.CostStats
-	EngineStats     EngineStatsConfig
-	Exporters       []*OpenTelemetryExporter
+	Enabled            bool
+	ConnectionStats    bool
+	EntityCachingStats bool
+	RouterRuntime      bool
+	GraphqlCache       bool
+	CircuitBreaker     bool
+	CostStats          config.CostStats
+	EngineStats        EngineStatsConfig
+	Exporters          []*OpenTelemetryExporter
 	// Metrics to exclude from the OTLP exporter.
 	ExcludeMetrics []*regexp.Regexp
 	// Metric labels to exclude from the OTLP exporter.

--- a/router/pkg/metric/entity_cache_metrics.go
+++ b/router/pkg/metric/entity_cache_metrics.go
@@ -1,0 +1,270 @@
+package metric
+
+import (
+	"context"
+	"slices"
+
+	"go.opentelemetry.io/otel/attribute"
+	otelmetric "go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/sdk/metric"
+	"go.uber.org/zap"
+
+	"github.com/wundergraph/cosmo/router/pkg/otel"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+)
+
+const (
+	cosmoEntityCacheMeterName    = "cosmo.router.entity_cache"
+	cosmoEntityCacheMeterVersion = "0.0.1"
+
+	entityCacheMetricBase         = "router.entity_cache."
+	entityCacheRequestsStatsKey   = entityCacheMetricBase + "requests.stats"
+	entityCacheKeysStatsKey       = entityCacheMetricBase + "keys.stats"
+	entityCacheLatencyKey         = entityCacheMetricBase + "latency"
+	entityCacheInvalidationsKey   = entityCacheMetricBase + "invalidations"
+	entityCachePopulationsKey     = entityCacheMetricBase + "populations"
+	entityCacheShadowStalenessKey = entityCacheMetricBase + "shadow.staleness"
+	entityCacheOperationErrorsKey = entityCacheMetricBase + "operation_errors"
+)
+
+type entityCacheInstruments struct {
+	requestsStats   otelmetric.Int64Counter
+	keysStats       otelmetric.Int64Counter
+	latency         otelmetric.Float64Histogram
+	invalidations   otelmetric.Int64Counter
+	populations     otelmetric.Int64Counter
+	shadowStaleness otelmetric.Int64Counter
+	operationErrors otelmetric.Int64Counter
+}
+
+// EntityCacheMetrics is a struct that holds the metrics for the entity cache.
+type EntityCacheMetrics struct {
+	instruments    *entityCacheInstruments
+	baseAttributes []attribute.KeyValue
+	logger         *zap.Logger
+}
+
+// NewEntityCacheMetrics creates a new EntityCacheMetrics instance.
+func NewEntityCacheMetrics(
+	logger *zap.Logger,
+	baseAttributes []attribute.KeyValue,
+	provider *metric.MeterProvider,
+) (*EntityCacheMetrics, error) {
+	meter := provider.Meter(cosmoEntityCacheMeterName, otelmetric.WithInstrumentationVersion(cosmoEntityCacheMeterVersion))
+
+	instruments, err := setupEntityCacheInstruments(meter)
+	if err != nil {
+		return nil, err
+	}
+
+	return &EntityCacheMetrics{
+		instruments:    instruments,
+		baseAttributes: slices.Clone(baseAttributes),
+		logger:         logger,
+	}, nil
+}
+
+func setupEntityCacheInstruments(m otelmetric.Meter) (*entityCacheInstruments, error) {
+	requestsStats, err := m.Int64Counter(
+		entityCacheRequestsStatsKey,
+		otelmetric.WithDescription("Entity cache request statistics (hits/misses)"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	keysStats, err := m.Int64Counter(
+		entityCacheKeysStatsKey,
+		otelmetric.WithDescription("Entity cache key lifecycle statistics"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	latency, err := m.Float64Histogram(
+		entityCacheLatencyKey,
+		otelmetric.WithDescription("L2 cache operation latency in milliseconds"),
+		otelmetric.WithUnit("ms"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	invalidations, err := m.Int64Counter(
+		entityCacheInvalidationsKey,
+		otelmetric.WithDescription("Cache invalidation counts by trigger source"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	populations, err := m.Int64Counter(
+		entityCachePopulationsKey,
+		otelmetric.WithDescription("Cache population counts by trigger source"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	shadowStaleness, err := m.Int64Counter(
+		entityCacheShadowStalenessKey,
+		otelmetric.WithDescription("Shadow mode: count where cached data differed from fresh data"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	operationErrors, err := m.Int64Counter(
+		entityCacheOperationErrorsKey,
+		otelmetric.WithDescription("Cache operation errors (get/set/delete failures)"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &entityCacheInstruments{
+		requestsStats:   requestsStats,
+		keysStats:       keysStats,
+		latency:         latency,
+		invalidations:   invalidations,
+		populations:     populations,
+		shadowStaleness: shadowStaleness,
+		operationErrors: operationErrors,
+	}, nil
+}
+
+func (m *EntityCacheMetrics) attrs(extra ...attribute.KeyValue) otelmetric.MeasurementOption {
+	return otelmetric.WithAttributes(slices.Concat(m.baseAttributes, extra)...)
+}
+
+// Shutdown performs cleanup of entity cache metrics resources.
+// EntityCacheMetrics uses synchronous instruments, so there are no callbacks to unregister.
+func (m *EntityCacheMetrics) Shutdown() error {
+	return nil
+}
+
+func (m *EntityCacheMetrics) RecordSnapshot(ctx context.Context, snapshot resolve.CacheAnalyticsSnapshot) {
+	for _, event := range snapshot.L1Reads {
+		cacheType := cacheTypeFromEntityType(event.EntityType)
+		switch event.Kind {
+		case resolve.CacheKeyHit:
+			m.recordRequestStat(ctx, otel.CacheMetricsRequestTypeHits, otel.EntityCacheLevelL1, cacheType)
+		case resolve.CacheKeyMiss:
+			m.recordRequestStat(ctx, otel.CacheMetricsRequestTypeMisses, otel.EntityCacheLevelL1, cacheType)
+		}
+	}
+
+	for _, event := range snapshot.L2Reads {
+		cacheType := cacheTypeFromEntityType(event.EntityType)
+		switch event.Kind {
+		case resolve.CacheKeyHit:
+			m.recordRequestStat(ctx, otel.CacheMetricsRequestTypeHits, otel.EntityCacheLevelL2, cacheType)
+		case resolve.CacheKeyMiss:
+			m.recordRequestStat(ctx, otel.CacheMetricsRequestTypeMisses, otel.EntityCacheLevelL2, cacheType)
+		}
+	}
+
+	for range snapshot.L1Writes {
+		m.instruments.keysStats.Add(ctx, 1,
+			m.attrs(
+				otel.CacheMetricsOperationAttribute.String(otel.EntityCacheOperationAdded),
+				otel.EntityCacheCacheLevelAttribute.String(otel.EntityCacheLevelL1),
+			),
+		)
+	}
+
+	for _, event := range snapshot.L2Writes {
+		m.instruments.keysStats.Add(ctx, 1,
+			m.attrs(
+				otel.CacheMetricsOperationAttribute.String(otel.EntityCacheOperationAdded),
+				otel.EntityCacheCacheLevelAttribute.String(otel.EntityCacheLevelL2),
+			),
+		)
+		m.instruments.populations.Add(ctx, 1,
+			m.attrs(otel.EntityCacheSourceAttribute.String(populationSource(event.Source))),
+		)
+	}
+
+	for _, event := range snapshot.FetchTimings {
+		if event.Source == resolve.FieldSourceL2 {
+			m.instruments.latency.Record(ctx, float64(event.DurationMs),
+				m.attrs(
+					otel.EntityCacheCacheLevelAttribute.String(otel.EntityCacheLevelL2),
+					otel.CacheMetricsOperationAttribute.String(otel.EntityCacheOperationGet),
+				),
+			)
+		}
+	}
+
+	for _, event := range snapshot.ShadowComparisons {
+		if !event.IsFresh {
+			m.instruments.shadowStaleness.Add(ctx, 1,
+				m.attrs(otel.CacheMetricsCacheTypeAttribute.String(cacheTypeFromEntityType(event.EntityType))),
+			)
+		}
+	}
+
+	for _, event := range snapshot.MutationEvents {
+		if event.HadCachedValue {
+			m.instruments.invalidations.Add(ctx, 1,
+				m.attrs(otel.EntityCacheSourceAttribute.String(invalidationSource(event.Source))),
+			)
+		}
+	}
+
+	for _, opErr := range snapshot.CacheOpErrors {
+		m.instruments.operationErrors.Add(ctx, 1,
+			m.attrs(
+				otel.CacheMetricsOperationAttribute.String(opErr.Operation),
+				otel.EntityCacheCacheNameAttribute.String(opErr.CacheName),
+				otel.EntityCacheEntityTypeAttribute.String(opErr.EntityType),
+			),
+		)
+	}
+}
+
+func cacheTypeFromEntityType(entityType string) string {
+	if entityType != "" {
+		return otel.EntityCacheTypeEntity
+	}
+	return otel.EntityCacheTypeRootField
+}
+
+// populationSource maps a cache write event's trigger source onto the metric
+// label. Falls back to "query" when the source is unset (empty string) — that
+// matches the pre-existing hardcoded default and keeps older analytics payloads
+// from losing their populate counts.
+func populationSource(s resolve.CacheOperationSource) string {
+	switch s {
+	case resolve.CacheSourceMutation:
+		return otel.EntityCacheSourceMutation
+	case resolve.CacheSourceSubscription:
+		return otel.EntityCacheSourceSubscription
+	case resolve.CacheSourceQuery:
+		return otel.EntityCacheSourceQuery
+	default:
+		return otel.EntityCacheSourceQuery
+	}
+}
+
+// invalidationSource maps a mutation/subscription event's trigger source onto
+// the metric label. Defaults to "mutation" when unset to preserve the previous
+// hardcoded value.
+func invalidationSource(s resolve.CacheOperationSource) string {
+	switch s {
+	case resolve.CacheSourceSubscription:
+		return otel.EntityCacheSourceSubscription
+	case resolve.CacheSourceQuery:
+		return otel.EntityCacheSourceQuery
+	case resolve.CacheSourceMutation:
+		return otel.EntityCacheSourceMutation
+	default:
+		return otel.EntityCacheSourceMutation
+	}
+}
+
+func (m *EntityCacheMetrics) recordRequestStat(ctx context.Context, typ, cacheLevel, cacheType string) {
+	m.instruments.requestsStats.Add(ctx, 1,
+		m.attrs(otel.CacheMetricsTypeAttribute.String(typ), otel.EntityCacheCacheLevelAttribute.String(cacheLevel), otel.CacheMetricsCacheTypeAttribute.String(cacheType)),
+	)
+}

--- a/router/pkg/metric/entity_cache_metrics_test.go
+++ b/router/pkg/metric/entity_cache_metrics_test.go
@@ -1,0 +1,353 @@
+package metric
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"go.uber.org/zap"
+
+	"github.com/wundergraph/cosmo/router/pkg/otel"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+)
+
+func newTestEntityCacheMetrics(t *testing.T) (*EntityCacheMetrics, *metric.ManualReader) {
+	t.Helper()
+	reader := metric.NewManualReader()
+	provider := metric.NewMeterProvider(metric.WithReader(reader))
+	m, err := NewEntityCacheMetrics(
+		zap.NewNop(),
+		[]attribute.KeyValue{attribute.String("service.name", "test-router")},
+		provider,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, m)
+	return m, reader
+}
+
+// collectMetrics reads all emitted metrics into a flat name → DataPoints map for assertion.
+func collectMetrics(t *testing.T, reader *metric.ManualReader) map[string]metricdata.Metrics {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+	out := make(map[string]metricdata.Metrics)
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			out[m.Name] = m
+		}
+	}
+	return out
+}
+
+// sumForAttrs returns the sum of all int64 counter data points matching every given attribute.
+func sumForAttrs(t *testing.T, m metricdata.Metrics, want ...attribute.KeyValue) int64 {
+	t.Helper()
+	data, ok := m.Data.(metricdata.Sum[int64])
+	require.Truef(t, ok, "metric %q is not Sum[int64]", m.Name)
+	var total int64
+	for _, dp := range data.DataPoints {
+		if attrsContainAll(dp.Attributes, want) {
+			total += dp.Value
+		}
+	}
+	return total
+}
+
+func attrsContainAll(set attribute.Set, want []attribute.KeyValue) bool {
+	for _, w := range want {
+		got, ok := set.Value(w.Key)
+		if !ok || got != w.Value {
+			return false
+		}
+	}
+	return true
+}
+
+func TestNewEntityCacheMetrics_ShutdownReturnsNil(t *testing.T) {
+	t.Parallel()
+	m, _ := newTestEntityCacheMetrics(t)
+	require.NoError(t, m.Shutdown())
+}
+
+func TestCacheTypeFromEntityType(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "entity", cacheTypeFromEntityType("User"))
+	require.Equal(t, "root_field", cacheTypeFromEntityType(""))
+}
+
+func TestRecordSnapshot_L1Reads_CountsHitsAndMisses(t *testing.T) {
+	t.Parallel()
+	m, reader := newTestEntityCacheMetrics(t)
+
+	snap := resolve.CacheAnalyticsSnapshot{
+		L1Reads: []resolve.CacheKeyEvent{
+			{Kind: resolve.CacheKeyHit, EntityType: "User"},
+			{Kind: resolve.CacheKeyHit, EntityType: "User"},
+			{Kind: resolve.CacheKeyMiss, EntityType: "User"},
+			{Kind: resolve.CacheKeyHit, EntityType: ""}, // root field
+		},
+	}
+	m.RecordSnapshot(context.Background(), snap)
+
+	ms := collectMetrics(t, reader)
+	stats := ms[entityCacheRequestsStatsKey]
+	require.Equal(t, int64(2), sumForAttrs(t, stats,
+		otel.CacheMetricsTypeAttribute.String("hits"),
+		otel.EntityCacheCacheLevelAttribute.String("l1"),
+		otel.CacheMetricsCacheTypeAttribute.String("entity"),
+	))
+	require.Equal(t, int64(1), sumForAttrs(t, stats,
+		otel.CacheMetricsTypeAttribute.String("misses"),
+		otel.EntityCacheCacheLevelAttribute.String("l1"),
+		otel.CacheMetricsCacheTypeAttribute.String("entity"),
+	))
+	require.Equal(t, int64(1), sumForAttrs(t, stats,
+		otel.CacheMetricsTypeAttribute.String("hits"),
+		otel.EntityCacheCacheLevelAttribute.String("l1"),
+		otel.CacheMetricsCacheTypeAttribute.String("root_field"),
+	))
+}
+
+func TestRecordSnapshot_L2Reads_CountsHitsAndMisses(t *testing.T) {
+	t.Parallel()
+	m, reader := newTestEntityCacheMetrics(t)
+
+	snap := resolve.CacheAnalyticsSnapshot{
+		L2Reads: []resolve.CacheKeyEvent{
+			{Kind: resolve.CacheKeyHit, EntityType: "Product"},
+			{Kind: resolve.CacheKeyMiss, EntityType: "Product"},
+			{Kind: resolve.CacheKeyMiss, EntityType: "Product"},
+		},
+	}
+	m.RecordSnapshot(context.Background(), snap)
+
+	ms := collectMetrics(t, reader)
+	stats := ms[entityCacheRequestsStatsKey]
+	require.Equal(t, int64(1), sumForAttrs(t, stats,
+		otel.CacheMetricsTypeAttribute.String("hits"),
+		otel.EntityCacheCacheLevelAttribute.String("l2"),
+	))
+	require.Equal(t, int64(2), sumForAttrs(t, stats,
+		otel.CacheMetricsTypeAttribute.String("misses"),
+		otel.EntityCacheCacheLevelAttribute.String("l2"),
+	))
+}
+
+func TestRecordSnapshot_WritesIncrementKeysStatsAndPopulations(t *testing.T) {
+	t.Parallel()
+	m, reader := newTestEntityCacheMetrics(t)
+
+	snap := resolve.CacheAnalyticsSnapshot{
+		L1Writes: []resolve.CacheWriteEvent{
+			{CacheKey: "k1"}, {CacheKey: "k2"},
+		},
+		L2Writes: []resolve.CacheWriteEvent{
+			{CacheKey: "k1"}, {CacheKey: "k2"}, {CacheKey: "k3"},
+		},
+	}
+	m.RecordSnapshot(context.Background(), snap)
+
+	ms := collectMetrics(t, reader)
+	keys := ms[entityCacheKeysStatsKey]
+	require.Equal(t, int64(2), sumForAttrs(t, keys,
+		otel.CacheMetricsOperationAttribute.String("added"),
+		otel.EntityCacheCacheLevelAttribute.String("l1"),
+	))
+	require.Equal(t, int64(3), sumForAttrs(t, keys,
+		otel.CacheMetricsOperationAttribute.String("added"),
+		otel.EntityCacheCacheLevelAttribute.String("l2"),
+	))
+
+	pops := ms[entityCachePopulationsKey]
+	require.Equal(t, int64(3), sumForAttrs(t, pops,
+		otel.EntityCacheSourceAttribute.String("query"),
+	))
+}
+
+func TestRecordSnapshot_FetchTimings_RecordsL2LatencyOnly(t *testing.T) {
+	t.Parallel()
+	m, reader := newTestEntityCacheMetrics(t)
+
+	snap := resolve.CacheAnalyticsSnapshot{
+		FetchTimings: []resolve.FetchTimingEvent{
+			{Source: resolve.FieldSourceL2, DurationMs: 12},
+			{Source: resolve.FieldSourceL2, DurationMs: 34},
+			{Source: resolve.FieldSourceSubgraph, DurationMs: 99}, // ignored
+		},
+	}
+	m.RecordSnapshot(context.Background(), snap)
+
+	ms := collectMetrics(t, reader)
+	lat := ms[entityCacheLatencyKey]
+	hist, ok := lat.Data.(metricdata.Histogram[float64])
+	require.True(t, ok)
+	// Only L2 entries recorded → 2 measurements across all data points.
+	var count uint64
+	var sum float64
+	for _, dp := range hist.DataPoints {
+		count += dp.Count
+		sum += dp.Sum
+	}
+	require.Equal(t, uint64(2), count)
+	require.InDelta(t, 46.0, sum, 0.0001)
+}
+
+func TestRecordSnapshot_ShadowComparisons_OnlyStalenessIsCounted(t *testing.T) {
+	t.Parallel()
+	m, reader := newTestEntityCacheMetrics(t)
+
+	snap := resolve.CacheAnalyticsSnapshot{
+		ShadowComparisons: []resolve.ShadowComparisonEvent{
+			{IsFresh: true, EntityType: "User"},
+			{IsFresh: false, EntityType: "User"},
+			{IsFresh: false, EntityType: "Product"},
+			{IsFresh: false, EntityType: ""}, // root_field
+		},
+	}
+	m.RecordSnapshot(context.Background(), snap)
+
+	ms := collectMetrics(t, reader)
+	staleness := ms[entityCacheShadowStalenessKey]
+	require.Equal(t, int64(2), sumForAttrs(t, staleness,
+		otel.CacheMetricsCacheTypeAttribute.String("entity"),
+	))
+	require.Equal(t, int64(1), sumForAttrs(t, staleness,
+		otel.CacheMetricsCacheTypeAttribute.String("root_field"),
+	))
+}
+
+func TestRecordSnapshot_MutationEvents_IncrementsInvalidationsWhenCached(t *testing.T) {
+	t.Parallel()
+	m, reader := newTestEntityCacheMetrics(t)
+
+	snap := resolve.CacheAnalyticsSnapshot{
+		MutationEvents: []resolve.MutationEvent{
+			{HadCachedValue: true},
+			{HadCachedValue: true},
+			{HadCachedValue: false}, // ignored
+		},
+	}
+	m.RecordSnapshot(context.Background(), snap)
+
+	ms := collectMetrics(t, reader)
+	inv := ms[entityCacheInvalidationsKey]
+	require.Equal(t, int64(2), sumForAttrs(t, inv,
+		otel.EntityCacheSourceAttribute.String("mutation"),
+	))
+}
+
+func TestRecordSnapshot_PopulationSource_CarriedThrough(t *testing.T) {
+	t.Parallel()
+	m, reader := newTestEntityCacheMetrics(t)
+
+	// L2 writes tagged with distinct sources must land under distinct labels.
+	snap := resolve.CacheAnalyticsSnapshot{
+		L2Writes: []resolve.CacheWriteEvent{
+			{Source: resolve.CacheSourceQuery},
+			{Source: resolve.CacheSourceQuery},
+			{Source: resolve.CacheSourceMutation},
+			{Source: resolve.CacheSourceSubscription},
+			{Source: ""}, // unset → default to "query"
+		},
+	}
+	m.RecordSnapshot(context.Background(), snap)
+
+	ms := collectMetrics(t, reader)
+	pops := ms[entityCachePopulationsKey]
+	require.Equal(t, int64(3), sumForAttrs(t, pops,
+		otel.EntityCacheSourceAttribute.String("query"),
+	))
+	require.Equal(t, int64(1), sumForAttrs(t, pops,
+		otel.EntityCacheSourceAttribute.String("mutation"),
+	))
+	require.Equal(t, int64(1), sumForAttrs(t, pops,
+		otel.EntityCacheSourceAttribute.String("subscription"),
+	))
+}
+
+func TestRecordSnapshot_InvalidationSource_CarriedThrough(t *testing.T) {
+	t.Parallel()
+	m, reader := newTestEntityCacheMetrics(t)
+
+	snap := resolve.CacheAnalyticsSnapshot{
+		MutationEvents: []resolve.MutationEvent{
+			{HadCachedValue: true, Source: resolve.CacheSourceMutation},
+			{HadCachedValue: true, Source: resolve.CacheSourceMutation},
+			{HadCachedValue: true, Source: resolve.CacheSourceSubscription},
+			{HadCachedValue: true, Source: ""}, // unset → default to "mutation"
+		},
+	}
+	m.RecordSnapshot(context.Background(), snap)
+
+	ms := collectMetrics(t, reader)
+	inv := ms[entityCacheInvalidationsKey]
+	require.Equal(t, int64(3), sumForAttrs(t, inv,
+		otel.EntityCacheSourceAttribute.String("mutation"),
+	))
+	require.Equal(t, int64(1), sumForAttrs(t, inv,
+		otel.EntityCacheSourceAttribute.String("subscription"),
+	))
+}
+
+func TestRecordSnapshot_CacheOpErrors_IncrementsOperationErrors(t *testing.T) {
+	t.Parallel()
+	m, reader := newTestEntityCacheMetrics(t)
+
+	snap := resolve.CacheAnalyticsSnapshot{
+		CacheOpErrors: []resolve.CacheOperationError{
+			{Operation: "get", CacheName: "default", EntityType: "User"},
+			{Operation: "set", CacheName: "default", EntityType: "User"},
+			{Operation: "get", CacheName: "default", EntityType: "User"},
+		},
+	}
+	m.RecordSnapshot(context.Background(), snap)
+
+	ms := collectMetrics(t, reader)
+	errs := ms[entityCacheOperationErrorsKey]
+	require.Equal(t, int64(2), sumForAttrs(t, errs,
+		otel.CacheMetricsOperationAttribute.String("get"),
+		otel.EntityCacheCacheNameAttribute.String("default"),
+		otel.EntityCacheEntityTypeAttribute.String("User"),
+	))
+	require.Equal(t, int64(1), sumForAttrs(t, errs,
+		otel.CacheMetricsOperationAttribute.String("set"),
+		otel.EntityCacheCacheNameAttribute.String("default"),
+		otel.EntityCacheEntityTypeAttribute.String("User"),
+	))
+}
+
+func TestRecordSnapshot_EmptySnapshot_NoMetricsEmitted(t *testing.T) {
+	t.Parallel()
+	m, reader := newTestEntityCacheMetrics(t)
+
+	m.RecordSnapshot(context.Background(), resolve.CacheAnalyticsSnapshot{})
+
+	ms := collectMetrics(t, reader)
+	// No instruments should have any data points recorded — the map may contain
+	// the instrument metadata but every Sum[int64] should be empty.
+	for name, m := range ms {
+		if s, ok := m.Data.(metricdata.Sum[int64]); ok {
+			require.Lenf(t, s.DataPoints, 0, "instrument %q unexpectedly has data points", name)
+		}
+	}
+}
+
+func TestRecordSnapshot_BaseAttributes_AppliedToAllInstruments(t *testing.T) {
+	t.Parallel()
+	m, reader := newTestEntityCacheMetrics(t)
+
+	snap := resolve.CacheAnalyticsSnapshot{
+		L1Reads: []resolve.CacheKeyEvent{{Kind: resolve.CacheKeyHit, EntityType: "User"}},
+	}
+	m.RecordSnapshot(context.Background(), snap)
+
+	ms := collectMetrics(t, reader)
+	stats := ms[entityCacheRequestsStatsKey]
+	require.Equal(t, int64(1), sumForAttrs(t, stats,
+		attribute.String("service.name", "test-router"),
+		otel.CacheMetricsTypeAttribute.String("hits"),
+	))
+}

--- a/router/pkg/otel/attributes.go
+++ b/router/pkg/otel/attributes.go
@@ -88,6 +88,31 @@ const (
 	CacheMetricsOperationAttribute = attribute.Key("operation")
 )
 
+// Entity cache metrics attributes
+const (
+	EntityCacheCacheLevelAttribute = attribute.Key("cache_level")
+	EntityCacheSourceAttribute     = attribute.Key("source")
+	EntityCacheCacheNameAttribute  = attribute.Key("cache_name")
+	EntityCacheEntityTypeAttribute = attribute.Key("entity_type")
+)
+
+// Entity cache metrics attribute values. Kept as constants so every recording
+// site uses the same string (no "l1"/"L1"/"tier-1" drift across metrics).
+const (
+	EntityCacheLevelL1 = "l1"
+	EntityCacheLevelL2 = "l2"
+
+	EntityCacheSourceQuery        = "query"
+	EntityCacheSourceMutation     = "mutation"
+	EntityCacheSourceSubscription = "subscription"
+
+	EntityCacheTypeEntity    = "entity"
+	EntityCacheTypeRootField = "root_field"
+
+	EntityCacheOperationGet   = "get"
+	EntityCacheOperationAdded = "added"
+)
+
 var (
 	RouterServerAttribute    = WgComponentName.String("router-server")
 	EngineTransportAttribute = WgComponentName.String("engine-transport")


### PR DESCRIPTION
> Replaces #2952, which was auto-closed as merged when a bad force-push momentarily collapsed the stack branches onto one commit. Same content, same stack position.

Part 4 of 6 — split out from #2777. Stacked on #2945.

## What's included
- **router/pkg/metric/entity_cache_metrics**: cache hit/miss/latency instruments recorded from the per-request cache analytics snapshot
- **otel attributes** for cache level/source/name/entity type (shared constants so recording sites can't drift)
- **`entity_caching_stats` opt-in config keys** for Prometheus and OTLP (yaml + env vars, schema, defaults) — opt-in per #2777 review #21
- **graph server wiring**: metric setup/shutdown and handler snapshot recording; cache analytics collection enables only when metrics are configured

The tree at this PR's tip is byte-identical to the pre-split router branch — the split is purely for reviewability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
