### PR TITLE
fix: avoid extra compositions due trailing newline

### DIFF
--- a/controlplane/src/core/repositories/SubgraphRepository.ts
+++ b/controlplane/src/core/repositories/SubgraphRepository.ts
@@ -421,11 +421,14 @@ export class SubgraphRepository {
     }
 
     // TODO: avoid downloading the schema use hash instead
-    if (data.schemaSDL && (subgraph.type === 'grpc_plugin' || data.schemaSDL !== subgraph.schemaSDL.trimEnd())) {
+    if (
+      data.schemaSDL &&
+      (subgraph.type === 'grpc_plugin' || data.schemaSDL.trimEnd() !== subgraph.schemaSDL.trimEnd())
+    ) {
       subgraphChanged = true;
       const updatedSubgraph = await subgraphRepo.addSchemaVersion({
         targetId: subgraph.targetId,
-        subgraphSchema: data.schemaSDL,
+        subgraphSchema: data.schemaSDL.trimEnd(),
         isV2Graph: data.isV2Graph,
         proto: data.proto,
       });

--- a/controlplane/test/subgraph/publish-subgraph.test.ts
+++ b/controlplane/test/subgraph/publish-subgraph.test.ts
@@ -81,6 +81,43 @@ describe('Publish subgraph tests', () => {
     expect(publishFederatedSubgraphResp.response?.code).toBe(EnumStatusCode.OK);
   });
 
+  test('that newlines do not cause extra compositions', async () => {
+    const { client, server } = await SetupTest({ dbname });
+    onTestFinished(() => server.close());
+
+    const subgraphName = genID('subgraph');
+
+    await createSubgraph(client, subgraphName, 'http://localhost:4001');
+    let publishFederatedSubgraphResp = await client.publishFederatedSubgraph({
+      name: subgraphName,
+      namespace: 'default',
+      schema: subgraphSDL,
+    });
+
+    expect(publishFederatedSubgraphResp.response?.code).toBe(EnumStatusCode.OK);
+    expect(publishFederatedSubgraphResp.hasChanged).toBe(true);
+
+    // Multiple newlines should not cause extra composition
+    publishFederatedSubgraphResp = await client.publishFederatedSubgraph({
+      name: subgraphName,
+      namespace: 'default',
+      schema: subgraphSDL + '\r\n\r\n\r\n\n\n\n',
+    });
+
+    expect(publishFederatedSubgraphResp.response?.code).toBe(EnumStatusCode.OK);
+    expect(publishFederatedSubgraphResp.hasChanged).toBe(false);
+
+    // Trimmed should not cause extra composition
+    publishFederatedSubgraphResp = await client.publishFederatedSubgraph({
+      name: subgraphName,
+      namespace: 'default',
+      schema: subgraphSDL.trimEnd(),
+    });
+
+    expect(publishFederatedSubgraphResp.response?.code).toBe(EnumStatusCode.OK);
+    expect(publishFederatedSubgraphResp.hasChanged).toBe(false);
+  });
+
   test.each(['organization-admin', 'organization-developer', 'subgraph-admin', 'subgraph-publisher'])(
     '%s should be able to publish to existing regular subgraph',
     async (role) => {

--- a/controlplane/test/test-data/feature-flags/products-standalone-feature.graphql
+++ b/controlplane/test/test-data/feature-flags/products-standalone-feature.graphql
@@ -3,7 +3,6 @@ type Product @key(fields: "upc sku") {
   sku: String!
   details: String!
   isPremium: Boolean! @tag(name: "exclude")
-  newField: String!
 }
 
 type Query {


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unnecessary subgraph compositions when schema updates differ only by trailing whitespace/newline formatting.
  * Normalized trailing whitespace when comparing and storing updated schema versions.
* **Tests**
  * Added a case ensuring re-publishing with formatting-only schema differences does not trigger extra compositions.
* **Chores**
  * Removed an unused `newField` from the `Product` test GraphQL schema.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [x] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [x] Tests or benchmarks have been added or updated.
- [ ] If applicable, I have provided instructions for reviewers for [manually validating my changes](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md#pull-requests-conventions).
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

<!--
Please add any additional information or context regarding your changes here.
-->
This fixes a regression that caused changes to be detected when only trailing newlines were either added or removed