### PR TITLE
fix: contracts composed multiple times

### DIFF
--- a/controlplane/src/core/repositories/SubgraphRepository.ts
+++ b/controlplane/src/core/repositories/SubgraphRepository.ts
@@ -571,6 +571,7 @@ export class SubgraphRepository {
         const federatedGraphDTOs = await fedGraphRepo.bySubgraphLabels({
           labels: baseSubgraph[0].labels?.map?.((l) => splitLabel(l)) ?? [],
           namespaceId: data.namespaceId,
+          excludeContracts: true,
         });
 
         for (const federatedGraphDTO of federatedGraphDTOs) {
@@ -622,13 +623,10 @@ export class SubgraphRepository {
       const affectedGraphs = await fedGraphRepo.bySubgraphLabels({
         labels: subgraph.labels,
         namespaceId: data.namespaceId,
+        excludeContracts: true,
       });
 
       for (const graph of affectedGraphs) {
-        if (graph.contract) {
-          continue;
-        }
-
         // If the subgraph has changed, always trigger composition
         if (affectedFederatedGraphById.has(graph.id) && !subgraphChanged) {
           /** If the federated graph matches the old labels AND the new labels,

--- a/controlplane/test/contracts.test.ts
+++ b/controlplane/test/contracts.test.ts
@@ -4,6 +4,7 @@ import { EnumStatusCode } from '@wundergraph/cosmo-connect/dist/common/common_pb
 import { joinLabel } from '@wundergraph/cosmo-shared';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 import { RouterConfig } from '@wundergraph/cosmo-connect/dist/node/v1/node_pb';
+import { Label } from '@wundergraph/cosmo-connect/dist/platform/v1/platform_pb';
 import { normalizeString } from '../../composition/tests/utils/utils.js';
 import { afterAllSetup, beforeAllSetup, genID, genUniqueLabel } from '../src/core/test-util.js';
 import { unsuccessfulBaseCompositionError } from '../src/core/errors/errors.js';
@@ -11,17 +12,19 @@ import { ClickHouseClient } from '../src/core/clickhouse/index.js';
 import {
   assertFeatureFlagExecutionConfig,
   assertNumberOfCompositions,
-  createAndPublishSubgraph, createFeatureFlag,
+  createAndPublishSubgraph,
+  createFeatureFlag,
   createFederatedGraph,
   createNamespace,
   createThenPublishSubgraph,
   DEFAULT_NAMESPACE,
   DEFAULT_ROUTER_URL,
   DEFAULT_SUBGRAPH_URL_ONE,
-  DEFAULT_SUBGRAPH_URL_TWO, featureFlagIntegrationTestSetUp, getDebugTestOptions,
+  DEFAULT_SUBGRAPH_URL_TWO,
+  featureFlagIntegrationTestSetUp,
+  getDebugTestOptions,
   SetupTest,
 } from './test-util.js';
-import { Label } from "@wundergraph/cosmo-connect/dist/platform/v1/platform_pb";
 
 const schemaDefinition = `schema {\n  query: Query\n}\n\n`;
 const isDebugMode = false;
@@ -2235,7 +2238,7 @@ describe('Contract tests', () => {
     'that a contract is not composed multiple times when a feature subgraph is published',
     getDebugTestOptions(isDebugMode),
     async (testContext) => {
-      const { client, server } = await SetupTest({ dbname, chClient, });
+      const { client, server } = await SetupTest({ dbname, chClient });
       testContext.onTestFinished(() => server.close());
 
       const namespace = genID('namespace').toLowerCase();

--- a/controlplane/test/contracts.test.ts
+++ b/controlplane/test/contracts.test.ts
@@ -11,18 +11,20 @@ import { ClickHouseClient } from '../src/core/clickhouse/index.js';
 import {
   assertFeatureFlagExecutionConfig,
   assertNumberOfCompositions,
-  createAndPublishSubgraph,
+  createAndPublishSubgraph, createFeatureFlag,
   createFederatedGraph,
   createNamespace,
   createThenPublishSubgraph,
   DEFAULT_NAMESPACE,
   DEFAULT_ROUTER_URL,
   DEFAULT_SUBGRAPH_URL_ONE,
-  DEFAULT_SUBGRAPH_URL_TWO,
+  DEFAULT_SUBGRAPH_URL_TWO, featureFlagIntegrationTestSetUp, getDebugTestOptions,
   SetupTest,
 } from './test-util.js';
+import { Label } from "@wundergraph/cosmo-connect/dist/platform/v1/platform_pb";
 
 const schemaDefinition = `schema {\n  query: Query\n}\n\n`;
+const isDebugMode = false;
 let dbname = '';
 
 vi.mock('../src/core/clickhouse/index.js', () => {
@@ -2228,4 +2230,77 @@ describe('Contract tests', () => {
     `),
     );
   });
+
+  test(
+    'that a contract is not composed multiple times when a feature subgraph is published',
+    getDebugTestOptions(isDebugMode),
+    async (testContext) => {
+      const { client, server } = await SetupTest({ dbname, chClient, });
+      testContext.onTestFinished(() => server.close());
+
+      const namespace = genID('namespace').toLowerCase();
+      const labels: Label[] = [];
+      const baseGraphName = genID('baseFederatedGraph');
+      const contractName = genID('contract');
+      const ffName = genID('featureFlag');
+
+      await createNamespace(client, namespace);
+      await featureFlagIntegrationTestSetUp(
+        client,
+        [
+          { name: 'users', hasFeatureSubgraph: true },
+          { name: 'products-standalone', hasFeatureSubgraph: true },
+        ],
+        baseGraphName,
+        labels,
+        namespace,
+      );
+
+      // Create a contract
+      const createContractResponse = await client.createContract({
+        name: contractName,
+        namespace,
+        sourceGraphName: baseGraphName,
+        excludeTags: [],
+        includeTags: [],
+        routingUrl: 'http://localhost:8081',
+        readme: 'test',
+      });
+
+      expect(createContractResponse.response?.code).toBe(EnumStatusCode.OK);
+
+      // Create a feature flag
+      await createFeatureFlag(client, ffName, labels, ['products-standalone-feature'], namespace, true);
+
+      /**
+       * We expect the base graph and contract to be composed twice, once for the creation and once when the
+       * feature flag was created
+       */
+      await assertNumberOfCompositions(client, baseGraphName, 2, namespace, EnumStatusCode.OK, true);
+      await assertNumberOfCompositions(client, contractName, 2, namespace, EnumStatusCode.OK, true);
+
+      // We expect to see feature flag to be composed
+      await assertNumberOfCompositions(client, baseGraphName, 3, namespace);
+      await assertNumberOfCompositions(client, contractName, 3, namespace);
+
+      // Update the feature subgraph
+      const updateFeatureSubgraphResp = await client.publishFederatedSubgraph({
+        name: 'products-standalone-feature',
+        namespace,
+        schema: fs
+          .readFileSync(join(process.cwd(), `test/test-data/feature-flags/products-feature-update.graphql`))
+          .toString(),
+      });
+
+      expect(updateFeatureSubgraphResp.response?.code).toBe(EnumStatusCode.OK);
+
+      // We expect to see a new composition for both the base graph and contract
+      await assertNumberOfCompositions(client, baseGraphName, 3, namespace, EnumStatusCode.OK, true);
+      await assertNumberOfCompositions(client, contractName, 3, namespace, EnumStatusCode.OK, true);
+
+      // And also expect a new composition for the feature flag
+      await assertNumberOfCompositions(client, baseGraphName, 5, namespace);
+      await assertNumberOfCompositions(client, contractName, 5, namespace);
+    },
+  );
 });


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated affected-graph impact calculations so contract-based federated graphs are no longer included when determining affected results for subgraph updates.
  * Improved composition behavior for feature-driven subgraph changes to avoid redundant processing of contract graphs.

* **Tests**
  * Added a regression test ensuring a contract is not composed multiple times when a feature subgraph is published or updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [x] Tests or benchmarks have been added or updated.
- [ ] If applicable, I have provided instructions for reviewers for [manually validating my changes](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md#pull-requests-conventions).
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

<!--
Please add any additional information or context regarding your changes here.
-->
