### PR TITLE
fix(composition): propagate composed directives regardless of subgrap…

### DIFF
--- a/composition/src/v1/normalization/normalization-factory.ts
+++ b/composition/src/v1/normalization/normalization-factory.ts
@@ -807,14 +807,17 @@ export class NormalizationFactory {
         }
         continue;
       }
+
       if (definitionData.isComposed) {
         definitionData.isReferenced = true;
       }
+
       const definitionErrorMessages: Array<string> = [];
       const directiveLocation = nodeKindToDirectiveLocation(data.kind);
       if (!definitionData.locations.has(directiveLocation)) {
         definitionErrorMessages.push(invalidDirectiveLocationErrorMessage(directiveName, directiveLocation));
       }
+
       if (directiveNodes.length > 1 && !definitionData.isRepeatable) {
         const handledDirectiveNames = getValueOrDefault(
           this.invalidRepeatedDirectiveNameByCoords,

--- a/composition/src/v1/normalization/utils.ts
+++ b/composition/src/v1/normalization/utils.ts
@@ -535,6 +535,8 @@ export function upsertFederatedDirectiveData({
       continue;
     }
 
+    existingData.isReferenced ||= directiveData.isReferenced;
+
     /* If at least one subgraph includes the directive name in a `@composeDirective` directive, the definition of
      * the custom directive should be propagated in the federated graph.
      * The directive itself must be referenced in at least once in one of those subgraphs to propagate also the usages

--- a/composition/tests/v1/directives/compose-directive.test.ts
+++ b/composition/tests/v1/directives/compose-directive.test.ts
@@ -1033,5 +1033,68 @@ describe('@composeDirective tests', () => {
       );
       expect(warnings).toHaveLength(0);
     });
+
+    test('that subgraph order does not affect the propagation of a composed directive', () => {
+      const aaaaa = createSubgraph(
+        'aaaaa',
+        `
+        schema
+        @link(import: ["@a"], url: "https://a/a/v1.0")
+        @composeDirective(name: "@a")  {
+          query: Query
+        }
+        
+        directive @a on FIELD_DEFINITION
+        
+        type Query @shareable {
+          a: ID
+        }
+        `,
+      );
+      const aaaab = createSubgraph(
+        'aaaab',
+        `
+        schema
+        @link(import: ["@a"], url: "https://a/a/v1.0")
+        @composeDirective(name: "@a")  {
+          query: Query
+        }
+        
+        directive @a on FIELD_DEFINITION
+        
+        type Query @shareable {
+          a: ID @a
+        }
+        `,
+      );
+      const { federatedGraphClientSchema, federatedGraphSchema, warnings } = federateSubgraphsSuccess(
+        [aaaaa, aaaab],
+        ROUTER_COMPATIBILITY_VERSION_ONE,
+      );
+      expect(schemaToSortedNormalizedString(federatedGraphClientSchema)).toBe(
+        normalizeString(
+          SCHEMA_QUERY_DEFINITION +
+            `
+      
+      type Query {
+        a: ID
+      }
+    `,
+        ),
+      );
+      expect(schemaToSortedNormalizedString(federatedGraphSchema)).toBe(
+        normalizeString(
+          SCHEMA_QUERY_DEFINITION +
+            `
+      directive @a on FIELD_DEFINITION
+      
+      type Query {
+        a: ID @a
+      }
+    `,
+        ),
+      );
+      expect(warnings).toHaveLength(0);
+    });
   });
 });


### PR DESCRIPTION
…h order

Fixes https://github.com/wundergraph/cosmo/issues/2920

<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved directive reference metadata handling during schema composition to ensure directives are accurately accumulated and consistently propagated across federated subgraphs.

* **Tests**
  * Added test validation confirming that composed directives propagate consistently and correctly independent of subgraph composition order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] If applicable, I have provided instructions for reviewers for [manually validating my changes](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md#pull-requests-conventions).
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

<!--
Please add any additional information or context regarding your changes here.
-->
