### PR TITLE
fix(router): consolidated config-reload memory-leak fix (#3006–#3009 bundle)

### DIFF
--- a/router/core/graph_server.go
+++ b/router/core/graph_server.go
@@ -681,6 +681,8 @@ type graphMux struct {
 	mux    *chi.Mux
 	reused atomic.Bool
 
+	planCacheOnEvictEnabled atomic.Bool
+
 	planCache                   *ristretto.Cache[uint64, *planWithMetaData]
 	planFallbackCache           *slowplancache.Cache[*planWithMetaData]
 	persistedOperationCache     *ristretto.Cache[uint64, NormalizationCacheEntry]
@@ -721,10 +723,14 @@ func (s *graphMux) buildOperationCaches(srv *graphServer) (computeSha256 bool, e
 			BufferItems:        64,
 		}
 		if srv.cacheWarmup != nil && srv.cacheWarmup.Enabled && srv.cacheWarmup.InMemoryFallback {
+			s.planCacheOnEvictEnabled.Store(true)
 			planCacheConfig.OnEvict = func(item *ristretto.Item[*planWithMetaData]) {
 				// This could be called before planFallbackCache is set, but it's not a problem
 				// because there is a nil guard inside, as well as items should not really be evicted
 				// on startup
+				if !s.planCacheOnEvictEnabled.Load() {
+					return
+				}
 				s.planFallbackCache.Set(item.Key, item.Value, item.Value.planningDuration)
 			}
 		}
@@ -961,6 +967,11 @@ func (s *graphMux) Shutdown(ctx context.Context) error {
 	// cancel the graph muxes context to close its resources like websocket connections, resolvers, etc.
 	s.cancel()
 
+	// ristretto Close() invokes OnEvict for every entry; skip slow-cache migration during shutdown.
+	s.planCacheOnEvictEnabled.Store(false)
+	if s.planFallbackCache != nil {
+		s.planFallbackCache.Wait()
+	}
 	s.planCache.Close()
 	s.planFallbackCache.Close()
 	s.persistedOperationCache.Close()

--- a/router/core/operation_planner.go
+++ b/router/core/operation_planner.go
@@ -18,8 +18,8 @@ import (
 )
 
 type planWithMetaData struct {
-	preparedPlan                      plan.Plan
-	operationDocument, schemaDocument *ast.Document
+	preparedPlan       plan.Plan
+	operationDocument  *ast.Document
 	typeFieldUsageInfo                []*graphqlschemausage.TypeFieldUsageInfo
 	argumentUsageInfo                 []*graphqlmetricsv1.ArgumentUsageInfo
 	content                           string
@@ -96,7 +96,6 @@ func (p *OperationPlanner) planOperation(content string, name string, includeQue
 	return &planWithMetaData{
 		preparedPlan:      preparedPlan,
 		operationDocument: &doc,
-		schemaDocument:    p.executor.RouterSchema,
 	}, nil
 }
 

--- a/router/core/router.go
+++ b/router/core/router.go
@@ -627,6 +627,10 @@ func (r *Router) serverTLSConfig() (*tls.Config, error) {
 
 // newGraphServer creates a new server.
 func (r *Router) newServer(ctx context.Context, response *routerconfig.Response) error {
+	// Extract slow-plan cache entries before building the new graph server, which
+	// overwrites ReloadPersistentState cache references and before the old graphMux shuts down.
+	r.reloadPersistentState.OnRouterConfigReload()
+
 	server, err := newGraphServer(ctx, r, response, r.proxy)
 	if err != nil {
 		r.logger.Error("Failed to create graph server. Keeping the old server", zap.Error(err))

--- a/router/pkg/slowplancache/slow_plan_cache.go
+++ b/router/pkg/slowplancache/slow_plan_cache.go
@@ -222,5 +222,14 @@ func (c *Cache[V]) Close() {
 		// This downside is also there in ristretto (if set is called concurrently)
 		// it is even documented in the ristretto code as a comment
 		close(c.writeCh)
+
+		// Drop cached entries so Close releases references to stored values
+		// (e.g. query plans holding schema AST pointers) before the Cache
+		// struct is GC'd.
+		c.entries.Range(func(key, _ any) bool {
+			c.entries.Delete(key)
+			return true
+		})
+		c.size = 0
 	})
 }

--- a/router/pkg/slowplancache/slow_plan_cache_test.go
+++ b/router/pkg/slowplancache/slow_plan_cache_test.go
@@ -411,6 +411,27 @@ func TestCache_DoubleClose(t *testing.T) {
 	})
 }
 
+func TestCache_CloseReleasesEntries(t *testing.T) {
+	t.Parallel()
+	c, err := New[*testPlan](10, 0)
+	require.NoError(t, err)
+
+	c.Set(1, &testPlan{content: "q1"}, 10*time.Millisecond)
+	c.Set(2, &testPlan{content: "q2"}, 20*time.Millisecond)
+	c.Set(3, &testPlan{content: "q3"}, 30*time.Millisecond)
+	c.Wait()
+
+	c.Close()
+
+	count := 0
+	c.entries.Range(func(_, _ any) bool {
+		count++
+		return true
+	})
+	require.Equal(t, 0, count, "entries sync.Map must be empty after Close")
+	require.Equal(t, int64(0), c.size)
+}
+
 func BenchmarkCache_Set(b *testing.B) {
 	c, err := New[*testPlan](1000, 0)
 	require.NoError(b, err)


### PR DESCRIPTION
## What

Consolidated bundle of the four **root-cause** fixes for memory retention on router config hot-reload, combined onto one branch so the leak can be validated end-to-end in a single checkout.

> ℹ️ **Not a replacement.** These commits are the originals authored in #3006, #3007, #3008, #3009. This PR exists purely to validate them together (and against the regression test in #3019). Review/merge the individual PRs as the source of truth.

## Commits (cherry-picked, in merge order)

| Commit | Original PR |
|---|---|
| clear slowplancache entries on Close | #3006 |
| stop pinning schema AST in cached plan entries | #3007 |
| call OnRouterConfigReload before CDN/manifest hot-reload | #3008 |
| skip plan cache OnEvict during graphMux shutdown | #3009 |

## Root cause

On reload, `graphMux.Shutdown()` → `planCache.Close()` triggers ristretto's `Clear()`, which fires the plan cache `OnEvict` for **every** entry, demoting the whole cache into `planFallbackCache`. That fallback is held by the long-lived `reloadPersistentState` (`core/graph_server.go:1609`), and `slowplancache.Close()` didn't clear its map — so the old plan cache + schema AST survived every reload. The fix set stops the demote-on-shutdown, clears the fallback on close, releases stale refs in the hot-reload path, and drops the unused schema-AST field.

## Validation

- Builds clean (`go build ./...`).
- Regression test #3019 (`TestReloadConfig_PlanCacheRetentionLeak`) is **red on `main`** and **green on this branch**.

## Why draft

Coordination/validation branch for #3006–#3009 — not intended to merge on its own.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown behavior so cached plans are released cleanly and no longer trigger delayed cache work during reload or shutdown.
  * Reduced the risk of stale cache entries lingering after a router configuration refresh.

* **Tests**
  * Added coverage to verify cache shutdown fully clears stored entries and resets cache state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->