### PR TITLE
fix(router): clear slowplancache entries on Close

### DIFF
--- a/router/pkg/slowplancache/slow_plan_cache.go
+++ b/router/pkg/slowplancache/slow_plan_cache.go
@@ -222,5 +222,14 @@ func (c *Cache[V]) Close() {
 		// This downside is also there in ristretto (if set is called concurrently)
 		// it is even documented in the ristretto code as a comment
 		close(c.writeCh)
+
+		// Drop cached entries so Close releases references to stored values
+		// (e.g. query plans holding schema AST pointers) before the Cache
+		// struct is GC'd.
+		c.entries.Range(func(key, _ any) bool {
+			c.entries.Delete(key)
+			return true
+		})
+		c.size = 0
 	})
 }

--- a/router/pkg/slowplancache/slow_plan_cache_test.go
+++ b/router/pkg/slowplancache/slow_plan_cache_test.go
@@ -411,6 +411,27 @@ func TestCache_DoubleClose(t *testing.T) {
 	})
 }
 
+func TestCache_CloseReleasesEntries(t *testing.T) {
+	t.Parallel()
+	c, err := New[*testPlan](10, 0)
+	require.NoError(t, err)
+
+	c.Set(1, &testPlan{content: "q1"}, 10*time.Millisecond)
+	c.Set(2, &testPlan{content: "q2"}, 20*time.Millisecond)
+	c.Set(3, &testPlan{content: "q3"}, 30*time.Millisecond)
+	c.Wait()
+
+	c.Close()
+
+	count := 0
+	c.entries.Range(func(_, _ any) bool {
+		count++
+		return true
+	})
+	require.Equal(t, 0, count, "entries sync.Map must be empty after Close")
+	require.Equal(t, int64(0), c.size)
+}
+
 func BenchmarkCache_Set(b *testing.B) {
 	c, err := New[*testPlan](1000, 0)
 	require.NoError(b, err)


### PR DESCRIPTION
## Problem

When the router hot-reloads execution config (CDN or manifest watcher), memory usage climbs and **does not return to the pre-reload baseline**. After several reloads, pods can hit memory limits.

One contributor: `slowplancache.Close()` stopped the background goroutine but **left entries in the underlying `sync.Map`**. Those entries can hold query plans that reference schema AST nodes, keeping the previous graph generation alive until the `Cache` struct itself is garbage-collected.

## Fix

Clear all entries from the map when `Close()` runs, and reset the size counter.

## Validation

- [x] Unit test `TestCache_CloseReleasesEntries` — map is empty after `Close()`
- [x] `go test ./router/pkg/slowplancache/...`
- [ ] CI

This is the first commit in a larger fix set; see #3005 for the remaining router reload changes.

Support ticket: monday.com #3221

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Closing the cache now fully clears stored entries and resets its size, helping release memory more reliably.
* **Tests**
  * Added coverage to verify that closing the cache removes all retained entries and leaves it empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->