### PR TITLE
fix(router): allow from_file header to be propagated

### DIFF
--- a/router-tests/protocol/header_set_test.go
+++ b/router-tests/protocol/header_set_test.go
@@ -5,6 +5,8 @@ import (
 
 	"fmt"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -538,6 +540,81 @@ func TestHeaderSetWithExpression(t *testing.T) {
 				Query: query,
 			})
 			assert.Equal(t, `{"data":{"headerValue":"test-client 1.0.0"}}`, res.Body)
+		})
+	})
+}
+
+func TestHeaderSetFromFile(t *testing.T) {
+	t.Parallel()
+
+	const customHeader = "X-Custom-Header"
+
+	writeHeaderFile := func(t *testing.T, content string) string {
+		t.Helper()
+		path := filepath.Join(t.TempDir(), "header-value.txt")
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+		return path
+	}
+
+	getRule := func(name, path string) *config.RequestHeaderRule {
+		return &config.RequestHeaderRule{
+			Operation: config.HeaderRuleOperationSet,
+			Name:      name,
+			FromFile:  &config.FileHeaderSource{Path: path},
+		}
+	}
+
+	global := func(name, path string) []core.Option {
+		return []core.Option{
+			core.WithHeaderRules(config.HeaderRules{
+				All: &config.GlobalHeaderRule{
+					Request: []*config.RequestHeaderRule{
+						getRule(name, path),
+					},
+				},
+			}),
+		}
+	}
+
+	subgraph := func(subgraphName, name, path string) []core.Option {
+		return []core.Option{
+			core.WithHeaderRules(config.HeaderRules{
+				Subgraphs: map[string]*config.GlobalHeaderRule{
+					subgraphName: {
+						Request: []*config.RequestHeaderRule{
+							getRule(name, path),
+						},
+					},
+				},
+			}),
+		}
+	}
+
+	t.Run("global request rule sets header from file contents", func(t *testing.T) {
+		t.Parallel()
+		path := writeHeaderFile(t, "file-value")
+		testenv.Run(t, &testenv.Config{
+			RouterOptions: global(customHeader, path),
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+				Header: http.Header{},
+				Query:  fmt.Sprintf(`query { headerValue(name:"%s") }`, customHeader),
+			})
+			assert.Equal(t, `{"data":{"headerValue":"file-value"}}`, res.Body)
+		})
+	})
+
+	t.Run("subgraph request rule sets header from file contents", func(t *testing.T) {
+		t.Parallel()
+		path := writeHeaderFile(t, "file-value")
+		testenv.Run(t, &testenv.Config{
+			RouterOptions: subgraph("test1", customHeader, path),
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+				Header: http.Header{},
+				Query:  fmt.Sprintf(`query { headerValue(name:"%s") }`, customHeader),
+			})
+			assert.Equal(t, `{"data":{"headerValue":"file-value"}}`, res.Body)
 		})
 	})
 }

--- a/router/core/header_rule_engine.go
+++ b/router/core/header_rule_engine.go
@@ -1059,7 +1059,7 @@ func PropagatedHeaders(rules []*config.RequestHeaderRule) (headerNames []string,
 	for _, rule := range rules {
 		switch rule.Operation {
 		case config.HeaderRuleOperationSet:
-			if rule.Name == "" || (rule.Value == "" && rule.ValueFrom == nil && rule.Expression == "") {
+			if rule.Name == "" || (rule.Value == "" && rule.ValueFrom == nil && rule.Expression == "" && rule.FromFile == nil) {
 				return nil, nil, fmt.Errorf("invalid header set rule %+v, no header name/value combination", rule)
 			}
 			headerNames = append(headerNames, rule.Name)

--- a/router/core/header_rule_engine_test.go
+++ b/router/core/header_rule_engine_test.go
@@ -353,7 +353,16 @@ func TestPropagatedHeaders(t *testing.T) {
 		})
 		require.Error(t, err)
 	})
-
+	t.Run("set with FromFile returns header name", func(t *testing.T) {
+		t.Parallel()
+		path := writeHeaderSourceFile(t, "secret-value")
+		names, regexps, err := PropagatedHeaders([]*config.RequestHeaderRule{
+			{Operation: config.HeaderRuleOperationSet, Name: "X-Secret", FromFile: &config.FileHeaderSource{Path: path}},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"X-Secret"}, names)
+		assert.Nil(t, regexps)
+	})
 	t.Run("propagate with no name or match errors", func(t *testing.T) {
 		t.Parallel()
 		_, _, err := PropagatedHeaders([]*config.RequestHeaderRule{


### PR DESCRIPTION
File headers were missing in the validation for the factory resolver. This PR adds this and also adds missing tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Request headers can now be set using values sourced directly from external files, providing greater flexibility in configuring headers across your routing setup.

* **Tests**
  - Added integration and unit tests to verify file-based header sourcing functionality works correctly.

* **Bug Fixes**
  - Enhanced validation for header set rules to ensure all required configuration fields are present and properly configured before processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] If applicable, I have provided instructions for reviewers for [manually validating my changes](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md#pull-requests-conventions).
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

<!--
Please add any additional information or context regarding your changes here.
-->
