### PR TITLE
docs(router): improve GraphQL Metrics documentation

### DIFF
--- a/docs-website/router/compliance-and-data-management.mdx
+++ b/docs-website/router/compliance-and-data-management.mdx
@@ -69,6 +69,8 @@ Besides measuring common request metrics, we also collect information about Grap
 
 * Used GraphQL types per operation
 
+You can disable this collection with `graphql_metrics.enabled: false` in the router config (see [GraphQL Metrics](/router/configuration#graphql-metrics)).
+
 ## Router self-registering
 
 When the router starts, it attempts to connect with the control plane to self-register. This mechanism is used to exchange cryptographic keys when using [ART](/router/advanced-request-tracing-art) and to ensure that certain limits are maintained when data is sent to Cosmo Cloud.

--- a/docs-website/router/configuration.mdx
+++ b/docs-website/router/configuration.mdx
@@ -876,10 +876,12 @@ telemetry:
 
 ## GraphQL Metrics
 
-| Environment Variable               | YAML               | Required                                      | Description      | Default Value                         |
-| ---------------------------------- | ------------------ | --------------------------------------------- | ---------------- | ------------------------------------- |
-| GRAPHQL_METRICS_ENABLED            | enabled            | <Icon icon="square" />                        |                  | true                                  |
-| GRAPHQL_METRICS_COLLECTOR_ENDPOINT | collector_endpoint | <Icon icon="square-check" iconType="solid" /> | Default endpoint | https://cosmo-metrics.wundergraph.com |
+The router collects GraphQL schema usage metrics, which are the types, fields, and arguments each client operation uses, and sends them to the Cosmo GraphQL Metrics collector. This data powers [field-level analytics](/studio/analytics/schema-field-usage) and [breaking-change detection](/studio/schema-checks). Set `enabled` to `false` (or `GRAPHQL_METRICS_ENABLED=false`) to stop the router from collecting and sending this data.
+
+| Environment Variable               | YAML               | Required               | Description                                                                                                                            | Default Value                         |
+| ---------------------------------- | ------------------ | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
+| GRAPHQL_METRICS_ENABLED            | enabled            | <Icon icon="square" /> | Enable collection and export of GraphQL schema usage metrics (field-level usage) to the collector. Set to `false` to disable.         | true                                  |
+| GRAPHQL_METRICS_COLLECTOR_ENDPOINT | collector_endpoint | <Icon icon="square" /> | Endpoint of the GraphQL Metrics collector that receives schema usage data. Self-hosted deployments point this at their own collector. | https://cosmo-metrics.wundergraph.com |
 
 ### Example YAML config:
 

--- a/docs-website/router/configuration.mdx
+++ b/docs-website/router/configuration.mdx
@@ -878,7 +878,7 @@ telemetry:
 
 The router collects GraphQL schema usage metrics, which are the types, fields, and arguments each client operation uses, and sends them to the Cosmo GraphQL Metrics collector. This data powers [field-level analytics](/studio/analytics/schema-field-usage) and [breaking-change detection](/studio/schema-checks). Set `enabled` to `false` (or `GRAPHQL_METRICS_ENABLED=false`) to stop the router from collecting and sending this data.
 
-| Environment Variable               | YAML               | Required               | Description                                                                                                                            | Default Value                         |
+| Environment Variable               | YAML               | Required               | Description                                                                                                                           | Default Value                         |
 | ---------------------------------- | ------------------ | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
 | GRAPHQL_METRICS_ENABLED            | enabled            | <Icon icon="square" /> | Enable collection and export of GraphQL schema usage metrics (field-level usage) to the collector. Set to `false` to disable.         | true                                  |
 | GRAPHQL_METRICS_COLLECTOR_ENDPOINT | collector_endpoint | <Icon icon="square" /> | Endpoint of the GraphQL Metrics collector that receives schema usage data. Self-hosted deployments point this at their own collector. | https://cosmo-metrics.wundergraph.com |


### PR DESCRIPTION
## Description

This PR improves the documentation for GraphQL Metrics configuration in the router by:

1. **Added introductory context** in the configuration guide explaining what GraphQL schema usage metrics are, what they're used for (field-level analytics and breaking-change detection), and how to disable them.

2. **Enhanced configuration table descriptions** with more detailed explanations of each setting:
   - `GRAPHQL_METRICS_ENABLED`: Clarified that it controls collection and export of schema usage metrics, with explicit mention of how to disable
   - `GRAPHQL_METRICS_COLLECTOR_ENDPOINT`: Added context about self-hosted deployments needing to point to their own collector

3. **Added cross-reference** in the compliance and data management guide directing users to the GraphQL Metrics configuration section and explaining how to disable metrics collection.

## Checklist

- [x] Documentation has been updated
- [x] Changes are clear and follow existing documentation style

Closes ROUTER-539


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Documentation**
  * Clarified which schema usage metrics the router collects (types/fields/arguments per operation) and how they enable field-level analytics and breaking-change detection.
  * Documented how to disable GraphQL metrics collection and export via router configuration or the `GRAPHQL_METRICS_ENABLED=false` environment variable.
  * Expanded guidance for the GraphQL metrics collector endpoint, including use in self-hosted deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->