### PR TITLE
docs(router): fix env var names in graceful shutdown docs

### DIFF
--- a/docs-website/router/deployment.mdx
+++ b/docs-website/router/deployment.mdx
@@ -51,9 +51,9 @@ For example, the following configuration was tested and could serve as a good st
 
 **Router**
 
-* `GRACE_PERIOD=20`
+* `GRACE_PERIOD=20s`
 
-* `SHUTDOWN_DELAY=30`
+* `SHUTDOWN_DELAY=30s`
 
 `Pod`
 

--- a/docs-website/router/deployment.mdx
+++ b/docs-website/router/deployment.mdx
@@ -51,9 +51,9 @@ For example, the following configuration was tested and could serve as a good st
 
 **Router**
 
-* `GRACE_PERIOD_SECONDS=20`
+* `GRACE_PERIOD=20`
 
-* `SHUTDOWN_DELAY_SECONDS=30`
+* `SHUTDOWN_DELAY=30`
 
 `Pod`
 
@@ -61,7 +61,7 @@ For example, the following configuration was tested and could serve as a good st
 
 With that configuration, your router has 30 seconds to respond to all active connections before forcefully shutting down the server. Kubernetes will not terminate the container until the termination period of 60 seconds is over. Because the readiness endpoint no longer responds `200` and the container is in`TERMINATION` state any new traffic from being redirected to the instance is prevented.
 
-`GRACE_PERIOD_SECONDS` becomes interesting when the router updates its schema. This is also the time the server has to gracefully shut down old clients before the switch is enforced.
+`GRACE_PERIOD` becomes interesting when the router updates its schema. This is also the time the server has to gracefully shut down old clients before the switch is enforced.
 
 <Info>
   For more information, we recommend the [Kubernetes Best Practice Terminating With Grace](https://cloud.google.com/blog/products/containers-kubernetes/kubernetes-best-practices-terminating-with-grace) article.


### PR DESCRIPTION
`GRACE_PERIOD_SECONDS` and `SHUTDOWN_DELAY_SECONDS` do not exist in the codebase. The actual env vars are `GRACE_PERIOD` and `SHUTDOWN_DELAY`, accepting Go duration strings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the “Graceful shutdown” Kubernetes example to use the latest Router environment variable names.
  * Reformatted the example into a clearer bullet list, aligning Router termination settings with `Pod`’s `terminationGracePeriodSeconds` to better illustrate readiness behavior during shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->