### PR TITLE
feat: fallback to owned organizations when the user has not been assigned to any group in Keycloak

### DIFF
--- a/controlplane/src/core/repositories/OrganizationRepository.ts
+++ b/controlplane/src/core/repositories/OrganizationRepository.ts
@@ -301,6 +301,7 @@ export class OrganizationRepository {
       .leftJoin(organizationBilling, eq(organizations.id, organizationBilling.organizationId))
       .leftJoin(billingSubscriptions, eq(organizations.id, billingSubscriptions.organizationId))
       .where(and(eq(users.id, input.userId), eq(organizationsMembers.active, true)))
+      .orderBy(asc(organizations.createdAt))
       .execute();
 
     return Promise.all(

--- a/controlplane/src/core/repositories/OrganizationRepository.ts
+++ b/controlplane/src/core/repositories/OrganizationRepository.ts
@@ -301,55 +301,56 @@ export class OrganizationRepository {
       .leftJoin(organizationBilling, eq(organizations.id, organizationBilling.organizationId))
       .leftJoin(billingSubscriptions, eq(organizations.id, billingSubscriptions.organizationId))
       .where(and(eq(users.id, input.userId), eq(organizationsMembers.active, true)))
-      .orderBy(asc(organizations.createdAt))
       .execute();
 
     return Promise.all(
-      userOrganizations.map(async (org) => {
-        const plan = org.billing?.plan || this.defaultBillingPlanId;
-        const groups = await this.getOrganizationMemberGroups({
-          userID: input.userId,
-          organizationID: org.id,
-        });
+      userOrganizations
+        .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime())
+        .map(async (org) => {
+          const plan = org.billing?.plan || this.defaultBillingPlanId;
+          const groups = await this.getOrganizationMemberGroups({
+            userID: input.userId,
+            organizationID: org.id,
+          });
 
-        const features = await this.getFeatures({ organizationId: org.id, plan });
-        return {
-          id: org.id,
-          name: org.name,
-          slug: org.slug,
-          creatorUserId: org.creatorUserId || undefined,
-          createdAt: org.createdAt.toISOString(),
-          rbac: new RBACEvaluator(groups, input.userId),
-          groups,
-          features,
-          billing: plan
-            ? {
-                plan,
-              }
-            : undefined,
-          subscription: org.subscription
-            ? {
-                status: org.subscription.status,
-                trialEnd: org.subscription.trialEnd?.toISOString(),
-                cancelAtPeriodEnd: org.subscription.cancelAtPeriodEnd,
-                currentPeriodEnd: org.subscription.currentPeriodEnd?.toISOString(),
-              }
-            : undefined,
-          deactivation: org.isDeactivated
-            ? {
-                reason: org.deactivationReason || undefined,
-                initiatedAt: org.deactivatedAt?.toISOString() ?? '',
-              }
-            : undefined,
-          deletion: org.queuedForDeletionAt
-            ? {
-                queuedAt: org.queuedForDeletionAt?.toISOString() ?? '',
-                queuedBy: org.queuedForDeletionBy || undefined,
-              }
-            : undefined,
-          kcGroupId: org.kcGroupId || undefined,
-        };
-      }),
+          const features = await this.getFeatures({ organizationId: org.id, plan });
+          return {
+            id: org.id,
+            name: org.name,
+            slug: org.slug,
+            creatorUserId: org.creatorUserId || undefined,
+            createdAt: org.createdAt.toISOString(),
+            rbac: new RBACEvaluator(groups, input.userId),
+            groups,
+            features,
+            billing: plan
+              ? {
+                  plan,
+                }
+              : undefined,
+            subscription: org.subscription
+              ? {
+                  status: org.subscription.status,
+                  trialEnd: org.subscription.trialEnd?.toISOString(),
+                  cancelAtPeriodEnd: org.subscription.cancelAtPeriodEnd,
+                  currentPeriodEnd: org.subscription.currentPeriodEnd?.toISOString(),
+                }
+              : undefined,
+            deactivation: org.isDeactivated
+              ? {
+                  reason: org.deactivationReason || undefined,
+                  initiatedAt: org.deactivatedAt?.toISOString() ?? '',
+                }
+              : undefined,
+            deletion: org.queuedForDeletionAt
+              ? {
+                  queuedAt: org.queuedForDeletionAt?.toISOString() ?? '',
+                  queuedBy: org.queuedForDeletionBy || undefined,
+                }
+              : undefined,
+            kcGroupId: org.kcGroupId || undefined,
+          };
+        }),
     );
   }
 

--- a/controlplane/src/core/services/AccessTokenAuthenticator.ts
+++ b/controlplane/src/core/services/AccessTokenAuthenticator.ts
@@ -6,7 +6,7 @@ import { OidcRepository } from '../repositories/OidcRepository.js';
 import { NamespaceLoginMethodRepository } from '../repositories/NamespaceLoginMethodRepository.js';
 import { OrganizationLoginMethodRepository } from '../repositories/OrganizationLoginMethodRepository.js';
 import { traced } from '../tracing.js';
-import type { LoginMethod } from '../../types/index.js';
+import type { LoginMethod, OrganizationDTO } from '../../types/index.js';
 import { buildAuthState } from '../util.js';
 import type { RBACEvaluator } from './RBACEvaluator.js';
 
@@ -38,23 +38,43 @@ export default class AccessTokenAuthenticator {
     const userInfoData = await this.authUtils.getUserInfo(accessToken);
 
     const orgSlug = organizationSlug || userInfoData.groups?.[0]?.split('/')?.[1];
-    if (!orgSlug) {
-      throw new AuthenticationError(EnumStatusCode.ERROR_NOT_AUTHENTICATED, 'Cannot determine organization slug');
-    }
+    let organization: Omit<OrganizationDTO, 'rbac'> | null = null;
+    let shouldCheckForUserMembership = true;
+    if (orgSlug) {
+      // The authenticated user is part of at least one group in Keycloak
+      organization = await this.orgRepo.bySlug(orgSlug);
+    } else {
+      /**
+       * The authenticated user is not part of any group in Keycloak, instead of failing, we'll check whether the
+       * user owns any organization and assume the first organization they created as the organization we are using.
+       */
+      const memberships = await this.orgRepo.memberships({ userId: userInfoData.sub });
+      const ownedOrganizations = memberships.filter((org) => org.creatorUserId === userInfoData.sub);
+      if (ownedOrganizations.length === 0) {
+        // The authenticated user doesn't own any organization, fallback to erroring
+        throw new AuthenticationError(EnumStatusCode.ERROR_NOT_AUTHENTICATED, 'Cannot determine organization slug');
+      }
 
-    const organization = await this.orgRepo.bySlug(orgSlug);
+      shouldCheckForUserMembership = false;
+      organization = ownedOrganizations[0];
+    }
 
     if (!organization || !organization?.id) {
       throw new AuthenticationError(EnumStatusCode.ERROR_NOT_AUTHENTICATED, 'Organization does not exist');
     }
 
-    const isMember = await this.orgRepo.isMemberOf({
-      userId: userInfoData.sub,
-      organizationId: organization.id,
-    });
+    if (shouldCheckForUserMembership) {
+      const isMember = await this.orgRepo.isMemberOf({
+        userId: userInfoData.sub,
+        organizationId: organization.id,
+      });
 
-    if (!isMember) {
-      throw new AuthenticationError(EnumStatusCode.ERROR_NOT_AUTHENTICATED, 'User is not a member of the organization');
+      if (!isMember) {
+        throw new AuthenticationError(
+          EnumStatusCode.ERROR_NOT_AUTHENTICATED,
+          'User is not a member of the organization',
+        );
+      }
     }
 
     const organizationDeactivated = !!organization.deactivation;

--- a/controlplane/test/auth/access-token-authentiocator.test.ts
+++ b/controlplane/test/auth/access-token-authentiocator.test.ts
@@ -1,0 +1,69 @@
+import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
+import { afterAllSetup, beforeAllSetup } from '../../src/core/test-util.js';
+import AccessTokenAuthenticator from '../../src/core/services/AccessTokenAuthenticator.js';
+import { OrganizationRepository } from '../../src/core/repositories/OrganizationRepository.js';
+import AuthUtils from '../../src/core/auth-utils.js';
+import { OidcRepository } from '../../src/core/repositories/OidcRepository.js';
+import { NamespaceLoginMethodRepository } from '../../src/core/repositories/NamespaceLoginMethodRepository.js';
+import { OrganizationLoginMethodRepository } from '../../src/core/repositories/OrganizationLoginMethodRepository.js';
+import { UserInfoEndpointResponse } from '../../src/types/index.js';
+import { SetupTest } from './../test-util.js';
+
+let dbname = '';
+
+describe('AccessTokenAuthenticator', () => {
+  beforeAll(async () => {
+    dbname = await beforeAllSetup();
+  });
+
+  afterAll(async () => {
+    await afterAllSetup(dbname);
+  });
+
+  test('that an user with no groups fallback to owned organizations', async (testContext) => {
+    const { server, users } = await SetupTest({ dbname, enableMultiUsers: true });
+    testContext.onTestFinished(() => server.close());
+
+    const authUtils = new AuthUtils(server.db, {
+      webBaseUrl: 'https://UNUSED/',
+      webErrorPath: 'UNUSED',
+      ssoCookieDomain: undefined,
+      jwtSecret: 'UNUSED',
+      oauth: {
+        clientID: 'UNUSED',
+        openIdApiBaseUrl: 'UNUSED',
+        openIdFrontendUrl: 'UNUSED',
+        redirectUri: 'UNUSED',
+        logoutRedirectUri: 'UNUSED',
+      },
+      session: { cookieName: 'UNUSED' },
+      pkce: { cookieName: 'UNUSED' },
+    });
+
+    const alice = users.adminAliceCompanyA;
+    authUtils.getUserInfo = vi.fn(() =>
+      Promise.resolve({
+        preferred_username: alice.userDisplayName,
+        name: alice.email,
+        email_verified: true,
+        sub: alice.userId,
+        given_name: 'Test',
+        family_name: 'Test',
+        email: alice.email,
+        groups: [],
+      } as UserInfoEndpointResponse),
+    );
+
+    const authenticator = new AccessTokenAuthenticator(
+      new OrganizationRepository(server.log, server.db),
+      authUtils,
+      new OidcRepository(server.db),
+      new NamespaceLoginMethodRepository(server.db),
+      new OrganizationLoginMethodRepository(server.db),
+    );
+
+    const context = await authenticator.authenticate('', null);
+    expect(context.organizationId).toBe(alice.organizationId);
+    expect(context.organizationSlug).toBe(alice.organizationSlug);
+  });
+});


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved organization selection during access-token authentication when no organization identifier is provided.
  * Users are now signed in through the first organization they created in that case.
  * Organization results are now returned in a consistent order for more predictable behavior.
  * Membership verification remains enforced when an organization is explicitly selected.
* **Tests**
  * Added coverage to validate the authentication fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [x] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] If applicable, I have provided instructions for reviewers for [manually validating my changes](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md#pull-requests-conventions).
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

<!--
Please add any additional information or context regarding your changes here.
-->
