### PR TITLE
fix(router): stop pinning schema AST in cached plan entries

### DIFF
--- a/router/core/operation_planner.go
+++ b/router/core/operation_planner.go
@@ -18,8 +18,8 @@ import (
 )
 
 type planWithMetaData struct {
-	preparedPlan                      plan.Plan
-	operationDocument, schemaDocument *ast.Document
+	preparedPlan       plan.Plan
+	operationDocument  *ast.Document
 	typeFieldUsageInfo                []*graphqlschemausage.TypeFieldUsageInfo
 	argumentUsageInfo                 []*graphqlmetricsv1.ArgumentUsageInfo
 	content                           string
@@ -96,7 +96,6 @@ func (p *OperationPlanner) planOperation(content string, name string, includeQue
 	return &planWithMetaData{
 		preparedPlan:      preparedPlan,
 		operationDocument: &doc,
-		schemaDocument:    p.executor.RouterSchema,
 	}, nil
 }
 


### PR DESCRIPTION
## Problem
`planWithMetaData` stored `schemaDocument` (full router schema AST, ~200MB) in every Ristretto plan cache entry but never read it. After config reload, cached plans pinned the previous schema generation.

## Fix
Remove the unused `schemaDocument` field.

## Test plan
- [x] `go test ./router/core/...`

Part of config hot-reload memory leak investigation (monday.com #3221).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal request planning by removing an unused piece of stored metadata.
  * Kept the visible operation handling flow the same, with no expected change in user behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->