### PR TITLE
fix(cli): correctly pass batch publish job status

### DIFF
--- a/cli/src/commands/subgraph/utils/poll-batch-publish-status.ts
+++ b/cli/src/commands/subgraph/utils/poll-batch-publish-status.ts
@@ -21,7 +21,8 @@ export async function pollBatchPublishStatus(
   const headers = getBaseHeaders();
   while (!signal.aborted) {
     const resp = await client.platform.getBatchPublishJobStatus({ jobId }, { headers, signal });
-    if (!resp.response?.code || !EXPECTED_STATUS_CODES.has(resp.response.code)) {
+    const respCode = resp.response?.code;
+    if (respCode === undefined || !EXPECTED_STATUS_CODES.has(respCode)) {
       return new PublishFederatedSubgraphsResponse({
         response: resp.response,
       });

--- a/cli/src/commands/subgraph/utils/poll-batch-publish-status.ts
+++ b/cli/src/commands/subgraph/utils/poll-batch-publish-status.ts
@@ -6,6 +6,12 @@ import { EnumStatusCode } from '@wundergraph/cosmo-connect/dist/common/common_pb
 import { Client } from '../../../core/client/client.js';
 import { getBaseHeaders } from '../../../core/config.js';
 
+const EXPECTED_STATUS_CODES = new Set([
+  EnumStatusCode.OK,
+  EnumStatusCode.ERR_SUBGRAPH_COMPOSITION_FAILED,
+  EnumStatusCode.ERR_DEPLOYMENT_FAILED,
+]);
+
 export async function pollBatchPublishStatus(
   client: Client,
   jobId: string,
@@ -15,7 +21,7 @@ export async function pollBatchPublishStatus(
   const headers = getBaseHeaders();
   while (!signal.aborted) {
     const resp = await client.platform.getBatchPublishJobStatus({ jobId }, { headers, signal });
-    if (resp.response?.code !== EnumStatusCode.OK) {
+    if (!resp.response?.code || !EXPECTED_STATUS_CODES.has(resp.response.code)) {
       return new PublishFederatedSubgraphsResponse({
         response: resp.response,
       });


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved polling behavior for subgraph batch publish status by refining which response codes are treated as final/expected. The system now avoids unnecessary retry cycles when a response is missing a code or contains non-success codes such as subgraph composition or deployment failures, while keeping existing handling for pending/processing and completed/failed job states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [x] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] If applicable, I have provided instructions for reviewers for [manually validating my changes](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md#pull-requests-conventions).
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

<!--
Please add any additional information or context regarding your changes here.
-->
