### PR TITLE
fix(router): guard subgraph connection-metrics trace against data race

### DIFF
--- a/router-tests/operations/request_tracing_security_test.go
+++ b/router-tests/operations/request_tracing_security_test.go
@@ -42,7 +42,7 @@ func TestRequestTracingSecurity(t *testing.T) {
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
-				Header: headers,
+				Header: headers.Clone(),
 				Query:  query,
 			})
 
@@ -75,7 +75,7 @@ func TestRequestTracingSecurity(t *testing.T) {
 			},
 		}, func(t *testing.T, xEnv *testenv.Environment) {
 			res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
-				Header: headers,
+				Header: headers.Clone(),
 				Query:  query,
 			})
 

--- a/router/internal/traceclient/traceclient.go
+++ b/router/internal/traceclient/traceclient.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"net/http"
 	"net/http/httptrace"
+	"sync"
 	"time"
 
 	rcontext "github.com/wundergraph/cosmo/router/internal/context"
@@ -40,10 +41,29 @@ type phaseTimings struct {
 	FirstByte    time.Time
 }
 
-type ClientTrace struct {
+type clientTraceData struct {
 	ConnectionGet      *GetConnection
 	ConnectionAcquired *AcquiredConnection
 	phases             phaseTimings
+}
+
+type ClientTrace struct {
+	mu   sync.Mutex
+	data clientTraceData
+}
+
+// snapshot returns a copy of the collected timings under the lock.
+func (c *ClientTrace) snapshot() clientTraceData {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.data
+}
+
+// update applies mutator to the collected timings under the lock.
+func (c *ClientTrace) update(mutator func(d *clientTraceData)) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	mutator(&c.data)
 }
 
 type ClientTraceContextKey struct{}
@@ -100,49 +120,53 @@ func (t *TraceInjectingRoundTripper) getClientTrace(ctx context.Context) *httptr
 
 	trace := &httptrace.ClientTrace{
 		GetConn: func(hostPort string) {
-			eC.ConnectionGet = &GetConnection{
-				Time:     time.Now(),
-				HostPort: hostPort,
-			}
+			eC.update(func(d *clientTraceData) {
+				d.ConnectionGet = &GetConnection{
+					Time:     time.Now(),
+					HostPort: hostPort,
+				}
+			})
 		},
 		GotConn: func(info httptrace.GotConnInfo) {
-			eC.ConnectionAcquired = &AcquiredConnection{
-				Time:     time.Now(),
-				Reused:   info.Reused,
-				WasIdle:  info.WasIdle,
-				IdleTime: info.IdleTime,
-			}
+			eC.update(func(d *clientTraceData) {
+				d.ConnectionAcquired = &AcquiredConnection{
+					Time:     time.Now(),
+					Reused:   info.Reused,
+					WasIdle:  info.WasIdle,
+					IdleTime: info.IdleTime,
+				}
+			})
 		},
 		DNSStart: func(_ httptrace.DNSStartInfo) {
-			eC.phases.DNSStart = time.Now()
+			eC.update(func(d *clientTraceData) { d.phases.DNSStart = time.Now() })
 		},
 		DNSDone: func(_ httptrace.DNSDoneInfo) {
-			eC.phases.DNSDone = time.Now()
+			eC.update(func(d *clientTraceData) { d.phases.DNSDone = time.Now() })
 		},
 		ConnectStart: func(_, _ string) {
-			eC.phases.ConnectStart = time.Now()
+			eC.update(func(d *clientTraceData) { d.phases.ConnectStart = time.Now() })
 		},
 		ConnectDone: func(_, _ string, _ error) {
-			eC.phases.ConnectDone = time.Now()
+			eC.update(func(d *clientTraceData) { d.phases.ConnectDone = time.Now() })
 		},
 		TLSHandshakeStart: func() {
-			eC.phases.TLSStart = time.Now()
+			eC.update(func(d *clientTraceData) { d.phases.TLSStart = time.Now() })
 		},
 		TLSHandshakeDone: func(_ tls.ConnectionState, _ error) {
-			eC.phases.TLSDone = time.Now()
+			eC.update(func(d *clientTraceData) { d.phases.TLSDone = time.Now() })
 		},
 		WroteRequest: func(_ httptrace.WroteRequestInfo) {
-			eC.phases.WroteRequest = time.Now()
+			eC.update(func(d *clientTraceData) { d.phases.WroteRequest = time.Now() })
 		},
 		GotFirstResponseByte: func() {
-			eC.phases.FirstByte = time.Now()
+			eC.update(func(d *clientTraceData) { d.phases.FirstByte = time.Now() })
 		},
 	}
 	return trace
 }
 
 func (t *TraceInjectingRoundTripper) processConnectionMetrics(ctx context.Context, req *http.Request) {
-	trace := GetClientTraceFromContext(ctx)
+	trace := GetClientTraceFromContext(ctx).snapshot()
 
 	var subgraph string
 	subgraphCtxVal := ctx.Value(rcontext.CurrentSubgraphContextKey{})

--- a/router/internal/traceclient/traceclient_test.go
+++ b/router/internal/traceclient/traceclient_test.go
@@ -100,11 +100,11 @@ func TestTraceInjectingRoundTripper(t *testing.T) {
 		_, _ = io.Copy(io.Discard, resp.Body)
 		_ = resp.Body.Close()
 
-		require.Positive(t, store.acquire, "connection acquire duration should be recorded")
-		require.Positive(t, store.dns, "DNS lookup duration should be recorded")
-		require.Positive(t, store.tcp, "TCP connect duration should be recorded")
-		require.Positive(t, store.tls, "TLS handshake duration should be recorded")
-		require.Positive(t, store.ttfb, "time to first byte should be recorded")
+		require.Equal(t, 1, store.acquire, "connection acquire duration should be recorded once")
+		require.Equal(t, 1, store.dns, "DNS lookup duration should be recorded once")
+		require.Equal(t, 1, store.tcp, "TCP connect duration should be recorded once")
+		require.Equal(t, 1, store.tls, "TLS handshake duration should be recorded once")
+		require.Equal(t, 1, store.ttfb, "time to first byte should be recorded once")
 	})
 
 	t.Run("records connection phase timings without racing concurrent httptrace callbacks", func(t *testing.T) {

--- a/router/internal/traceclient/traceclient_test.go
+++ b/router/internal/traceclient/traceclient_test.go
@@ -3,8 +3,11 @@ package traceclient
 import (
 	"context"
 	"crypto/tls"
+	"io"
 	"net/http"
+	"net/http/httptest"
 	"net/http/httptrace"
+	"net/url"
 	"sync"
 	"testing"
 
@@ -42,32 +45,6 @@ func (rt *writeLoopRoundTripper) RoundTrip(req *http.Request) (*http.Response, e
 	}, nil
 }
 
-// allPhasesRoundTripper fires every httptrace callback synchronously so each
-// connection phase is observed and recorded.
-type allPhasesRoundTripper struct{}
-
-func (allPhasesRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	ct := httptrace.ContextClientTrace(req.Context())
-
-	ct.GetConn("subgraph.local:443")
-	ct.DNSStart(httptrace.DNSStartInfo{})
-	ct.DNSDone(httptrace.DNSDoneInfo{})
-	ct.ConnectStart("tcp", "subgraph.local:443")
-	ct.ConnectDone("tcp", "subgraph.local:443", nil)
-	ct.TLSHandshakeStart()
-	ct.TLSHandshakeDone(tls.ConnectionState{}, nil)
-	ct.WroteRequest(httptrace.WroteRequestInfo{})
-	ct.GotFirstResponseByte()
-	ct.GotConn(httptrace.GotConnInfo{Reused: true})
-
-	return &http.Response{
-		StatusCode: http.StatusOK,
-		Body:       http.NoBody,
-		Header:     make(http.Header),
-		Request:    req,
-	}, nil
-}
-
 // recordingConnectionMetricStore counts how many times each measurement is recorded.
 type recordingConnectionMetricStore struct {
 	acquire, dns, tcp, tls, ttfb int
@@ -92,29 +69,42 @@ func (s *recordingConnectionMetricStore) Shutdown(_ context.Context) error { ret
 
 func TestTraceInjectingRoundTripper(t *testing.T) {
 	t.Run("records a metric for every observed connection phase", func(t *testing.T) {
-		store := &recordingConnectionMetricStore{}
-		exprCtx := &expr.Context{}
+		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("ok"))
+		}))
+		defer server.Close()
 
+		// Hit the server via the "localhost" hostname (not the 127.0.0.1 literal it
+		// listens on) so the transport actually performs a DNS lookup.
+		serverURL, err := url.Parse(server.URL)
+		require.NoError(t, err)
+		requestURL := "https://localhost:" + serverURL.Port() + "/"
+
+		store := &recordingConnectionMetricStore{}
+		base := &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
 		rt := NewTraceInjectingRoundTripper(
-			allPhasesRoundTripper{},
+			base,
 			store,
 			func(ctx context.Context, req *http.Request) (*expr.Context, string) {
-				return exprCtx, "employees"
+				return &expr.Context{}, "employees"
 			},
 		)
 
-		req, err := http.NewRequest(http.MethodPost, "https://subgraph.local/graphql", http.NoBody)
+		req, err := http.NewRequest(http.MethodGet, requestURL, http.NoBody)
 		require.NoError(t, err)
 
 		resp, err := rt.RoundTrip(req)
 		require.NoError(t, err)
+		_, _ = io.Copy(io.Discard, resp.Body)
 		_ = resp.Body.Close()
 
-		require.Equal(t, 1, store.acquire)
-		require.Equal(t, 1, store.dns)
-		require.Equal(t, 1, store.tcp)
-		require.Equal(t, 1, store.tls)
-		require.Equal(t, 1, store.ttfb)
+		require.Positive(t, store.acquire, "connection acquire duration should be recorded")
+		require.Positive(t, store.dns, "DNS lookup duration should be recorded")
+		require.Positive(t, store.tcp, "TCP connect duration should be recorded")
+		require.Positive(t, store.tls, "TLS handshake duration should be recorded")
+		require.Positive(t, store.ttfb, "time to first byte should be recorded")
 	})
 
 	t.Run("records connection phase timings without racing concurrent httptrace callbacks", func(t *testing.T) {

--- a/router/internal/traceclient/traceclient_test.go
+++ b/router/internal/traceclient/traceclient_test.go
@@ -2,10 +2,14 @@ package traceclient
 
 import (
 	"context"
+	"crypto/tls"
 	"net/http"
 	"net/http/httptrace"
 	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/wundergraph/cosmo/router/internal/expr"
 	"github.com/wundergraph/cosmo/router/pkg/metric"
@@ -38,7 +42,81 @@ func (rt *writeLoopRoundTripper) RoundTrip(req *http.Request) (*http.Response, e
 	}, nil
 }
 
+// allPhasesRoundTripper fires every httptrace callback synchronously so each
+// connection phase is observed and recorded.
+type allPhasesRoundTripper struct{}
+
+func (allPhasesRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	ct := httptrace.ContextClientTrace(req.Context())
+
+	ct.GetConn("subgraph.local:443")
+	ct.DNSStart(httptrace.DNSStartInfo{})
+	ct.DNSDone(httptrace.DNSDoneInfo{})
+	ct.ConnectStart("tcp", "subgraph.local:443")
+	ct.ConnectDone("tcp", "subgraph.local:443", nil)
+	ct.TLSHandshakeStart()
+	ct.TLSHandshakeDone(tls.ConnectionState{}, nil)
+	ct.WroteRequest(httptrace.WroteRequestInfo{})
+	ct.GotFirstResponseByte()
+	ct.GotConn(httptrace.GotConnInfo{Reused: true})
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       http.NoBody,
+		Header:     make(http.Header),
+		Request:    req,
+	}, nil
+}
+
+// recordingConnectionMetricStore counts how many times each measurement is recorded.
+type recordingConnectionMetricStore struct {
+	acquire, dns, tcp, tls, ttfb int
+}
+
+func (s *recordingConnectionMetricStore) MeasureConnectionAcquireDuration(_ context.Context, _ float64, _ ...attribute.KeyValue) {
+	s.acquire++
+}
+func (s *recordingConnectionMetricStore) MeasureDNSLookupDuration(_ context.Context, _ float64, _ ...attribute.KeyValue) {
+	s.dns++
+}
+func (s *recordingConnectionMetricStore) MeasureTCPConnectDuration(_ context.Context, _ float64, _ ...attribute.KeyValue) {
+	s.tcp++
+}
+func (s *recordingConnectionMetricStore) MeasureTLSHandshakeDuration(_ context.Context, _ float64, _ ...attribute.KeyValue) {
+	s.tls++
+}
+func (s *recordingConnectionMetricStore) MeasureTimeToFirstByte(_ context.Context, _ float64, _ ...attribute.KeyValue) {
+	s.ttfb++
+}
+func (s *recordingConnectionMetricStore) Shutdown(_ context.Context) error { return nil }
+
 func TestTraceInjectingRoundTripper(t *testing.T) {
+	t.Run("records a metric for every observed connection phase", func(t *testing.T) {
+		store := &recordingConnectionMetricStore{}
+		exprCtx := &expr.Context{}
+
+		rt := NewTraceInjectingRoundTripper(
+			allPhasesRoundTripper{},
+			store,
+			func(ctx context.Context, req *http.Request) (*expr.Context, string) {
+				return exprCtx, "employees"
+			},
+		)
+
+		req, err := http.NewRequest(http.MethodPost, "https://subgraph.local/graphql", http.NoBody)
+		require.NoError(t, err)
+
+		resp, err := rt.RoundTrip(req)
+		require.NoError(t, err)
+		_ = resp.Body.Close()
+
+		require.Equal(t, 1, store.acquire)
+		require.Equal(t, 1, store.dns)
+		require.Equal(t, 1, store.tcp)
+		require.Equal(t, 1, store.tls)
+		require.Equal(t, 1, store.ttfb)
+	})
+
 	t.Run("records connection phase timings without racing concurrent httptrace callbacks", func(t *testing.T) {
 		var wg sync.WaitGroup
 

--- a/router/internal/traceclient/traceclient_test.go
+++ b/router/internal/traceclient/traceclient_test.go
@@ -1,0 +1,66 @@
+package traceclient
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptrace"
+	"sync"
+	"testing"
+
+	"github.com/wundergraph/cosmo/router/internal/expr"
+	"github.com/wundergraph/cosmo/router/pkg/metric"
+)
+
+// writeLoopRoundTripper mimics net/http: connection hooks fire on the request
+// goroutine, but WroteRequest / GotFirstResponseByte fire on a separate goroutine
+// with no happens-before edge back to the caller of RoundTrip.
+type writeLoopRoundTripper struct {
+	wg *sync.WaitGroup
+}
+
+func (rt *writeLoopRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	ct := httptrace.ContextClientTrace(req.Context())
+
+	// Set ConnectionGet so processConnectionMetrics gets past its early return.
+	ct.GetConn("subgraph.local:443")
+	ct.GotConn(httptrace.GotConnInfo{})
+
+	rt.wg.Go(func() {
+		ct.WroteRequest(httptrace.WroteRequestInfo{})
+		ct.GotFirstResponseByte()
+	})
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       http.NoBody,
+		Header:     make(http.Header),
+		Request:    req,
+	}, nil
+}
+
+func TestTraceInjectingRoundTripper(t *testing.T) {
+	t.Run("records connection phase timings without racing concurrent httptrace callbacks", func(t *testing.T) {
+		var wg sync.WaitGroup
+
+		rt := NewTraceInjectingRoundTripper(
+			&writeLoopRoundTripper{wg: &wg},
+			&metric.NoopConnectionMetricStore{},
+			func(ctx context.Context, req *http.Request) (*expr.Context, string) {
+				return &expr.Context{}, "employees"
+			},
+		)
+
+		req, err := http.NewRequest(http.MethodPost, "https://subgraph.local/graphql", http.NoBody)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		resp, err := rt.RoundTrip(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = resp.Body.Close()
+
+		wg.Wait()
+	})
+}


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of request tracing by safely collecting connection timing data during concurrent HTTP trace callbacks and using a consistent timing snapshot for metric calculations.
* **Tests**
  * Added a round-trip test to verify trace-based connection metrics are recorded correctly, including when trace callbacks run across goroutines.
  * Improved request tracing security test isolation by cloning request headers for each subtest.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

`TraceInjectingRoundTripper` recorded subgraph connection phase timings via httptrace callbacks that fire on net/http's writeLoop goroutine, then read them back on the request goroutine right after `RoundTrip` returns, causes a data race. 

This PR guards `ClientTrace` with a mutex: callbacks mutate through an `update` helper and `processConnectionMetrics` reads a `snapshot` taken under the lock.

## Checklist

- [x] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [x] Tests or benchmarks have been added or updated.
- [x] If applicable, I have provided instructions for reviewers for [manually validating my changes](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md#pull-requests-conventions).
- [x] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev).