### PR TITLE
chore: propose @openfed__queryCache rfc

### DIFF
--- a/rfc/openfed__queryCache-v1.md
+++ b/rfc/openfed__queryCache-v1.md
@@ -1,0 +1,94 @@
+---
+title: "@openfed__queryCache: return a cache from a root query field"
+author: David Stutt
+---
+
+# Introduction
+```graphql
+directive @openfed__queryCache(
+  maxAge: Int!
+  includeHeaders: Boolean = false
+  shadowMode: Boolean = false
+) on FIELD_DEFINITION
+```
+
+The intention of `@openfed__queryCache` is to allow the user to configure type agnostic caching for a query.
+The premise is simple:
+Has the query root field with its appropriate argument values been requested before within the maxAge limit?
+Yes: retrieve from the cache
+No: fetch and repopulate the cache
+
+# Cache key
+
+## No field arguments
+If the operation provides no argument values (regardless of whether the field defines arguments), the cache key might
+simply be `Query.fieldName`.
+
+## Field arguments
+If the the operation provides argument values, those values will need to be deterministically ordered.
+For instance:
+```graphql
+query {
+  user(a: 1, b: 2)
+}
+```
+
+and
+```graphql
+query {
+  user(b: 2, a: 1)
+}
+```
+
+should hit the same cache value.
+
+This should also be true for more complex inputs, e.g.:
+
+```graphql
+query {
+  user(
+    inputA: {
+      a: "hello",
+      b: "world"
+    },
+    inputB: {
+      a: 6.9
+      inputC: {
+        x: 1,
+        y: true,
+      },
+    },
+  )
+}
+```
+and
+```graphql
+query {
+  user(
+    inputB: {
+      inputC: {
+        y: true,
+        x: 1,
+      },
+      a: 6.9
+    },
+    inputA: {
+      b: "world"
+      a: "hello",
+    },
+  )
+}
+```
+should hit the same cache value.
+
+# Interaction with @openfed__entityCache
+`@openfed__queryCache` is intended to be type agnostic.
+If the user defines this directive on a query field, the input is used as a key, and a value (if it exists) is
+retrieved.
+If the user intends to use the entity cache from a query field, a different method would be used (upcoming RFC).
+
+# Errors
+Errors will be returned from composition if:
+1. The directive is defined on a non query root field.
+2. The query root field defines any other caching directive.
+3. The max age is <= 0.


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a new query-response caching directive.
  * Introduced options to control cache duration, header-based cache variation, and a shadow mode for safer rollout.
  * Clarified how cache keys are generated for queries with and without arguments.

* **Bug Fixes**
  * Added validation to prevent invalid directive use on non-query fields.
  * Prevented conflicting cache directives from being applied to the same query field.
  * Rejected non-positive cache duration values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] If applicable, I have provided instructions for reviewers for [manually validating my changes](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md#pull-requests-conventions).
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

<!--
Please add any additional information or context regarding your changes here.
-->
