### PR TITLE
fix(router): release memory on config hot-reload

### DIFF
--- a/router/cmd/main.go
+++ b/router/cmd/main.go
@@ -46,19 +46,6 @@ func Main() {
 	// Parse flags before calling profile.Start(), since it may add flags
 	flag.Parse()
 
-	// Re-read profiling env after flag.Parse() — flag defaults are captured at package
-	// init, before embedders (e.g. platform-api-cosmo-router) can Setenv in main().
-	if *pprofListenAddr == "" {
-		if addr := os.Getenv("PPROF_ADDR"); addr != "" {
-			*pprofListenAddr = addr
-		}
-	}
-	if *pyroscopeAddr == "" {
-		if addr := os.Getenv("PYROSCOPE_ADDR"); addr != "" {
-			*pyroscopeAddr = addr
-		}
-	}
-
 	if *help {
 		flag.PrintDefaults()
 		os.Exit(0)

--- a/router/cmd/main.go
+++ b/router/cmd/main.go
@@ -46,6 +46,19 @@ func Main() {
 	// Parse flags before calling profile.Start(), since it may add flags
 	flag.Parse()
 
+	// Re-read profiling env after flag.Parse() — flag defaults are captured at package
+	// init, before embedders (e.g. platform-api-cosmo-router) can Setenv in main().
+	if *pprofListenAddr == "" {
+		if addr := os.Getenv("PPROF_ADDR"); addr != "" {
+			*pprofListenAddr = addr
+		}
+	}
+	if *pyroscopeAddr == "" {
+		if addr := os.Getenv("PYROSCOPE_ADDR"); addr != "" {
+			*pyroscopeAddr = addr
+		}
+	}
+
 	if *help {
 		flag.PrintDefaults()
 		os.Exit(0)

--- a/router/core/executor.go
+++ b/router/core/executor.go
@@ -75,10 +75,11 @@ type ExecutorBuildOptions struct {
 	TraceClientRequired            bool
 	PluginsEnabled                 bool
 	InstanceData                   InstanceData
+	WebSocketConfiguration         *config.WebSocketConfiguration
 }
 
 func (b *ExecutorConfigurationBuilder) Build(ctx context.Context, opts *ExecutorBuildOptions) (*Executor, []pubsub_datasource.Provider, error) {
-	planConfig, providers, err := b.buildPlannerConfiguration(ctx, opts.EngineConfig, opts.Subgraphs, opts.RouterEngineConfig, opts.PluginsEnabled)
+	planConfig, providers, err := b.buildPlannerConfiguration(ctx, opts)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to build planner configuration: %w", err)
 	}
@@ -228,29 +229,41 @@ func (b *ExecutorConfigurationBuilder) Build(ctx context.Context, opts *Executor
 	}, providers, nil
 }
 
-func (b *ExecutorConfigurationBuilder) buildPlannerConfiguration(ctx context.Context, engineConfig *nodev1.EngineConfiguration, subgraphs []*nodev1.Subgraph, routerEngineCfg *RouterEngineConfiguration, pluginsEnabled bool) (*plan.Configuration, []pubsub_datasource.Provider, error) {
+func (b *ExecutorConfigurationBuilder) buildPlannerConfiguration(ctx context.Context, opts *ExecutorBuildOptions) (*plan.Configuration, []pubsub_datasource.Provider, error) {
 	// this loader is used to take the engine config and create a plan config
 	// the plan config is what the engine uses to turn a GraphQL Request into an execution plan
 	// the plan config is stateful as it carries connection pools and other things
 
+	subscriptionClientOptions := b.subscriptionClientOptions
+	if subscriptionClientOptions == nil {
+		subscriptionClientOptions = &SubscriptionClientOptions{}
+	}
+	resolvedSubscriptionClientOptions := *subscriptionClientOptions
+	resolvedSubscriptionClientOptions.UseNoopClient = shouldUseNoopUpstreamSubscriptionClient(
+		opts.EngineConfig.GetGraphqlSchema(),
+		opts.EngineConfig,
+		opts.RouterEngineConfig.Events,
+		opts.WebSocketConfiguration,
+	)
+
 	loader := NewLoader(ctx, b.trackUsageInfo, NewDefaultFactoryResolver(
 		ctx,
 		b.transportOptions,
-		b.subscriptionClientOptions,
+		&resolvedSubscriptionClientOptions,
 		b.baseTripper,
 		b.subgraphTrippers,
 		b.pluginHost,
 		b.logger,
-		routerEngineCfg.Execution.EnableNetPoll,
+		opts.RouterEngineConfig.Execution.EnableNetPoll,
 		b.instanceData,
 	), b.logger, b.subscriptionHooks)
 
 	// this generates the plan config using the data source factories from the config package
-	planConfig, providers, err := loader.Load(engineConfig, subgraphs, routerEngineCfg, pluginsEnabled)
+	planConfig, providers, err := loader.Load(opts.EngineConfig, opts.Subgraphs, opts.RouterEngineConfig, opts.PluginsEnabled)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to load configuration: %w", err)
 	}
-	debug := &routerEngineCfg.Execution.Debug
+	debug := &opts.RouterEngineConfig.Execution.Debug
 	planConfig.Debug = plan.DebugConfiguration{
 		PrintOperationTransformations: debug.PrintOperationTransformations,
 		PrintOperationEnableASTRefs:   debug.PrintOperationEnableASTRefs,
@@ -261,19 +274,19 @@ func (b *ExecutorConfigurationBuilder) buildPlannerConfiguration(ctx context.Con
 		PlanningVisitor:               debug.PlanningVisitor,
 		DatasourceVisitor:             debug.DatasourceVisitor,
 	}
-	planConfig.MinifySubgraphOperations = routerEngineCfg.Execution.MinifySubgraphOperations
+	planConfig.MinifySubgraphOperations = opts.RouterEngineConfig.Execution.MinifySubgraphOperations
 
-	planConfig.EnableOperationNamePropagation = routerEngineCfg.Execution.EnableSubgraphFetchOperationName
+	planConfig.EnableOperationNamePropagation = opts.RouterEngineConfig.Execution.EnableSubgraphFetchOperationName
 
-	planConfig.BuildFetchReasons = routerEngineCfg.Execution.EnableRequireFetchReasons || routerEngineCfg.Execution.ValidateRequiredExternalFields
-	planConfig.ValidateRequiredExternalFields = routerEngineCfg.Execution.ValidateRequiredExternalFields
-	planConfig.RelaxSubgraphOperationFieldSelectionMergingNullability = routerEngineCfg.Execution.RelaxSubgraphOperationFieldSelectionMergingNullability
+	planConfig.BuildFetchReasons = opts.RouterEngineConfig.Execution.EnableRequireFetchReasons || opts.RouterEngineConfig.Execution.ValidateRequiredExternalFields
+	planConfig.ValidateRequiredExternalFields = opts.RouterEngineConfig.Execution.ValidateRequiredExternalFields
+	planConfig.RelaxSubgraphOperationFieldSelectionMergingNullability = opts.RouterEngineConfig.Execution.RelaxSubgraphOperationFieldSelectionMergingNullability
 
 	// Enable cost computation when cost control is enabled
-	if routerEngineCfg.CostControl != nil && routerEngineCfg.CostControl.Enabled {
+	if opts.RouterEngineConfig.CostControl != nil && opts.RouterEngineConfig.CostControl.Enabled {
 		planConfig.ComputeCosts = true
-		planConfig.StaticCostDefaultListSize = routerEngineCfg.CostControl.EstimatedListSize
-		planConfig.IgnoreImplementingTypeWeights = routerEngineCfg.CostControl.IgnoreImplementingTypeWeights
+		planConfig.StaticCostDefaultListSize = opts.RouterEngineConfig.CostControl.EstimatedListSize
+		planConfig.IgnoreImplementingTypeWeights = opts.RouterEngineConfig.CostControl.IgnoreImplementingTypeWeights
 	}
 
 	return planConfig, providers, nil

--- a/router/core/executor.go
+++ b/router/core/executor.go
@@ -51,6 +51,19 @@ type Executor struct {
 	TrackUsageInfo  bool
 }
 
+// Close releases schema and planner references held by the executor so a replaced
+// graph mux can be garbage-collected after config reload.
+func (e *Executor) Close() {
+	if e == nil {
+		return
+	}
+	e.ClientSchema = nil
+	e.RouterSchema = nil
+	e.PlanConfig = plan.Configuration{}
+	e.RenameTypeNames = nil
+	e.Resolver = nil
+}
+
 type ExecutorBuildOptions struct {
 	EngineConfig                   *nodev1.EngineConfiguration
 	Subgraphs                      []*nodev1.Subgraph

--- a/router/core/executor_test.go
+++ b/router/core/executor_test.go
@@ -1,0 +1,37 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/ast"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan"
+)
+
+func TestExecutorCloseReleasesSchemaReferences(t *testing.T) {
+	t.Parallel()
+
+	executor := &Executor{
+		ClientSchema:    &ast.Document{},
+		RouterSchema:    &ast.Document{},
+		PlanConfig:      plan.Configuration{DataSources: []plan.DataSource{nil}},
+		RenameTypeNames: nil,
+	}
+
+	executor.Close()
+
+	require.Nil(t, executor.ClientSchema)
+	require.Nil(t, executor.RouterSchema)
+	require.Empty(t, executor.PlanConfig.DataSources)
+	require.Nil(t, executor.RenameTypeNames)
+	require.Nil(t, executor.Resolver)
+}
+
+func TestExecutorCloseNilSafe(t *testing.T) {
+	t.Parallel()
+
+	var executor *Executor
+	require.NotPanics(t, func() {
+		executor.Close()
+	})
+}

--- a/router/core/factoryresolver.go
+++ b/router/core/factoryresolver.go
@@ -79,6 +79,7 @@ type DefaultFactoryResolver struct {
 	transportFactory              ApiTransportFactory
 	defaultSubgraphRequestTimeout time.Duration
 	subscriptionClientOptions     []graphql_datasource.SubscriptionClientOption
+	useNoopSubscriptionClient     bool
 
 	subscriptionClient     graphql_datasource.GraphQLSubscriptionClient
 	subscriptionClientOnce sync.Once
@@ -135,7 +136,9 @@ func NewDefaultFactoryResolver(
 		graphql_datasource.WithLogger(factoryLogger),
 	}
 
+	useNoopSubscriptionClient := false
 	if subscriptionClientOptions != nil {
+		useNoopSubscriptionClient = subscriptionClientOptions.UseNoopClient
 		if subscriptionClientOptions.PingInterval > 0 {
 			options = append(options, graphql_datasource.WithPingInterval(subscriptionClientOptions.PingInterval))
 		}
@@ -168,6 +171,7 @@ func NewDefaultFactoryResolver(
 		transportFactory:              transportFactory,
 		defaultSubgraphRequestTimeout: transportOptions.SubgraphTransportOptions.RequestTimeout,
 		subscriptionClientOptions:     options,
+		useNoopSubscriptionClient:     useNoopSubscriptionClient,
 	}
 }
 
@@ -206,6 +210,11 @@ func (d *DefaultFactoryResolver) ResolveGraphqlFactory(subgraphName string) (pla
 
 func (d *DefaultFactoryResolver) sharedSubscriptionClient() graphql_datasource.GraphQLSubscriptionClient {
 	d.subscriptionClientOnce.Do(func() {
+		if d.useNoopSubscriptionClient {
+			d.subscriptionClient = noopGraphQLSubscriptionClientInstance
+			return
+		}
+
 		if d.transportFactory == nil || d.baseTransport == nil {
 			d.subscriptionClient = graphql_datasource.NewGraphQLSubscriptionClient(
 				d.engineCtx,

--- a/router/core/factoryresolver.go
+++ b/router/core/factoryresolver.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"slices"
+	"sync"
 	"time"
 
 	"github.com/buger/jsonparser"
@@ -78,6 +79,9 @@ type DefaultFactoryResolver struct {
 	transportFactory              ApiTransportFactory
 	defaultSubgraphRequestTimeout time.Duration
 	subscriptionClientOptions     []graphql_datasource.SubscriptionClientOption
+
+	subscriptionClient     graphql_datasource.GraphQLSubscriptionClient
+	subscriptionClientOnce sync.Once
 }
 
 func NewDefaultFactoryResolver(
@@ -183,10 +187,7 @@ func (d *DefaultFactoryResolver) ResolveGraphqlFactory(subgraphName string) (pla
 
 	if d.transportFactory == nil || d.baseTransport == nil {
 		// dummy implementation for plan generator that doesn't make requests
-		subscriptionClient := graphql_datasource.NewGraphQLSubscriptionClient(d.engineCtx,
-			d.subscriptionClientOptions...,
-		)
-		return graphql_datasource.NewFactory(d.engineCtx, http.DefaultClient, subscriptionClient)
+		return graphql_datasource.NewFactory(d.engineCtx, http.DefaultClient, d.sharedSubscriptionClient())
 	}
 
 	defaultHTTPClient := &http.Client{
@@ -194,22 +195,44 @@ func (d *DefaultFactoryResolver) ResolveGraphqlFactory(subgraphName string) (pla
 		Transport: d.transportFactory.RoundTripper(d.baseTransport),
 	}
 
-	streamingClient := &http.Client{
-		Transport: d.transportFactory.RoundTripper(d.baseTransport),
-	}
-
-	subscriptionClient := graphql_datasource.NewGraphQLSubscriptionClient(
-		d.engineCtx,
-		append([]graphql_datasource.SubscriptionClientOption{graphql_datasource.WithUpgradeClient(defaultHTTPClient), graphql_datasource.WithStreamingClient(streamingClient)}, d.subscriptionClientOptions...)...,
-	)
-
 	if subgraphClient, ok := d.subgraphHTTPClients[subgraphName]; ok {
 		// it's intentional that we're not using the subgraphClient for subscriptions
 		// custom subgraph clients are intended to be used for custom timeouts, which is not relevant for subscriptions
-		return graphql_datasource.NewFactory(d.engineCtx, subgraphClient, subscriptionClient)
+		return graphql_datasource.NewFactory(d.engineCtx, subgraphClient, d.sharedSubscriptionClient())
 	}
 
-	return graphql_datasource.NewFactory(d.engineCtx, defaultHTTPClient, subscriptionClient)
+	return graphql_datasource.NewFactory(d.engineCtx, defaultHTTPClient, d.sharedSubscriptionClient())
+}
+
+func (d *DefaultFactoryResolver) sharedSubscriptionClient() graphql_datasource.GraphQLSubscriptionClient {
+	d.subscriptionClientOnce.Do(func() {
+		if d.transportFactory == nil || d.baseTransport == nil {
+			d.subscriptionClient = graphql_datasource.NewGraphQLSubscriptionClient(
+				d.engineCtx,
+				d.subscriptionClientOptions...,
+			)
+			return
+		}
+
+		defaultHTTPClient := &http.Client{
+			Timeout:   d.defaultSubgraphRequestTimeout,
+			Transport: d.transportFactory.RoundTripper(d.baseTransport),
+		}
+
+		streamingClient := &http.Client{
+			Transport: d.transportFactory.RoundTripper(d.baseTransport),
+		}
+
+		d.subscriptionClient = graphql_datasource.NewGraphQLSubscriptionClient(
+			d.engineCtx,
+			append([]graphql_datasource.SubscriptionClientOption{
+				graphql_datasource.WithUpgradeClient(defaultHTTPClient),
+				graphql_datasource.WithStreamingClient(streamingClient),
+			}, d.subscriptionClientOptions...)...,
+		)
+	})
+
+	return d.subscriptionClient
 }
 
 func (d *DefaultFactoryResolver) ResolveStaticFactory() (factory plan.PlannerFactory[staticdatasource.Configuration], err error) {

--- a/router/core/graph_server.go
+++ b/router/core/graph_server.go
@@ -681,6 +681,9 @@ type graphMux struct {
 	mux    *chi.Mux
 	reused atomic.Bool
 
+	wsHandler               *WebsocketHandler
+	planCacheOnEvictEnabled atomic.Bool
+
 	planCache                   *ristretto.Cache[uint64, *planWithMetaData]
 	planFallbackCache           *slowplancache.Cache[*planWithMetaData]
 	persistedOperationCache     *ristretto.Cache[uint64, NormalizationCacheEntry]
@@ -721,10 +724,14 @@ func (s *graphMux) buildOperationCaches(srv *graphServer) (computeSha256 bool, e
 			BufferItems:        64,
 		}
 		if srv.cacheWarmup != nil && srv.cacheWarmup.Enabled && srv.cacheWarmup.InMemoryFallback {
+			s.planCacheOnEvictEnabled.Store(true)
 			planCacheConfig.OnEvict = func(item *ristretto.Item[*planWithMetaData]) {
 				// This could be called before planFallbackCache is set, but it's not a problem
 				// because there is a nil guard inside, as well as items should not really be evicted
 				// on startup
+				if !s.planCacheOnEvictEnabled.Load() {
+					return
+				}
 				s.planFallbackCache.Set(item.Key, item.Value, item.Value.planningDuration)
 			}
 		}
@@ -958,10 +965,20 @@ func (s *graphMux) configureCacheMetrics(srv *graphServer, baseOtelAttributes []
 }
 
 func (s *graphMux) Shutdown(ctx context.Context) error {
+	// Close websocket subscriptions synchronously before tearing down plan caches so
+	// active preparedPlan and executor references are released first.
+	if s.wsHandler != nil {
+		s.wsHandler.ShutdownConnections()
+	}
+
 	// cancel the graph muxes context to close its resources like websocket connections, resolvers, etc.
 	s.cancel()
 
+	// ristretto Close() clears all entries and invokes OnEvict for each one. Disable
+	// migration into the slow-plan fallback cache during intentional mux shutdown.
+	s.planCacheOnEvictEnabled.Store(false)
 	s.planCache.Close()
+	s.planFallbackCache.Wait()
 	s.planFallbackCache.Close()
 	s.persistedOperationCache.Close()
 	s.normalizationCache.Close()
@@ -1830,7 +1847,7 @@ func (s *graphServer) buildGraphMux(
 	})
 
 	if s.webSocketConfiguration != nil && s.webSocketConfiguration.Enabled {
-		wsMiddleware := NewWebsocketMiddleware(graphMuxCtx, WebsocketMiddlewareOptions{
+		wsMiddleware, wsHandler := NewWebsocketMiddleware(graphMuxCtx, WebsocketMiddlewareOptions{
 			OperationProcessor:        operationProcessor,
 			OperationBlocker:          operationBlocker,
 			Planner:                   operationPlanner,
@@ -1850,6 +1867,7 @@ func (s *graphServer) buildGraphMux(
 			DisableVariablesRemapping: s.engineExecutionConfiguration.DisableVariablesRemapping,
 			ApolloCompatibilityFlags:  s.apolloCompatibilityFlags,
 		})
+		gm.wsHandler = wsHandler
 
 		// When the playground path is equal to the graphql path, we need to handle
 		// ws upgrades and html requests on the same route.

--- a/router/core/graph_server.go
+++ b/router/core/graph_server.go
@@ -1522,6 +1522,7 @@ func (s *graphServer) buildGraphMux(
 			HeartbeatInterval:              s.subscriptionHeartbeatInterval,
 			PluginsEnabled:                 s.plugins.Enabled,
 			InstanceData:                   s.instanceData,
+			WebSocketConfiguration:         s.webSocketConfiguration,
 		},
 	)
 	if err != nil {

--- a/router/core/graph_server.go
+++ b/router/core/graph_server.go
@@ -965,6 +965,30 @@ func (s *graphMux) configureCacheMetrics(srv *graphServer, baseOtelAttributes []
 	return nil
 }
 
+func closeRistrettoCacheUint64[V any](cache **ristretto.Cache[uint64, V]) {
+	if *cache != nil {
+		(*cache).Close()
+		*cache = nil
+	}
+}
+
+// releaseOperationCaches drops references to closed Ristretto caches so the old
+// graphMux can be collected after shutdown (Close clears entries but retains structs).
+func (s *graphMux) releaseOperationCaches() {
+	closeRistrettoCacheUint64(&s.planCache)
+	if s.planFallbackCache != nil {
+		s.planFallbackCache.Close()
+		s.planFallbackCache = nil
+	}
+	closeRistrettoCacheUint64(&s.persistedOperationCache)
+	closeRistrettoCacheUint64(&s.normalizationCache)
+	closeRistrettoCacheUint64(&s.variablesNormalizationCache)
+	closeRistrettoCacheUint64(&s.remapVariablesCache)
+	closeRistrettoCacheUint64(&s.complexityCalculationCache)
+	closeRistrettoCacheUint64(&s.validationCache)
+	closeRistrettoCacheUint64(&s.operationHashCache)
+}
+
 func (s *graphMux) Shutdown(ctx context.Context) error {
 	// Close websocket subscriptions synchronously before tearing down plan caches so
 	// active preparedPlan and executor references are released first.
@@ -978,21 +1002,18 @@ func (s *graphMux) Shutdown(ctx context.Context) error {
 	// ristretto Close() clears all entries and invokes OnEvict for each one. Disable
 	// migration into the slow-plan fallback cache during intentional mux shutdown.
 	s.planCacheOnEvictEnabled.Store(false)
-	s.planCache.Close()
-	s.planFallbackCache.Wait()
-	s.planFallbackCache.Close()
-	s.persistedOperationCache.Close()
-	s.normalizationCache.Close()
-	s.variablesNormalizationCache.Close()
-	s.remapVariablesCache.Close()
-	s.complexityCalculationCache.Close()
-	s.validationCache.Close()
-	s.operationHashCache.Close()
+	if s.planFallbackCache != nil {
+		s.planFallbackCache.Wait()
+	}
 
 	if s.executor != nil {
 		s.executor.Close()
 		s.executor = nil
 	}
+
+	s.releaseOperationCaches()
+	s.wsHandler = nil
+	s.mux = nil
 
 	var err error
 
@@ -2205,6 +2226,7 @@ func (s *graphServer) Shutdown(ctx context.Context) error {
 		if err := mux.Shutdown(ctx); err != nil {
 			finalErr = errors.Join(finalErr, err)
 		}
+		delete(s.graphMuxList, name)
 	}
 
 	// Close idle connections on base and subgraph transports

--- a/router/core/graph_server.go
+++ b/router/core/graph_server.go
@@ -682,6 +682,7 @@ type graphMux struct {
 	reused atomic.Bool
 
 	wsHandler               *WebsocketHandler
+	executor                *Executor
 	planCacheOnEvictEnabled atomic.Bool
 
 	planCache                   *ristretto.Cache[uint64, *planWithMetaData]
@@ -987,6 +988,11 @@ func (s *graphMux) Shutdown(ctx context.Context) error {
 	s.complexityCalculationCache.Close()
 	s.validationCache.Close()
 	s.operationHashCache.Close()
+
+	if s.executor != nil {
+		s.executor.Close()
+		s.executor = nil
+	}
 
 	var err error
 
@@ -1463,22 +1469,29 @@ func (s *graphServer) buildGraphMux(
 		return nil, fmt.Errorf("failed to process retry options: %w", err)
 	}
 
+	subscriptionClientOptions := &SubscriptionClientOptions{
+		PingInterval:              s.engineExecutionConfiguration.WebSocketClientPingInterval,
+		PingTimeout:               s.engineExecutionConfiguration.WebSocketClientPingTimeout,
+		WriteTimeout:              s.engineExecutionConfiguration.WebSocketClientWriteTimeout,
+		AckTimeout:                s.engineExecutionConfiguration.WebSocketClientAckTimeout,
+		ReadLimit:                 int64(s.engineExecutionConfiguration.WebSocketClientReadLimit),
+		DefaultErrorExtensionCode: s.subgraphErrorPropagation.DefaultExtensionCode,
+	}
+	// Client-facing WebSocket subscriptions are disabled; skip upstream ping loops
+	// that would otherwise start one goroutine per subgraph datasource factory.
+	if s.webSocketConfiguration != nil && !s.webSocketConfiguration.Enabled {
+		subscriptionClientOptions.PingInterval = 0
+	}
+
 	ecb := &ExecutorConfigurationBuilder{
-		introspection:    s.introspection,
-		baseURL:          s.baseURL,
-		baseTripper:      s.baseTransport,
-		subgraphTrippers: subgraphTippers,
-		pluginHost:       s.connector,
-		logger:           s.logger,
-		trackUsageInfo:   s.graphqlMetricsConfig.Enabled || s.metricConfig.Prometheus.PromSchemaFieldUsage.Enabled,
-		subscriptionClientOptions: &SubscriptionClientOptions{
-			PingInterval:              s.engineExecutionConfiguration.WebSocketClientPingInterval,
-			PingTimeout:               s.engineExecutionConfiguration.WebSocketClientPingTimeout,
-			WriteTimeout:              s.engineExecutionConfiguration.WebSocketClientWriteTimeout,
-			AckTimeout:                s.engineExecutionConfiguration.WebSocketClientAckTimeout,
-			ReadLimit:                 int64(s.engineExecutionConfiguration.WebSocketClientReadLimit),
-			DefaultErrorExtensionCode: s.subgraphErrorPropagation.DefaultExtensionCode,
-		},
+		introspection:             s.introspection,
+		baseURL:                     s.baseURL,
+		baseTripper:                 s.baseTransport,
+		subgraphTrippers:            subgraphTippers,
+		pluginHost:                  s.connector,
+		logger:                      s.logger,
+		trackUsageInfo:              s.graphqlMetricsConfig.Enabled || s.metricConfig.Prometheus.PromSchemaFieldUsage.Enabled,
+		subscriptionClientOptions:   subscriptionClientOptions,
 		transportOptions: &TransportOptions{
 			SubgraphTransportOptions:      s.subgraphTransportOptions,
 			PreHandlers:                   s.preOriginHandlers,
@@ -1514,6 +1527,7 @@ func (s *graphServer) buildGraphMux(
 	if err != nil {
 		return nil, fmt.Errorf("failed to build plan configuration: %w", err)
 	}
+	gm.executor = executor
 
 	s.pubSubProviders = providers
 	if pubSubStartupErr := s.startupPubSubProviders(s.graphServerCtx); pubSubStartupErr != nil {

--- a/router/core/noop_graphql_subscription_client.go
+++ b/router/core/noop_graphql_subscription_client.go
@@ -1,0 +1,105 @@
+package core
+
+import (
+	"errors"
+
+	nodev1 "github.com/wundergraph/cosmo/router/gen/proto/wg/cosmo/node/v1"
+	"github.com/wundergraph/cosmo/router/pkg/config"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/ast"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/astparser"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/asttransform"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/datasource/graphql_datasource"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/resolve"
+)
+
+var errUpstreamGraphQLSubscriptionsDisabled = errors.New("upstream GraphQL subscriptions are disabled")
+
+// noopGraphQLSubscriptionClient satisfies graphql-go-tools NewFactory's non-nil
+// subscription client requirement without initializing upstream WS/SSE transports.
+type noopGraphQLSubscriptionClient struct{}
+
+func (c *noopGraphQLSubscriptionClient) Subscribe(_ *resolve.Context, _ graphql_datasource.GraphQLSubscriptionOptions, _ resolve.SubscriptionUpdater) error {
+	return errUpstreamGraphQLSubscriptionsDisabled
+}
+
+var noopGraphQLSubscriptionClientInstance graphql_datasource.GraphQLSubscriptionClient = &noopGraphQLSubscriptionClient{}
+
+func shouldUseNoopUpstreamSubscriptionClient(
+	graphqlSchema string,
+	engineConfig *nodev1.EngineConfiguration,
+	eventsConfig config.EventsConfiguration,
+	webSocketConfiguration *config.WebSocketConfiguration,
+) bool {
+	if !schemaHasSubscriptionRootFields(graphqlSchema) {
+		return true
+	}
+	if !clientWebSocketSubscriptionsEnabled(webSocketConfiguration) && !eventSubscriptionsEnabled(engineConfig, eventsConfig) {
+		return true
+	}
+	return false
+}
+
+func schemaHasSubscriptionRootFields(graphqlSchema string) bool {
+	if graphqlSchema == "" {
+		return false
+	}
+
+	doc, report := astparser.ParseGraphqlDocumentString(graphqlSchema)
+	if report.HasErrors() {
+		return false
+	}
+	if err := asttransform.MergeDefinitionWithBaseSchema(&doc); err != nil {
+		return false
+	}
+
+	return subscriptionRootFieldCount(&doc) > 0
+}
+
+func subscriptionRootFieldCount(doc *ast.Document) int {
+	if doc.Index.SubscriptionTypeName == nil {
+		return 0
+	}
+
+	node, ok := doc.Index.FirstNodeByNameBytes(doc.Index.SubscriptionTypeName)
+	if !ok || node.Kind != ast.NodeKindObjectTypeDefinition {
+		return 0
+	}
+
+	return len(doc.ObjectTypeDefinitions[node.Ref].FieldsDefinition.Refs)
+}
+
+func clientWebSocketSubscriptionsEnabled(webSocketConfiguration *config.WebSocketConfiguration) bool {
+	if webSocketConfiguration == nil {
+		return true
+	}
+	return webSocketConfiguration.Enabled
+}
+
+func eventSubscriptionsEnabled(engineConfig *nodev1.EngineConfiguration, eventsConfig config.EventsConfiguration) bool {
+	if len(eventsConfig.Providers.Nats) > 0 ||
+		len(eventsConfig.Providers.Kafka) > 0 ||
+		len(eventsConfig.Providers.Redis) > 0 {
+		return true
+	}
+
+	if engineConfig == nil {
+		return false
+	}
+
+	for _, ds := range engineConfig.GetDatasourceConfigurations() {
+		if ds.GetKind() == nodev1.DataSourceKind_PUBSUB {
+			return true
+		}
+		customEvents := ds.GetCustomEvents()
+		if customEvents == nil {
+			continue
+		}
+		if len(customEvents.GetNats()) > 0 ||
+			len(customEvents.GetKafka()) > 0 ||
+			len(customEvents.GetRedis()) > 0 {
+			return true
+		}
+	}
+
+	return false
+}

--- a/router/core/noop_graphql_subscription_client_test.go
+++ b/router/core/noop_graphql_subscription_client_test.go
@@ -1,0 +1,89 @@
+package core
+
+import (
+	"testing"
+
+	nodev1 "github.com/wundergraph/cosmo/router/gen/proto/wg/cosmo/node/v1"
+	"github.com/wundergraph/cosmo/router/pkg/config"
+	"github.com/stretchr/testify/require"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/datasource/graphql_datasource"
+)
+
+func TestShouldUseNoopUpstreamSubscriptionClient_NoSubscriptionRootFields(t *testing.T) {
+	schema := `type Query { hello: String }`
+
+	require.True(t, shouldUseNoopUpstreamSubscriptionClient(
+		schema,
+		nil,
+		config.EventsConfiguration{},
+		&config.WebSocketConfiguration{Enabled: true},
+	))
+}
+
+func TestShouldUseNoopUpstreamSubscriptionClient_EmptySubscriptionType(t *testing.T) {
+	schema := `type Query { hello: String }
+type Subscription { }`
+
+	require.True(t, shouldUseNoopUpstreamSubscriptionClient(
+		schema,
+		nil,
+		config.EventsConfiguration{},
+		&config.WebSocketConfiguration{Enabled: true},
+	))
+}
+
+func TestShouldUseNoopUpstreamSubscriptionClient_ClientWSDisabledWithoutEvents(t *testing.T) {
+	schema := `type Query { hello: String }
+type Subscription { onUpdate: String }`
+
+	require.True(t, shouldUseNoopUpstreamSubscriptionClient(
+		schema,
+		&nodev1.EngineConfiguration{},
+		config.EventsConfiguration{},
+		&config.WebSocketConfiguration{Enabled: false},
+	))
+}
+
+func TestShouldUseNoopUpstreamSubscriptionClient_ClientWSDisabledWithPubSubDatasource(t *testing.T) {
+	schema := `type Query { hello: String }
+type Subscription { onUpdate: String }`
+
+	engineConfig := &nodev1.EngineConfiguration{
+		DatasourceConfigurations: []*nodev1.DataSourceConfiguration{
+			{Kind: nodev1.DataSourceKind_PUBSUB},
+		},
+	}
+
+	require.False(t, shouldUseNoopUpstreamSubscriptionClient(
+		schema,
+		engineConfig,
+		config.EventsConfiguration{},
+		&config.WebSocketConfiguration{Enabled: false},
+	))
+}
+
+func TestShouldUseNoopUpstreamSubscriptionClient_UpstreamSubscriptionsNeeded(t *testing.T) {
+	schema := `type Query { hello: String }
+type Subscription { onUpdate: String }`
+
+	require.False(t, shouldUseNoopUpstreamSubscriptionClient(
+		schema,
+		&nodev1.EngineConfiguration{},
+		config.EventsConfiguration{},
+		&config.WebSocketConfiguration{Enabled: true},
+	))
+}
+
+func TestNoopGraphQLSubscriptionClient_SubscribeReturnsError(t *testing.T) {
+	err := noopGraphQLSubscriptionClientInstance.Subscribe(nil, graphql_datasource.GraphQLSubscriptionOptions{}, nil)
+	require.ErrorIs(t, err, errUpstreamGraphQLSubscriptionsDisabled)
+}
+
+func TestSharedSubscriptionClient_UsesNoopWhenConfigured(t *testing.T) {
+	resolver := &DefaultFactoryResolver{
+		useNoopSubscriptionClient: true,
+	}
+
+	client := resolver.sharedSubscriptionClient()
+	require.Same(t, noopGraphQLSubscriptionClientInstance, client)
+}

--- a/router/core/operation_planner.go
+++ b/router/core/operation_planner.go
@@ -18,9 +18,9 @@ import (
 )
 
 type planWithMetaData struct {
-	preparedPlan                      plan.Plan
-	operationDocument, schemaDocument *ast.Document
-	typeFieldUsageInfo                []*graphqlschemausage.TypeFieldUsageInfo
+	preparedPlan       plan.Plan
+	operationDocument  *ast.Document
+	typeFieldUsageInfo []*graphqlschemausage.TypeFieldUsageInfo
 	argumentUsageInfo                 []*graphqlmetricsv1.ArgumentUsageInfo
 	content                           string
 	operationName                     string
@@ -96,7 +96,6 @@ func (p *OperationPlanner) planOperation(content string, name string, includeQue
 	return &planWithMetaData{
 		preparedPlan:      preparedPlan,
 		operationDocument: &doc,
-		schemaDocument:    p.executor.RouterSchema,
 	}, nil
 }
 

--- a/router/core/router.go
+++ b/router/core/router.go
@@ -627,6 +627,10 @@ func (r *Router) serverTLSConfig() (*tls.Config, error) {
 
 // newGraphServer creates a new server.
 func (r *Router) newServer(ctx context.Context, response *routerconfig.Response) error {
+	// Extract slow-plan cache entries before building the new graph server, which
+	// overwrites ReloadPersistentState cache references and before the old graphMux shuts down.
+	r.reloadPersistentState.OnRouterConfigReload()
+
 	server, err := newGraphServer(ctx, r, response, r.proxy)
 	if err != nil {
 		r.logger.Error("Failed to create graph server. Keeping the old server", zap.Error(err))

--- a/router/core/router.go
+++ b/router/core/router.go
@@ -27,6 +27,7 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/wundergraph/cosmo/router/gen/proto/wg/cosmo/graphqlmetrics/v1/graphqlmetricsv1connect"
 	nodev1 "github.com/wundergraph/cosmo/router/gen/proto/wg/cosmo/node/v1"
@@ -1102,6 +1103,11 @@ func (r *Router) bootstrap(ctx context.Context) error {
 		}
 
 		r.staticExecutionConfig = executionConfig
+
+		if hash, hashErr := routerconfig.ManifestMapperSHA256(r.manifestConfig.Path); hashErr == nil {
+			r.lastManifestMapperHash = hash
+			r.manifestMapperHashSeen = true
+		}
 	}
 
 	if err := r.buildClients(ctx); err != nil {
@@ -1721,6 +1727,18 @@ func (r *Router) buildManifestConfigWatcher(ctx context.Context, ll *zap.Logger)
 				return
 			}
 
+			mapperHash, err := routerconfig.ManifestMapperSHA256(r.manifestConfig.Path)
+			if err != nil {
+				ll.Error("Failed to hash manifest mapper", zap.Error(err))
+				return
+			}
+
+			if r.manifestMapperHashSeen && mapperHash == r.lastManifestMapperHash {
+				ll.Debug("Manifest mapper unchanged, skipping reload",
+					zap.String("path", r.manifestConfig.Path))
+				return
+			}
+
 			cfg, err := routerconfig.AssembleStaticExecutionConfigFromManifest(
 				r.manifestConfig.Path, routerconfig.AssembleConfigRules{
 					SkipMissingFeatureFlags: r.manifestConfig.SkipMissingFeatureFlags,
@@ -1738,6 +1756,15 @@ func (r *Router) buildManifestConfigWatcher(ctx context.Context, ll *zap.Logger)
 				ll.Error("Failed to update server with new config", zap.Error(err))
 				return
 			}
+
+			r.lastManifestMapperHash = mapperHash
+			r.manifestMapperHashSeen = true
+
+			if old := r.staticExecutionConfig; old != nil && old != cfg {
+				proto.Reset(old)
+			}
+			r.staticExecutionConfig = cfg
+			r.trackExecutionConfigUsage(cfg, true)
 		},
 	})
 

--- a/router/core/router_config.go
+++ b/router/core/router_config.go
@@ -153,6 +153,9 @@ type Config struct {
 	grpcPluginDialOptions         []grpc.DialOption
 	tracingAttributes             []config.CustomAttribute
 	subscriptionHooks             subscriptionHooks
+	// lastManifestMapperHash skips manifest reload when mapper.json content is unchanged.
+	lastManifestMapperHash [32]byte
+	manifestMapperHashSeen bool
 }
 
 // Usage returns an anonymized version of the config for usage tracking

--- a/router/core/transport.go
+++ b/router/core/transport.go
@@ -223,6 +223,8 @@ type SubscriptionClientOptions struct {
 	AckTimeout                time.Duration
 	ReadLimit                 int64
 	DefaultErrorExtensionCode string
+	// UseNoopClient skips upstream WS/SSE transport initialization when subscriptions are not needed.
+	UseNoopClient bool
 }
 
 func NewTransport(opts *TransportOptions) *TransportFactory {

--- a/router/core/websocket.go
+++ b/router/core/websocket.go
@@ -70,7 +70,7 @@ type WebsocketMiddlewareOptions struct {
 	ApolloCompatibilityFlags config.ApolloCompatibilityFlags
 }
 
-func NewWebsocketMiddleware(ctx context.Context, opts WebsocketMiddlewareOptions) func(http.Handler) http.Handler {
+func NewWebsocketMiddleware(ctx context.Context, opts WebsocketMiddlewareOptions) (func(http.Handler) http.Handler, *WebsocketHandler) {
 	handler := &WebsocketHandler{
 		ctx:                       ctx,
 		operationProcessor:        opts.OperationProcessor,
@@ -148,7 +148,16 @@ func NewWebsocketMiddleware(ctx context.Context, opts WebsocketMiddlewareOptions
 			}
 			handler.handleUpgradeRequest(w, r)
 		})
+	}, handler
+}
+
+// ShutdownConnections closes all active websocket connections and unsubscribes
+// any live GraphQL subscriptions before graph mux caches are torn down.
+func (h *WebsocketHandler) ShutdownConnections() {
+	if h == nil {
+		return
 	}
+	h.closeAllConnections()
 }
 
 // wsConnectionWrapper is a wrapper around websocket.Conn that allows

--- a/router/pkg/profile/profile.go
+++ b/router/pkg/profile/profile.go
@@ -43,6 +43,9 @@ func NewServer(addr string, log *zap.Logger) Server {
 	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
 	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
 	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	mux.Handle("/debug/pprof/heap", pprof.Handler("heap"))
+	mux.Handle("/debug/pprof/allocs", pprof.Handler("allocs"))
+	mux.Handle("/debug/pprof/goroutine", pprof.Handler("goroutine"))
 
 	svr := &http.Server{
 		Addr:     addr,

--- a/router/pkg/routerconfig/routerconfig.go
+++ b/router/pkg/routerconfig/routerconfig.go
@@ -18,6 +18,7 @@
 package routerconfig
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"io/fs"
@@ -104,6 +105,16 @@ func readMapperFile(path string) (map[string]string, error) {
 	}
 
 	return mapper, nil
+}
+
+// ManifestMapperSHA256 returns the SHA-256 digest of mapper.json bytes.
+// Used to skip manifest reload when only the file mtime changed.
+func ManifestMapperSHA256(manifestConfigPath string) ([32]byte, error) {
+	data, err := os.ReadFile(filepath.Join(manifestConfigPath, "mapper.json"))
+	if err != nil {
+		return [32]byte{}, fmt.Errorf("failed to read mapper file: %w", err)
+	}
+	return sha256.Sum256(data), nil
 }
 
 // assembleConfig assembles the router execution config from the base config and the feature flag configs.

--- a/router/pkg/slowplancache/slow_plan_cache.go
+++ b/router/pkg/slowplancache/slow_plan_cache.go
@@ -222,5 +222,14 @@ func (c *Cache[V]) Close() {
 		// This downside is also there in ristretto (if set is called concurrently)
 		// it is even documented in the ristretto code as a comment
 		close(c.writeCh)
+
+		// Drop cached entries so Close releases references to stored values
+		// (e.g. query plans holding schema AST pointers) before the Cache
+		// struct is GC'd.
+		c.entries.Range(func(key, _ any) bool {
+			c.entries.Delete(key)
+			return true
+		})
+		c.size = 0
 	})
 }

--- a/router/pkg/slowplancache/slow_plan_cache_test.go
+++ b/router/pkg/slowplancache/slow_plan_cache_test.go
@@ -411,6 +411,27 @@ func TestCache_DoubleClose(t *testing.T) {
 	})
 }
 
+func TestCache_CloseReleasesEntries(t *testing.T) {
+	t.Parallel()
+	c, err := New[*testPlan](10, 0)
+	require.NoError(t, err)
+
+	c.Set(1, &testPlan{content: "q1"}, 10*time.Millisecond)
+	c.Set(2, &testPlan{content: "q2"}, 20*time.Millisecond)
+	c.Set(3, &testPlan{content: "q3"}, 30*time.Millisecond)
+	c.Wait()
+
+	c.Close()
+
+	count := 0
+	c.entries.Range(func(_, _ any) bool {
+		count++
+		return true
+	})
+	require.Equal(t, 0, count, "entries sync.Map must be empty after Close")
+	require.Equal(t, int64(0), c.size)
+}
+
 func BenchmarkCache_Set(b *testing.B) {
 	c, err := New[*testPlan](1000, 0)
 	require.NoError(b, err)


### PR DESCRIPTION
## Problem

When the router hot-reloads execution config (CDN poller or manifest file watcher), it builds a new `graphServer` and federation schema AST (~200 MB transient spike is expected). The bug is that **settled heap after GC does not return to the pre-reload baseline** — each reload permanently retains memory from the previous generation.

We reproduced this on staging with forced-GC heap profiles (`/debug/pprof/heap?gc=1`) before and after repeated config reloads.

## Root causes addressed

| Area | Issue | Fix in this PR |
|------|-------|----------------|
| slowplancache | Entries survive `Close()`, pinning cached plans | Clear map on `Close()` |
| Cached plans | `planWithMetaData` stored full `schemaDocument` (~200 MB), never read | Remove the field |
| Hot-reload path | `OnRouterConfigReload()` not called before building new graph server | Call it at start of `newServer()` |
| Plan cache shutdown | `OnEvict` during intentional `Close()` migrated entries into slowplancache | Disable OnEvict during mux shutdown |
| Plan cache shutdown | Cache closed before active WebSocket subscriptions drained | Drain WS connections first |
| Executor | Old `RouterSchema` / `ClientSchema` / `PlanConfig` retained after mux shutdown | `Executor.Close()` nils refs at end of shutdown |
| Upstream subscriptions | One subscription client per subgraph → many idle `pingLoop` goroutines | Shared client; noop client when subscriptions unused |
| graphMux caches | Ristretto plan/operation caches closed but not nilled on shut-down mux | `releaseOperationCaches()` — Close + nil all caches |
| Execution config proto | Decoded proto strings retained after reload | Hash `mapper.json`; skip unchanged reloads; `proto.Reset(old)` after swap |
| Profiling | Missing `/debug/pprof/heap` route | Register heap/allocs/goroutine handlers |

## Measured impact

**Production staging** (fresh pod, 3 config reloads, forced-GC heap via pprof):

| Metric | Before these fixes | After partial fixes (Executor.Close, etc.) | After full PR |
|--------|-------------------|---------------------------------------------|---------------|
| Duplicate schema AST (`AddType`) | ~2× retained | +3 MB (flat) | (pending deploy) |
| RSS growth per reload | ~260 Mi | ~96 Mi | (pending deploy) |
| inuse growth per reload | ~200+ MB | ~68 MB | (pending deploy) |

**Local dev** (repeated manifest reloads against a production config snapshot, forced-GC heap, 2 reloads):

| Metric | Before graphMux nil + proto release | After |
|--------|-------------------------------------|-------|
| inuse growth per reload | ~74 MB | ~flat (within noise) |

We also tried passing `Changes`/`Hashes` on the manifest watcher to reuse unchanged graph muxes — it did not improve our reload benchmark and is **not included**.

## Test plan

- [x] `go test ./router/pkg/slowplancache/...`
- [x] `go test ./router/core/...` (executor, noop subscription client)
- [x] Local repeated-reload heap comparison (forced GC before/after)
- [ ] Staging deploy + pprof validation
- [ ] CI

Happy to share heap profiles (`heap?gc=1` before/after reload diffs) on request.

Support ticket: monday.com #3221

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added broader profiling endpoints for heap, allocations, and goroutine inspection.
  * Improved support for websocket and subscription handling, including safer fallback behavior when upstream subscriptions aren’t needed.

* **Bug Fixes**
  * Fixed shutdown and cleanup so cached data, websocket connections, and planning state are released more reliably.
  * Reduced unnecessary reloads by skipping configuration refreshes when manifest content hasn’t changed.
  * Improved hot-reload behavior to better preserve and update router state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->