### PR TITLE
fix(studio): fix typo in SCIM setting description

### DIFF
--- a/studio/src/pages/[organizationSlug]/settings.tsx
+++ b/studio/src/pages/[organizationSlug]/settings.tsx
@@ -1178,7 +1178,7 @@ const Scim = () => {
             <Badge variant="outline">Enterprise feature</Badge>
           </CardTitle>
           <CardDescription>
-            Enabling SCIM allows the admin to provision and unprovision the users from the Identity prodviders.{' '}
+            Enabling SCIM allows the admin to provision and unprovision the users from the Identity providers.{' '}
             <Link href={docsBaseURL + '/studio/scim'} className="text-sm text-primary" target="_blank" rel="noreferrer">
               Learn more
             </Link>

--- a/studio/src/pages/[organizationSlug]/settings.tsx
+++ b/studio/src/pages/[organizationSlug]/settings.tsx
@@ -1178,7 +1178,7 @@ const Scim = () => {
             <Badge variant="outline">Enterprise feature</Badge>
           </CardTitle>
           <CardDescription>
-            Enabling SCIM allows the admin to provision and unprovision the users from the Identity providers.{' '}
+            Enabling SCIM allows the admin to manage user provisioning from identity providers.{' '}
             <Link href={docsBaseURL + '/studio/scim'} className="text-sm text-primary" target="_blank" rel="noreferrer">
               Learn more
             </Link>
@@ -1197,7 +1197,7 @@ const Scim = () => {
       {scim?.enabled && (
         <CardContent>
           <div className="flex flex-col gap-y-2">
-            <span className="px-1">SCIM server url</span>
+            <span className="px-1">SCIM server URL</span>
             <CLI command={scimBaseURL} />
           </div>
         </CardContent>


### PR DESCRIPTION
Fixes a typo in the SCIM card description in organization settings: "prodviders" → "providers".

Closes [COSMO-323](https://linear.app/wundergraph/issue/COSMO-323/typo-in-scim-setting-description-in-studio)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected typos in the SCIM settings text (“Identity providers” now spelled correctly).
  * Updated SCIM label capitalization from “SCIM server url” to “SCIM server URL” for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->