### PR TITLE
feat: switch to npm trusted publishing

### DIFF
--- a/.github/workflows/dummy-ci.yaml
+++ b/.github/workflows/dummy-ci.yaml
@@ -5,8 +5,8 @@ on:
   pull_request:
     paths:
       - 'scripts/**'
-      - '.github/workflows/image-release.yml'
-      - '.github/workflows/cli-binary-release.yaml'
+      - '.github/workflows/*.yaml'
+      - '.github/workflows/*.yml'
       - '.github/actions/**'
       - 'docs-website/**'
       - 'CLAUDE.md'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -88,6 +88,7 @@ jobs:
         if: inputs.scope != ''
         env:
           PACKAGE_SCOPE: ${{ inputs.scope }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           # Validate package name (scoped or unscoped), reject shell metacharacters
           [[ "$PACKAGE_SCOPE" =~ ^@?[A-Za-z0-9][A-Za-z0-9._/-]*$ ]] || {
@@ -95,5 +96,3 @@ jobs:
             exit 1
           }
           pnpm lerna publish from-package --scope "$PACKAGE_SCOPE" -y
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -89,4 +89,3 @@ jobs:
         run: pnpm lerna publish from-package --scope ${{ inputs.scope }} -y
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,11 +2,6 @@ name: Release
 
 on:
   workflow_dispatch:
-    inputs:
-      scope:
-        description: 'Package to republish (e.g. wgc). Leave empty for a full release.'
-        required: false
-        default: ''
 
 permissions:
   contents: write
@@ -60,7 +55,6 @@ jobs:
         # commits and bumps CHANGELOG.md and package.json files, but does not
         # publish anything.
       - name: Generate next version (dry-run)
-        if: inputs.scope == ''
         run: pnpm lerna version --ignore-scripts --dry-run --yes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -71,11 +65,9 @@ jobs:
 
         # Reset dry-run changes to let publish do the real thing for the release
       - name: Revert changes
-        if: inputs.scope == ''
         run: git reset --hard
 
       - name: Publish packages & Create Github Releases
-        if: inputs.scope == ''
         run: |
           git config --global user.email "bot@wundergraph.com"
           git config --global user.name "hardworker-bot"
@@ -83,16 +75,3 @@ jobs:
           pnpm release
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-
-      - name: Republish single package
-        if: inputs.scope != ''
-        env:
-          PACKAGE_SCOPE: ${{ inputs.scope }}
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          # Validate package name (scoped or unscoped), reject shell metacharacters
-          [[ "$PACKAGE_SCOPE" =~ ^@?[A-Za-z0-9][A-Za-z0-9._/-]*$ ]] || {
-            echo "Error: Invalid package name format: $PACKAGE_SCOPE" >&2
-            exit 1
-          }
-          pnpm lerna publish from-package --scope "$PACKAGE_SCOPE" -y

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,6 +2,11 @@ name: Release
 
 on:
   workflow_dispatch:
+    inputs:
+      scope:
+        description: 'Package to republish (e.g. wgc). Leave empty for a full release.'
+        required: false
+        default: ''
 
 permissions:
   contents: write
@@ -42,11 +47,6 @@ jobs:
 
       - uses: ./.github/actions/node
 
-      - run: npm config set //registry.npmjs.org/:_authToken $NPM_TOKEN
-        shell: bash
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
       - name: Install
         run: pnpm install --frozen-lockfile
 
@@ -60,6 +60,7 @@ jobs:
         # commits and bumps CHANGELOG.md and package.json files, but does not
         # publish anything.
       - name: Generate next version (dry-run)
+        if: inputs.scope == ''
         run: pnpm lerna version --ignore-scripts --dry-run --yes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -70,14 +71,22 @@ jobs:
 
         # Reset dry-run changes to let publish do the real thing for the release
       - name: Revert changes
+        if: inputs.scope == ''
         run: git reset --hard
 
       - name: Publish packages & Create Github Releases
+        if: inputs.scope == ''
         run: |
           git config --global user.email "bot@wundergraph.com"
           git config --global user.name "hardworker-bot"
           pnpm whoami
           pnpm release
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Republish single package
+        if: inputs.scope != ''
+        run: pnpm lerna publish from-package --scope ${{ inputs.scope }} -y
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -86,6 +86,14 @@ jobs:
 
       - name: Republish single package
         if: inputs.scope != ''
-        run: pnpm lerna publish from-package --scope ${{ inputs.scope }} -y
+        env:
+          PACKAGE_SCOPE: ${{ inputs.scope }}
+        run: |
+          # Validate package name (scoped or unscoped), reject shell metacharacters
+          [[ "$PACKAGE_SCOPE" =~ ^@?[A-Za-z0-9][A-Za-z0-9._/-]*$ ]] || {
+            echo "Error: Invalid package name format: $PACKAGE_SCOPE" >&2
+            exit 1
+          }
+          pnpm lerna publish from-package --scope "$PACKAGE_SCOPE" -y
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

Use NPM trusted publishers feature instead of static token


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

- **Chores**
  - Simplified the release workflow’s publishing credential handling by removing the npm registry authentication setup.
  - The publish-and-release step now runs with only the GitHub token, reducing token-related configuration during releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [x] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] If applicable, I have provided instructions for reviewers for [manually validating my changes](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md#pull-requests-conventions).
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

<!--
Please add any additional information or context regarding your changes here.
-->
