### PR TITLE
fix(router): skip plan cache OnEvict during graphMux shutdown

### DIFF
--- a/router/core/graph_server.go
+++ b/router/core/graph_server.go
@@ -681,6 +681,8 @@ type graphMux struct {
 	mux    *chi.Mux
 	reused atomic.Bool
 
+	planCacheOnEvictEnabled atomic.Bool
+
 	planCache                   *ristretto.Cache[uint64, *planWithMetaData]
 	planFallbackCache           *slowplancache.Cache[*planWithMetaData]
 	persistedOperationCache     *ristretto.Cache[uint64, NormalizationCacheEntry]
@@ -721,10 +723,14 @@ func (s *graphMux) buildOperationCaches(srv *graphServer) (computeSha256 bool, e
 			BufferItems:        64,
 		}
 		if srv.cacheWarmup != nil && srv.cacheWarmup.Enabled && srv.cacheWarmup.InMemoryFallback {
+			s.planCacheOnEvictEnabled.Store(true)
 			planCacheConfig.OnEvict = func(item *ristretto.Item[*planWithMetaData]) {
 				// This could be called before planFallbackCache is set, but it's not a problem
 				// because there is a nil guard inside, as well as items should not really be evicted
 				// on startup
+				if !s.planCacheOnEvictEnabled.Load() {
+					return
+				}
 				s.planFallbackCache.Set(item.Key, item.Value, item.Value.planningDuration)
 			}
 		}
@@ -961,6 +967,11 @@ func (s *graphMux) Shutdown(ctx context.Context) error {
 	// cancel the graph muxes context to close its resources like websocket connections, resolvers, etc.
 	s.cancel()
 
+	// ristretto Close() invokes OnEvict for every entry; skip slow-cache migration during shutdown.
+	s.planCacheOnEvictEnabled.Store(false)
+	if s.planFallbackCache != nil {
+		s.planFallbackCache.Wait()
+	}
 	s.planCache.Close()
 	s.planFallbackCache.Close()
 	s.persistedOperationCache.Close()


### PR DESCRIPTION
## Problem
`planCache.Close()` invokes `OnEvict` for every entry, migrating them into `slowplancache` immediately before both caches are torn down during mux shutdown.

## Fix
Disable `OnEvict` during intentional mux shutdown and wait for pending slow-cache writes before closing plan caches.

## Test plan
- [x] `go test ./router/core/...`

Part of config hot-reload memory leak investigation (monday.com #3221).