### PR TITLE
chore: fix flaky nats test

### DIFF
--- a/router-tests/events/nats_events_test.go
+++ b/router-tests/events/nats_events_test.go
@@ -1098,6 +1098,10 @@ func TestNatsEvents(t *testing.T) {
 		})
 		require.NoError(t, err)
 		env.WaitForSubscriptionCount(1, EventWaitTimeout)
+		// Make sure to wait for the trigger count because we might already have the
+		// subscription count incremented before the trigger was actually created.
+		// In that case we wouldn't yet have a durable consumer on the NATS server.
+		env.WaitForTriggerCount(1, EventWaitTimeout)
 
 		// Verify the durable consumer was created on the stream
 		stream, err := js.Stream(env.Context, streamName)
@@ -1155,6 +1159,11 @@ func TestNatsEvents(t *testing.T) {
 		})
 		require.NoError(t, err)
 		env.WaitForSubscriptionCount(1, EventWaitTimeout)
+		// SubscriptionCount is incremented before the engine starts the trigger, so the
+		// durable consumer may not exist on the NATS server yet. The trigger count is only
+		// incremented after Source.Start (and thus createOrUpdateDurableConsumer) returns,
+		// so wait for it before asserting on the consumer.
+		env.WaitForTriggerCount(1, EventWaitTimeout)
 
 		// Verify the durable consumer was created on the stream
 		stream, err := js.Stream(env.Context, streamName)

--- a/router-tests/events/nats_events_test.go
+++ b/router-tests/events/nats_events_test.go
@@ -1159,10 +1159,9 @@ func TestNatsEvents(t *testing.T) {
 		})
 		require.NoError(t, err)
 		env.WaitForSubscriptionCount(1, EventWaitTimeout)
-		// SubscriptionCount is incremented before the engine starts the trigger, so the
-		// durable consumer may not exist on the NATS server yet. The trigger count is only
-		// incremented after Source.Start (and thus createOrUpdateDurableConsumer) returns,
-		// so wait for it before asserting on the consumer.
+		// Make sure to wait for the trigger count because we might already have the
+		// subscription count incremented before the trigger was actually created.
+		// In that case we wouldn't yet have a durable consumer on the NATS server.
 		env.WaitForTriggerCount(1, EventWaitTimeout)
 
 		// Verify the durable consumer was created on the stream


### PR DESCRIPTION
This PR fixes a flaky NATS test because we do not wait for the durable consumer to be created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved reliability of JetStream consumer lifecycle tests by adding a wait for the durable-consumer to become observable before asserting stream consumer counts, reducing flaky timing-related failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

<!--
Please add any additional information or context regarding your changes here.
-->