### PR TITLE
fix(controlplane): handle unpublished subgraph in proposal update

### DIFF
--- a/controlplane/src/core/repositories/ProposalRepository.ts
+++ b/controlplane/src/core/repositories/ProposalRepository.ts
@@ -61,12 +61,12 @@ export class ProposalRepository {
     await this.db.insert(schema.proposalSubgraphs).values(
       proposalSubgraphs.map((subgraph) => ({
         proposalId: proposal[0].id,
-        subgraphId: subgraph.subgraphId,
+        subgraphId: subgraph.subgraphId || null,
         subgraphName: subgraph.subgraphName,
         schemaSDL: subgraph.schemaSDL || null,
         isDeleted: subgraph.isDeleted,
         isNew: subgraph.isNew,
-        currentSchemaVersionId: subgraph.currentSchemaVersionId,
+        currentSchemaVersionId: subgraph.currentSchemaVersionId || null,
         labels: subgraph.isNew ? normalizeLabels(subgraph.labels).map((l) => joinLabel(l)) : undefined,
       })),
     );
@@ -387,12 +387,12 @@ export class ProposalRepository {
       await this.db.insert(schema.proposalSubgraphs).values(
         proposalSubgraphs.map((subgraph) => ({
           proposalId: id,
-          subgraphId: subgraph.subgraphId,
+          subgraphId: subgraph.subgraphId || null,
           subgraphName: subgraph.subgraphName,
           schemaSDL: subgraph.schemaSDL || null,
           isDeleted: subgraph.isDeleted,
           isNew: subgraph.isNew,
-          currentSchemaVersionId: subgraph.currentSchemaVersionId,
+          currentSchemaVersionId: subgraph.currentSchemaVersionId || null,
           labels: subgraph.isNew ? normalizeLabels(subgraph.labels).map((l) => joinLabel(l)) : undefined,
         })),
       );

--- a/controlplane/test/proposal/update-proposal.test.ts
+++ b/controlplane/test/proposal/update-proposal.test.ts
@@ -2336,8 +2336,6 @@ describe('Update proposal tests', () => {
     });
     expect(getProposalResponse.response?.code).toBe(EnumStatusCode.OK);
     expect(getProposalResponse.proposal?.subgraphs.length).toBe(2);
-    expect(
-      getProposalResponse.proposal?.subgraphs.some((sg) => sg.name === unpublishedSubgraphName),
-    ).toBe(true);
+    expect(getProposalResponse.proposal?.subgraphs.some((sg) => sg.name === unpublishedSubgraphName)).toBe(true);
   });
 });

--- a/controlplane/test/proposal/update-proposal.test.ts
+++ b/controlplane/test/proposal/update-proposal.test.ts
@@ -2222,4 +2222,122 @@ describe('Update proposal tests', () => {
     expect(updateProposalResponse.response?.code).toBe(EnumStatusCode.ERR_NOT_FOUND);
     expect(updateProposalResponse.response?.details).toMatch(new RegExp(`Proposal .*${proposalName} not found`));
   });
+
+  test('should update a proposal that includes an existing subgraph which has never been published', async () => {
+    const { client, server } = await SetupTest({
+      dbname,
+      chClient,
+      setupBilling: { plan: 'enterprise' },
+      enabledFeatures: ['proposals'],
+    });
+    onTestFinished(() => server.close());
+
+    const publishedSubgraphName = genID('subgraph1');
+    const unpublishedSubgraphName = genID('subgraph2');
+    const fedGraphName = genID('fedGraph');
+    const label = genUniqueLabel('label');
+    const proposalName = genID('proposal');
+
+    const publishedSubgraphSDL = `
+      type Query {
+        hello: String!
+      }
+    `;
+
+    // A published subgraph so the federated graph has a valid composition.
+    await createThenPublishSubgraph(
+      client,
+      publishedSubgraphName,
+      DEFAULT_NAMESPACE,
+      publishedSubgraphSDL,
+      [label],
+      DEFAULT_SUBGRAPH_URL_ONE,
+    );
+
+    // A subgraph that belongs to the federated graph (matching label) but has
+    // never been published, so it has no current schema version.
+    const createUnpublishedResponse = await client.createFederatedSubgraph({
+      name: unpublishedSubgraphName,
+      namespace: DEFAULT_NAMESPACE,
+      labels: [label],
+      routingUrl: DEFAULT_SUBGRAPH_URL_TWO,
+    });
+    expect(createUnpublishedResponse.response?.code).toBe(EnumStatusCode.OK);
+
+    await createFederatedGraph(client, fedGraphName, DEFAULT_NAMESPACE, [joinLabel(label)], DEFAULT_ROUTER_URL);
+
+    const enableResponse = await enableProposalsForNamespace(client);
+    expect(enableResponse.response?.code).toBe(EnumStatusCode.OK);
+
+    const updatedPublishedSDL = `
+      type Query {
+        hello: String!
+        world: String!
+      }
+    `;
+
+    const createProposalResponse = await client.createProposal({
+      federatedGraphName: fedGraphName,
+      namespace: DEFAULT_NAMESPACE,
+      name: proposalName,
+      origin: ProposalOrigin.INTERNAL,
+      subgraphs: [
+        {
+          name: publishedSubgraphName,
+          schemaSDL: updatedPublishedSDL,
+          isDeleted: false,
+          isNew: false,
+          labels: [],
+        },
+      ],
+      namingConvention: ProposalNamingConvention.INCREMENTAL,
+    });
+    expect(createProposalResponse.response?.code).toBe(EnumStatusCode.OK);
+
+    const unpublishedSubgraphSDL = `
+      type Query {
+        goodbye: String!
+      }
+    `;
+
+    // Updating the proposal to include the unpublished subgraph must not fail
+    // with an invalid-UUID error: its missing current schema version should be
+    // stored as null rather than an empty string.
+    const updateProposalResponse = await client.updateProposal({
+      proposalName: createProposalResponse.proposalName,
+      federatedGraphName: fedGraphName,
+      namespace: DEFAULT_NAMESPACE,
+      updateAction: {
+        case: 'updatedSubgraphs',
+        value: {
+          subgraphs: [
+            {
+              name: publishedSubgraphName,
+              schemaSDL: updatedPublishedSDL,
+              isDeleted: false,
+              isNew: false,
+              labels: [],
+            },
+            {
+              name: unpublishedSubgraphName,
+              schemaSDL: unpublishedSubgraphSDL,
+              isDeleted: false,
+              isNew: false,
+              labels: [],
+            },
+          ],
+        },
+      },
+    });
+    expect(updateProposalResponse.response?.code).toBe(EnumStatusCode.OK);
+
+    const getProposalResponse = await client.getProposal({
+      proposalId: createProposalResponse.proposalId,
+    });
+    expect(getProposalResponse.response?.code).toBe(EnumStatusCode.OK);
+    expect(getProposalResponse.proposal?.subgraphs.length).toBe(2);
+    expect(
+      getProposalResponse.proposal?.subgraphs.some((sg) => sg.name === unpublishedSubgraphName),
+    ).toBe(true);
+  });
 });


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of optional fields in proposal submissions to ensure consistent data storage.

* **Tests**
  * Added test coverage for updating proposals containing both published and unpublished subgraphs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Updating (or creating) a proposal that includes a subgraph which exists but has **never been published** failed with a Postgres error:

```
invalid input syntax for type uuid: ""
```

An unpublished subgraph's `schemaVersionId` is an empty string, which was passed directly into the `proposalSubgraphs` insert for the `current_schema_version_id` (and `subgraph_id`) uuid columns. Postgres rejects `""` for a uuid column (it accepts a valid uuid or `NULL`).

This fix coerces `subgraphId` and `currentSchemaVersionId` to `null` in both `createProposal` and `updateProposal`. Storing `null` is correct — a never-published subgraph has no base schema version to diff against, and downstream readers (e.g. `getProposal`) already skip subgraphs without a `currentSchemaVersionId`.

Resolves ENG-9775.

## Checklist

- [x] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [x] Tests or benchmarks have been added or updated.
- [ ] If applicable, I have provided instructions for reviewers for [manually validating my changes](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md#pull-requests-conventions).
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.
