### PR TITLE
fix(router): clear slowplancache entries on Close

### DIFF
--- a/router/pkg/slowplancache/slow_plan_cache.go
+++ b/router/pkg/slowplancache/slow_plan_cache.go
@@ -222,5 +222,14 @@ func (c *Cache[V]) Close() {
 		// This downside is also there in ristretto (if set is called concurrently)
 		// it is even documented in the ristretto code as a comment
 		close(c.writeCh)
+
+		// Drop cached entries so Close releases references to stored values
+		// (e.g. query plans holding schema AST pointers) before the Cache
+		// struct is GC'd.
+		c.entries.Range(func(key, _ any) bool {
+			c.entries.Delete(key)
+			return true
+		})
+		c.size = 0
 	})
 }

--- a/router/pkg/slowplancache/slow_plan_cache_test.go
+++ b/router/pkg/slowplancache/slow_plan_cache_test.go
@@ -411,6 +411,27 @@ func TestCache_DoubleClose(t *testing.T) {
 	})
 }
 
+func TestCache_CloseReleasesEntries(t *testing.T) {
+	t.Parallel()
+	c, err := New[*testPlan](10, 0)
+	require.NoError(t, err)
+
+	c.Set(1, &testPlan{content: "q1"}, 10*time.Millisecond)
+	c.Set(2, &testPlan{content: "q2"}, 20*time.Millisecond)
+	c.Set(3, &testPlan{content: "q3"}, 30*time.Millisecond)
+	c.Wait()
+
+	c.Close()
+
+	count := 0
+	c.entries.Range(func(_, _ any) bool {
+		count++
+		return true
+	})
+	require.Equal(t, 0, count, "entries sync.Map must be empty after Close")
+	require.Equal(t, int64(0), c.size)
+}
+
 func BenchmarkCache_Set(b *testing.B) {
 	c, err := New[*testPlan](1000, 0)
 	require.NoError(b, err)


### PR DESCRIPTION
## Problem
After `slowplancache.Close()`, entries remained in the underlying `sync.Map`, keeping references to cached query plans (and any schema pointers they hold) until the Cache struct was garbage-collected.

## Fix
Clear all entries and reset the size counter when `Close()` runs.

## Test plan
- [x] `TestCache_CloseReleasesEntries`
- [x] `go test ./router/pkg/slowplancache/...`

Part of config hot-reload memory leak investigation (monday.com #3221).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache shutdown so stored entries are fully cleared when the cache is closed.
  * Ensured cached data is released immediately, with internal cache size reset to zero.

* **Tests**
  * Added coverage to verify that closing the cache removes all stored entries and leaves no retained size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->