### PR TITLE
fix: prevent stack overflow in schema checks by not sending parsed ASTs to the composition worker

### DIFF
--- a/controlplane/src/core/composition/composer.ts
+++ b/controlplane/src/core/composition/composer.ts
@@ -665,7 +665,12 @@ export class Composer {
 
         const { results } = await composeGraphsInWorker({
           federatedGraph: graph,
-          subgraphsToCompose,
+          subgraphsToCompose: subgraphsToCompose.map((entry) => ({
+            subgraphs: entry.subgraphs,
+            isFeatureFlagComposition: entry.isFeatureFlagComposition,
+            featureFlagName: entry.featureFlagName,
+            featureFlagId: entry.featureFlagId,
+          })),
           tagOptionsByContractName,
           compositionOptions,
           skipRouterConfig: true,

--- a/controlplane/test/feature-flag/check-with-feature-flags.test.ts
+++ b/controlplane/test/feature-flag/check-with-feature-flags.test.ts
@@ -55,6 +55,19 @@ const FS_USERS_SDL = `
   }
 `;
 
+// Builds a subgraph SDL with `fieldCount` scalar fields. Large field counts produce a long GraphQL
+// AST token linked-list, which previously overflowed the stack when the parsed AST was structured-cloned
+// across the composition worker boundary ("Maximum call stack size exceeded"). ~1000 fields is already
+// past the overflow threshold; we use more to stay comfortably clear of it.
+const buildLargeSdl = (fieldCount: number) => {
+  let sdl = 'type Query {\n  user(id: ID!): User\n  users: [User!]!\n}\n\ntype User @key(fields: "id") {\n  id: ID!\n';
+  for (let i = 0; i < fieldCount; i++) {
+    sdl += `  field${i}: String\n`;
+  }
+  sdl += '}\n';
+  return sdl;
+};
+
 // Valid non-breaking change for the FS (adds a field).
 const FS_USERS_SDL_VALID_UPDATE = `
   type Query {
@@ -1041,6 +1054,85 @@ describe('Feature flag aware subgraph checks', () => {
       delete: true,
     });
     expect(checkResp.response?.code).toBe(EnumStatusCode.OK);
+    expect(checkResp.compositionErrors).toHaveLength(0);
+  });
+
+  test('base subgraph check on a large schema does not overflow the composition worker', async (testContext) => {
+    const { client, server } = await SetupTest({ dbname, chClient });
+    testContext.onTestFinished(() => server.close());
+
+    const label = genUniqueLabel();
+    const baseSubgraphName = genID('base');
+    const fedGraphName = genID('fedgraph');
+
+    const largeSdl = buildLargeSdl(1500);
+
+    await createAndPublishSubgraph(
+      client,
+      baseSubgraphName,
+      'default',
+      largeSdl,
+      [label],
+      DEFAULT_SUBGRAPH_URL_ONE,
+    );
+    await createFederatedGraph(client, fedGraphName, 'default', [joinLabel(label)], DEFAULT_ROUTER_URL);
+
+    // Non-breaking change on the same large schema (adds one more field).
+    const largeSdlUpdate = buildLargeSdl(1501);
+
+    const checkResp = await client.checkSubgraphSchema({
+      subgraphName: baseSubgraphName,
+      namespace: 'default',
+      schema: Uint8Array.from(Buffer.from(largeSdlUpdate)),
+    });
+
+    expect(checkResp.response?.code).toBe(EnumStatusCode.OK);
+    // Before the fix this contained "Maximum call stack size exceeded".
+    expect(checkResp.compositionErrors).toHaveLength(0);
+  });
+
+  test('feature subgraph check on a large schema does not overflow the composition worker', async (testContext) => {
+    const { client, server } = await SetupTest({ dbname, chClient });
+    testContext.onTestFinished(() => server.close());
+
+    const label = genUniqueLabel();
+    const baseSubgraphName = genID('base');
+    const featureSubgraphName = genID('fs');
+    const fedGraphName = genID('fedgraph');
+    const featureFlagName = genID('flag').toLowerCase();
+
+    const largeSdl = buildLargeSdl(1500);
+
+    await createAndPublishSubgraph(
+      client,
+      baseSubgraphName,
+      'default',
+      largeSdl,
+      [label],
+      DEFAULT_SUBGRAPH_URL_ONE,
+    );
+    await createThenPublishFeatureSubgraph(
+      client,
+      featureSubgraphName,
+      baseSubgraphName,
+      'default',
+      largeSdl,
+      [label],
+      DEFAULT_SUBGRAPH_URL_TWO,
+    );
+    await createFederatedGraph(client, fedGraphName, 'default', [joinLabel(label)], DEFAULT_ROUTER_URL);
+    await createFeatureFlag(client, featureFlagName, [label], [featureSubgraphName], 'default', true);
+
+    const largeSdlUpdate = buildLargeSdl(1501);
+
+    const checkResp = await client.checkSubgraphSchema({
+      subgraphName: featureSubgraphName,
+      namespace: 'default',
+      schema: Uint8Array.from(Buffer.from(largeSdlUpdate)),
+    });
+
+    expect(checkResp.response?.code).toBe(EnumStatusCode.OK);
+    // Before the fix this contained "Maximum call stack size exceeded".
     expect(checkResp.compositionErrors).toHaveLength(0);
   });
 });

--- a/controlplane/test/feature-flag/check-with-feature-flags.test.ts
+++ b/controlplane/test/feature-flag/check-with-feature-flags.test.ts
@@ -1067,14 +1067,7 @@ describe('Feature flag aware subgraph checks', () => {
 
     const largeSdl = buildLargeSdl(1500);
 
-    await createAndPublishSubgraph(
-      client,
-      baseSubgraphName,
-      'default',
-      largeSdl,
-      [label],
-      DEFAULT_SUBGRAPH_URL_ONE,
-    );
+    await createAndPublishSubgraph(client, baseSubgraphName, 'default', largeSdl, [label], DEFAULT_SUBGRAPH_URL_ONE);
     await createFederatedGraph(client, fedGraphName, 'default', [joinLabel(label)], DEFAULT_ROUTER_URL);
 
     // Non-breaking change on the same large schema (adds one more field).
@@ -1103,14 +1096,7 @@ describe('Feature flag aware subgraph checks', () => {
 
     const largeSdl = buildLargeSdl(1500);
 
-    await createAndPublishSubgraph(
-      client,
-      baseSubgraphName,
-      'default',
-      largeSdl,
-      [label],
-      DEFAULT_SUBGRAPH_URL_ONE,
-    );
+    await createAndPublishSubgraph(client, baseSubgraphName, 'default', largeSdl, [label], DEFAULT_SUBGRAPH_URL_ONE);
     await createThenPublishFeatureSubgraph(
       client,
       featureSubgraphName,


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved schema checks for large GraphQL schemas.
  * Prevented stack overflow errors when validating base or feature-flag subgraphs by adjusting SDL generation in the checks.
  * Ensured large-schema validations complete successfully without triggering composition errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [x] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [x] Tests or benchmarks have been added or updated.
- [ ] If applicable, I have provided instructions for reviewers for [manually validating my changes](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md#pull-requests-conventions).
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

