### PR TITLE
fix(router): call OnRouterConfigReload before config hot-reload

### DIFF
--- a/router/core/router.go
+++ b/router/core/router.go
@@ -627,6 +627,10 @@ func (r *Router) serverTLSConfig() (*tls.Config, error) {
 
 // newGraphServer creates a new server.
 func (r *Router) newServer(ctx context.Context, response *routerconfig.Response) error {
+	// Extract slow-plan cache entries before building the new graph server, which
+	// overwrites ReloadPersistentState cache references and before the old graphMux shuts down.
+	r.reloadPersistentState.OnRouterConfigReload()
+
 	server, err := newGraphServer(ctx, r, response, r.proxy)
 	if err != nil {
 		r.logger.Error("Failed to create graph server. Keeping the old server", zap.Error(err))


### PR DESCRIPTION
## Problem
Supervisor restarts call `OnRouterConfigReload()` to extract slow-plan cache entries before replacing the graph server. CDN and manifest hot-reload paths skipped this hook, leaving stale cache references on the old graphMux.

## Fix
Call `OnRouterConfigReload()` at the start of `newServer()`.

## Test plan
- [x] `go test ./router/core/...`

Part of config hot-reload memory leak investigation (monday.com #3221).