### PR TITLE
fix(router): release executor schema refs on graphMux shutdown

### DIFF
--- a/router/core/executor.go
+++ b/router/core/executor.go
@@ -51,6 +51,19 @@ type Executor struct {
 	TrackUsageInfo  bool
 }
 
+// Close releases schema and planner references held by the executor so a replaced
+// graph mux can be garbage-collected after config reload.
+func (e *Executor) Close() {
+	if e == nil {
+		return
+	}
+	e.ClientSchema = nil
+	e.RouterSchema = nil
+	e.PlanConfig = plan.Configuration{}
+	e.RenameTypeNames = nil
+	e.Resolver = nil
+}
+
 type ExecutorBuildOptions struct {
 	EngineConfig                   *nodev1.EngineConfiguration
 	Subgraphs                      []*nodev1.Subgraph

--- a/router/core/executor_test.go
+++ b/router/core/executor_test.go
@@ -1,0 +1,37 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/ast"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan"
+)
+
+func TestExecutorCloseReleasesSchemaReferences(t *testing.T) {
+	t.Parallel()
+
+	executor := &Executor{
+		ClientSchema:    &ast.Document{},
+		RouterSchema:    &ast.Document{},
+		PlanConfig:      plan.Configuration{DataSources: []plan.DataSource{nil}},
+		RenameTypeNames: nil,
+	}
+
+	executor.Close()
+
+	require.Nil(t, executor.ClientSchema)
+	require.Nil(t, executor.RouterSchema)
+	require.Empty(t, executor.PlanConfig.DataSources)
+	require.Nil(t, executor.RenameTypeNames)
+	require.Nil(t, executor.Resolver)
+}
+
+func TestExecutorCloseNilSafe(t *testing.T) {
+	t.Parallel()
+
+	var executor *Executor
+	require.NotPanics(t, func() {
+		executor.Close()
+	})
+}

--- a/router/core/graph_server.go
+++ b/router/core/graph_server.go
@@ -681,6 +681,8 @@ type graphMux struct {
 	mux    *chi.Mux
 	reused atomic.Bool
 
+	executor *Executor
+
 	planCache                   *ristretto.Cache[uint64, *planWithMetaData]
 	planFallbackCache           *slowplancache.Cache[*planWithMetaData]
 	persistedOperationCache     *ristretto.Cache[uint64, NormalizationCacheEntry]
@@ -970,6 +972,11 @@ func (s *graphMux) Shutdown(ctx context.Context) error {
 	s.complexityCalculationCache.Close()
 	s.validationCache.Close()
 	s.operationHashCache.Close()
+
+	if s.executor != nil {
+		s.executor.Close()
+		s.executor = nil
+	}
 
 	var err error
 
@@ -1497,6 +1504,7 @@ func (s *graphServer) buildGraphMux(
 	if err != nil {
 		return nil, fmt.Errorf("failed to build plan configuration: %w", err)
 	}
+	gm.executor = executor
 
 	s.pubSubProviders = providers
 	if pubSubStartupErr := s.startupPubSubProviders(s.graphServerCtx); pubSubStartupErr != nil {


### PR DESCRIPTION
## Problem
After config hot-reload, the shut-down `Executor` retained federation/client schema AST and plan config references, keeping the previous graph generation alive.

## Fix
Add `Executor.Close()` to nil schema, plan config, and resolver references. Call it from `graphMux.Shutdown()` after plan caches are closed.

## Test plan
- [x] `TestExecutorCloseReleasesSchemaReferences`
- [x] `go test ./router/core/...`

Part of config hot-reload memory leak investigation (monday.com #3221).