### PR TITLE
feat(docs): encourage authors to provide instructions for validating changes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,6 +25,7 @@ Examples of good PR titles:
 - [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
 - [ ] I have followed the coding standards of the project.
 - [ ] Tests or benchmarks have been added or updated.
+- [ ] If applicable, I have provided instructions for reviewers for [manually validating my changes](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md#pull-requests-conventions).
 - [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
 - [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,8 @@ We merge all pull requests in `squash merge` mode. You're not enforced to use [c
 
 When updating your branch after a review has been requested, prefer using a merge strategy (e.g. `git merge main`) rather than rebasing. This preserves the review context and avoids force-pushes that can disrupt the review process.
 
+If you're fixing a bug, or adding a feature which is not trivial, ensure the reviewers can validate the changes manually. Add `## How to test` section to the pull request description, with individual steps that reviewer can take to test the changes. Pictures and/or videos help a lot.
+
 ## Local Development
 
 ### Prerequisites


### PR DESCRIPTION
I would like to encourage PR authors to include `## How to test` section to their changes. This way
validating the changes becomes easier for reviewers/agents.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated pull request template with a new checklist item requesting manual reviewer validation instructions
  * Enhanced contributor guidelines to recommend including "How to test" sections with manual validation steps and supporting media for non-trivial bug fixes and new features
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [X] I have discussed my proposed changes in an issue and have received approval to proceed.
- [X] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated. (n/a)
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website). (n/a)
- [X] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

<!--
Please add any additional information or context regarding your changes here.
-->
