### PR TITLE
fix(router): resolve plan cache memory leaks on config reload

### DIFF
--- a/router/core/graph_server.go
+++ b/router/core/graph_server.go
@@ -681,7 +681,7 @@ type graphMux struct {
 	mux    *chi.Mux
 	reused atomic.Bool
 
-	planCacheOnEvictEnabled atomic.Bool
+	planCacheHookEnabled atomic.Bool
 
 	planCache                   *ristretto.Cache[uint64, *planWithMetaData]
 	planFallbackCache           *slowplancache.Cache[*planWithMetaData]
@@ -723,12 +723,12 @@ func (s *graphMux) buildOperationCaches(srv *graphServer) (computeSha256 bool, e
 			BufferItems:        64,
 		}
 		if srv.cacheWarmup != nil && srv.cacheWarmup.Enabled && srv.cacheWarmup.InMemoryFallback {
-			s.planCacheOnEvictEnabled.Store(true)
+			s.planCacheHookEnabled.Store(true)
 			planCacheConfig.OnEvict = func(item *ristretto.Item[*planWithMetaData]) {
 				// This could be called before planFallbackCache is set, but it's not a problem
 				// because there is a nil guard inside, as well as items should not really be evicted
 				// on startup
-				if !s.planCacheOnEvictEnabled.Load() {
+				if !s.planCacheHookEnabled.Load() {
 					return
 				}
 				s.planFallbackCache.Set(item.Key, item.Value, item.Value.planningDuration)
@@ -967,12 +967,11 @@ func (s *graphMux) Shutdown(ctx context.Context) error {
 	// cancel the graph muxes context to close its resources like websocket connections, resolvers, etc.
 	s.cancel()
 
-	// ristretto Close() invokes OnEvict for every entry; skip slow-cache migration during shutdown.
-	s.planCacheOnEvictEnabled.Store(false)
-	if s.planFallbackCache != nil {
-		s.planFallbackCache.Wait()
-	}
+	// Bypass ristretto OnEvict hook, to avoid it migrating plan caches into slowplancache.
+	// This is not meant to run on graph mux shutdown.
+	s.planCacheHookEnabled.Store(false)
 	s.planCache.Close()
+
 	s.planFallbackCache.Close()
 	s.persistedOperationCache.Close()
 	s.normalizationCache.Close()

--- a/router/core/graph_server.go
+++ b/router/core/graph_server.go
@@ -681,6 +681,8 @@ type graphMux struct {
 	mux    *chi.Mux
 	reused atomic.Bool
 
+	planCacheOnEvictEnabled atomic.Bool
+
 	planCache                   *ristretto.Cache[uint64, *planWithMetaData]
 	planFallbackCache           *slowplancache.Cache[*planWithMetaData]
 	persistedOperationCache     *ristretto.Cache[uint64, NormalizationCacheEntry]
@@ -721,10 +723,14 @@ func (s *graphMux) buildOperationCaches(srv *graphServer) (computeSha256 bool, e
 			BufferItems:        64,
 		}
 		if srv.cacheWarmup != nil && srv.cacheWarmup.Enabled && srv.cacheWarmup.InMemoryFallback {
+			s.planCacheOnEvictEnabled.Store(true)
 			planCacheConfig.OnEvict = func(item *ristretto.Item[*planWithMetaData]) {
 				// This could be called before planFallbackCache is set, but it's not a problem
 				// because there is a nil guard inside, as well as items should not really be evicted
 				// on startup
+				if !s.planCacheOnEvictEnabled.Load() {
+					return
+				}
 				s.planFallbackCache.Set(item.Key, item.Value, item.Value.planningDuration)
 			}
 		}
@@ -961,6 +967,11 @@ func (s *graphMux) Shutdown(ctx context.Context) error {
 	// cancel the graph muxes context to close its resources like websocket connections, resolvers, etc.
 	s.cancel()
 
+	// ristretto Close() invokes OnEvict for every entry; skip slow-cache migration during shutdown.
+	s.planCacheOnEvictEnabled.Store(false)
+	if s.planFallbackCache != nil {
+		s.planFallbackCache.Wait()
+	}
 	s.planCache.Close()
 	s.planFallbackCache.Close()
 	s.persistedOperationCache.Close()

--- a/router/core/operation_planner.go
+++ b/router/core/operation_planner.go
@@ -20,11 +20,11 @@ import (
 type planWithMetaData struct {
 	preparedPlan       plan.Plan
 	operationDocument  *ast.Document
-	typeFieldUsageInfo                []*graphqlschemausage.TypeFieldUsageInfo
-	argumentUsageInfo                 []*graphqlmetricsv1.ArgumentUsageInfo
-	content                           string
-	operationName                     string
-	planningDuration                  time.Duration
+	typeFieldUsageInfo []*graphqlschemausage.TypeFieldUsageInfo
+	argumentUsageInfo  []*graphqlmetricsv1.ArgumentUsageInfo
+	content            string
+	operationName      string
+	planningDuration   time.Duration
 }
 
 type OperationPlanner struct {

--- a/router/core/operation_planner.go
+++ b/router/core/operation_planner.go
@@ -18,8 +18,8 @@ import (
 )
 
 type planWithMetaData struct {
-	preparedPlan                      plan.Plan
-	operationDocument, schemaDocument *ast.Document
+	preparedPlan       plan.Plan
+	operationDocument  *ast.Document
 	typeFieldUsageInfo                []*graphqlschemausage.TypeFieldUsageInfo
 	argumentUsageInfo                 []*graphqlmetricsv1.ArgumentUsageInfo
 	content                           string
@@ -96,7 +96,6 @@ func (p *OperationPlanner) planOperation(content string, name string, includeQue
 	return &planWithMetaData{
 		preparedPlan:      preparedPlan,
 		operationDocument: &doc,
-		schemaDocument:    p.executor.RouterSchema,
 	}, nil
 }
 

--- a/router/pkg/slowplancache/slow_plan_cache.go
+++ b/router/pkg/slowplancache/slow_plan_cache.go
@@ -230,6 +230,9 @@ func (c *Cache[V]) Close() {
 			c.entries.Delete(key)
 			return true
 		})
+
 		c.size = 0
+		c.minKey = 0
+		c.minDur = 0
 	})
 }

--- a/router/pkg/slowplancache/slow_plan_cache.go
+++ b/router/pkg/slowplancache/slow_plan_cache.go
@@ -222,5 +222,14 @@ func (c *Cache[V]) Close() {
 		// This downside is also there in ristretto (if set is called concurrently)
 		// it is even documented in the ristretto code as a comment
 		close(c.writeCh)
+
+		// Drop cached entries so Close releases references to stored values
+		// (e.g. query plans holding schema AST pointers) before the Cache
+		// struct is GC'd.
+		c.entries.Range(func(key, _ any) bool {
+			c.entries.Delete(key)
+			return true
+		})
+		c.size = 0
 	})
 }

--- a/router/pkg/slowplancache/slow_plan_cache_test.go
+++ b/router/pkg/slowplancache/slow_plan_cache_test.go
@@ -411,6 +411,27 @@ func TestCache_DoubleClose(t *testing.T) {
 	})
 }
 
+func TestCache_CloseReleasesEntries(t *testing.T) {
+	t.Parallel()
+	c, err := New[*testPlan](10, 0)
+	require.NoError(t, err)
+
+	c.Set(1, &testPlan{content: "q1"}, 10*time.Millisecond)
+	c.Set(2, &testPlan{content: "q2"}, 20*time.Millisecond)
+	c.Set(3, &testPlan{content: "q3"}, 30*time.Millisecond)
+	c.Wait()
+
+	c.Close()
+
+	count := 0
+	c.entries.Range(func(_, _ any) bool {
+		count++
+		return true
+	})
+	require.Equal(t, 0, count, "entries sync.Map must be empty after Close")
+	require.Equal(t, int64(0), c.size)
+}
+
 func BenchmarkCache_Set(b *testing.B) {
 	c, err := New[*testPlan](1000, 0)
 	require.NoError(b, err)


### PR DESCRIPTION
Combines #3006, #3007, and #3009 with the following additional changes:

- Do not wait for pending slow-cache writes on mux shutdown, cache is about to be closed anyways
- Reset minKey and minDur fields when closing the slowplancache

#3008 currently not included here, needs some more work. Will be merged separetely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plan cache shutdown so cached entries are fully released and internal tracking is reset.
  * Prevented cache eviction handling from writing entries into fallback storage during router shutdown.
  * Cleaned up plan metadata handling to return only the data that is actually used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [x] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [x] Tests or benchmarks have been added or updated.
- [ ] If applicable, I have provided instructions for reviewers for [manually validating my changes](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md#pull-requests-conventions).
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

<!--
Please add any additional information or context regarding your changes here.
-->
