### PR TITLE
fix: incorrect number of feature flag composition when publishing feature subgraphs

### DIFF
--- a/controlplane/src/core/repositories/SubgraphRepository.ts
+++ b/controlplane/src/core/repositories/SubgraphRepository.ts
@@ -595,13 +595,23 @@ export class SubgraphRepository {
             caches: featureFlagCaches,
           });
 
-          // If an enabled feature flag includes the feature graph that has just been published, push it to the array
-          if (enabledFeatureFlags.length > 0 && !splitConfigFeature?.enabled) {
-            affectedFederatedGraphById.set(federatedGraphDTO.id, federatedGraphDTO);
+          /**
+           * When split config is not enabled, the federated graph and all enabled feature flags will be considered
+           * as affected as we need to compose everything; however, if the feature is enabled for the organization,
+           * we need to verify whether the feature subgraph is part of the feature flag, if so, we can consider it
+           * as affected.
+           */
+          const isLegacyComposition = !splitConfigFeature?.enabled;
+          for (const featureFlag of enabledFeatureFlags) {
+            if (isLegacyComposition ||
+              featureFlag.featureSubgraphs.some((fsg) => fsg.id === subgraph.id)) {
+              affectedFeatureFlagIds.add(featureFlag.id);
+            }
           }
 
-          for (const featureFlag of enabledFeatureFlags) {
-            affectedFeatureFlagIds.add(featureFlag.id);
+          if (isLegacyComposition && enabledFeatureFlags.length > 0) {
+            // It looks like the federated graph is affected
+            affectedFederatedGraphById.set(federatedGraphDTO.id, federatedGraphDTO);
           }
         }
       }

--- a/controlplane/src/core/repositories/SubgraphRepository.ts
+++ b/controlplane/src/core/repositories/SubgraphRepository.ts
@@ -603,8 +603,7 @@ export class SubgraphRepository {
            */
           const isLegacyComposition = !splitConfigFeature?.enabled;
           for (const featureFlag of enabledFeatureFlags) {
-            if (isLegacyComposition ||
-              featureFlag.featureSubgraphs.some((fsg) => fsg.id === subgraph.id)) {
+            if (isLegacyComposition || featureFlag.featureSubgraphs.some((fsg) => fsg.id === subgraph.id)) {
               affectedFeatureFlagIds.add(featureFlag.id);
             }
           }

--- a/controlplane/test/feature-flag/feature-flag-integration.test.ts
+++ b/controlplane/test/feature-flag/feature-flag-integration.test.ts
@@ -4045,8 +4045,8 @@ describe('Feature flag integration tests', () => {
         const namespace = genID('namespace').toLowerCase();
         const labels: Label[] = [];
         const baseGraphName = genID('baseFederatedGraphName');
-        const ffName1 = genID('featureFlagName1');
-        const ffName2 = genID('featureFlagName2');
+        const ffName1 = genID('featureFlagName');
+        const ffName2 = genID('featureFlagName');
 
         await createNamespace(client, namespace);
 
@@ -4119,6 +4119,82 @@ describe('Feature flag integration tests', () => {
 
         // Only one feature flag should have composed
         await assertNumberOfCompositions(client, baseGraphName, 4, namespace);
+        await assertFeatureFlagExecutionConfig(blobStorage, key, false);
+      },
+    );
+
+    test(
+      'that publishing a feature subgraph only recomposes the feature flags that share the same feature subgraph',
+      getDebugTestOptions(isDebugMode),
+      async (testContext) => {
+        const { client, server, blobStorage } = await SetupTest({
+          dbname,
+          chClient,
+          enabledFeatures: ['split-config-loading'],
+        });
+        testContext.onTestFinished(() => server.close());
+
+        const namespace = genID('namespace').toLowerCase();
+        const labels: Label[] = [];
+        const baseGraphName = genID('baseFederatedGraphName');
+        const ffName1 = genID('featureFlagName');
+        const ffName2 = genID('featureFlagName');
+        const ffName3 = genID('featureFlagName');
+
+        await createNamespace(client, namespace);
+
+        const federatedGraphResponse = await featureFlagIntegrationTestSetUp(
+          client,
+          [
+            { name: 'users', hasFeatureSubgraph: true },
+            { name: 'products-standalone', hasFeatureSubgraph: true },
+          ],
+          baseGraphName,
+          labels,
+          namespace,
+        );
+
+        expect(blobStorage.keys()).toHaveLength(2);
+        const key = blobStorage.keys()[0];
+        const mapperKey = blobStorage.keys()[1];
+        expect(key).toContain(`${federatedGraphResponse.graph!.id}/manifest/latest.json`);
+        expect(mapperKey).toContain(`${federatedGraphResponse.graph!.id}/manifest/mapper.json`);
+
+        await assertFeatureFlagExecutionConfig(blobStorage, key, false);
+
+        // The base composition
+        await assertNumberOfCompositions(client, baseGraphName, 1, namespace);
+
+        await createFeatureFlag(client, ffName1, labels, ['products-standalone-feature'], namespace, true);
+        await createFeatureFlag(client, ffName2, labels, ['products-standalone-feature'], namespace, true);
+        await createFeatureFlag(client, ffName3, labels, ['users-feature'], namespace, true);
+
+        expect(blobStorage.keys()).toHaveLength(5);
+        expect(blobStorage.keys()).toEqual(
+          expect.arrayContaining([
+            expect.stringContaining(`${federatedGraphResponse.graph!.id}/manifest/feature-flags/${ffName1}.json`),
+            expect.stringContaining(`${federatedGraphResponse.graph!.id}/manifest/feature-flags/${ffName2}.json`),
+            expect.stringContaining(`${federatedGraphResponse.graph!.id}/manifest/feature-flags/${ffName3}.json`),
+          ]),
+        );
+
+        // The base composition and the feature flags composition
+        await assertNumberOfCompositions(client, baseGraphName, 4, namespace);
+        await assertFeatureFlagExecutionConfig(blobStorage, key, false);
+
+        // Update the feature subgraph
+        const updateFeatureSubgraphResp = await client.publishFederatedSubgraph({
+          name: 'products-standalone-feature',
+          namespace,
+          schema: fs
+            .readFileSync(join(process.cwd(), `test/test-data/feature-flags/products-feature-update.graphql`))
+            .toString(),
+        });
+
+        expect(updateFeatureSubgraphResp.response?.code).toBe(EnumStatusCode.OK);
+
+        // Only the feature flags that share `products-standalone-feature` should recompose
+        await assertNumberOfCompositions(client, baseGraphName, 6, namespace);
         await assertFeatureFlagExecutionConfig(blobStorage, key, false);
       },
     );

--- a/controlplane/test/feature-flag/feature-flag-integration.test.ts
+++ b/controlplane/test/feature-flag/feature-flag-integration.test.ts
@@ -4102,7 +4102,7 @@ describe('Feature flag integration tests', () => {
           ]),
         );
 
-        // The base composition and the feature flags composition
+        // The base composition + one composition for each feature flag
         await assertNumberOfCompositions(client, baseGraphName, 3, namespace);
         await assertFeatureFlagExecutionConfig(blobStorage, key, false);
 
@@ -4117,7 +4117,7 @@ describe('Feature flag integration tests', () => {
 
         expect(updateFeatureSubgraphResp.response?.code).toBe(EnumStatusCode.OK);
 
-        // Only one feature flag should have composed
+        // Only one feature flag should have recomposed
         await assertNumberOfCompositions(client, baseGraphName, 4, namespace);
         await assertFeatureFlagExecutionConfig(blobStorage, key, false);
       },
@@ -4178,7 +4178,7 @@ describe('Feature flag integration tests', () => {
           ]),
         );
 
-        // The base composition and the feature flags composition
+        // The base composition + one composition for each feature flag
         await assertNumberOfCompositions(client, baseGraphName, 4, namespace);
         await assertFeatureFlagExecutionConfig(blobStorage, key, false);
 
@@ -4193,7 +4193,7 @@ describe('Feature flag integration tests', () => {
 
         expect(updateFeatureSubgraphResp.response?.code).toBe(EnumStatusCode.OK);
 
-        // Only the feature flags that share `products-standalone-feature` should recompose
+        // Only the two feature flags that share `products-standalone-feature` should recompose
         await assertNumberOfCompositions(client, baseGraphName, 6, namespace);
         await assertFeatureFlagExecutionConfig(blobStorage, key, false);
       },

--- a/controlplane/test/feature-flag/feature-flag-integration.test.ts
+++ b/controlplane/test/feature-flag/feature-flag-integration.test.ts
@@ -4030,5 +4030,88 @@ describe('Feature flag integration tests', () => {
         await assertFeatureFlagExecutionConfig(blobStorage, key, false);
       },
     );
+
+    test(
+      'that publishing a feature subgraph only recomposes affected feature flags',
+      getDebugTestOptions(isDebugMode),
+      async (testContext) => {
+        const { client, server, blobStorage } = await SetupTest({
+          dbname,
+          chClient,
+          enabledFeatures: ['split-config-loading'],
+        });
+        testContext.onTestFinished(() => server.close());
+
+        const namespace = genID('namespace').toLowerCase();
+        const labels: Label[] = [];
+        const baseGraphName = genID('baseFederatedGraphName');
+        const ffName1 = genID('featureFlagName1');
+        const ffName2 = genID('featureFlagName2');
+
+        await createNamespace(client, namespace);
+
+        const federatedGraphResponse = await featureFlagIntegrationTestSetUp(
+          client,
+          [
+            { name: 'users', hasFeatureSubgraph: true },
+            { name: 'products-standalone', hasFeatureSubgraph: true },
+          ],
+          baseGraphName,
+          labels,
+          namespace,
+        );
+
+        await createThenPublishFeatureSubgraph(
+          client,
+          'products-standalone-feature-v2',
+          'products-standalone',
+          namespace,
+          fs.readFileSync(join(process.cwd(), `test/test-data/feature-flags/products-standalone-feature.graphql`)).toString(),
+          labels,
+          'http://localhost:10000/graphql'
+        );
+
+        expect(blobStorage.keys()).toHaveLength(2);
+        const key = blobStorage.keys()[0];
+        const mapperKey = blobStorage.keys()[1];
+        expect(key).toContain(`${federatedGraphResponse.graph!.id}/manifest/latest.json`);
+        expect(mapperKey).toContain(`${federatedGraphResponse.graph!.id}/manifest/mapper.json`);
+
+        await assertFeatureFlagExecutionConfig(blobStorage, key, false);
+
+        // The base composition
+        await assertNumberOfCompositions(client, baseGraphName, 1, namespace);
+
+        await createFeatureFlag(client, ffName1, labels, ['users-feature', 'products-standalone-feature-v2'], namespace, true);
+        await createFeatureFlag(client, ffName2, labels, ['products-standalone-feature'], namespace, true);
+
+        expect(blobStorage.keys()).toHaveLength(4);
+        expect(blobStorage.keys()).toEqual(
+          expect.arrayContaining([
+            expect.stringContaining(`${federatedGraphResponse.graph!.id}/manifest/feature-flags/${ffName1}.json`),
+            expect.stringContaining(`${federatedGraphResponse.graph!.id}/manifest/feature-flags/${ffName2}.json`),
+          ]),
+        )
+
+        // The base composition and the feature flags composition
+        await assertNumberOfCompositions(client, baseGraphName, 3, namespace);
+        await assertFeatureFlagExecutionConfig(blobStorage, key, false);
+
+        // Update the feature subgraph
+        const updateFeatureSubgraphResp = await client.publishFederatedSubgraph({
+          name: 'products-standalone-feature',
+          namespace,
+          schema: fs
+            .readFileSync(join(process.cwd(), `test/test-data/feature-flags/products-feature-update.graphql`))
+            .toString(),
+        });
+
+        expect(updateFeatureSubgraphResp.response?.code).toBe(EnumStatusCode.OK);
+
+        // Only one feature flag should have composed
+        await assertNumberOfCompositions(client, baseGraphName, 4, namespace);
+        await assertFeatureFlagExecutionConfig(blobStorage, key, false);
+      },
+    );
   });
 });

--- a/controlplane/test/feature-flag/feature-flag-integration.test.ts
+++ b/controlplane/test/feature-flag/feature-flag-integration.test.ts
@@ -4066,9 +4066,11 @@ describe('Feature flag integration tests', () => {
           'products-standalone-feature-v2',
           'products-standalone',
           namespace,
-          fs.readFileSync(join(process.cwd(), `test/test-data/feature-flags/products-standalone-feature.graphql`)).toString(),
+          fs
+            .readFileSync(join(process.cwd(), `test/test-data/feature-flags/products-standalone-feature.graphql`))
+            .toString(),
           labels,
-          'http://localhost:10000/graphql'
+          'http://localhost:10000/graphql',
         );
 
         expect(blobStorage.keys()).toHaveLength(2);
@@ -4082,7 +4084,14 @@ describe('Feature flag integration tests', () => {
         // The base composition
         await assertNumberOfCompositions(client, baseGraphName, 1, namespace);
 
-        await createFeatureFlag(client, ffName1, labels, ['users-feature', 'products-standalone-feature-v2'], namespace, true);
+        await createFeatureFlag(
+          client,
+          ffName1,
+          labels,
+          ['users-feature', 'products-standalone-feature-v2'],
+          namespace,
+          true,
+        );
         await createFeatureFlag(client, ffName2, labels, ['products-standalone-feature'], namespace, true);
 
         expect(blobStorage.keys()).toHaveLength(4);
@@ -4091,7 +4100,7 @@ describe('Feature flag integration tests', () => {
             expect.stringContaining(`${federatedGraphResponse.graph!.id}/manifest/feature-flags/${ffName1}.json`),
             expect.stringContaining(`${federatedGraphResponse.graph!.id}/manifest/feature-flags/${ffName2}.json`),
           ]),
-        )
+        );
 
         // The base composition and the feature flags composition
         await assertNumberOfCompositions(client, baseGraphName, 3, namespace);

--- a/controlplane/test/feature-flag/feature-flag-integration.test.ts
+++ b/controlplane/test/feature-flag/feature-flag-integration.test.ts
@@ -4118,6 +4118,7 @@ describe('Feature flag integration tests', () => {
         expect(updateFeatureSubgraphResp.response?.code).toBe(EnumStatusCode.OK);
 
         // Only one feature flag should have recomposed
+        await assertNumberOfCompositions(client, baseGraphName, 1, namespace, EnumStatusCode.OK, true);
         await assertNumberOfCompositions(client, baseGraphName, 4, namespace);
         await assertFeatureFlagExecutionConfig(blobStorage, key, false);
       },
@@ -4194,6 +4195,7 @@ describe('Feature flag integration tests', () => {
         expect(updateFeatureSubgraphResp.response?.code).toBe(EnumStatusCode.OK);
 
         // Only the two feature flags that share `products-standalone-feature` should recompose
+        await assertNumberOfCompositions(client, baseGraphName, 1, namespace, EnumStatusCode.OK, true);
         await assertNumberOfCompositions(client, baseGraphName, 6, namespace);
         await assertFeatureFlagExecutionConfig(blobStorage, key, false);
       },


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved schema update recomposition when split-config is enabled: only feature flags that depend on the updated published feature subgraph are marked for reprocessing, avoiding unnecessary recomposition.
  * Preserved existing behavior when split-config is disabled, including handling of affected federated graphs.
* **Tests**
  * Added integration tests for split-config loading that validate selective recomposition counts after feature subgraph publish/update events, with base feature-flag execution configuration remaining unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [x] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [x] Tests or benchmarks have been added or updated.
- [x] If applicable, I have provided instructions for reviewers for [manually validating my changes](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md#pull-requests-conventions).
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

<!--
Please add any additional information or context regarding your changes here.
-->