### PR TITLE
fix(router): drain websocket subscriptions before plan cache close

### DIFF
--- a/router/core/graph_server.go
+++ b/router/core/graph_server.go
@@ -681,6 +681,8 @@ type graphMux struct {
 	mux    *chi.Mux
 	reused atomic.Bool
 
+	wsHandler *WebsocketHandler
+
 	planCache                   *ristretto.Cache[uint64, *planWithMetaData]
 	planFallbackCache           *slowplancache.Cache[*planWithMetaData]
 	persistedOperationCache     *ristretto.Cache[uint64, NormalizationCacheEntry]
@@ -958,6 +960,10 @@ func (s *graphMux) configureCacheMetrics(srv *graphServer, baseOtelAttributes []
 }
 
 func (s *graphMux) Shutdown(ctx context.Context) error {
+	if s.wsHandler != nil {
+		s.wsHandler.ShutdownConnections()
+	}
+
 	// cancel the graph muxes context to close its resources like websocket connections, resolvers, etc.
 	s.cancel()
 
@@ -1830,7 +1836,7 @@ func (s *graphServer) buildGraphMux(
 	})
 
 	if s.webSocketConfiguration != nil && s.webSocketConfiguration.Enabled {
-		wsMiddleware := NewWebsocketMiddleware(graphMuxCtx, WebsocketMiddlewareOptions{
+		wsMiddleware, wsHandler := NewWebsocketMiddleware(graphMuxCtx, WebsocketMiddlewareOptions{
 			OperationProcessor:        operationProcessor,
 			OperationBlocker:          operationBlocker,
 			Planner:                   operationPlanner,
@@ -1850,6 +1856,7 @@ func (s *graphServer) buildGraphMux(
 			DisableVariablesRemapping: s.engineExecutionConfiguration.DisableVariablesRemapping,
 			ApolloCompatibilityFlags:  s.apolloCompatibilityFlags,
 		})
+		gm.wsHandler = wsHandler
 
 		// When the playground path is equal to the graphql path, we need to handle
 		// ws upgrades and html requests on the same route.

--- a/router/core/websocket.go
+++ b/router/core/websocket.go
@@ -70,7 +70,7 @@ type WebsocketMiddlewareOptions struct {
 	ApolloCompatibilityFlags config.ApolloCompatibilityFlags
 }
 
-func NewWebsocketMiddleware(ctx context.Context, opts WebsocketMiddlewareOptions) func(http.Handler) http.Handler {
+func NewWebsocketMiddleware(ctx context.Context, opts WebsocketMiddlewareOptions) (func(http.Handler) http.Handler, *WebsocketHandler) {
 	handler := &WebsocketHandler{
 		ctx:                       ctx,
 		operationProcessor:        opts.OperationProcessor,
@@ -148,7 +148,15 @@ func NewWebsocketMiddleware(ctx context.Context, opts WebsocketMiddlewareOptions
 			}
 			handler.handleUpgradeRequest(w, r)
 		})
+	}, handler
+}
+
+// ShutdownConnections closes active websocket subscriptions before cache teardown.
+func (h *WebsocketHandler) ShutdownConnections() {
+	if h == nil {
+		return
 	}
+	h.closeAllConnections()
 }
 
 // wsConnectionWrapper is a wrapper around websocket.Conn that allows


### PR DESCRIPTION
## Problem
During `graphMux` shutdown, Ristretto plan caches were closed while active client websocket subscriptions could still hold `preparedPlan` and executor references.

## Fix
Close websocket subscriptions synchronously at the start of `graphMux.Shutdown()`, before plan caches are closed.

## Test plan
- [x] `go test ./router/core/...`

Part of config hot-reload memory leak investigation (monday.com #3221).