### PR TITLE
feat(studio): improve Studio UX — health cards, subgraph drawer, navigation, trace status

### DIFF
--- a/studio/src/components/analytics/data-table.tsx
+++ b/studio/src/components/analytics/data-table.tsx
@@ -51,6 +51,45 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import { useToast } from '@/components/ui/use-toast';
 import { calculateUrlLength, checkFilterLimits, MAX_URL_LENGTH } from './metrics';
 
+function getStatusCategory(row: Row<any>): string {
+  const httpStatusCode = (row.getValue('httpStatusCode') as string | undefined) ?? '';
+  const statusMessage = ((row.getValue('statusMessage') as string | undefined) ?? '').toLowerCase();
+
+  if (httpStatusCode.startsWith('4')) return 'Validation';
+  if (httpStatusCode.startsWith('5')) return 'Server';
+
+  if (
+    statusMessage.includes('deadline exceeded') ||
+    statusMessage.includes('timeout') ||
+    statusMessage.includes('timed out') ||
+    statusMessage.includes('context deadline')
+  ) {
+    return 'Timeout';
+  }
+
+  if (
+    statusMessage.includes('connection') ||
+    statusMessage.includes('connect') ||
+    statusMessage.includes('unavailable') ||
+    statusMessage.includes('econnrefused') ||
+    statusMessage.includes('econnreset') ||
+    statusMessage.includes('socket hang up') ||
+    statusMessage.includes('network')
+  ) {
+    return 'Connection';
+  }
+
+  if (
+    statusMessage.includes('unauthorized') ||
+    statusMessage.includes('forbidden') ||
+    statusMessage.includes('permission')
+  ) {
+    return 'Auth';
+  }
+
+  return 'Error';
+}
+
 export function AnalyticsDataTable<T>({
   tableRef,
   data,
@@ -531,8 +570,12 @@ export function AnalyticsDataTable<T>({
                               </Tooltip>
                             </TooltipProvider>
                           );
+                          text = (
+                            <span className="text-xs font-medium text-destructive/90">{getStatusCategory(row)}</span>
+                          );
                         } else {
                           icon = <HiOutlineCheck className="h-5 w-5" />;
+                          text = <span className="text-xs text-muted-foreground">OK</span>;
                         }
                       } else {
                         text = flexRender(cell.column.columnDef.cell, cell.getContext());

--- a/studio/src/components/federatedgraphs-cards.tsx
+++ b/studio/src/components/federatedgraphs-cards.tsx
@@ -1,31 +1,40 @@
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useFireworks } from '@/hooks/use-fireworks';
 import { docsBaseURL } from '@/lib/constants';
-import { formatMetric } from '@/lib/format-metric';
+import { formatDurationMetric, formatMetric } from '@/lib/format-metric';
+import { formatNumber } from '@/lib/format-number';
 import { useChartData } from '@/lib/insights-helpers';
 import { cn } from '@/lib/utils';
-import { CommandLineIcon, DocumentArrowDownIcon, ExclamationTriangleIcon } from '@heroicons/react/24/outline';
-import { ArrowRightIcon, Component2Icon, LightningBoltIcon, PlayIcon } from '@radix-ui/react-icons';
+import { CommandLineIcon, DocumentArrowDownIcon } from '@heroicons/react/24/outline';
+import { ArrowRightIcon, LightningBoltIcon, PlayIcon } from '@radix-ui/react-icons';
+import { EnumStatusCode } from '@wundergraph/cosmo-connect/dist/common/common_pb';
+import {
+  getDashboardAnalyticsView,
+  getFederatedGraphByName,
+  getGraphMetrics,
+} from '@wundergraph/cosmo-connect/dist/platform/v1/platform-PlatformService_connectquery';
 import { FederatedGraph } from '@wundergraph/cosmo-connect/dist/platform/v1/platform_pb';
 import copy from 'copy-to-clipboard';
 import { getTime, parseISO, subDays } from 'date-fns';
 import Link from 'next/link';
-import { Dispatch, SetStateAction, useContext, useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import { Dispatch, SetStateAction, useContext, useEffect, useMemo, useState } from 'react';
 import { FiCheck, FiCopy } from 'react-icons/fi';
 import { LuSquareDot } from 'react-icons/lu';
 import { MdNearbyError } from 'react-icons/md';
 import { Line, LineChart, ResponsiveContainer, XAxis } from 'recharts';
 import { UserContext } from './app-provider';
-import { ComposeStatusMessage } from './compose-status';
 import { ComposeStatusBulb } from './compose-status-bulb';
 import { EmptyState } from './empty-state';
 import { TimeAgo } from './time-ago';
 import { Button } from './ui/button';
+import { Badge } from './ui/badge';
 import { Card } from './ui/card';
 import { CLI } from './ui/cli';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from './ui/dialog';
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './ui/tooltip';
+import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
 import { MigrationDialog } from './migration-dialog';
+import { useQuery } from '@connectrpc/connect-query';
 import { useCheckUserAccess } from '@/hooks/use-check-user-access';
 import { useWorkspace } from '@/hooks/use-workspace';
 import { useOnboarding } from '@/hooks/use-onboarding';
@@ -312,6 +321,7 @@ export const Empty = ({
 
 const GraphCard = ({ graph, hasStaleMetrics }: { graph: FederatedGraph; hasStaleMetrics: boolean }) => {
   const user = useContext(UserContext);
+  const router = useRouter();
   const { data, ticks, domain, timeFormatter } = useChartData(
     4,
     graph.requestSeries.length > 0 ? graph.requestSeries : fallbackData,
@@ -320,6 +330,76 @@ const GraphCard = ({ graph, hasStaleMetrics }: { graph: FederatedGraph; hasStale
   const totalRequests = graph.requestSeries.reduce((total, r) => total + r.totalRequests, 0);
 
   const totalErrors = graph.requestSeries.reduce((total, r) => total + r.erroredRequests, 0);
+  const isReady = Boolean(graph.lastUpdatedAt);
+  const isHealthy = totalErrors === 0;
+  const errorRatePct = totalRequests > 0 ? (totalErrors / totalRequests) * 100 : 0;
+  const rpm = totalRequests / (4 * 60);
+  const rpmLabel =
+    totalRequests === 0
+      ? formatNumber(0, { minimumFractionDigits: 3, maximumFractionDigits: 3 })
+      : formatMetric(rpm);
+
+  const { data: graphMetrics } = useQuery(
+    getGraphMetrics,
+    { namespace: graph.namespace, federatedGraphName: graph.name, range: 4 },
+    { enabled: isReady, refetchOnWindowFocus: false },
+  );
+
+  const p95LatencyValue = Number.parseInt(graphMetrics?.latency?.value || '0');
+  const p95LatencyLabel =
+    isReady && graphMetrics?.response?.code === EnumStatusCode.OK && p95LatencyValue > 0
+      ? formatDurationMetric(p95LatencyValue, { maximumFractionDigits: 3 })
+      : 'N/A';
+  const p95LatencyTone =
+    p95LatencyLabel === 'N/A'
+      ? 'muted'
+      : p95LatencyValue >= 1000
+        ? 'critical'
+        : p95LatencyValue >= 500
+          ? 'slow'
+          : 'normal';
+
+  const shouldFetchTopErrorSubgraph = isReady && !isHealthy && graph.supportsFederation;
+  const { data: graphDetails } = useQuery(
+    getFederatedGraphByName,
+    { name: graph.name, namespace: graph.namespace },
+    { enabled: shouldFetchTopErrorSubgraph, refetchOnWindowFocus: false },
+  );
+  const { data: dashboardView } = useQuery(
+    getDashboardAnalyticsView,
+    { namespace: graph.namespace, federatedGraphName: graph.name, range: 4 },
+    { enabled: shouldFetchTopErrorSubgraph, refetchOnWindowFocus: false },
+  );
+
+  const topErrorSubgraphName = useMemo(() => {
+    const subgraphMetrics = dashboardView?.subgraphMetrics ?? [];
+    const subgraphs = graphDetails?.subgraphs ?? [];
+    if (subgraphMetrics.length === 0 || subgraphs.length === 0) return undefined;
+
+    const top = subgraphMetrics.reduce((best, next) => (next.errorRate > best.errorRate ? next : best), subgraphMetrics[0]);
+    const match = subgraphs.find((s) => s.id === top.subgraphID);
+    return match?.name;
+  }, [dashboardView?.subgraphMetrics, graphDetails?.subgraphs]);
+
+  const orgSlug = user?.currentOrganization?.slug;
+  const graphBasePath = `/${orgSlug}/${graph.namespace}/graph/${graph.name}`;
+  const topErrorSubgraphAnalyticsPath =
+    topErrorSubgraphName && orgSlug
+      ? `/${orgSlug}/${graph.namespace}/subgraph/${topErrorSubgraphName}/analytics?graph=${encodeURIComponent(graph.name)}`
+      : undefined;
+
+  const primaryCta = (() => {
+    if (!orgSlug) return { label: 'View', href: graphBasePath };
+    if (!isReady) return { label: 'View details', href: graphBasePath };
+    if (!isHealthy) return { label: 'Investigate', href: topErrorSubgraphAnalyticsPath ?? `${graphBasePath}/analytics` };
+    return { label: 'View', href: graphBasePath };
+  })();
+
+  const statusText = (() => {
+    if (!isReady) return 'Waiting for first schema publish.';
+    if (!isHealthy) return topErrorSubgraphName ? topErrorSubgraphName : 'Elevated errors';
+    return 'All good.';
+  })();
 
   const parsedURL = () => {
     try {
@@ -332,12 +412,29 @@ const GraphCard = ({ graph, hasStaleMetrics }: { graph: FederatedGraph; hasStale
     } catch {}
   };
 
+  const endpointLabel = () => {
+    const url = parsedURL();
+    if (!url) return undefined;
+    return url;
+  };
+
   return (
-    <Link
-      href={`/${user?.currentOrganization?.slug}/${graph.namespace}/graph/${graph.name}`}
-      className="project-list-item group"
+    <div
+      role="link"
+      tabIndex={0}
+      aria-label={`View ${graph.name}`}
+      className="project-list-item group cursor-pointer rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+      onClick={() => {
+        router.push(graphBasePath);
+      }}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          router.push(graphBasePath);
+        }
+      }}
     >
-      <Card className="flex h-full flex-col py-4 transition-all group-hover:border-input-active">
+      <Card className="flex h-full flex-col pt-4 pb-3 transition-all group-hover:border-input-active">
         <div className="pointer-events-none -mx-1.5 h-20 pb-4">
           <ResponsiveContainer width="100%" height="100%">
             <LineChart data={data}>
@@ -361,29 +458,16 @@ const GraphCard = ({ graph, hasStaleMetrics }: { graph: FederatedGraph; hasStale
             </LineChart>
           </ResponsiveContainer>
         </div>
-        {hasStaleMetrics ? (
-          <Tooltip delayDuration={100}>
-            <TooltipTrigger asChild>
-              <div
-                className="flex w-full items-center justify-end gap-1 px-4 font-mono text-xs text-gray-100"
-                tabIndex={0}
-                role="img"
-                aria-label="Analytics are not available at this moment"
-              >
-                <ExclamationTriangleIcon width={12} height={12} aria-hidden />
-                N/A
-              </div>
-            </TooltipTrigger>
-            <TooltipContent>Analytics are not available at this moment</TooltipContent>
-          </Tooltip>
-        ) : (
-          <div className="flex w-full justify-end px-4 font-mono text-xs text-muted-foreground">
-            {`${formatMetric(totalRequests / (4 * 60))} RPM`}
-          </div>
-        )}
-
         <div className="mt-3 flex flex-1 flex-col items-start px-6">
-          <div className="text-base font-semibold">{graph.name}</div>
+          <div className="flex w-full items-start justify-between gap-3">
+            <div className="min-w-0 text-base font-semibold">{graph.name}</div>
+            <Badge
+              className="shrink-0 tracking-[0.44px]"
+              variant={isHealthy ? 'success' : 'destructive'}
+            >
+              {isHealthy ? 'Healthy' : 'Degraded'}
+            </Badge>
+          </div>
           <Tooltip delayDuration={100}>
             <TooltipTrigger asChild>
               <p
@@ -391,83 +475,98 @@ const GraphCard = ({ graph, hasStaleMetrics }: { graph: FederatedGraph; hasStale
                   italic: !graph.routingURL,
                 })}
               >
-                {parsedURL()}
+                {endpointLabel()}
               </p>
             </TooltipTrigger>
-            <TooltipContent>{parsedURL()}</TooltipContent>
+            <TooltipContent>{endpointLabel()}</TooltipContent>
           </Tooltip>
-          <div className="mb-3 mt-5 flex flex-wrap items-center gap-x-5 gap-y-2">
-            <div className="flex items-center gap-x-2">
-              {graph.supportsFederation ? (
-                <Component2Icon className="h-4 w-4 text-[#0284C7]" />
-              ) : (
-                <LuSquareDot className="h-4 w-4 text-[#0284C7]" />
-              )}
-              {graph.supportsFederation ? (
-                <p className="text-sm">
-                  {`${formatMetric(graph.connectedSubgraphs)} ${
-                    graph.connectedSubgraphs === 1 ? 'subgraph' : 'subgraphs'
-                  }`}
-                </p>
-              ) : (
-                <p className="text-sm">monograph</p>
-              )}
-            </div>
 
-            <TooltipProvider>
-              <Tooltip delayDuration={100}>
-                <TooltipTrigger>
-                  <div className="flex items-center gap-x-2">
-                    <MdNearbyError className="h-4 w-4 text-destructive" />
-                    <p className="text-sm">{`${formatMetric(totalErrors)} ${
-                      totalErrors === 1 ? 'error' : 'errors'
-                    }`}</p>
-                  </div>
-                </TooltipTrigger>
-                <TooltipContent>{`${totalErrors} errors in the last 4 hours.`}</TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-
-            {graph.contract && (
-              <div className="flex items-center gap-x-2 text-sm">
-                <DocumentArrowDownIcon className="h-4 w-4 text-primary" />
-                Contract
-              </div>
+          <div className="mt-1 w-full text-xs text-muted-foreground">
+            {graph.supportsFederation
+              ? `${formatMetric(graph.connectedSubgraphs)} ${graph.connectedSubgraphs === 1 ? 'subgraph' : 'subgraphs'}`
+              : 'monograph'}{' '}
+            · updated{' '}
+            {graph.lastUpdatedAt ? (
+              <TimeAgo date={getTime(parseISO(graph.lastUpdatedAt))} tooltip={false} compact />
+            ) : (
+              'never'
             )}
           </div>
-          <TooltipProvider>
-            <Tooltip delayDuration={200}>
-              <TooltipTrigger className="flex items-start text-xs">
-                <div className="flex h-4 w-4 items-center justify-center">
+
+          <div className="mt-4 -mx-6 w-[calc(100%+3rem)] overflow-hidden border-y bg-muted/30 text-sm">
+            <div className="grid grid-cols-3 divide-x divide-border">
+              <div className="px-6 py-4">
+                <div className="text-[12px] font-medium tracking-[0px] text-muted-foreground">ERROR RATE</div>
+                <div
+                  className={cn(
+                    'mt-2 text-2xl font-semibold tabular-nums',
+                    isHealthy ? 'text-[#6e677e] dark:text-muted-foreground' : 'text-destructive',
+                  )}
+                >
+                  {`${errorRatePct.toFixed(0)}%`}
+                </div>
+              </div>
+              <div className="px-6 py-4">
+                <div className="text-[12px] font-medium tracking-[0px] text-muted-foreground">P95 LATENCY</div>
+                <div
+                  className={cn(
+                    'mt-2 text-2xl font-semibold tabular-nums',
+                    p95LatencyTone === 'muted' && 'text-muted-foreground',
+                    p95LatencyTone === 'normal' && 'text-[#6e677e] dark:text-muted-foreground',
+                    // Use a darker yellow in light mode for AA contrast.
+                    p95LatencyTone === 'slow' && 'text-yellow-700 dark:text-yellow-500',
+                    p95LatencyTone === 'critical' && 'text-destructive',
+                  )}
+                  style={p95LatencyTone === 'normal' ? { color: 'rgb(110, 103, 126)' } : undefined}
+                >
+                  {p95LatencyLabel}
+                </div>
+              </div>
+              <div className="px-6 py-4">
+                <div className="text-[12px] font-medium tracking-[0px] text-muted-foreground">RPM</div>
+                <div className="mt-2 text-2xl font-semibold tabular-nums text-[#6e677e] dark:text-muted-foreground">
+                  {rpmLabel}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="mt-5 flex w-full items-center justify-between gap-4 pb-1 text-sm">
+            <div className={cn('flex min-w-0 items-center gap-2', isReady && !isHealthy && 'text-destructive')}>
+              {isReady && !isHealthy ? (
+                <MdNearbyError className="h-4 w-4 shrink-0" />
+              ) : (
+                <div className="flex h-4 w-4 shrink-0 items-center justify-center">
                   <ComposeStatusBulb
                     validGraph={graph.isComposable && !!graph.lastUpdatedAt}
                     emptyGraph={!graph.lastUpdatedAt && !graph.isComposable}
                   />
                 </div>
+              )}
 
-                <p className="ml-1 text-left text-muted-foreground">
-                  {graph.lastUpdatedAt ? (
-                    <>
-                      Schema last updated <TimeAgo date={getTime(parseISO(graph.lastUpdatedAt))} tooltip={false} />
-                    </>
-                  ) : (
-                    'Not ready'
-                  )}
-                </p>
-              </TooltipTrigger>
-              <TooltipContent>
-                <ComposeStatusMessage
-                  isComposable={graph.isComposable}
-                  lastUpdatedAt={graph.lastUpdatedAt}
-                  subgraphsCount={graph.connectedSubgraphs}
-                  isContract={!!graph.contract}
-                />
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+              <div className={cn('min-w-0 truncate', isReady && isHealthy && 'text-muted-foreground')}>
+                {statusText}
+                {isReady && !isHealthy && (
+                  <span className="text-destructive">{` · ${errorRatePct.toFixed(0)}% error rate`}</span>
+                )}
+              </div>
+            </div>
+
+            <button
+              type="button"
+              className="shrink-0 font-medium text-primary underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                router.push(primaryCta.href);
+              }}
+            >
+              {primaryCta.label}
+            </button>
+          </div>
         </div>
       </Card>
-    </Link>
+    </div>
   );
 };
 

--- a/studio/src/components/graph-visualization.tsx
+++ b/studio/src/components/graph-visualization.tsx
@@ -297,6 +297,16 @@ function GraphVisualization({
   const [nodeStates, setNodeStates, onNodesChange] = useNodesState(nodes);
   const [edgeStates, setEdgeStates, onEdgesChange] = useEdgesState(edges);
 
+  const handleNodesChange = useCallback(
+    (changes: any[]) => {
+      // Keep the selected node highlighted even when clicking on the pane.
+      // ReactFlow emits `select` changes on pane click; we ignore them if we already have a selected node.
+      const nextChanges = selectedNodeId ? changes.filter((c) => c.type !== 'select') : changes;
+      onNodesChange(nextChanges);
+    },
+    [onNodesChange, selectedNodeId],
+  );
+
   const onConnect = useCallback(
     (params: Edge) =>
       setEdges((eds) => addEdge({ ...params, type: ConnectionLineType.SmoothStep, animated: true }, eds)),
@@ -316,7 +326,14 @@ function GraphVisualization({
     if (!graphWrapperRef.current) return;
 
     const duration = 500;
-    const padding = 0.45;
+    const padding = isDrawerOpen ? 0.45 : defaultZoom.padding;
+
+    // When closing, behave like clicking \"Re-center\" (fit container again).
+    if (!isDrawerOpen) {
+      reactFlowInstance.fitView({ ...defaultZoom, padding, duration });
+      return;
+    }
+
     const wrapperWidth = graphWrapperRef.current.clientWidth;
     const wrapperHeight = graphWrapperRef.current.clientHeight;
     const drawerWidth = Math.min(wrapperWidth * 0.4, 460);
@@ -331,7 +348,7 @@ function GraphVisualization({
       padding,
     });
 
-    const targetVp = isDrawerOpen ? { ...baseVp, x: baseVp.x - drawerWidth / 2 } : baseVp;
+    const targetVp = { ...baseVp, x: baseVp.x - drawerWidth / 2 };
     reactFlowInstance.setViewport(targetVp, { duration });
   }, [isDrawerOpen, nodesInitialized, reactFlowInstance, nodeStates]);
 
@@ -345,11 +362,24 @@ function GraphVisualization({
     return () => window.removeEventListener('keydown', onKeyDown);
   }, [isDrawerOpen]);
 
+  // When drawer closes, clear node selection highlight.
   useEffect(() => {
-    setNodeStates(nodes);
+    if (!isDrawerOpen) {
+      setSelectedNodeId(null);
+    }
+  }, [isDrawerOpen]);
+
+  useEffect(() => {
+    // When layout updates, preserve the selected node highlight.
+    setNodeStates(
+      nodes.map((n) => ({
+        ...n,
+        selected: selectedNodeId ? n.id === selectedNodeId : false,
+      })),
+    );
     setEdgeStates(edges);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [nodes, edges]);
+  }, [nodes, edges, selectedNodeId]);
 
   useEffect(() => {
     if (nodesInitialized) {
@@ -409,7 +439,7 @@ function GraphVisualization({
         <ReactFlow
           nodes={nodeStates}
           edges={edgeStates}
-          onNodesChange={onNodesChange}
+          onNodesChange={handleNodesChange}
           onEdgesChange={onEdgesChange}
           onNodeClick={(_, node) => {
             if (node?.data?.kind !== 'subgraph') return;

--- a/studio/src/components/graph-visualization.tsx
+++ b/studio/src/components/graph-visualization.tsx
@@ -4,7 +4,7 @@ import {
   Subgraph,
   SubgraphMetrics,
 } from '@wundergraph/cosmo-connect/dist/platform/v1/platform_pb';
-import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import ReactFlow, {
   addEdge,
   Background,
@@ -24,12 +24,21 @@ import { ArrowsPointingInIcon } from '@heroicons/react/24/outline';
 import 'reactflow/dist/style.css';
 import { GraphContext } from './layout/graph-layout';
 import ReactFlowGraphNode from './reactflow-graph-node';
-import { buttonVariants } from './ui/button';
+import { Button, buttonVariants } from './ui/button';
 import SubgraphMetricsEdge from '@/components/reactflow-metrics-edge';
 import { useDateRangeQueryState } from '@/components/analytics/useAnalyticsQueryState';
 import { Tabs, TabsList, TabsTrigger } from './ui/tabs';
 import { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectTrigger, SelectValue } from './ui/select';
 import { sentenceCase } from 'change-case';
+import { useQuery } from '@connectrpc/connect-query';
+import { getSubgraphMetricsErrorRate } from '@wundergraph/cosmo-connect/dist/platform/v1/platform-PlatformService_connectquery';
+import { useRouter } from 'next/router';
+import { useWorkspace } from '@/hooks/use-workspace';
+import { useCurrentOrganization } from '@/hooks/use-current-organization';
+import { Badge } from './ui/badge';
+import { Cross2Icon } from '@radix-ui/react-icons';
+import Link from 'next/link';
+import { formatDistanceToNow } from 'date-fns';
 
 export interface Graph {
   id: string;
@@ -48,21 +57,87 @@ const edgeTypes = { metricsEdge: SubgraphMetricsEdge };
 const defaultZoom = {
   minZoom: 0.7,
   maxZoom: 2,
-  padding: 0.3,
+  padding: 0.4,
+};
+
+const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value));
+
+const getBounds = (nodes: Node[]) => {
+  let minX = Number.POSITIVE_INFINITY;
+  let minY = Number.POSITIVE_INFINITY;
+  let maxX = Number.NEGATIVE_INFINITY;
+  let maxY = Number.NEGATIVE_INFINITY;
+
+  for (const n of nodes) {
+    const w = n.width ?? nodeWidth;
+    const h = n.height ?? nodeHeight;
+    const x = n.position?.x ?? 0;
+    const y = n.position?.y ?? 0;
+    minX = Math.min(minX, x);
+    minY = Math.min(minY, y);
+    maxX = Math.max(maxX, x + w);
+    maxY = Math.max(maxY, y + h);
+  }
+
+  if (!Number.isFinite(minX)) return { minX: 0, minY: 0, maxX: 0, maxY: 0 };
+  return { minX, minY, maxX, maxY };
+};
+
+const viewportForBounds = ({
+  bounds,
+  width,
+  height,
+  minZoom,
+  maxZoom,
+  padding,
+}: {
+  bounds: { minX: number; minY: number; maxX: number; maxY: number };
+  width: number;
+  height: number;
+  minZoom: number;
+  maxZoom: number;
+  padding: number;
+}) => {
+  const bw = Math.max(1, bounds.maxX - bounds.minX);
+  const bh = Math.max(1, bounds.maxY - bounds.minY);
+  const pad = 1 + padding * 2;
+  const zoom = clamp(Math.min(width / (bw * pad), height / (bh * pad)), minZoom, maxZoom);
+  const x = (width - bw * zoom) / 2 - bounds.minX * zoom;
+  const y = (height - bh * zoom) / 2 - bounds.minY * zoom;
+  return { x, y, zoom };
+};
+
+const Sparkline = ({ values }: { values: number[] }) => {
+  const width = 180;
+  const height = 36;
+  const px = 2;
+  const py = 2;
+
+  if (!values.length) {
+    return <div className="h-10 w-full rounded-md bg-muted/30" />;
+  }
+
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const span = Math.max(1e-9, max - min);
+
+  const toX = (i: number) => px + (i * (width - px * 2)) / Math.max(1, values.length - 1);
+  const toY = (v: number) => py + (height - py * 2) - ((v - min) / span) * (height - py * 2);
+
+  const d = values.map((v, i) => `${i === 0 ? 'M' : 'L'} ${toX(i).toFixed(2)} ${toY(v).toFixed(2)}`).join(' ');
+
+  return (
+    <svg viewBox={`0 0 ${width} ${height}`} className="h-10 w-full">
+      <path d={d} fill="none" stroke="hsl(var(--destructive))" strokeWidth="1.75" opacity="0.9" />
+    </svg>
+  );
 };
 
 const getLayoutedElements = (dagreGraph: dagre.graphlib.Graph, nodes: Node[], edges: Edge[]) => {
-  dagreGraph.setGraph({
-    rankdir: 'LR',
-    nodesep: 30,
-    ranksep: 20,
-  });
+  dagreGraph.setGraph({ rankdir: 'LR', nodesep: 30, ranksep: 20 });
 
   nodes.forEach((node) => {
-    dagreGraph.setNode(node.id, {
-      width: nodeWidth,
-      height: nodeHeight,
-    });
+    dagreGraph.setNode(node.id, { width: nodeWidth, height: nodeHeight });
   });
 
   edges.forEach((edge) => {
@@ -75,14 +150,10 @@ const getLayoutedElements = (dagreGraph: dagre.graphlib.Graph, nodes: Node[], ed
     const nodeWithPosition = dagreGraph.node(node.id);
     node.targetPosition = Position.Top;
     node.sourcePosition = Position.Bottom;
-
-    // We are shifting the dagre node position (anchor=center center) to the top left
-    // so it matches the React Flow node anchor point (top left).
     node.position = {
       x: nodeWithPosition.x - nodeWidth / 2,
       y: nodeWithPosition.y - nodeHeight / 2,
     };
-
     return node;
   });
 
@@ -102,12 +173,21 @@ function GraphVisualization({
   const reactFlowInstance = useReactFlow();
   const nodesInitialized = useNodesInitialized();
   const dr = useDateRangeQueryState();
+  const router = useRouter();
+  const {
+    namespace: { name: namespace },
+  } = useWorkspace();
+  const organizationSlug = useCurrentOrganization()?.slug;
+  const graphSlug = router.query.slug as string | undefined;
 
   const [nodes, setNodes] = useState<Node[]>([]);
   const [edges, setEdges] = useState<Edge[]>([]);
-
   const [showAll, setShowAll] = useState(false);
   const [topCategory, setTopCategory] = useState('latency');
+  const [selectedSubgraphName, setSelectedSubgraphName] = useState<string | null>(null);
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const graphWrapperRef = useRef<HTMLDivElement | null>(null);
 
   const subgraphs = useMemo(() => {
     let tempSubgraphs = [...(graphData?.subgraphs ?? [])];
@@ -115,25 +195,13 @@ function GraphVisualization({
     tempSubgraphs.sort((a, b) => {
       const metricA = subgraphMetrics?.find((x) => x.subgraphID === a.id);
       const metricB = subgraphMetrics?.find((x) => x.subgraphID === b.id);
-
-      if (!metricA || !metricB) {
-        return 0;
-      }
-
-      if (topCategory === 'latency') {
-        return metricB.latency - metricA.latency;
-      }
-      if (topCategory === 'errorRate') {
-        return metricB.errorRate - metricA.errorRate;
-      }
-
+      if (!metricA || !metricB) return 0;
+      if (topCategory === 'latency') return metricB.latency - metricA.latency;
+      if (topCategory === 'errorRate') return metricB.errorRate - metricA.errorRate;
       return metricB.requestRate - metricA.requestRate;
     });
 
-    if (!showAll) {
-      tempSubgraphs = tempSubgraphs.slice(0, 5);
-    }
-
+    if (!showAll) tempSubgraphs = tempSubgraphs.slice(0, 5);
     return tempSubgraphs;
   }, [showAll, topCategory, graphData?.subgraphs, subgraphMetrics]);
 
@@ -142,7 +210,6 @@ function GraphVisualization({
 
     const buildGraphs = (subgraphs: Subgraph[]): Graph[] => {
       const rootName = supportsFederation ? graphData.graph?.name : 'router';
-
       const graphs: Graph[] = [
         {
           id: `root-${rootName}`,
@@ -165,10 +232,10 @@ function GraphVisualization({
       return graphs;
     };
 
-    let graphs = buildGraphs(subgraphs);
+    const graphs = buildGraphs(subgraphs);
 
-    const buildNodes = (spans: Graph[]): Node[] => {
-      return spans.map((span, index) => {
+    const buildNodes = (spans: Graph[]): Node[] =>
+      spans.map((span) => {
         if (span.kind === 'graph') {
           return {
             id: span.id,
@@ -182,10 +249,7 @@ function GraphVisualization({
             },
             connectable: false,
             deletable: false,
-            position: {
-              x: 0,
-              y: 0,
-            },
+            position: { x: 0, y: 0 },
           };
         }
         const sm = subgraphMetrics?.find((x) => x.subgraphID === span.subgraphId);
@@ -201,18 +265,14 @@ function GraphVisualization({
           },
           connectable: false,
           deletable: false,
-          position: {
-            x: 0,
-            y: 0,
-          },
+          position: { x: 0, y: 0 },
         };
       });
-    };
 
-    const buildEdges = (spans: Graph[]): Edge[] => {
-      return spans
+    const buildEdges = (spans: Graph[]): Edge[] =>
+      spans
         .filter((s) => !!s.parentId)
-        .map((span, index) => {
+        .map((span) => {
           const sm = subgraphMetrics?.find((x) => x.subgraphID === span.subgraphId);
           return {
             id: span.id,
@@ -220,30 +280,16 @@ function GraphVisualization({
             animated: true,
             target: span.id,
             type: 'metricsEdge',
-            data: {
-              latency: sm?.latency,
-            },
+            data: { latency: sm?.latency },
           };
         });
-    };
 
-    if (!graphs.length) {
-      return;
-    }
+    if (!graphs.length) return;
 
-    const n = buildNodes(graphs);
-    const e = buildEdges(graphs);
-
-    // Create a new directed graph per graph
-    // otherwise a single graph will contain all nodes and edges from all graphs
-    // this will cause the layout to be incorrect when not all nodes and edges have unique ids
     const dagreGraph = new dagre.graphlib.Graph();
-    dagreGraph.setDefaultEdgeLabel(function () {
-      return { minlen: 5, weight: 1 };
-    });
+    dagreGraph.setDefaultEdgeLabel(() => ({ minlen: 5, weight: 1 }));
 
-    const { nodes: layoutedNodes, edges: layoutedEdges } = getLayoutedElements(dagreGraph, n, e);
-
+    const { nodes: layoutedNodes, edges: layoutedEdges } = getLayoutedElements(dagreGraph, buildNodes(graphs), buildEdges(graphs));
     setNodes(layoutedNodes);
     setEdges(layoutedEdges);
   }, [graphData?.graph, subgraphs, subgraphMetrics, federatedGraphMetrics, supportsFederation]);
@@ -256,6 +302,48 @@ function GraphVisualization({
       setEdges((eds) => addEdge({ ...params, type: ConnectionLineType.SmoothStep, animated: true }, eds)),
     [],
   );
+
+  // Sync selected state onto nodes
+  useEffect(() => {
+    setNodeStates((prev) =>
+      prev.map((n) => ({ ...n, selected: selectedNodeId ? n.id === selectedNodeId : false })),
+    );
+  }, [selectedNodeId, setNodeStates]);
+
+  // Animate viewport when drawer opens/closes
+  useEffect(() => {
+    if (!nodesInitialized) return;
+    if (!graphWrapperRef.current) return;
+
+    const duration = 500;
+    const padding = 0.45;
+    const wrapperWidth = graphWrapperRef.current.clientWidth;
+    const wrapperHeight = graphWrapperRef.current.clientHeight;
+    const drawerWidth = Math.min(wrapperWidth * 0.4, 460);
+
+    const bounds = getBounds(nodeStates);
+    const baseVp = viewportForBounds({
+      bounds,
+      width: wrapperWidth,
+      height: wrapperHeight,
+      minZoom: defaultZoom.minZoom,
+      maxZoom: defaultZoom.maxZoom,
+      padding,
+    });
+
+    const targetVp = isDrawerOpen ? { ...baseVp, x: baseVp.x - drawerWidth / 2 } : baseVp;
+    reactFlowInstance.setViewport(targetVp, { duration });
+  }, [isDrawerOpen, nodesInitialized, reactFlowInstance, nodeStates]);
+
+  // Close on Esc
+  useEffect(() => {
+    if (!isDrawerOpen) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setIsDrawerOpen(false);
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [isDrawerOpen]);
 
   useEffect(() => {
     setNodeStates(nodes);
@@ -270,70 +358,270 @@ function GraphVisualization({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [nodesInitialized]);
 
+  // Drawer data
+  const selectedSubgraph = useMemo(
+    () => graphData?.subgraphs?.find((s) => s.name === selectedSubgraphName),
+    [graphData?.subgraphs, selectedSubgraphName],
+  );
+
+  const selectedSubgraphMetrics = useMemo(
+    () => subgraphMetrics?.find((m) => m.subgraphID === selectedSubgraph?.id),
+    [selectedSubgraph?.id, subgraphMetrics],
+  );
+
+  const { data: errorRateSeriesData } = useQuery(
+    getSubgraphMetricsErrorRate,
+    { subgraphName: selectedSubgraph?.name ?? '', namespace, range: 1, filters: [] },
+    { enabled: Boolean(isDrawerOpen && selectedSubgraph?.name) },
+  );
+
+  const last1hErrorRateValues = useMemo(
+    () => (errorRateSeriesData?.series ?? []).map((p) => Number(p.errorRate ?? 0)),
+    [errorRateSeriesData?.series],
+  );
+
+  const compositionLabel = useMemo(() => {
+    const compositionId = graphData?.graph?.compositionId;
+    const lastUpdatedAt = graphData?.graph?.lastUpdatedAt;
+    if (!compositionId) return undefined;
+    const short = compositionId.split('-')[0];
+    const ago = lastUpdatedAt ? formatDistanceToNow(new Date(lastUpdatedAt), { addSuffix: true }) : undefined;
+    return ago ? `${short} · ${ago}` : short;
+  }, [graphData?.graph?.compositionId, graphData?.graph?.lastUpdatedAt]);
+
+  const isHealthy = Number(selectedSubgraphMetrics?.errorRate ?? 0) === 0;
+
+  const analyticsHref =
+    organizationSlug && namespace && selectedSubgraph?.name && graphSlug
+      ? `/${organizationSlug}/${namespace}/subgraph/${encodeURIComponent(selectedSubgraph.name)}/analytics?graph=${encodeURIComponent(graphSlug)}`
+      : '#';
+
+  const schemaHref =
+    organizationSlug && namespace && selectedSubgraph?.name && graphSlug
+      ? `/${organizationSlug}/${namespace}/subgraph/${encodeURIComponent(selectedSubgraph.name)}/schema?graph=${encodeURIComponent(graphSlug)}`
+      : '#';
+
+  const canNavigate = Boolean(organizationSlug && namespace && selectedSubgraph?.name && graphSlug);
+
   return (
-    <ReactFlow
-      nodes={nodeStates}
-      edges={edgeStates}
-      onNodesChange={onNodesChange}
-      onEdgesChange={onEdgesChange}
-      onConnect={onConnect as any}
-      fitView={true}
-      fitViewOptions={defaultZoom}
-      connectionLineType={ConnectionLineType.SmoothStep}
-      proOptions={{ hideAttribution: true }}
-      attributionPosition="top-right"
-      nodeTypes={nodeTypes}
-      edgeTypes={edgeTypes}
-    >
-      <Background />
-      <Panel position="top-left" className="flex w-full flex-wrap items-center justify-between gap-2 pr-8">
-        <div>
-          <h2 className="flex items-center gap-x-2">
-            <span className="font-semibold leading-none tracking-tight">Graph Metrics</span>
-          </h2>
-          <span className="text-xs text-muted-foreground">Latency & Request Per Minute (RPM)</span>
-        </div>
-        <div className="flex items-center gap-x-2">
-          <Tabs
-            defaultValue="top"
-            onValueChange={(v) => {
-              if (v === 'all') {
-                setShowAll(true);
-              } else {
-                setShowAll(false);
-              }
-            }}
-          >
-            <TabsList>
-              <TabsTrigger value="top">Top 5</TabsTrigger>
-              <TabsTrigger value="all">All</TabsTrigger>
-            </TabsList>
-          </Tabs>
-          <Select onValueChange={(v) => setTopCategory(v)}>
-            <SelectTrigger className="w-[180px] bg-background">
-              <SelectValue>{sentenceCase(topCategory)}</SelectValue>
-            </SelectTrigger>
-            <SelectContent>
-              <SelectGroup>
-                <SelectLabel>Sort by</SelectLabel>
-                <SelectItem value="latency">Latency</SelectItem>
-                <SelectItem value="requestRate">Request Rate</SelectItem>
-                <SelectItem value="errorRate">Error Rate</SelectItem>
-              </SelectGroup>
-            </SelectContent>
-          </Select>
-        </div>
-      </Panel>
-      <Panel position="bottom-left" className="space-y-4" onClick={() => reactFlowInstance.fitView(defaultZoom)}>
-        <ArrowsPointingInIcon
+    <>
+      <div ref={graphWrapperRef} className="relative h-full overflow-hidden rounded-lg">
+        <ReactFlow
+          nodes={nodeStates}
+          edges={edgeStates}
+          onNodesChange={onNodesChange}
+          onEdgesChange={onEdgesChange}
+          onNodeClick={(_, node) => {
+            if (node?.data?.kind !== 'subgraph') return;
+            const subgraphName = node.data.label as string | undefined;
+            if (!subgraphName) return;
+            setSelectedNodeId(node.id);
+            setSelectedSubgraphName(subgraphName);
+            setIsDrawerOpen(true);
+          }}
+          onConnect={onConnect as any}
+          fitView={true}
+          fitViewOptions={defaultZoom}
+          connectionLineType={ConnectionLineType.SmoothStep}
+          proOptions={{ hideAttribution: true }}
+          attributionPosition="top-right"
+          nodeTypes={nodeTypes}
+          edgeTypes={edgeTypes}
+          className="h-full"
+        >
+          <Background />
+
+          {/* Top gradient scrim */}
+          <div className="pointer-events-none absolute left-0 top-0 z-[4] h-16 w-full">
+            <div className="h-full w-full rounded-t-lg bg-gradient-to-b from-background/90 via-background/60 to-transparent backdrop-blur-sm" />
+          </div>
+
+          {/* Header */}
+          <Panel position="top-left" className="relative !z-20 flex w-full flex-wrap items-center justify-between gap-2 pr-8">
+            <div>
+              <h2 className="flex items-center gap-x-2">
+                <span className="font-semibold leading-none tracking-tight">Graph Metrics</span>
+              </h2>
+              <span className="text-xs text-muted-foreground">Latency & Request Per Minute (RPM)</span>
+            </div>
+            <div className="flex items-center gap-x-2">
+              <Tabs
+                defaultValue="top"
+                onValueChange={(v) => setShowAll(v === 'all')}
+              >
+                <TabsList>
+                  <TabsTrigger value="top">Top 5</TabsTrigger>
+                  <TabsTrigger value="all">All</TabsTrigger>
+                </TabsList>
+              </Tabs>
+              <Select onValueChange={(v) => setTopCategory(v)}>
+                <SelectTrigger className="w-[180px] bg-background">
+                  <SelectValue>{sentenceCase(topCategory)}</SelectValue>
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectGroup>
+                    <SelectLabel>Sort by</SelectLabel>
+                    <SelectItem value="latency">Latency</SelectItem>
+                    <SelectItem value="requestRate">Request Rate</SelectItem>
+                    <SelectItem value="errorRate">Error Rate</SelectItem>
+                  </SelectGroup>
+                </SelectContent>
+              </Select>
+            </div>
+          </Panel>
+
+          {/* Re-center */}
+          <Panel position="bottom-left" className="space-y-4">
+            <button
+              type="button"
+              onClick={() => reactFlowInstance.fitView(defaultZoom)}
+              className={cn(buttonVariants({ variant: 'secondary' }), 'h-8 px-2 text-xs')}
+              aria-label="Re-center"
+              title="Re-center"
+            >
+              <ArrowsPointingInIcon className="h-4 w-4" />
+              <span className="ml-2 hidden sm:inline">Re-center</span>
+            </button>
+          </Panel>
+        </ReactFlow>
+
+        {/* In-card drawer */}
+        <div
+          aria-hidden={!isDrawerOpen}
           className={cn(
-            buttonVariants({ variant: 'secondary', size: 'icon' }),
-            'h-8 w-8 shrink-0 cursor-pointer select-none p-1.5',
+            'absolute inset-y-0 right-0 z-30 w-2/5 min-w-[280px] max-w-[460px] border-l bg-card/95 p-5 backdrop-blur-sm',
+            'transition-transform duration-500 ease-in-out',
+            isDrawerOpen ? 'translate-x-0' : 'translate-x-full pointer-events-none',
           )}
-          title="Center"
-        />
-      </Panel>
-    </ReactFlow>
+        >
+          <div className="flex h-full flex-col gap-4">
+
+            {/* Drawer header */}
+            <div className="flex items-start justify-between gap-3">
+              <h3 className="truncate text-lg font-semibold text-foreground">
+                {selectedSubgraph?.name ?? 'Subgraph'}
+              </h3>
+              <div className="flex shrink-0 items-center gap-2">
+                <Badge
+                  className="tracking-[0.44px]"
+                  variant={isHealthy ? 'success' : 'destructive'}
+                >
+                  {isHealthy ? 'Healthy' : 'Degraded'}
+                </Badge>
+                <button
+                  type="button"
+                  onClick={() => setIsDrawerOpen(false)}
+                  className="rounded-md p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+                  aria-label="Close"
+                >
+                  <Cross2Icon className="h-4 w-4" />
+                </button>
+              </div>
+            </div>
+
+            {/* Scrollable body */}
+            <div className="flex flex-1 flex-col gap-4 overflow-y-auto pr-1">
+
+              {/* Last 1h error rate + sparkline */}
+              <div className="flex h-[68px] items-center gap-5 self-stretch rounded-lg bg-muted/30 p-3.5">
+                <div className="flex w-[97px] flex-col gap-[3px]">
+                  <div className="text-xs text-muted-foreground">Last 1h error rate</div>
+                  <div className="text-base font-medium text-foreground">
+                    {last1hErrorRateValues.length
+                      ? `${last1hErrorRateValues[last1hErrorRateValues.length - 1]!.toFixed(4)} RPM`
+                      : '—'}
+                  </div>
+                </div>
+                <div className="flex flex-1 items-center self-stretch">
+                  <Sparkline values={last1hErrorRateValues} />
+                </div>
+              </div>
+
+              {/* 2×2 metrics */}
+              <div className="relative self-stretch rounded-lg bg-muted/30 p-3.5 text-sm">
+                <div className="absolute inset-x-3.5 top-1/2 h-px bg-border" />
+                <div className="absolute inset-y-3.5 left-1/2 w-px bg-border" />
+                <div className="grid grid-cols-2 gap-y-2.5">
+                  <div className="flex flex-col gap-[3px]">
+                    <div className="text-xs text-muted-foreground">Success RPM</div>
+                    <div className="text-base font-medium text-foreground">
+                      {Math.max(
+                        0,
+                        Number(selectedSubgraphMetrics?.requestRate ?? 0) - Number(selectedSubgraphMetrics?.errorRate ?? 0),
+                      ).toFixed(3)}
+                    </div>
+                  </div>
+                  <div className="flex flex-col gap-[3px] pl-3.5">
+                    <div className="text-xs text-muted-foreground">Error RPM</div>
+                    <div className="text-base font-medium text-foreground">
+                      {Number(selectedSubgraphMetrics?.errorRate ?? 0).toFixed(3)}
+                    </div>
+                  </div>
+                  <div className="flex flex-col gap-[3px] pt-2.5">
+                    <div className="text-xs text-muted-foreground">p95 Latency</div>
+                    <div className="text-base font-medium text-foreground">
+                      {selectedSubgraphMetrics?.latency
+                        ? `${Number(selectedSubgraphMetrics.latency).toFixed(2)} ms`
+                        : '—'}
+                    </div>
+                  </div>
+                  <div className="flex flex-col gap-[3px] pl-3.5 pt-2.5">
+                    <div className="text-xs text-muted-foreground">Error %</div>
+                    <div className="text-base font-medium text-foreground">
+                      {(() => {
+                        const req = Number(selectedSubgraphMetrics?.requestRate ?? 0);
+                        const err = Number(selectedSubgraphMetrics?.errorRate ?? 0);
+                        if (!req) return '0.00%';
+                        return `${((err / req) * 100).toFixed(2)}%`;
+                      })()}
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              {/* Metadata */}
+              <div className="flex flex-col gap-2">
+                <div className="flex items-center justify-between text-xs">
+                  <span className="text-muted-foreground">ID</span>
+                  <span className="font-mono text-foreground">
+                    {selectedSubgraph?.id ? `…${selectedSubgraph.id.slice(-9)}` : '—'}
+                  </span>
+                </div>
+                <div className="h-px w-full bg-border" />
+                <div className="flex items-center justify-between gap-3 text-xs">
+                  <span className="text-muted-foreground">Routing URL</span>
+                  <span className="truncate text-foreground">{selectedSubgraph?.routingURL ?? '—'}</span>
+                </div>
+                <div className="h-px w-full bg-border" />
+                <div className="flex items-center justify-between gap-3 text-xs">
+                  <span className="text-muted-foreground">Last composition</span>
+                  {compositionLabel ? (
+                    <span className="flex items-center gap-1 text-foreground">
+                      <span className="font-mono">{compositionLabel.split(' · ')[0]}</span>
+                      <span>•</span>
+                      <span>{compositionLabel.split(' · ')[1] ?? ''}</span>
+                    </span>
+                  ) : (
+                    <span className="text-foreground">—</span>
+                  )}
+                </div>
+                <div className="h-px w-full bg-border" />
+              </div>
+
+              {/* Action buttons */}
+              <div className="mt-auto flex flex-col gap-2 pb-1">
+                <Button asChild variant="default" disabled={!canNavigate}>
+                  <Link href={analyticsHref}>View full Analytics</Link>
+                </Button>
+                <Button asChild variant="secondary" disabled={!canNavigate}>
+                  <Link href={schemaHref}>View Schema</Link>
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
   );
 }
 

--- a/studio/src/components/layout/graph-layout.tsx
+++ b/studio/src/components/layout/graph-layout.tsx
@@ -29,7 +29,8 @@ import { Link } from '../ui/link';
 import { Loader } from '../ui/loader';
 import { PageHeader } from './head';
 import { LayoutProps } from './layout';
-import { NavLink, SideNav } from './sidenav';
+import { NavChild, NavLink, SideNav } from './sidenav';
+import { buildGraphSideNavLinks } from './graph-sidenav-links';
 import { useFeature } from '@/hooks/use-feature';
 import { WorkspaceSelector } from '@/components/dashboard/workspace-selector';
 import { useWorkspace } from '@/hooks/use-workspace';
@@ -64,98 +65,16 @@ const GraphLayoutSidebarNavigation = ({ organizationSlug, namespace, slug }: Gra
   const links: NavLink[] = useMemo(() => {
     const basePath = `/${organizationSlug}/${namespace}/graph/${slug}`;
 
-    const graphLinks = [
-      {
-        title: 'Overview',
-        href: basePath,
-        icon: <HomeIcon className="h-4 w-4" />,
-      },
-      {
-        title: 'Subgraphs',
-        href: basePath + '/subgraphs',
-        icon: <Component2Icon className="h-4 w-4" />,
-      },
-      {
-        title: 'Feature Flags',
-        href: basePath + '/feature-flags',
-        icon: <MdOutlineFeaturedPlayList className="h-4 w-4" />,
-        matchExact: false,
-      },
-      {
-        title: 'Playground',
-        href: basePath + '/playground',
-        icon: <PlayIcon className="h-4 w-4" />,
-      },
-      {
-        title: 'Schema',
-        href: basePath + '/schema',
-        matchExact: false,
-        icon: <FileTextIcon className="h-4 w-4" />,
-      },
-      {
-        title: 'Analytics',
-        href: basePath + '/analytics',
-        matchExact: false,
-        icon: <ChartBarIcon className="h-4 w-4" />,
-      },
-      {
-        title: 'Operations',
-        href: basePath + '/operations',
-        matchExact: false,
-        icon: <CommandLineIcon className="h-4 w-4" />,
-      },
-      {
-        title: 'Routers',
-        href: basePath + '/routers',
-        matchExact: false,
-        icon: <ServerStackIcon className="h-4 w-4" />,
-      },
-      {
-        title: 'Compositions',
-        href: basePath + '/compositions',
-        matchExact: false,
-        icon: <PiCubeFocus className="h-4 w-4" />,
-      },
-      {
-        title: 'Clients',
-        href: basePath + '/clients',
-        icon: <PiDevices className="h-4 w-4" />,
-      },
-      {
-        title: 'Changelog',
-        href: basePath + '/changelog',
-        icon: <PiGitBranch className="h-4 w-4" />,
-      },
-      {
-        title: 'Checks',
-        href: basePath + '/checks',
-        matchExact: false,
-        icon: <CheckCircledIcon className="h-4 w-4" />,
-      },
-      {
-        title: 'Overrides',
-        href: basePath + '/overrides',
-        matchExact: true,
-        icon: <PiToggleRight className="h-4 w-4" />,
-      },
-      {
-        title: 'Cache Operations',
-        href: basePath + '/cache-operations',
-        matchExact: false,
-        icon: <PiBracketsCurlyBold className="h-4 w-4" />,
-      },
+    const subgraphChildren: NavChild[] = [
+      { title: 'All subgraphs', href: basePath + '/subgraphs' },
+      { title: 'Featured', href: basePath + '/subgraphs?tab=featureSubgraphs' },
     ];
 
-    if (proposalsFeature?.enabled) {
-      graphLinks.push({
-        title: 'Proposals',
-        href: basePath + '/proposals',
-        matchExact: false,
-        icon: <ClipboardIcon className="h-4 w-4" />,
-      });
-    }
-
-    return graphLinks;
+    return buildGraphSideNavLinks({
+      basePath,
+      proposalsEnabled: Boolean(proposalsFeature?.enabled),
+      subgraphChildren,
+    });
   }, [organizationSlug, namespace, slug, proposalsFeature]);
 
   return <SideNav links={links} />;

--- a/studio/src/components/layout/graph-sidenav-links.tsx
+++ b/studio/src/components/layout/graph-sidenav-links.tsx
@@ -1,0 +1,120 @@
+import {
+  ChartBarIcon,
+  ClipboardIcon,
+  CommandLineIcon,
+  ServerStackIcon,
+} from '@heroicons/react/24/outline';
+import {
+  CheckCircledIcon,
+  Component2Icon,
+  FileTextIcon,
+  HomeIcon,
+  PlayIcon,
+} from '@radix-ui/react-icons';
+import { MdOutlineFeaturedPlayList } from 'react-icons/md';
+import { PiBracketsCurlyBold, PiCubeFocus, PiDevices, PiGitBranch, PiToggleRight } from 'react-icons/pi';
+import { NavChild, NavLink } from './sidenav';
+
+export const buildGraphSideNavLinks = ({
+  basePath,
+  proposalsEnabled,
+  subgraphChildren,
+}: {
+  basePath: string;
+  proposalsEnabled: boolean;
+  subgraphChildren: NavChild[];
+}): NavLink[] => {
+  const graphLinks: NavLink[] = [
+    {
+      title: 'Overview',
+      href: basePath,
+      icon: <HomeIcon className="h-4 w-4" />,
+    },
+    {
+      title: 'Subgraphs',
+      href: basePath + '/subgraphs',
+      icon: <Component2Icon className="h-4 w-4" />,
+      children: subgraphChildren,
+    },
+    {
+      title: 'Feature Flags',
+      href: basePath + '/feature-flags',
+      icon: <MdOutlineFeaturedPlayList className="h-4 w-4" />,
+      matchExact: false,
+    },
+    {
+      title: 'Playground',
+      href: basePath + '/playground',
+      icon: <PlayIcon className="h-4 w-4" />,
+    },
+    {
+      title: 'Schema',
+      href: basePath + '/schema',
+      matchExact: false,
+      icon: <FileTextIcon className="h-4 w-4" />,
+    },
+    {
+      title: 'Analytics',
+      href: basePath + '/analytics',
+      matchExact: false,
+      icon: <ChartBarIcon className="h-4 w-4" />,
+    },
+    {
+      title: 'Operations',
+      href: basePath + '/operations',
+      matchExact: false,
+      icon: <CommandLineIcon className="h-4 w-4" />,
+    },
+    {
+      title: 'Routers',
+      href: basePath + '/routers',
+      matchExact: false,
+      icon: <ServerStackIcon className="h-4 w-4" />,
+    },
+    {
+      title: 'Compositions',
+      href: basePath + '/compositions',
+      matchExact: false,
+      icon: <PiCubeFocus className="h-4 w-4" />,
+    },
+    {
+      title: 'Clients',
+      href: basePath + '/clients',
+      icon: <PiDevices className="h-4 w-4" />,
+    },
+    {
+      title: 'Changelog',
+      href: basePath + '/changelog',
+      icon: <PiGitBranch className="h-4 w-4" />,
+    },
+    {
+      title: 'Checks',
+      href: basePath + '/checks',
+      matchExact: false,
+      icon: <CheckCircledIcon className="h-4 w-4" />,
+    },
+    {
+      title: 'Overrides',
+      href: basePath + '/overrides',
+      matchExact: true,
+      icon: <PiToggleRight className="h-4 w-4" />,
+    },
+    {
+      title: 'Cache Operations',
+      href: basePath + '/cache-operations',
+      matchExact: false,
+      icon: <PiBracketsCurlyBold className="h-4 w-4" />,
+    },
+  ];
+
+  if (proposalsEnabled) {
+    graphLinks.push({
+      title: 'Proposals',
+      href: basePath + '/proposals',
+      matchExact: false,
+      icon: <ClipboardIcon className="h-4 w-4" />,
+    });
+  }
+
+  return graphLinks;
+};

--- a/studio/src/components/layout/sidenav.tsx
+++ b/studio/src/components/layout/sidenav.tsx
@@ -1,6 +1,6 @@
 import { docsBaseURL } from '@/lib/constants';
 import { cn } from '@/lib/utils';
-import { CaretSortIcon, Cross2Icon, HamburgerMenuIcon } from '@radix-ui/react-icons';
+import { CaretSortIcon, ChevronDownIcon, Cross2Icon, HamburgerMenuIcon } from '@radix-ui/react-icons';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { ReactNode, useContext, useState } from 'react';
@@ -24,6 +24,11 @@ import {
 } from '../ui/dropdown-menu';
 import NewFeaturesPopup from '../dashboard/NewFeaturesPopup';
 
+export type NavChild = {
+  title: string;
+  href: string;
+};
+
 export type NavLink = {
   title: ReactNode;
   className?: string;
@@ -31,6 +36,7 @@ export type NavLink = {
   matchExact?: boolean;
   icon: ReactNode;
   separator?: boolean;
+  children?: NavChild[];
 };
 
 const isActive = (path: string, currentPath: string, exact = true) => {
@@ -128,6 +134,74 @@ const Organizations = () => {
   );
 };
 
+const ExpandableNavItem = ({ item }: { item: NavLink & { children: NavChild[] } }) => {
+  const router = useRouter();
+  const currentPath = router.asPath.split('?')[0];
+
+  const matchesHref = (targetHref: string) => {
+    const [targetPath, targetQueryString] = targetHref.split('?');
+    if (encodeURI(targetPath) !== currentPath) return false;
+    if (!targetQueryString) return true;
+
+    const targetParams = new URLSearchParams(targetQueryString);
+    for (const [k, v] of targetParams.entries()) {
+      if (router.query[k] !== v) return false;
+    }
+    return true;
+  };
+
+  const isCurrent = isActive(encodeURI(item.href.split('?')[0]), currentPath, item.matchExact);
+  const isChildActive = item.children.some((child) => matchesHref(child.href));
+
+  // Keep \"Subgraphs\" highlighted while viewing a subgraph in graph context.
+  const isSubgraphPageInGraphContext =
+    router.pathname.includes('/subgraph/') && typeof router.query.graph === 'string' && item.title === 'Subgraphs';
+
+  const isHighlighted = isCurrent || isChildActive || isSubgraphPageInGraphContext;
+
+  const [isOpen, setIsOpen] = useState(isChildActive);
+
+  return (
+    <div>
+      <div className={cn('flex items-center rounded-md', isHighlighted && 'bg-accent/80')}>
+        <Link
+          href={item.href}
+          className="flex flex-1 items-center gap-2 rounded-l-md px-3 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground"
+        >
+          {item.icon}
+          <span className={cn('whitespace-nowrap', item.className)}>{item.title}</span>
+        </Link>
+        <button
+          onClick={() => setIsOpen((prev) => !prev)}
+          className="flex h-9 items-center rounded-r-md px-2 py-2 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+          aria-label={isOpen ? 'Collapse' : 'Expand'}
+        >
+          <ChevronDownIcon className={cn('h-3 w-3 transition-transform duration-200', isOpen && 'rotate-180')} />
+        </button>
+      </div>
+      {isOpen && (
+        <div className="ml-7 mt-1 space-y-0.5 border-l pl-2">
+          {item.children.map((child, i) => {
+            const isChildCurrent = matchesHref(child.href);
+            return (
+              <Link
+                key={i}
+                href={child.href}
+                className={cn(
+                  'flex items-center rounded-md px-3 py-1.5 text-sm hover:bg-accent hover:text-accent-foreground',
+                  isChildCurrent ? 'bg-accent/60 font-medium' : 'text-muted-foreground',
+                )}
+              >
+                {child.title}
+              </Link>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};
+
 interface SideNavLayoutProps extends LayoutProps {
   links?: Partial<NavLink>[];
   isBannerDisplayed?: boolean;
@@ -178,9 +252,10 @@ export const SideNav = (props: SideNavLayoutProps) => {
 
               return (
                 <div key={index}>
-                  {item.href ? (
+                  {item.children && item.children.length > 0 ? (
+                    <ExpandableNavItem item={item as NavLink & { children: NavChild[] }} />
+                  ) : item.href ? (
                     <Link
-                      key={index}
                       href={item.href}
                       className={cn(
                         'group flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground',

--- a/studio/src/components/layout/subgraph-layout.tsx
+++ b/studio/src/components/layout/subgraph-layout.tsx
@@ -14,10 +14,14 @@ import { Loader } from '../ui/loader';
 import { TitleLayoutProps } from './graph-layout';
 import { PageHeader } from './head';
 import { LayoutProps } from './layout';
-import { NavLink, SideNav } from './sidenav';
+import { NavChild, NavLink, SideNav } from './sidenav';
 import { WorkspaceSelector } from '@/components/dashboard/workspace-selector';
 import { useWorkspace } from '@/hooks/use-workspace';
 import { useCurrentOrganization } from '@/hooks/use-current-organization';
+import Link from 'next/link';
+import { Tabs, TabsList, TabsTrigger } from '../ui/tabs';
+import { buildGraphSideNavLinks } from './graph-sidenav-links';
+import { useFeature } from '@/hooks/use-feature';
 
 export interface SubgraphContextProps {
   subgraph: GetSubgraphByNameResponse['graph'];
@@ -34,6 +38,8 @@ export const SubgraphLayout = ({ children }: LayoutProps) => {
   } = useWorkspace();
   const organizationSlug = useCurrentOrganization()?.slug;
   const slug = router.query.subgraphSlug as string;
+  const graphName = router.query.graph as string | undefined;
+  const proposalsFeature = useFeature('proposals');
 
   const { data, isLoading, error, refetch } = useQuery(getSubgraphByName, {
     name: slug,
@@ -53,6 +59,21 @@ export const SubgraphLayout = ({ children }: LayoutProps) => {
 
   const links: NavLink[] = useMemo(() => {
     const basePath = `/${organizationSlug}/${namespace}/subgraph/${slug}`;
+
+    // If we have graph context, render the SAME graph sidebar.
+    if (graphName) {
+      const graphBasePath = `/${organizationSlug}/${namespace}/graph/${graphName}`;
+      const subgraphChildren: NavChild[] = [
+        { title: 'All subgraphs', href: graphBasePath + '/subgraphs' },
+        { title: 'Featured', href: graphBasePath + '/subgraphs?tab=featureSubgraphs' },
+      ];
+
+      return buildGraphSideNavLinks({
+        basePath: graphBasePath,
+        proposalsEnabled: Boolean(proposalsFeature?.enabled),
+        subgraphChildren,
+      });
+    }
 
     return [
       {
@@ -77,7 +98,7 @@ export const SubgraphLayout = ({ children }: LayoutProps) => {
         icon: <ChartBarIcon className="h-4 w-4" />,
       },
     ];
-  }, [organizationSlug, namespace, slug]);
+  }, [organizationSlug, namespace, slug, graphName, proposalsFeature]);
 
   let render: React.ReactNode;
 
@@ -138,9 +159,27 @@ export const SubgraphPageLayout = ({
     </>
   );
 
+  const router = useRouter();
+  const organizationSlug = router.query.organizationSlug as string;
+  const namespace = router.query.namespace as string;
+  const subgraphSlug = router.query.subgraphSlug as string;
+  const graphName = router.query.graph as string | undefined;
+
+  const baseSubgraphPath = `/${organizationSlug}/${namespace}/subgraph/${subgraphSlug}`;
+  const querySuffix = graphName ? `?graph=${encodeURIComponent(graphName)}` : '';
+  const pathname = router.asPath.split('?')[0] ?? '';
+  const activeTab =
+    pathname.endsWith('/schema')
+      ? 'schema'
+      : pathname.endsWith('/graphs')
+        ? 'graphs'
+        : pathname.includes('/analytics')
+          ? 'analytics'
+          : 'overview';
+
   return (
     <div className="flex h-[calc(100vh_-_104px)] flex-col lg:h-screen">
-      <div className="flex w-full flex-wrap items-center justify-between gap-4 border-b bg-background py-4">
+      <div className="flex w-full flex-col gap-2 border-b bg-background py-4">
         <div
           className={cn(
             'flex w-full flex-col justify-between gap-y-4 px-4 md:w-auto lg:flex-row lg:items-center lg:px-6 xl:px-8',
@@ -149,7 +188,37 @@ export const SubgraphPageLayout = ({
           <WorkspaceSelector truncateNamespace={false}>{breadcrumb}</WorkspaceSelector>
           {items}
         </div>
-        {toolbar}
+        <div className="flex w-full flex-wrap items-center justify-between gap-4 px-4 lg:px-6 xl:px-8">
+          <Tabs value={activeTab} className="w-full md:w-auto">
+            <TabsList className="grid w-full grid-cols-4">
+              <TabsTrigger value="overview" asChild>
+                <Link href={`${baseSubgraphPath}${querySuffix}`} className="flex items-center gap-x-2">
+                  <HomeIcon className="h-4 w-4" />
+                  Overview
+                </Link>
+              </TabsTrigger>
+              <TabsTrigger value="schema" asChild>
+                <Link href={`${baseSubgraphPath}/schema${querySuffix}`} className="flex items-center gap-x-2">
+                  <FileTextIcon className="h-4 w-4" />
+                  Schema
+                </Link>
+              </TabsTrigger>
+              <TabsTrigger value="graphs" asChild>
+                <Link href={`${baseSubgraphPath}/graphs${querySuffix}`} className="flex items-center gap-x-2">
+                  <PiGraphLight className="size-4" />
+                  Graphs
+                </Link>
+              </TabsTrigger>
+              <TabsTrigger value="analytics" asChild>
+                <Link href={`${baseSubgraphPath}/analytics${querySuffix}`} className="flex items-center gap-x-2">
+                  <ChartBarIcon className="h-4 w-4" />
+                  Analytics
+                </Link>
+              </TabsTrigger>
+            </TabsList>
+          </Tabs>
+          {toolbar}
+        </div>
       </div>
       <div
         ref={scrollRef}

--- a/studio/src/components/reactflow-graph-node.tsx
+++ b/studio/src/components/reactflow-graph-node.tsx
@@ -3,12 +3,22 @@ import { PiGraphLight } from 'react-icons/pi';
 import { Handle, NodeProps, Position } from 'reactflow';
 import { VscError, VscRecord } from 'react-icons/vsc';
 import React from 'react';
+import { cn } from '@/lib/utils';
 
-function ReactFlowGraphNode({ data }: NodeProps) {
+function ReactFlowGraphNode({ data, selected }: NodeProps) {
+  const isSubgraph = data.kind === 'subgraph';
   return (
     <>
       {data.parentId && <Handle type="target" position={Position.Left} isConnectable={false} />}
-      <div className="nodrag grid w-[120px] grid-cols-1 divide-y rounded border border-border-emphasized bg-white text-left text-xs shadow-sm shadow-black/5 ring-1 ring-black/[.08] transition duration-150 dark:divide-gray-700 dark:bg-secondary dark:shadow-black/60 dark:ring-white/15">
+      <div
+        className={cn(
+          'nodrag grid w-[120px] grid-cols-1 divide-y rounded border border-border-emphasized bg-white text-left text-xs shadow-sm shadow-black/5 ring-1 ring-black/[.08] transition duration-150 dark:divide-gray-700 dark:bg-secondary dark:shadow-black/60 dark:ring-white/15',
+          isSubgraph && 'cursor-pointer hover:border-primary/40 hover:ring-primary/20 hover:shadow-md',
+          selected &&
+            isSubgraph &&
+            'border-primary/60 ring-2 ring-primary/30 shadow-md shadow-[0_0_18px_hsl(var(--primary)/0.35)]',
+        )}
+      >
         <div className="flex items-center justify-center px-1.5">
           <div className="flex items-center justify-center">
             {data.kind === 'graph' ? (
@@ -17,7 +27,7 @@ function ReactFlowGraphNode({ data }: NodeProps) {
               <Component2Icon className="h-3 w-3 text-secondary-foreground" />
             )}
           </div>
-          <div className="cursor-help truncate px-1 py-1" title={data.label}>
+          <div className={cn('truncate px-1 py-1', isSubgraph ? 'cursor-pointer' : 'cursor-help')} title={data.label}>
             {data.label}
           </div>
         </div>

--- a/studio/src/components/subgraphs-table.tsx
+++ b/studio/src/components/subgraphs-table.tsx
@@ -283,6 +283,10 @@ export const SubgraphsTable = ({
           <TableBody>
             {subgraphs.map(({ id, name, routingURL, lastUpdatedAt, labels, namespace, baseSubgraphName, type }) => {
               const path = `/${organizationSlug}/${namespace}/subgraph/${name}`;
+              const graphQuery =
+                router.asPath.split('/')[3] === 'graph' && typeof router.query.slug === 'string'
+                  ? `?graph=${encodeURIComponent(router.query.slug)}`
+                  : '';
               let analyticsPath = `${path}/analytics`;
               if (router.asPath.split('/')[3] === 'graph') {
                 const query = [
@@ -303,7 +307,7 @@ export const SubgraphsTable = ({
                 <TableRow
                   key={name}
                   className=" group cursor-pointer py-1 hover:bg-secondary/30"
-                  onClick={() => router.push(path)}
+                  onClick={() => router.push(`${path}${graphQuery}`)}
                 >
                   <TableCell className="px-4 font-medium">
                     <Tooltip delayDuration={200}>

--- a/studio/src/components/time-ago.tsx
+++ b/studio/src/components/time-ago.tsx
@@ -6,13 +6,44 @@ export interface TimeAgoProps {
   date: Date | number;
   suffix?: boolean;
   tooltip?: boolean;
+  compact?: boolean;
 }
 
-const formatTimeAgo = (date: Date | number, suffix?: boolean) => {
+const formatTimeAgo = (date: Date | number, suffix?: boolean, compact?: boolean) => {
   const diff = differenceInSeconds(new Date(), date);
 
   if (diff < 60) {
     return 'just now';
+  }
+
+  if (compact) {
+    const minutes = Math.floor(diff / 60);
+    const hours = Math.floor(diff / (60 * 60));
+    const days = Math.floor(diff / (60 * 60 * 24));
+    const months = Math.floor(diff / (60 * 60 * 24 * 30));
+    const years = Math.floor(diff / (60 * 60 * 24 * 365));
+
+    let value: number;
+    let unit: string;
+
+    if (years >= 1) {
+      value = years;
+      unit = 'y';
+    } else if (months >= 1) {
+      value = months;
+      unit = 'mo';
+    } else if (days >= 1) {
+      value = days;
+      unit = 'd';
+    } else if (hours >= 1) {
+      value = hours;
+      unit = 'h';
+    } else {
+      value = minutes;
+      unit = 'm';
+    }
+
+    return suffix ? `${value}${unit} ago` : `${value}${unit}`;
   }
 
   return formatDistanceToNowStrict(date, {
@@ -22,23 +53,23 @@ const formatTimeAgo = (date: Date | number, suffix?: boolean) => {
 };
 
 export const TimeAgo: React.FC<TimeAgoProps> = (props) => {
-  const { date, suffix = true, tooltip = true } = props;
+  const { date, suffix = true, tooltip = true, compact = false } = props;
 
-  const [timeAgo, setTimeAgo] = React.useState(formatTimeAgo(date, suffix));
+  const [timeAgo, setTimeAgo] = React.useState(formatTimeAgo(date, suffix, compact));
 
   React.useEffect(() => {
     const diff = differenceInSeconds(new Date(), date);
     let interval: any = null;
     if (diff < 600) {
       interval = setInterval(() => {
-        setTimeAgo(formatTimeAgo(date, suffix));
+        setTimeAgo(formatTimeAgo(date, suffix, compact));
       }, 1000);
     }
 
     return () => {
       if (interval) clearInterval(interval);
     };
-  }, [date, suffix]);
+  }, [date, suffix, compact]);
 
   if (tooltip) {
     return (

--- a/studio/src/components/ui/badge.tsx
+++ b/studio/src/components/ui/badge.tsx
@@ -10,7 +10,8 @@ const badgeVariants = cva(
       variant: {
         default: 'border-transparent bg-primary text-primary-foreground hover:bg-primary/80',
         secondary: 'border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80',
-        success: 'border-transparent bg-success/10 text-success',
+        success:
+          'border-success/30 bg-success/15 text-success hover:border-success/40 hover:bg-success/20 dark:border-success/40',
         destructive: 'border-transparent bg-destructive/10 text-destructive',
         muted: 'border-transparent bg-muted text-muted-foreground hover:bg-muted/80',
         outline: 'text-foreground',

--- a/studio/src/pages/[organizationSlug]/[namespace]/subgraph/[subgraphSlug]/index.tsx
+++ b/studio/src/pages/[organizationSlug]/[namespace]/subgraph/[subgraphSlug]/index.tsx
@@ -145,7 +145,9 @@ const SubgraphOverviewPage = () => {
               <dt className="text-sm text-muted-foreground">Linked Subgraph</dt>
               <dd className="flex gap-x-2">
                 <Link
-                  href={`/${router.query.organizationSlug}/${linkedSubgraph.namespace}/subgraph/${linkedSubgraph.name}`}
+                  href={`/${router.query.organizationSlug}/${linkedSubgraph.namespace}/subgraph/${linkedSubgraph.name}${
+                    typeof router.query.graph === 'string' ? `?graph=${encodeURIComponent(router.query.graph)}` : ''
+                  }`}
                   className="flex items-center gap-1 hover:underline"
                 >
                   {`${linkedSubgraph.namespace}/${linkedSubgraph.name}`}


### PR DESCRIPTION
## Summary

Presentation-layer UX improvements for Cosmo Studio, focused on answering "is everything OK right now?" faster and preserving context while navigating. No changes to data-fetching logic or API contracts — Tailwind + shadcn/ui only, no new dependencies.

- **Graph cards — health signal** (`federatedgraphs-cards.tsx`): added a health status badge (Healthy/Degraded), key metrics (error rate, P95 latency, RPM), and an actionable alert row that identifies the failing subgraph with a direct "Investigate" link.
- **Subgraph drawer redesign** (`graph-visualization.tsx`, `reactflow-graph-node.tsx`): compact 2×2 metric grid, health badge, truncated UUID, cleaned-up metadata row; tested in light and dark modes.
- **Navigation context fix** (`sidenav.tsx`, `subgraph-layout.tsx`, `graph-sidenav-links.tsx`, `graph-layout.tsx`): keep parent graph nav intact when entering a subgraph instead of replacing it; nested subgraph pages use a segmented control consistent with the rest of the product.
- **Trace status visibility** (`analytics/data-table.tsx`): readable status labels (OK / Validation / GraphQL Error) instead of an identical warning icon for every errored trace.
- Minor supporting tweaks to `time-ago.tsx`, `ui/badge.tsx`, `subgraphs-table.tsx`.

## Test plan

- [ ] `make full-demo-up`, open Studio at http://localhost:3000
- [ ] Graphs list → health badge, metrics, and alert row render correctly
- [ ] Click a subgraph node in Graph Overview → drawer shows metric grid + health badge
- [ ] Navigate into a subgraph → parent graph context preserved in left nav
- [ ] Analytics → Traces → status column shows readable labels
- [ ] Verify light and dark modes

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added richer graph and subgraph navigation, including expandable sidebar sections and preserved graph context across pages.
  * Introduced a subgraph metrics drawer with health, latency, error-rate, and RPM insights.
  * Improved graph cards with clearer health status, metrics, and direct navigation actions.

* **Bug Fixes**
  * Preserved current graph view and query context when opening subgraphs and linked pages.
  * Enhanced error status labels in analytics tables for faster identification of issue types.

* **UI Improvements**
  * Added compact time display support and updated badge styling for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->