### PR TITLE
fix(router): renew APQ TTL without corrupting stored query

### DIFF
--- a/router-tests/operations/automatic_persisted_queries_test.go
+++ b/router-tests/operations/automatic_persisted_queries_test.go
@@ -2,6 +2,8 @@ package integration
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"net/http"
 	"os"
@@ -196,6 +198,13 @@ func TestAutomaticPersistedQueries(t *testing.T) {
 				require.Equal(t, `{"data":{"__typename":"Query"}}`, res3.Body)
 			})
 		})
+
+		// Note: the in-memory (local cache) TTL-renewal path for issue #3062 is
+		// covered deterministically by the unit tests in
+		// router/core/operation_processor_apq_ttl_test.go. The in-memory store
+		// (ristretto) is eventually consistent, so an HTTP-level cross-variable read
+		// here would be racy; the Redis (distributed) end-to-end regression below
+		// uses a synchronous store and is the authoritative integration guard.
 	})
 
 	t.Run("redis cache", func(t *testing.T) {
@@ -480,6 +489,91 @@ func TestAutomaticPersistedQueries(t *testing.T) {
 					Header:     header2,
 				})
 				require.Equal(t, `{"data":{"__typename":"Query"}}`, res3.Body)
+			})
+		})
+
+		// Regression test for https://github.com/wundergraph/cosmo/issues/3062 with a
+		// distributed (Redis) APQ store. TTL renewal must keep the raw query in Redis,
+		// not the per-request normalized (directive-stripped) representation.
+		t.Run("ttl renewal preserves a query with @skip directives", func(t *testing.T) {
+			t.Parallel()
+
+			// Hermetic query: the conditionally-included field is a second aliased
+			// __typename, so the assertion depends only on @skip evaluation and not
+			// on any subgraph data.
+			const query = `query SkipRenewal($skip: Boolean!) { a: __typename b: __typename @skip(if: $skip) }`
+			sum := sha256.Sum256([]byte(query))
+			sha := hex.EncodeToString(sum[:])
+			extensions := fmt.Sprintf(`{"persistedQuery": {"version": 1, "sha256Hash": %q}}`, sha)
+
+			const skippedBody = `{"data":{"a":"Query"}}`
+			const includedBody = `{"data":{"a":"Query","b":"Query"}}`
+
+			key := uuid.New().String()
+			t.Cleanup(func() {
+				del := client.Del(context.Background(), key+sha)
+				require.NoError(t, del.Err())
+			})
+
+			testenv.Run(t, &testenv.Config{
+				RouterOptions: []core.Option{
+					core.WithStorageProviders(config.StorageProviders{
+						Redis: []config.RedisStorageProvider{
+							{
+								URLs: []string{redisUrl},
+								ID:   "redis",
+							},
+						},
+					}),
+				},
+				ApqConfig: config.AutomaticPersistedQueriesConfig{
+					Enabled: true,
+					Cache: config.AutomaticPersistedQueriesCacheConfig{
+						TTL: 5, // a TTL is required to reach the renewal branch
+					},
+					Storage: config.AutomaticPersistedQueriesStorageConfig{
+						ProviderID:   "redis",
+						ObjectPrefix: key,
+					},
+				},
+			}, func(t *testing.T, xEnv *testenv.Environment) {
+				header := make(http.Header)
+				header.Add("graphql-client-name", "my-client")
+
+				// 1) Register with skip:true (full query body). Stores the raw query.
+				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+					Query:         query,
+					OperationName: []byte(`"SkipRenewal"`),
+					Variables:     []byte(`{"skip":true}`),
+					Extensions:    []byte(extensions),
+					Header:        header,
+				})
+				require.Equal(t, skippedBody, res.Body)
+
+				// 2) Hash-only replay with skip:true is a cache hit that renews the TTL.
+				res = xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+					OperationName: []byte(`"SkipRenewal"`),
+					Variables:     []byte(`{"skip":true}`),
+					Extensions:    []byte(extensions),
+					Header:        header,
+				})
+				require.Equal(t, skippedBody, res.Body)
+
+				// The Redis entry must still be the raw query after renewal, not the
+				// normalized, directive-stripped form.
+				stored, err := client.Get(context.Background(), key+sha).Result()
+				require.NoError(t, err)
+				require.Equal(t, query, stored)
+
+				// 3) Hash-only request with skip:false must still return the conditional
+				//    field, resolved from the uncorrupted Redis store.
+				res = xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+					OperationName: []byte(`"SkipRenewal"`),
+					Variables:     []byte(`{"skip":false}`),
+					Extensions:    []byte(extensions),
+					Header:        header,
+				})
+				require.Equal(t, includedBody, res.Body)
 			})
 		})
 	})

--- a/router/core/operation_processor.go
+++ b/router/core/operation_processor.go
@@ -447,8 +447,11 @@ func (o *OperationKit) FetchPersistedOperation(ctx context.Context, clientInfo *
 	}
 	if fromCache {
 		if fromCacheHasTTL, _ := o.persistedOperationCacheKeyHasTtl(clientInfo.Name, includeOperationName); fromCacheHasTTL {
-			// if it is an APQ request, we need to save it again to renew the TTL expiration
-			if err = o.operationProcessor.persistedOperationClient.SaveOperation(ctx, clientInfo.Name, o.parsedOperation.GraphQLRequestExtensions.PersistedQuery.Sha256Hash, o.parsedOperation.NormalizedRepresentation); err != nil {
+			// If it is an APQ request, renew the store TTL. We must NOT write the
+			// normalized representation back: it has @skip/@include evaluated for the
+			// current request's variables, which would corrupt the stored raw query
+			// for subsequent requests using different variables (see issue #3062).
+			if err = o.operationProcessor.persistedOperationClient.RenewOperationTTL(ctx, clientInfo.Name, o.parsedOperation.GraphQLRequestExtensions.PersistedQuery.Sha256Hash); err != nil {
 				return false, false, err
 			}
 		}

--- a/router/core/operation_processor_apq_ttl_test.go
+++ b/router/core/operation_processor_apq_ttl_test.go
@@ -1,0 +1,236 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/dgraph-io/ristretto/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/astparser"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/asttransform"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/engine/plan"
+
+	"github.com/wundergraph/cosmo/router/internal/persistedoperation"
+	"github.com/wundergraph/cosmo/router/internal/persistedoperation/apq"
+	"github.com/wundergraph/cosmo/router/pkg/config"
+)
+
+// ttlMockKVClient is a minimal apq.KVClient backed by an in-memory map so the
+// test can assert exactly what body was written to the KV store (Redis).
+type ttlMockKVClient struct {
+	store map[string][]byte
+}
+
+func newTTLMockKVClient() *ttlMockKVClient {
+	return &ttlMockKVClient{store: make(map[string][]byte)}
+}
+
+func (m *ttlMockKVClient) Get(_ context.Context, operationHash string) ([]byte, error) {
+	val, ok := m.store[operationHash]
+	if !ok {
+		return nil, nil
+	}
+	return val, nil
+}
+
+func (m *ttlMockKVClient) Set(_ context.Context, operationHash string, operationBody []byte, _ int) error {
+	m.store[operationHash] = operationBody
+	return nil
+}
+
+func (m *ttlMockKVClient) Close() {}
+
+const (
+	apqTTLSha256   = "1111111111111111111111111111111111111111111111111111111111111111"
+	apqTTLRawQuery = `query Q($skipB: Boolean!) { a b @skip(if: $skipB) }`
+)
+
+func newAPQTTLProcessor(t *testing.T, kv apq.KVClient) (*OperationProcessor, *persistedoperation.Client, *ristretto.Cache[uint64, NormalizationCacheEntry]) {
+	t.Helper()
+
+	clientSchema, report := astparser.ParseGraphqlDocumentString(`type Query { a: String b: String }`)
+	require.False(t, report.HasErrors(), "failed to parse client schema")
+	require.NoError(t, asttransform.MergeDefinitionWithBaseSchema(&clientSchema))
+
+	apqClient, err := apq.NewClient(&apq.Options{
+		ApqConfig: &config.AutomaticPersistedQueriesConfig{
+			Enabled: true,
+			Cache: config.AutomaticPersistedQueriesCacheConfig{
+				TTL:  300,
+				Size: config.BytesString(1 << 20), // 1MB; only used by the in-memory APQ store
+			},
+		},
+		KVClient: kv,
+	})
+	require.NoError(t, err)
+
+	poClient, err := persistedoperation.NewClient(&persistedoperation.Options{
+		ApqClient: apqClient,
+	})
+	require.NoError(t, err)
+
+	normalizationCache, err := ristretto.NewCache[uint64, NormalizationCacheEntry](&ristretto.Config[uint64, NormalizationCacheEntry]{
+		NumCounters: 1000,
+		MaxCost:     1000,
+		BufferItems: 64,
+	})
+	require.NoError(t, err)
+	t.Cleanup(normalizationCache.Close)
+
+	executor := &Executor{
+		PlanConfig:   plan.Configuration{},
+		ClientSchema: &clientSchema,
+	}
+	processor := NewOperationProcessor(OperationProcessorOptions{
+		Executor:                            executor,
+		MaxOperationSizeInBytes:             10 << 20,
+		ParseKitPoolSize:                    1,
+		PersistedOperationClient:            poClient,
+		EnablePersistedOperationsCache:      true,
+		PersistedOpsNormalizationCache:      normalizationCache,
+		AutomaticPersistedOperationCacheTtl: 300,
+	})
+
+	return processor, poClient, normalizationCache
+}
+
+// runAPQRequest drives the same processing sequence the prehandler uses:
+// fetch -> (parse) -> normalize operation -> normalize variables -> remap.
+// It returns the normalized representation produced for the request.
+func runAPQRequest(t *testing.T, processor *OperationProcessor, clientInfo *ClientInfo, body string) string {
+	t.Helper()
+
+	kit, err := processor.NewKit()
+	require.NoError(t, err)
+	defer kit.Free()
+
+	require.NoError(t, kit.UnmarshalOperationFromBody([]byte(body)))
+
+	skipParse, isApq, err := kit.FetchPersistedOperation(context.Background(), clientInfo)
+	require.NoError(t, err)
+
+	if !skipParse {
+		require.NoError(t, kit.Parse())
+	}
+
+	_, err = kit.NormalizeOperation(clientInfo.Name, isApq)
+	require.NoError(t, err)
+
+	_, _, err = kit.NormalizeVariables()
+	require.NoError(t, err)
+
+	_, err = kit.RemapVariables(false)
+	require.NoError(t, err)
+
+	return kit.parsedOperation.NormalizedRepresentation
+}
+
+// TestAPQTTLRenewalDoesNotCorruptStoredQuery is the regression test for the APQ
+// TTL renewal path in FetchPersistedOperation (issue #3062, based on PR #3061).
+//
+// When a cached APQ operation whose KV entry has a TTL is re-executed, the router
+// renews the expiration. It must NOT write back the normalized representation,
+// which has @skip/@include evaluated and stripped for the current request's
+// variable values. Doing so corrupts the stored query so that a later request
+// resolving the same hash with different variables gets a query missing the
+// conditional field.
+func TestAPQTTLRenewalDoesNotCorruptStoredQuery(t *testing.T) {
+	t.Parallel()
+
+	kv := newTTLMockKVClient()
+	processor, _, normalizationCache := newAPQTTLProcessor(t, kv)
+	clientInfo := &ClientInfo{Name: "test"}
+
+	// Request 1: APQ registration. Query + hash are both in the body, so the
+	// raw query is saved to the KV store.
+	registerBody := fmt.Sprintf(
+		`{"query":%q,"variables":{"skipB":true},"extensions":{"persistedQuery":{"version":1,"sha256Hash":%q}}}`,
+		apqTTLRawQuery, apqTTLSha256,
+	)
+	runAPQRequest(t, processor, clientInfo, registerBody)
+	require.Equal(t, apqTTLRawQuery, string(kv.store[apqTTLSha256]), "registration must store the raw query")
+
+	// ristretto Set is asynchronous; make request 1's normalization entry visible
+	// so request 2 hits the cache and takes the TTL-renewal branch.
+	normalizationCache.Wait()
+
+	// Request 2: hash-only request with the same skip variable. This is a
+	// persisted-operation cache hit whose key has a TTL, so it renews the TTL.
+	replaySkipTrueBody := fmt.Sprintf(
+		`{"variables":{"skipB":true},"extensions":{"persistedQuery":{"version":1,"sha256Hash":%q}}}`,
+		apqTTLSha256,
+	)
+	runAPQRequest(t, processor, clientInfo, replaySkipTrueBody)
+
+	// The stored query must still be the raw query. On the buggy code it has been
+	// overwritten with the normalized, directive-stripped form (`query Q { a }`).
+	require.Equal(t, apqTTLRawQuery, string(kv.store[apqTTLSha256]),
+		"TTL renewal overwrote the stored raw query with the normalized, directive-stripped form")
+
+	// Request 3: hash-only request with skipB:false. This resolves the same hash
+	// but with different variables. It must receive the conditional field `b`,
+	// which is only possible if the stored query was not corrupted.
+	replaySkipFalseBody := fmt.Sprintf(
+		`{"variables":{"skipB":false},"extensions":{"persistedQuery":{"version":1,"sha256Hash":%q}}}`,
+		apqTTLSha256,
+	)
+	normalized := runAPQRequest(t, processor, clientInfo, replaySkipFalseBody)
+
+	require.Contains(t, normalized, "b",
+		"skipB:false must include field b; a corrupted store would drop it")
+	require.Equal(t, apqTTLRawQuery, string(kv.store[apqTTLSha256]),
+		"the stored raw query must remain intact after renewals")
+}
+
+// TestAPQTTLRenewalInMemoryStoreKeepsRawQuery covers the non-distributed (in-memory)
+// APQ path of RenewTTL, where there is no KVClient. It asserts the stored body
+// (read back via the persisted-operation client) remains the raw query after a
+// TTL-renewal replay, and is never the normalized, directive-stripped form.
+func TestAPQTTLRenewalInMemoryStoreKeepsRawQuery(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	processor, poClient, normalizationCache := newAPQTTLProcessor(t, nil)
+	clientInfo := &ClientInfo{Name: "test"}
+
+	// Request 1: APQ registration saves the raw query into the in-memory store.
+	registerBody := fmt.Sprintf(
+		`{"query":%q,"variables":{"skipB":true},"extensions":{"persistedQuery":{"version":1,"sha256Hash":%q}}}`,
+		apqTTLRawQuery, apqTTLSha256,
+	)
+	runAPQRequest(t, processor, clientInfo, registerBody)
+	normalizationCache.Wait()
+
+	// The in-memory APQ store (ristretto) is eventually consistent; wait until the
+	// raw query is retrievable before exercising renewal.
+	require.Eventually(t, func() bool {
+		body, _, err := poClient.PersistedOperation(ctx, clientInfo.Name, apqTTLSha256)
+		return err == nil && string(body) == apqTTLRawQuery
+	}, 2*time.Second, 20*time.Millisecond, "registration must store the raw query in the in-memory APQ store")
+
+	// Request 2: hash-only replay triggers the TTL-renewal branch for the in-memory store.
+	replaySkipTrueBody := fmt.Sprintf(
+		`{"variables":{"skipB":true},"extensions":{"persistedQuery":{"version":1,"sha256Hash":%q}}}`,
+		apqTTLSha256,
+	)
+	runAPQRequest(t, processor, clientInfo, replaySkipTrueBody)
+
+	// The stored body must remain the raw query and must never become the
+	// normalized, directive-stripped form (`query Q { a }`). Poll to allow the
+	// renewal's re-Set to settle, and fail fast if a corrupted value ever appears.
+	require.Eventually(t, func() bool {
+		body, _, err := poClient.PersistedOperation(ctx, clientInfo.Name, apqTTLSha256)
+		require.NoError(t, err)
+		return string(body) == apqTTLRawQuery
+	}, 2*time.Second, 20*time.Millisecond, "in-memory store must retain the raw query after TTL renewal")
+
+	// Final, definitive assertion: the stored body is exactly the raw query, i.e.
+	// it still declares the conditional field `b` and its @skip directive.
+	body, _, err := poClient.PersistedOperation(ctx, clientInfo.Name, apqTTLSha256)
+	require.NoError(t, err)
+	require.Equal(t, apqTTLRawQuery, string(body),
+		"TTL renewal must not overwrite the in-memory store with the normalized form")
+}

--- a/router/internal/persistedoperation/apq/client.go
+++ b/router/internal/persistedoperation/apq/client.go
@@ -20,6 +20,9 @@ type Client interface {
 	IsDistributed() bool
 	PersistedOperation(ctx context.Context, clientName string, sha256Hash string) ([]byte, error)
 	SaveOperation(ctx context.Context, clientName, sha256Hash string, operationBody []byte) error
+	// RenewTTL refreshes the store TTL of an existing APQ entry without altering
+	// its stored body. It is a no-op if the entry is absent.
+	RenewTTL(ctx context.Context, clientName, sha256Hash string) error
 	Close()
 }
 
@@ -91,6 +94,31 @@ func (c *client) SaveOperation(ctx context.Context, clientName, sha256Hash strin
 
 	// we don't use the client name in the APQ cache, because operations should be persisted across all clients
 	c.cache.Set("", sha256Hash, operationBody, c.ttl)
+	return nil
+}
+
+// RenewTTL refreshes the store TTL of an existing APQ entry by re-writing the
+// body already present in the store. APQ operations are content-addressed by
+// sha256(rawQuery), so the stored body is invariant and re-writing it is safe.
+// This must not be given the normalized representation, which has @skip/@include
+// directives evaluated for the current request's variables (see issue #3062).
+func (c *client) RenewTTL(ctx context.Context, _, sha256Hash string) error {
+	if c.kvClient != nil {
+		body, err := c.kvClient.Get(ctx, sha256Hash)
+		if err != nil {
+			return err
+		}
+		if len(body) == 0 {
+			// Nothing stored (e.g. evicted); nothing to renew.
+			return nil
+		}
+		return c.kvClient.Set(ctx, sha256Hash, body, c.ttl)
+	}
+
+	// in-memory APQ (clientName intentionally unused; APQ keys on hash only)
+	if body := c.cache.Get("", sha256Hash); len(body) > 0 {
+		c.cache.Set("", sha256Hash, body, c.ttl)
+	}
 	return nil
 }
 

--- a/router/internal/persistedoperation/client.go
+++ b/router/internal/persistedoperation/client.go
@@ -130,6 +130,25 @@ func (c *Client) SaveOperation(ctx context.Context, clientName, sha256Hash, oper
 	return nil
 }
 
+// RenewOperationTTL renews the APQ store TTL for a cached persisted operation
+// without rewriting its body. This preserves the raw registered query, unlike a
+// SaveOperation of the normalized representation (which would corrupt the stored
+// query because @skip/@include are evaluated per request). See issue #3062.
+func (c *Client) RenewOperationTTL(ctx context.Context, clientName, sha256Hash string) error {
+	if c.apqClient == nil || !c.apqClient.Enabled() {
+		return nil
+	}
+	// Mirror SaveOperation's manifest guard: the manifest is authoritative for
+	// in-memory APQ, so manifest-owned operations are not tracked in the APQ store.
+	// Distributed APQ (Redis) still renews so all router instances retain the entry.
+	if !c.apqClient.IsDistributed() && c.ManifestEnabled() {
+		if _, found := c.pqlStore.LookupByHash(sha256Hash); found {
+			return nil
+		}
+	}
+	return c.apqClient.RenewTTL(ctx, clientName, sha256Hash)
+}
+
 func (c *Client) APQEnabled() bool {
 	return c.apqClient != nil && c.apqClient.Enabled()
 }


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic persisted query TTL renewal without altering the original query content.
  * Fixed issues affecting queries that use conditional directives such as `@skip`.
  * Ensured cached queries continue to resolve conditional fields correctly after TTL renewal.

* **Tests**
  * Added regression coverage for TTL renewal across distributed and in-memory persistence scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Fixes #3062.

Automatic Persisted Queries (APQ) corrupted the stored query on TTL renewal.
When a persisted operation whose store entry has a TTL is re-executed and
resolved from the in-memory normalization cache, the router re-saved it to renew
the expiration but wrote back the **normalized representation** instead of the
original raw query. Normalization evaluates and strips `@skip`/`@include` using
the current request's variables, so the stored query was overwritten with a
variable-specific, directive-stripped version. Subsequent requests resolving the
same hash with different variables then silently lost the conditionally-included
fields (HTTP 200, fields absent). Only TTL-renewal on later cache hits was
affected; initial registration correctly stored the raw query.

## Root cause

In `FetchPersistedOperation` (`router/core/operation_processor.go`), the APQ
cache-hit-with-TTL branch called `SaveOperation(..., NormalizedRepresentation)`.
On the hash-only replay path the raw query is not in memory, so the normalized
(stripped) form was written to the APQ store (Redis or in-memory).

## Fix

Renew the TTL at the storage layer without rewriting the body:

- `apq.Client.RenewTTL` — re-writes the raw body already present in the store via
  the existing `Get`+`Set` (APQ is content-addressed by `sha256(rawQuery)`, so
  the stored body is invariant). No-op when the entry is absent. Covers both the
  Redis and in-memory stores.
- `persistedoperation.Client.RenewOperationTTL` — wraps it and preserves the
  existing PQL-manifest ownership guard used by `SaveOperation`.
- `FetchPersistedOperation` now calls `RenewOperationTTL` instead of
  `SaveOperation(NormalizedRepresentation)`.

No change to the `apq.KVClient` interface, APQ registration, or
persisted-operation lookup semantics. No generated code changes.

## Tests

- Unit (`router/core/operation_processor_apq_ttl_test.go`): regression tests for
  the KV-backed (Redis-style mock) and in-memory APQ stores — asserting the
  stored body stays the raw query and that a `skip:false` replay still resolves
  the conditional field after a `skip:true` renewal. Based on the regression test
  from #3061.
- Integration (`router-tests/operations/automatic_persisted_queries_test.go`): a
  Redis-backed end-to-end regression in the existing `redis cache` group,
  asserting the Redis entry remains the raw query after renewal and that a
  `skip:false` request returns the conditional field.

Both were verified to fail on the unpatched code and pass with the fix.

## How to test

1. Configure APQ with a Redis store and `automatic_persisted_queries.cache.ttl > 0`.
2. Register `query Q($skip: Boolean!) { a: __typename b: __typename @skip(if: $skip) }`
   with `{"skip": true}` (query + sha in the request).
3. Replay hash-only with `{"skip": true}` (triggers TTL renewal).
4. Send hash-only with `{"skip": false}` → the response must include `b`.
   On the unpatched router, `b` is missing and Redis holds the stripped
   `query Q { a: __typename }`.

Automated:

```
cd router && make test
cd router-tests && go test -race -run '^TestAutomaticPersistedQueries$' ./operations/
```

## Notes for upgraders

Entries already corrupted in Redis by an affected router cannot be reconstructed
from hash-only requests. After upgrading, flush the APQ key prefix or wait for
the TTL to expire; affected clients re-register on the next miss.

## Checklist

- [x] I have discussed my proposed changes in an issue (#3062) and provided a reproduction.
- [x] I have followed the coding standards of the project.
- [x] Tests or benchmarks have been added or updated.
- [x] I have provided instructions for reviewers for manually validating my changes.
- [ ] Documentation has been updated on https://github.com/wundergraph/docs-website (N/A — bug fix, no user-facing config change).
- [x] I have read the Contributors Guide.

## Open Source AI Manifesto

This contribution follows the principles of the [Open Source AI Manifesto](https://human-oss.dev).
