### PR TITLE
fix(router): proto.Reset stale execution config after manifest reload

### DIFF
--- a/router/core/router.go
+++ b/router/core/router.go
@@ -27,6 +27,7 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/wundergraph/cosmo/router/gen/proto/wg/cosmo/graphqlmetrics/v1/graphqlmetricsv1connect"
 	nodev1 "github.com/wundergraph/cosmo/router/gen/proto/wg/cosmo/node/v1"
@@ -1696,6 +1697,12 @@ func (r *Router) buildExecutionConfigWatcher(ctx context.Context, ll *zap.Logger
 				ll.Error("Failed to update server with new config", zap.Error(err))
 				return
 			}
+
+			if old := r.staticExecutionConfig; old != nil && old != cfg {
+				proto.Reset(old)
+			}
+			r.staticExecutionConfig = cfg
+			r.trackExecutionConfigUsage(cfg, true)
 		},
 	})
 


### PR DESCRIPTION
## Problem
After manifest hot-reload, decoded proto strings from the previous `staticExecutionConfig` could remain retained even after the new config was assembled.

## Fix
After a successful manifest reload, `proto.Reset` the previous config before retaining the new pointer.

## Test plan
- [x] `go test ./router/core/...`

Part of config hot-reload memory leak investigation (monday.com #3221).