### PR TITLE
feat(composition): support in/exclude contract tags simultaneously

### DIFF
--- a/composition/src/errors/errors.ts
+++ b/composition/src/errors/errors.ts
@@ -2085,7 +2085,7 @@ export function invalidMutuallyExclusiveCacheDirectivesError(fieldCoords: string
 export function intersectingExcludeAndIncludeContractTagsError(tagNames: Array<string>): Error {
   return new Error(
     `Cannot create contract because the following tag${tagNames.length > 1 ? 's are' : ' is'}` +
-      ` provided to both the include and  exclude tag sets (which must be mutually exclusive): "` +
+      ` provided to both the include and exclude tag sets (which must be mutually exclusive): "` +
       tagNames.join(QUOTATION_JOIN) +
       `".`,
   );

--- a/composition/src/errors/errors.ts
+++ b/composition/src/errors/errors.ts
@@ -2081,3 +2081,12 @@ export function invalidMutuallyExclusiveCacheDirectivesError(fieldCoords: string
       ` and "@openfed__cachePopulate".`,
   );
 }
+
+export function intersectingExcludeAndIncludeContractTagsError(tagNames: Array<string>): Error {
+  return new Error(
+    `Cannot create contract because the following tag${tagNames.length > 1 ? 's are' : ' is'}` +
+      ` provided to both the include and  exclude tag sets (which must be mutually exclusive): "` +
+      tagNames.join(QUOTATION_JOIN) +
+      `".`,
+  );
+}

--- a/composition/src/v1/federation/federation-factory.ts
+++ b/composition/src/v1/federation/federation-factory.ts
@@ -35,6 +35,7 @@ import {
   incompatibleParentKindFatalError,
   incompatibleParentTypeMergeError,
   incompatibleSharedEnumError,
+  intersectingExcludeAndIncludeContractTagsError,
   invalidFieldShareabilityError,
   invalidImplementedTypeError,
   invalidInputFieldTypeErrorMessage,
@@ -3037,10 +3038,10 @@ export class FederationFactory {
   }
 
   mergeSubscriptionFilterTargetResults({
-    directiveNode,
     abstractTypeData,
-    targets,
+    directiveNode,
     directiveSubgraphName,
+    targets,
   }: MergeSubscriptionFilterTargetResultParams): SubscriptionFilterTargetResult {
     const aggregatedErrors: Array<Error> = [];
     let firstCondition: SubscriptionCondition | null = null;
@@ -3067,7 +3068,6 @@ export class FederationFactory {
               result.errors.map((error) => error.message).join(LITERAL_NEW_LINE),
             );
       aggregatedErrors.push(wrapped);
-      continue;
     }
     if (firstCondition === null || aggregatedErrors.length > 0) {
       return { errors: aggregatedErrors, success: false };
@@ -3252,6 +3252,85 @@ export class FederationFactory {
        ** However, contracts require @inaccessible to exclude applicable tagged types. */
       this.routerDefinitions.push(INACCESSIBLE_DEFINITION);
     }
+    const tagIntersection = contractTagOptions.tagNamesToExclude.intersection(contractTagOptions.tagNamesToInclude);
+    if (tagIntersection.size > 0) {
+      return {
+        errors: [intersectingExcludeAndIncludeContractTagsError([...tagIntersection])],
+        success: false,
+        warnings: this.warnings,
+      };
+    }
+    if (contractTagOptions.tagNamesToInclude.size > 0) {
+      for (const [parentTypeName, parentDefinitionData] of this.parentDefinitionDataByTypeName) {
+        if (isNodeDataInaccessible(parentDefinitionData)) {
+          continue;
+        }
+        const parentTagData = this.parentTagDataByTypeName.get(parentTypeName);
+        if (!parentTagData) {
+          parentDefinitionData.federatedDirectivesData.directivesByName.set(INACCESSIBLE, [
+            generateSimpleDirective(INACCESSIBLE),
+          ]);
+          this.inaccessibleCoords.add(parentTypeName);
+          // If the parent is inaccessible, there is no need to assess further
+          continue;
+        }
+        if (!contractTagOptions.tagNamesToInclude.isDisjointFrom(parentTagData.tagNames)) {
+          continue;
+        }
+        if (parentTagData.childTagDataByChildName.size < 1) {
+          parentDefinitionData.federatedDirectivesData.directivesByName.set(INACCESSIBLE, [
+            generateSimpleDirective(INACCESSIBLE),
+          ]);
+          this.inaccessibleCoords.add(parentTypeName);
+          // If the parent is inaccessible, there is no need to assess further
+          continue;
+        }
+        switch (parentDefinitionData.kind) {
+          case Kind.SCALAR_TYPE_DEFINITION:
+          // intentional fallthrough
+          case Kind.UNION_TYPE_DEFINITION:
+            continue;
+          case Kind.ENUM_TYPE_DEFINITION:
+            this.handleChildTagInclusions(
+              parentDefinitionData,
+              parentDefinitionData.enumValueDataByName,
+              parentTagData.childTagDataByChildName,
+              contractTagOptions.tagNamesToInclude,
+            );
+            break;
+          case Kind.INPUT_OBJECT_TYPE_DEFINITION:
+            this.handleChildTagInclusions(
+              parentDefinitionData,
+              parentDefinitionData.inputValueDataByName,
+              parentTagData.childTagDataByChildName,
+              contractTagOptions.tagNamesToInclude,
+            );
+            break;
+          default:
+            let accessibleFields = parentDefinitionData.fieldDataByName.size;
+            for (const [fieldName, fieldData] of parentDefinitionData.fieldDataByName) {
+              if (isNodeDataInaccessible(fieldData)) {
+                accessibleFields -= 1;
+                continue;
+              }
+              const childTagData = parentTagData.childTagDataByChildName.get(fieldName);
+              if (!childTagData || contractTagOptions.tagNamesToInclude.isDisjointFrom(childTagData.tagNames)) {
+                getValueOrDefault(fieldData.federatedDirectivesData.directivesByName, INACCESSIBLE, () => [
+                  generateSimpleDirective(INACCESSIBLE),
+                ]);
+                this.inaccessibleCoords.add(fieldData.federatedCoords);
+                accessibleFields -= 1;
+              }
+            }
+            if (accessibleFields < 1) {
+              parentDefinitionData.federatedDirectivesData.directivesByName.set(INACCESSIBLE, [
+                generateSimpleDirective(INACCESSIBLE),
+              ]);
+              this.inaccessibleCoords.add(parentTypeName);
+            }
+        }
+      }
+    }
     if (contractTagOptions.tagNamesToExclude.size > 0) {
       for (const [parentTypeName, parentTagData] of this.parentTagDataByTypeName) {
         const parentDefinitionData = getOrThrowError(
@@ -3341,76 +3420,6 @@ export class FederationFactory {
               this.inaccessibleCoords.add(parentTypeName);
             }
           }
-        }
-      }
-    } else if (contractTagOptions.tagNamesToInclude.size > 0) {
-      for (const [parentTypeName, parentDefinitionData] of this.parentDefinitionDataByTypeName) {
-        if (isNodeDataInaccessible(parentDefinitionData)) {
-          continue;
-        }
-        const parentTagData = this.parentTagDataByTypeName.get(parentTypeName);
-        if (!parentTagData) {
-          parentDefinitionData.federatedDirectivesData.directivesByName.set(INACCESSIBLE, [
-            generateSimpleDirective(INACCESSIBLE),
-          ]);
-          this.inaccessibleCoords.add(parentTypeName);
-          // If the parent is inaccessible, there is no need to assess further
-          continue;
-        }
-        if (!contractTagOptions.tagNamesToInclude.isDisjointFrom(parentTagData.tagNames)) {
-          continue;
-        }
-        if (parentTagData.childTagDataByChildName.size < 1) {
-          parentDefinitionData.federatedDirectivesData.directivesByName.set(INACCESSIBLE, [
-            generateSimpleDirective(INACCESSIBLE),
-          ]);
-          this.inaccessibleCoords.add(parentTypeName);
-          // If the parent is inaccessible, there is no need to assess further
-          continue;
-        }
-        switch (parentDefinitionData.kind) {
-          case Kind.SCALAR_TYPE_DEFINITION:
-          // intentional fallthrough
-          case Kind.UNION_TYPE_DEFINITION:
-            continue;
-          case Kind.ENUM_TYPE_DEFINITION:
-            this.handleChildTagInclusions(
-              parentDefinitionData,
-              parentDefinitionData.enumValueDataByName,
-              parentTagData.childTagDataByChildName,
-              contractTagOptions.tagNamesToInclude,
-            );
-            break;
-          case Kind.INPUT_OBJECT_TYPE_DEFINITION:
-            this.handleChildTagInclusions(
-              parentDefinitionData,
-              parentDefinitionData.inputValueDataByName,
-              parentTagData.childTagDataByChildName,
-              contractTagOptions.tagNamesToInclude,
-            );
-            break;
-          default:
-            let accessibleFields = parentDefinitionData.fieldDataByName.size;
-            for (const [fieldName, fieldData] of parentDefinitionData.fieldDataByName) {
-              if (isNodeDataInaccessible(fieldData)) {
-                accessibleFields -= 1;
-                continue;
-              }
-              const childTagData = parentTagData.childTagDataByChildName.get(fieldName);
-              if (!childTagData || contractTagOptions.tagNamesToInclude.isDisjointFrom(childTagData.tagNames)) {
-                getValueOrDefault(fieldData.federatedDirectivesData.directivesByName, INACCESSIBLE, () => [
-                  generateSimpleDirective(INACCESSIBLE),
-                ]);
-                this.inaccessibleCoords.add(fieldData.federatedCoords);
-                accessibleFields -= 1;
-              }
-            }
-            if (accessibleFields < 1) {
-              parentDefinitionData.federatedDirectivesData.directivesByName.set(INACCESSIBLE, [
-                generateSimpleDirective(INACCESSIBLE),
-              ]);
-              this.inaccessibleCoords.add(parentTypeName);
-            }
         }
       }
     }

--- a/composition/tests/utils/utils.ts
+++ b/composition/tests/utils/utils.ts
@@ -7,6 +7,7 @@ import {
   federateSubgraphsContract,
   federateSubgraphsWithContracts,
   type FederationFailure,
+  type FederationResult,
   type FederationResultWithContractsSuccess,
   type FederationSuccess,
   type NormalizationFailure,
@@ -137,4 +138,29 @@ export function createSubgraph(name: SubgraphName, sdlString: string): Subgraph 
 
 export function createSubgraphWithDefaultName(sdlString: string): Subgraph {
   return createSubgraph(DEFAULT_SUBGRAPH_NAME, sdlString);
+}
+
+export function getContractFailure(
+  resultByContractName: Map<string, FederationResult>,
+  contractName: string,
+): FederationFailure {
+  const result = resultByContractName.get(contractName)!;
+  expect(result).toBeDefined();
+  expect(result.success, 'get contract by name failed when expected to fail').toBe(false);
+  return result as FederationFailure;
+}
+
+export function getContractSuccess(
+  resultByContractName: Map<string, FederationResult>,
+  contractName: string,
+): FederationSuccess {
+  const result = resultByContractName.get(contractName)!;
+  expect(result).toBeDefined();
+  if (!result.success) {
+    for (const error of result.errors) {
+      console.dir(error, { depth: null });
+    }
+  }
+  expect(result.success, 'get contract by name failed when expected to succeed').toBe(true);
+  return result as FederationSuccess;
 }

--- a/composition/tests/v1/contracts.test.ts
+++ b/composition/tests/v1/contracts.test.ts
@@ -1079,7 +1079,7 @@ describe('Contract tests', () => {
       );
     });
 
-    test('that a Union member is removed from a union if not included', () => {
+    test('that a Union member is removed from a Union if the Object is not included by tag', () => {
       const subgraphA = createSubgraph(
         'a',
         `

--- a/composition/tests/v1/contracts.test.ts
+++ b/composition/tests/v1/contracts.test.ts
@@ -1,6 +1,9 @@
 import {
   type ContractTagOptions,
   type FederationSuccess,
+  inaccessibleQueryRootTypeError,
+  intersectingExcludeAndIncludeContractTagsError,
+  noQueryRootTypeError,
   parse,
   ROUTER_COMPATIBILITY_VERSION_ONE,
   type Subgraph,
@@ -8,14 +11,20 @@ import {
 import { describe, expect, test } from 'vitest';
 import { INACCESSIBLE_DIRECTIVE, SCHEMA_QUERY_DEFINITION, TAG_DIRECTIVE } from './utils/utils';
 import {
+  createSubgraph,
   federateSubgraphsContractSuccess,
   federateSubgraphsSuccess,
   federateSubgraphsWithContractsSuccess,
+  getContractFailure,
+  getContractSuccess,
   normalizeString,
   schemaToSortedNormalizedString,
 } from '../utils/utils';
 
 describe('Contract tests', () => {
+  const contractNameA = 'contractA';
+  const contractNameB = 'contractB';
+
   describe('Exclude tags', () => {
     const excludedTagsOne: ContractTagOptions = {
       tagNamesToExclude: new Set<string>(['one', 'includeMe']),
@@ -1066,6 +1075,347 @@ describe('Contract tests', () => {
           `,
         ),
       );
+    });
+  });
+
+  describe('Include and exclude tags', () => {
+    test('that an Object can be included while one of its fields are excluded', () => {
+      const subgraphA = createSubgraph(
+        'a',
+        `
+        enum Enum {
+          A
+        }
+        
+        input Input {
+          a: ID
+        }
+        
+        interface Interface {
+          a: ID
+        }
+        
+        type Object {
+          a: ID
+        }
+        
+        type Query @tag(name: "include") {
+          a: ID
+          b: ID @tag(name: "exclude")
+        }
+        
+        scalar Scalar
+        
+        union Union = Object
+      `,
+      );
+      const { federationResultByContractName } = federateSubgraphsWithContractsSuccess(
+        [subgraphA],
+        new Map<string, ContractTagOptions>([
+          [
+            contractNameA,
+            { tagNamesToExclude: new Set<string>(['exclude']), tagNamesToInclude: new Set<string>(['include']) },
+          ],
+        ]),
+        ROUTER_COMPATIBILITY_VERSION_ONE,
+      );
+      const { federatedGraphClientSchema, federatedGraphSchema, warnings } = getContractSuccess(
+        federationResultByContractName,
+        contractNameA,
+      );
+      expect(schemaToSortedNormalizedString(federatedGraphSchema)).toBe(
+        normalizeString(
+          SCHEMA_QUERY_DEFINITION +
+            INACCESSIBLE_DIRECTIVE +
+            TAG_DIRECTIVE +
+            `
+            enum Enum @inaccessible {
+              A
+            }
+            
+            input Input @inaccessible {
+              a: ID
+            }
+            
+            interface Interface @inaccessible {
+              a: ID
+            }
+            
+            type Object @inaccessible {
+              a: ID
+            }
+            
+            type Query @tag(name: "include") {
+              a: ID
+              b: ID @tag(name: "exclude") @inaccessible
+            }
+            
+                        
+            scalar Scalar @inaccessible
+            
+            union Union @inaccessible = Object
+          `,
+        ),
+      );
+      expect(schemaToSortedNormalizedString(federatedGraphClientSchema!)).toBe(
+        normalizeString(
+          SCHEMA_QUERY_DEFINITION +
+            `
+            type Query {
+              a: ID
+            }
+          `,
+        ),
+      );
+      expect(warnings).toHaveLength(0);
+    });
+
+    test('that errors are returned if the last Query field is excluded', () => {
+      const subgraphA = createSubgraph(
+        'a',
+        `
+        type Query @tag(name: "include") {
+          a: ID @tag(name: "exclude")
+        }
+      `,
+      );
+      const { federationResultByContractName } = federateSubgraphsWithContractsSuccess(
+        [subgraphA],
+        new Map<string, ContractTagOptions>([
+          [
+            contractNameA,
+            { tagNamesToExclude: new Set<string>(['exclude']), tagNamesToInclude: new Set<string>(['include']) },
+          ],
+        ]),
+        ROUTER_COMPATIBILITY_VERSION_ONE,
+      );
+      const { errors, warnings } = getContractFailure(federationResultByContractName, contractNameA);
+      expect(errors).toHaveLength(2);
+      expect(errors).toStrictEqual([inaccessibleQueryRootTypeError, noQueryRootTypeError()]);
+      expect(warnings).toHaveLength(0);
+    });
+
+    test('that all tags are respected', () => {
+      const subgraphA = createSubgraph(
+        'a',
+        `
+        
+        type ObjectA @tag(name: "tag-a") @tag(name: "tag-c") {
+          a: Float
+          b: Float
+          c: Float
+          d: Float
+          e: Float
+        }
+        
+        type Query {
+          """Check to see if a discount code exists and is available"""
+          a(input: Input!): ObjectB @tag(name: "tag-a") @tag(name: "tag-c")
+          x: ID @tag(name: "tag-c")
+          y: ID @tag(name: "tag-b")
+        }
+        
+        input Input @tag(name: "tag-a") @tag(name: "tag-c") {
+          a: [String!]!
+          b: [String!]!
+          c: String!
+        }
+        
+        type ObjectB @tag(name: "tag-a") @tag(name: "tag-c") {
+          a: Boolean!
+          b: String @tag(name: "tag-b")
+          c: ObjectA
+        }
+      `,
+      );
+      const { federationResultByContractName } = federateSubgraphsWithContractsSuccess(
+        [subgraphA],
+        new Map<string, ContractTagOptions>([
+          [
+            contractNameA,
+            {
+              tagNamesToExclude: new Set<string>(),
+              tagNamesToInclude: new Set<string>(['tag-a', 'tag-b']),
+            },
+          ],
+          [
+            contractNameB,
+            {
+              tagNamesToExclude: new Set<string>(['tag-b']),
+              tagNamesToInclude: new Set<string>(['tag-c']),
+            },
+          ],
+        ]),
+        ROUTER_COMPATIBILITY_VERSION_ONE,
+      );
+      const {
+        federatedGraphSchema: routerSchemaA,
+        federatedGraphClientSchema: clientSchemaA,
+        warnings: warningsA,
+      } = getContractSuccess(federationResultByContractName, contractNameA);
+      expect(schemaToSortedNormalizedString(routerSchemaA)).toBe(
+        normalizeString(
+          SCHEMA_QUERY_DEFINITION +
+            INACCESSIBLE_DIRECTIVE +
+            TAG_DIRECTIVE +
+            `
+          
+          input Input @tag(name: "tag-a") @tag(name: "tag-c") {
+            a: [String!]!
+            b: [String!]!
+            c: String!
+          }
+          
+          type ObjectA @tag(name: "tag-a") @tag(name: "tag-c") {
+            a: Float
+            b: Float
+            c: Float
+            d: Float
+            e: Float
+          }
+          
+          type ObjectB @tag(name: "tag-a") @tag(name: "tag-c") {
+            a: Boolean!
+            b: String @tag(name: "tag-b")
+            c: ObjectA
+          }
+          
+          type Query {
+            """Check to see if a discount code exists and is available"""
+            a(input: Input!): ObjectB @tag(name: "tag-a") @tag(name: "tag-c")
+            x: ID @tag(name: "tag-c") @inaccessible
+            y: ID @tag(name: "tag-b")
+          }
+          `,
+        ),
+      );
+      expect(schemaToSortedNormalizedString(clientSchemaA)).toBe(
+        normalizeString(
+          SCHEMA_QUERY_DEFINITION +
+            `
+          input Input {
+            a: [String!]!
+            b: [String!]!
+            c: String!
+          }
+          
+          type ObjectA {
+            a: Float
+            b: Float
+            c: Float
+            d: Float
+            e: Float
+          }
+          
+          type ObjectB {
+            a: Boolean!
+            b: String
+            c: ObjectA
+          }
+          
+          type Query {
+            """Check to see if a discount code exists and is available"""
+            a(input: Input!): ObjectB
+            y: ID
+          }
+          `,
+        ),
+      );
+      expect(warningsA).toHaveLength(0);
+      const {
+        federatedGraphSchema: routerSchemaB,
+        federatedGraphClientSchema: clientSchemaB,
+        warnings: warningsB,
+      } = getContractSuccess(federationResultByContractName, contractNameB);
+      expect(schemaToSortedNormalizedString(routerSchemaB)).toBe(
+        normalizeString(
+          SCHEMA_QUERY_DEFINITION +
+            INACCESSIBLE_DIRECTIVE +
+            TAG_DIRECTIVE +
+            `
+          input Input @tag(name: "tag-a") @tag(name: "tag-c") {
+            a: [String!]!
+            b: [String!]!
+            c: String!
+          }
+          
+          type ObjectA @tag(name: "tag-a") @tag(name: "tag-c") {
+            a: Float
+            b: Float
+            c: Float
+            d: Float
+            e: Float
+          }
+          
+          type ObjectB @tag(name: "tag-a") @tag(name: "tag-c") {
+            a: Boolean!
+            b: String @tag(name: "tag-b") @inaccessible
+            c: ObjectA
+          }
+          
+          type Query {
+            """Check to see if a discount code exists and is available"""
+            a(input: Input!): ObjectB @tag(name: "tag-a") @tag(name: "tag-c")
+            x: ID @tag(name: "tag-c")
+            y: ID @tag(name: "tag-b") @inaccessible
+          }
+          `,
+        ),
+      );
+      expect(schemaToSortedNormalizedString(clientSchemaB)).toBe(
+        normalizeString(
+          SCHEMA_QUERY_DEFINITION +
+            `
+          input Input {
+            a: [String!]!
+            b: [String!]!
+            c: String!
+          }
+          
+          type ObjectA {
+            a: Float
+            b: Float
+            c: Float
+            d: Float
+            e: Float
+          }
+          
+          type ObjectB {
+            a: Boolean!
+            c: ObjectA
+          }
+          
+          type Query {
+            """Check to see if a discount code exists and is available"""
+            a(input: Input!): ObjectB
+            x: ID
+          }
+          `,
+        ),
+      );
+      expect(warningsB).toHaveLength(0);
+    });
+
+    test('that an error is returned if a tag is added to both the include and exclude sets', () => {
+      const subgraphA = createSubgraph(
+        'a',
+        `
+        type Query @tag(name: "a") {
+          a: ID
+        }
+      `,
+      );
+      const { federationResultByContractName } = federateSubgraphsWithContractsSuccess(
+        [subgraphA],
+        new Map<string, ContractTagOptions>([
+          [contractNameA, { tagNamesToExclude: new Set<string>(['a']), tagNamesToInclude: new Set<string>(['a']) }],
+        ]),
+        ROUTER_COMPATIBILITY_VERSION_ONE,
+      );
+      const { errors, warnings } = getContractFailure(federationResultByContractName, contractNameA);
+      expect(errors).toHaveLength(1);
+      expect(errors).toStrictEqual([intersectingExcludeAndIncludeContractTagsError(['a'])]);
+      expect(warnings).toHaveLength(0);
     });
   });
 

--- a/composition/tests/v1/contracts.test.ts
+++ b/composition/tests/v1/contracts.test.ts
@@ -24,6 +24,8 @@ import {
 describe('Contract tests', () => {
   const contractNameA = 'contractA';
   const contractNameB = 'contractB';
+  const exclude = 'exclude';
+  const include = 'include';
 
   describe('Exclude tags', () => {
     const excludedTagsOne: ContractTagOptions = {
@@ -1076,9 +1078,266 @@ describe('Contract tests', () => {
         ),
       );
     });
+
+    test('that a Union member is removed from a union if not included', () => {
+      const subgraphA = createSubgraph(
+        'a',
+        `
+        type ObjectA {
+          a: ID
+        }
+        
+        type ObjectB @tag(name: "include") {
+          a: ID
+        }
+        
+        type Query @tag(name: "include") {
+          a: ID
+        }
+        
+        union Union @tag(name: "include") = ObjectA | ObjectB
+      `,
+      );
+      const { federationResultByContractName } = federateSubgraphsWithContractsSuccess(
+        [subgraphA],
+        new Map<string, ContractTagOptions>([
+          [contractNameA, { tagNamesToExclude: new Set<string>(), tagNamesToInclude: new Set<string>([include]) }],
+        ]),
+        ROUTER_COMPATIBILITY_VERSION_ONE,
+      );
+      const { federatedGraphClientSchema, federatedGraphSchema, warnings } = getContractSuccess(
+        federationResultByContractName,
+        contractNameA,
+      );
+      expect(schemaToSortedNormalizedString(federatedGraphSchema)).toBe(
+        normalizeString(
+          SCHEMA_QUERY_DEFINITION +
+            INACCESSIBLE_DIRECTIVE +
+            TAG_DIRECTIVE +
+            `
+          type ObjectA @inaccessible {
+            a: ID
+          }
+          
+          type ObjectB @tag(name: "include") {
+            a: ID
+          }
+          
+          type Query @tag(name: "include") {
+            a: ID
+          }
+          
+          union Union @tag(name: "include") = ObjectA | ObjectB
+          `,
+        ),
+      );
+      expect(schemaToSortedNormalizedString(federatedGraphClientSchema!)).toBe(
+        normalizeString(
+          SCHEMA_QUERY_DEFINITION +
+            `
+          type ObjectB {
+            a: ID
+          }
+          
+          type Query {
+            a: ID
+          }
+          
+          union Union = ObjectB
+          `,
+        ),
+      );
+      expect(warnings).toHaveLength(0);
+    });
   });
 
   describe('Include and exclude tags', () => {
+    test('that an Enum can be included while one of its values are excluded', () => {
+      const subgraphA = createSubgraph(
+        'a',
+        `
+        enum Enum @tag(name: "include") {
+          A
+          B @tag(name: "exclude")
+        }
+        
+        type Query @tag(name: "include") {
+          a: ID
+        }
+      `,
+      );
+      const { federationResultByContractName } = federateSubgraphsWithContractsSuccess(
+        [subgraphA],
+        new Map<string, ContractTagOptions>([
+          [
+            contractNameA,
+            { tagNamesToExclude: new Set<string>([exclude]), tagNamesToInclude: new Set<string>([include]) },
+          ],
+        ]),
+        ROUTER_COMPATIBILITY_VERSION_ONE,
+      );
+      const { federatedGraphClientSchema, federatedGraphSchema, warnings } = getContractSuccess(
+        federationResultByContractName,
+        contractNameA,
+      );
+      expect(schemaToSortedNormalizedString(federatedGraphSchema)).toBe(
+        normalizeString(
+          SCHEMA_QUERY_DEFINITION +
+            INACCESSIBLE_DIRECTIVE +
+            TAG_DIRECTIVE +
+            `
+            enum Enum @tag(name: "include") {
+              A
+              B @tag(name: "exclude") @inaccessible
+            }
+            
+            type Query @tag(name: "include") {
+              a: ID
+            }
+          `,
+        ),
+      );
+      expect(schemaToSortedNormalizedString(federatedGraphClientSchema!)).toBe(
+        normalizeString(
+          SCHEMA_QUERY_DEFINITION +
+            `
+            enum Enum {
+              A
+            }
+            
+            type Query {
+              a: ID
+            }
+          `,
+        ),
+      );
+      expect(warnings).toHaveLength(0);
+    });
+
+    test('that an Input can be included while one of its fields are excluded', () => {
+      const subgraphA = createSubgraph(
+        'a',
+        `
+        input Input @tag(name: "include") {
+          a: ID
+          b: ID @tag(name: "exclude")
+        }
+        
+        type Query @tag(name: "include") {
+          a: ID
+        }
+      `,
+      );
+      const { federationResultByContractName } = federateSubgraphsWithContractsSuccess(
+        [subgraphA],
+        new Map<string, ContractTagOptions>([
+          [
+            contractNameA,
+            { tagNamesToExclude: new Set<string>([exclude]), tagNamesToInclude: new Set<string>([include]) },
+          ],
+        ]),
+        ROUTER_COMPATIBILITY_VERSION_ONE,
+      );
+      const { federatedGraphClientSchema, federatedGraphSchema, warnings } = getContractSuccess(
+        federationResultByContractName,
+        contractNameA,
+      );
+      expect(schemaToSortedNormalizedString(federatedGraphSchema)).toBe(
+        normalizeString(
+          SCHEMA_QUERY_DEFINITION +
+            INACCESSIBLE_DIRECTIVE +
+            TAG_DIRECTIVE +
+            `
+          input Input @tag(name: "include") {
+            a: ID
+            b: ID @tag(name: "exclude") @inaccessible
+          }
+            
+          type Query @tag(name: "include") {
+            a: ID
+          }
+          `,
+        ),
+      );
+      expect(schemaToSortedNormalizedString(federatedGraphClientSchema!)).toBe(
+        normalizeString(
+          SCHEMA_QUERY_DEFINITION +
+            `
+          input Input {
+            a: ID
+          }
+            
+          type Query {
+            a: ID
+          }
+          `,
+        ),
+      );
+      expect(warnings).toHaveLength(0);
+    });
+
+    test('that an Interface can be included while one of its fields are excluded', () => {
+      const subgraphA = createSubgraph(
+        'a',
+        `
+        interface Interface @tag(name: "include") {
+          a: ID
+          b: ID @tag(name: "exclude")
+        }
+        
+        type Query @tag(name: "include") {
+          a: ID
+        }
+      `,
+      );
+      const { federationResultByContractName } = federateSubgraphsWithContractsSuccess(
+        [subgraphA],
+        new Map<string, ContractTagOptions>([
+          [
+            contractNameA,
+            { tagNamesToExclude: new Set<string>([exclude]), tagNamesToInclude: new Set<string>([include]) },
+          ],
+        ]),
+        ROUTER_COMPATIBILITY_VERSION_ONE,
+      );
+      const { federatedGraphClientSchema, federatedGraphSchema, warnings } = getContractSuccess(
+        federationResultByContractName,
+        contractNameA,
+      );
+      expect(schemaToSortedNormalizedString(federatedGraphSchema)).toBe(
+        normalizeString(
+          SCHEMA_QUERY_DEFINITION +
+            INACCESSIBLE_DIRECTIVE +
+            TAG_DIRECTIVE +
+            `
+          interface Interface @tag(name: "include") {
+            a: ID
+            b: ID @tag(name: "exclude") @inaccessible
+          }
+            
+          type Query @tag(name: "include") {
+            a: ID
+          }
+          `,
+        ),
+      );
+      expect(schemaToSortedNormalizedString(federatedGraphClientSchema!)).toBe(
+        normalizeString(
+          SCHEMA_QUERY_DEFINITION +
+            `
+          interface Interface {
+            a: ID
+          }
+            
+          type Query {
+            a: ID
+          }
+          `,
+        ),
+      );
+      expect(warnings).toHaveLength(0);
+    });
+
     test('that an Object can be included while one of its fields are excluded', () => {
       const subgraphA = createSubgraph(
         'a',
@@ -1114,7 +1373,7 @@ describe('Contract tests', () => {
         new Map<string, ContractTagOptions>([
           [
             contractNameA,
-            { tagNamesToExclude: new Set<string>(['exclude']), tagNamesToInclude: new Set<string>(['include']) },
+            { tagNamesToExclude: new Set<string>([exclude]), tagNamesToInclude: new Set<string>([include]) },
           ],
         ]),
         ROUTER_COMPATIBILITY_VERSION_ONE,
@@ -1184,7 +1443,7 @@ describe('Contract tests', () => {
         new Map<string, ContractTagOptions>([
           [
             contractNameA,
-            { tagNamesToExclude: new Set<string>(['exclude']), tagNamesToInclude: new Set<string>(['include']) },
+            { tagNamesToExclude: new Set<string>([exclude]), tagNamesToInclude: new Set<string>([include]) },
           ],
         ]),
         ROUTER_COMPATIBILITY_VERSION_ONE,
@@ -1415,6 +1674,56 @@ describe('Contract tests', () => {
       const { errors, warnings } = getContractFailure(federationResultByContractName, contractNameA);
       expect(errors).toHaveLength(1);
       expect(errors).toStrictEqual([intersectingExcludeAndIncludeContractTagsError(['a'])]);
+      expect(warnings).toHaveLength(0);
+    });
+
+    test('that if a tag is included and excluded by different tags, it is excluded over all', () => {
+      const subgraphA = createSubgraph(
+        'a',
+        `
+        type Query  {
+          a: ID @tag(name: "include")
+          b: ID @tag(name: "include") @tag(name: "exclude")
+        }
+      `,
+      );
+      const { federationResultByContractName } = federateSubgraphsWithContractsSuccess(
+        [subgraphA],
+        new Map<string, ContractTagOptions>([
+          [
+            contractNameA,
+            { tagNamesToExclude: new Set<string>([exclude]), tagNamesToInclude: new Set<string>([include]) },
+          ],
+        ]),
+        ROUTER_COMPATIBILITY_VERSION_ONE,
+      );
+      const { federatedGraphClientSchema, federatedGraphSchema, warnings } = getContractSuccess(
+        federationResultByContractName,
+        contractNameA,
+      );
+      expect(schemaToSortedNormalizedString(federatedGraphSchema)).toBe(
+        normalizeString(
+          SCHEMA_QUERY_DEFINITION +
+            INACCESSIBLE_DIRECTIVE +
+            TAG_DIRECTIVE +
+            `
+          type Query  {
+            a: ID @tag(name: "include")
+            b: ID @tag(name: "include") @tag(name: "exclude") @inaccessible
+          }
+          `,
+        ),
+      );
+      expect(schemaToSortedNormalizedString(federatedGraphClientSchema!)).toBe(
+        normalizeString(
+          SCHEMA_QUERY_DEFINITION +
+            `
+            type Query {
+              a: ID
+            }
+          `,
+        ),
+      );
       expect(warnings).toHaveLength(0);
     });
   });


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved contract tag filtering so include and exclude rules are applied independently when they don’t overlap, yielding accurate router vs client schema differences.
  * Added broader contract-tag coverage across multiple schema element types, including correct omission/inaccessibility behavior.
* **Bug Fixes**
  * Detects and fails immediately on invalid tag configurations where the same tag appears in both include and exclude sets.
  * Refines handling for missing tag data and edge cases like excluding the last `Query` field.
* **Tests**
  * Expanded contract-tag test suites and added helper assertions for contract success/failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] If applicable, I have provided instructions for reviewers for [manually validating my changes](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md#pull-requests-conventions).
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

<!--
Please add any additional information or context regarding your changes here.
-->
