### PR TITLE
feat(router): configurable Pyroscope application name and tags

### DIFF
--- a/router/cmd/main.go
+++ b/router/cmd/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/wundergraph/cosmo/router/internal/versioninfo"
 	"github.com/wundergraph/cosmo/router/pkg/config"
 	"github.com/wundergraph/cosmo/router/pkg/logging"
+	"github.com/wundergraph/cosmo/router/pkg/mondaytweaks"
 	"github.com/wundergraph/cosmo/router/pkg/profile"
 	"github.com/wundergraph/cosmo/router/pkg/watcher"
 
@@ -45,6 +46,21 @@ func Main() {
 
 	// Parse flags before calling profile.Start(), since it may add flags
 	flag.Parse()
+
+	// Re-read profiling env after flag.Parse() — flag defaults are captured at package
+	// init, before embedders (e.g. platform-api-cosmo-router) can Setenv in main().
+	if mondaytweaks.RereadProfilingEnvAfterFlagParse {
+		if *pprofListenAddr == "" {
+			if addr := os.Getenv("PPROF_ADDR"); addr != "" {
+				*pprofListenAddr = addr
+			}
+		}
+		if *pyroscopeAddr == "" {
+			if addr := os.Getenv("PYROSCOPE_ADDR"); addr != "" {
+				*pyroscopeAddr = addr
+			}
+		}
+	}
 
 	if *help {
 		flag.PrintDefaults()
@@ -122,11 +138,14 @@ func Main() {
 		logger := baseLogger.With(zap.String("component", "pyroscope"))
 		logger.Info("starting pyroscope server")
 
+		applicationName := profile.PyroscopeApplicationName(result.Config.Telemetry.ServiceName)
+		tags := profile.PyroscopeTags()
+
 		pyro, err := pyroscope.Start(pyroscope.Config{
-			ApplicationName: "wundergraph.cosmo.router",
+			ApplicationName: applicationName,
 			ServerAddress:   *pyroscopeAddr,
 			Logger:          logger.Sugar(),
-			Tags:            map[string]string{"hostname": os.Getenv("HOSTNAME")},
+			Tags:            tags,
 
 			ProfileTypes: []pyroscope.ProfileType{
 				pyroscope.ProfileCPU,

--- a/router/docs/Profiling.md
+++ b/router/docs/Profiling.md
@@ -118,5 +118,12 @@ To use Pyroscope for continuous profiling of the router:
 2. Run the router with either `PYROSCOPE_ADDR=http://localhost:4040` or
    `-pyroscope-addr http://localhost:4040` to enable sending continuous profiling data to Pyroscope.
    You can view this data in Grafana.
+
+   Optional Pyroscope environment variables:
+
+   - `PYROSCOPE_APPLICATION_NAME` — overrides the application name sent to Pyroscope. When unset,
+     falls back to `telemetry.service_name` from config, then `wundergraph.cosmo.router`.
+   - `PYROSCOPE_TAGS` — comma-separated `key=value` pairs appended to built-in tags (e.g.
+     `region=us-east-1,team=platform`). Custom tags override built-in tags on key collision.
 3. Visit the drilldown profiles section in Grafana at `http://localhost:9300`
 4. Select the router from the service dropdown

--- a/router/pkg/mondaytweaks/mondaytweaks.go
+++ b/router/pkg/mondaytweaks/mondaytweaks.go
@@ -1,0 +1,15 @@
+// Package mondaytweaks defines compile-time feature flags for monday.com-specific
+// behavioural overrides in the cosmo router. All monday-specific toggles live in
+// one place so they are easy to audit and remove when upstreamed.
+package mondaytweaks
+
+const (
+	// RereadProfilingEnvAfterFlagParse re-reads PPROF_ADDR/PYROSCOPE_ADDR after flag.Parse
+	// so platform-api-cosmo-router embed main() can Setenv before routercmd.Main().
+	RereadProfilingEnvAfterFlagParse = true
+
+	// ResolvePyroscopeNameAndTagsFromEnv reads PYROSCOPE_APPLICATION_NAME and
+	// PYROSCOPE_TAGS when starting the Pyroscope client. When disabled, uses the
+	// upstream hardcoded application name and hostname-only tags.
+	ResolvePyroscopeNameAndTagsFromEnv = true
+)

--- a/router/pkg/profile/pyroscope.go
+++ b/router/pkg/profile/pyroscope.go
@@ -1,0 +1,84 @@
+package profile
+
+import (
+	"os"
+	"strings"
+
+	"github.com/wundergraph/cosmo/router/pkg/mondaytweaks"
+)
+
+const (
+	DefaultPyroscopeApplicationName = "wundergraph.cosmo.router"
+
+	EnvPyroscopeApplicationName = "PYROSCOPE_APPLICATION_NAME"
+	EnvPyroscopeTags            = "PYROSCOPE_TAGS"
+)
+
+// PyroscopeApplicationName resolves the Pyroscope application name.
+// When mondaytweaks.ResolvePyroscopeNameAndTagsFromEnv is enabled, precedence is:
+// PYROSCOPE_APPLICATION_NAME > telemetryServiceName > default.
+// Otherwise returns the upstream hardcoded default.
+func PyroscopeApplicationName(telemetryServiceName string) string {
+	if !mondaytweaks.ResolvePyroscopeNameAndTagsFromEnv {
+		return DefaultPyroscopeApplicationName
+	}
+
+	if name := os.Getenv(EnvPyroscopeApplicationName); name != "" {
+		return name
+	}
+	if telemetryServiceName != "" {
+		return telemetryServiceName
+	}
+	return DefaultPyroscopeApplicationName
+}
+
+// PyroscopeTags builds Pyroscope tags for the running process.
+// When mondaytweaks.ResolvePyroscopeNameAndTagsFromEnv is enabled, PYROSCOPE_TAGS
+// (comma-separated key=value pairs) is merged with HOSTNAME. Custom tags override
+// built-in tags on key collision. Otherwise returns hostname-only tags.
+func PyroscopeTags() map[string]string {
+	if !mondaytweaks.ResolvePyroscopeNameAndTagsFromEnv {
+		return pyroscopeHostnameTag()
+	}
+
+	tags := pyroscopeHostnameTag()
+	for key, value := range ParseKeyValueEnv(os.Getenv(EnvPyroscopeTags)) {
+		tags[key] = value
+	}
+	return tags
+}
+
+func pyroscopeHostnameTag() map[string]string {
+	tags := map[string]string{}
+	if hostname := os.Getenv("HOSTNAME"); hostname != "" {
+		tags["hostname"] = hostname
+	}
+	return tags
+}
+
+// ParseKeyValueEnv parses comma-separated key=value pairs.
+func ParseKeyValueEnv(raw string) map[string]string {
+	tags := map[string]string{}
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return tags
+	}
+
+	for part := range strings.SplitSeq(raw, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		key, value, ok := strings.Cut(part, "=")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key == "" || value == "" {
+			continue
+		}
+		tags[key] = value
+	}
+	return tags
+}

--- a/router/pkg/profile/pyroscope_test.go
+++ b/router/pkg/profile/pyroscope_test.go
@@ -1,0 +1,75 @@
+package profile
+
+import (
+	"testing"
+)
+
+func TestPyroscopeApplicationName(t *testing.T) {
+	tests := []struct {
+		name                 string
+		pyroscopeAppName     string
+		telemetryServiceName string
+		want                 string
+	}{
+		{
+			name:             "PYROSCOPE_APPLICATION_NAME wins",
+			pyroscopeAppName: "custom-service",
+			want:             "custom-service",
+		},
+		{
+			name:                 "telemetry service name is second",
+			telemetryServiceName: "platform-api-cosmo-router",
+			want:                 "platform-api-cosmo-router",
+		},
+		{
+			name: "default when unset",
+			want: DefaultPyroscopeApplicationName,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(EnvPyroscopeApplicationName, tc.pyroscopeAppName)
+
+			if got := PyroscopeApplicationName(tc.telemetryServiceName); got != tc.want {
+				t.Fatalf("PyroscopeApplicationName() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPyroscopeTags(t *testing.T) {
+	t.Setenv("HOSTNAME", "pod-123")
+	t.Setenv(EnvPyroscopeTags, "region=us-east-1, team=platform")
+
+	got := PyroscopeTags()
+	if got["hostname"] != "pod-123" {
+		t.Fatalf("hostname tag = %q, want %q", got["hostname"], "pod-123")
+	}
+	if got["region"] != "us-east-1" {
+		t.Fatalf("region tag = %q, want %q", got["region"], "us-east-1")
+	}
+	if got["team"] != "platform" {
+		t.Fatalf("team tag = %q, want %q", got["team"], "platform")
+	}
+}
+
+func TestPyroscopeTags_CustomOverridesBuiltIn(t *testing.T) {
+	t.Setenv("HOSTNAME", "pod-123")
+	t.Setenv(EnvPyroscopeTags, "hostname=override-host")
+
+	got := PyroscopeTags()
+	if got["hostname"] != "override-host" {
+		t.Fatalf("hostname tag = %q, want override from PYROSCOPE_TAGS", got["hostname"])
+	}
+}
+
+func TestParseKeyValueEnv(t *testing.T) {
+	got := ParseKeyValueEnv(" region=us-east-1 ,team=platform,invalid,=bad,key=")
+	if len(got) != 2 {
+		t.Fatalf("ParseKeyValueEnv() len = %d, want 2 (%v)", len(got), got)
+	}
+	if got["region"] != "us-east-1" || got["team"] != "platform" {
+		t.Fatalf("ParseKeyValueEnv() = %v", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `mondaytweaks` profiling flags for embedders such as `platform-api-cosmo-router`
- Support `PYROSCOPE_APPLICATION_NAME` (falls back to `telemetry.service_name`, then default)
- Support `PYROSCOPE_TAGS` as comma-separated `key=value` pairs merged with `hostname`
- Re-read `PPROF_ADDR` / `PYROSCOPE_ADDR` after `flag.Parse()` so embedder `main()` can `Setenv` first

## Test plan
- [x] `go test ./router/pkg/profile/...`
- [ ] Merge companion PR in `platform-api-cosmo-router` and bump router pin

## Companion PR
- platform-api-cosmo-router: (pending)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added more flexible profiling setup, including optional environment-based overrides for application name and tags.
  * Profiling settings can now be refreshed after command-line flags are parsed in supported builds.

* **Documentation**
  * Expanded profiling docs with the new optional environment variables and how they affect naming and tags.

* **Tests**
  * Added coverage for profiling name resolution, tag merging, and parsing of key-value environment input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->