### PR TITLE
feat(router): add MCP multi-collection routing behind /mcp/{collection}

### DIFF
--- a/router/pkg/mcpserver/collections.go
+++ b/router/pkg/mcpserver/collections.go
@@ -110,7 +110,7 @@ func (s *GraphQLSchemaServer) reloadCollection(slug string, c *collection) {
 		}
 	}
 
-	registered, _ := s.registerOperationTools(c.server, selected, nil)
+	registered, _ := s.registerOperationTools(c.server, selected)
 	c.registeredTools = registered
 }
 

--- a/router/pkg/mcpserver/collections.go
+++ b/router/pkg/mcpserver/collections.go
@@ -1,0 +1,135 @@
+package mcpserver
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"regexp"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"go.uber.org/zap"
+
+	"github.com/wundergraph/cosmo/router/pkg/schemaloader"
+)
+
+// collectionSlugPattern validates URL-safe collection slugs.
+var collectionSlugPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9_-]*$`)
+
+// collection is a named subset of operation-execution tools served by its own
+// MCP server at /mcp/{slug}.
+type collection struct {
+	server *mcp.Server
+	// operationNames is the desired set of operations for this collection.
+	operationNames map[string]struct{}
+	// registeredTools tracks the tools currently registered on the server so
+	// they can be removed on reload.
+	registeredTools []string
+}
+
+// collectionKey is a context key for the collection resolved from the request path.
+type collectionKey struct{}
+
+// collectionFromContext returns the collection resolved by the collection
+// middleware, if the request was routed through one.
+func collectionFromContext(ctx context.Context) (*collection, bool) {
+	c, ok := ctx.Value(collectionKey{}).(*collection)
+	return c, ok
+}
+
+// RegisterCollection registers a named collection of operations served at
+// /mcp/{slug}. The collection's MCP server exposes only the operation-execution
+// tools for the given operation names; the built-in tools (get_schema,
+// execute_graphql, get_operation_info) remain available on /mcp only.
+// Operation names that are not loaded are skipped with a warning and picked up
+// on the next Reload, since collections may be registered before operations
+// are loaded.
+func (s *GraphQLSchemaServer) RegisterCollection(slug string, operationNames []string) error {
+	if !collectionSlugPattern.MatchString(slug) {
+		return fmt.Errorf("invalid collection slug %q: must match %s", slug, collectionSlugPattern)
+	}
+
+	s.collectionsMu.Lock()
+	defer s.collectionsMu.Unlock()
+
+	if _, exists := s.collections[slug]; exists {
+		return fmt.Errorf("collection %q is already registered", slug)
+	}
+
+	c := &collection{
+		server:         newMCPServer(s.graphName + "-" + slug),
+		operationNames: make(map[string]struct{}, len(operationNames)),
+	}
+	for _, name := range operationNames {
+		c.operationNames[name] = struct{}{}
+	}
+
+	s.collections[slug] = c
+
+	s.reloadCollection(slug, c)
+
+	return nil
+}
+
+// reloadCollections rebuilds the tools of every registered collection from the
+// currently loaded operations.
+func (s *GraphQLSchemaServer) reloadCollections() {
+	s.collectionsMu.Lock()
+	defer s.collectionsMu.Unlock()
+
+	for slug, c := range s.collections {
+		s.reloadCollection(slug, c)
+	}
+}
+
+// reloadCollection rebuilds a single collection's tools. It is a no-op until
+// operations have been loaded via Reload, which then rebuilds every
+// collection. Callers must hold collectionsMu.
+func (s *GraphQLSchemaServer) reloadCollection(slug string, c *collection) {
+	if s.operationsManager == nil {
+		return
+	}
+
+	c.server.RemoveTools(c.registeredTools...)
+	c.registeredTools = nil
+
+	operations := s.operationsManager.GetFilteredOperations()
+	selected := make([]schemaloader.Operation, 0, len(c.operationNames))
+	found := make(map[string]struct{}, len(c.operationNames))
+	for _, op := range operations {
+		if _, ok := c.operationNames[op.Name]; ok {
+			selected = append(selected, op)
+			found[op.Name] = struct{}{}
+		}
+	}
+	for name := range c.operationNames {
+		if _, ok := found[name]; !ok {
+			s.logger.Warn("operation not found for MCP collection, skipping",
+				zap.String("collection", slug),
+				zap.String("operation", name))
+		}
+	}
+
+	registered, _ := s.registerOperationTools(c.server, selected, nil)
+	c.registeredTools = registered
+}
+
+// collectionMiddleware resolves the {collection} URL parameter against the
+// registry, responding 404 for unknown slugs before the request reaches the
+// streamable handler, whose getServer-nil path would yield a 400 instead.
+func (s *GraphQLSchemaServer) collectionMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		slug := chi.URLParam(r, "collection")
+
+		s.collectionsMu.RLock()
+		c := s.collections[slug]
+		s.collectionsMu.RUnlock()
+
+		if c == nil {
+			http.NotFound(w, r)
+			return
+		}
+
+		next.ServeHTTP(w, r.WithContext(context.WithValue(r.Context(), collectionKey{}, c)))
+	})
+}

--- a/router/pkg/mcpserver/collections.go
+++ b/router/pkg/mcpserver/collections.go
@@ -17,21 +17,18 @@ import (
 var collectionSlugPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9_-]*$`)
 
 // collection is a named subset of operation-execution tools served by its own
-// MCP server at /mcp/{slug}.
+// MCP server at /mcp/{slug}. It holds the desired set of operation names and
+// the currently registered tools, which are replaced on reload.
 type collection struct {
-	server *mcp.Server
-	// operationNames is the desired set of operations for this collection.
-	operationNames map[string]struct{}
-	// registeredTools tracks the tools currently registered on the server so
-	// they can be removed on reload.
+	server          *mcp.Server
+	operationNames  map[string]struct{}
 	registeredTools []string
 }
 
 // collectionKey is a context key for the collection resolved from the request path.
 type collectionKey struct{}
 
-// collectionFromContext returns the collection resolved by the collection
-// middleware, if the request was routed through one.
+// collectionFromContext returns the collection resolved by the collection middleware.
 func collectionFromContext(ctx context.Context) (*collection, bool) {
 	c, ok := ctx.Value(collectionKey{}).(*collection)
 	return c, ok
@@ -39,7 +36,7 @@ func collectionFromContext(ctx context.Context) (*collection, bool) {
 
 // RegisterCollection registers a named collection of operations served at
 // /mcp/{slug}. The collection's MCP server exposes only the operation-execution
-// tools for the given operation names; the built-in tools (get_schema,
+// tools for the given operation names. The built-in tools (get_schema,
 // execute_graphql, get_operation_info) remain available on /mcp only.
 // Operation names that are not loaded are skipped with a warning and picked up
 // on the next Reload, since collections may be registered before operations
@@ -83,8 +80,7 @@ func (s *GraphQLSchemaServer) reloadCollections() {
 }
 
 // reloadCollection rebuilds a single collection's tools. It is a no-op until
-// operations have been loaded via Reload, which then rebuilds every
-// collection. Callers must hold collectionsMu.
+// operations have been loaded. Callers must hold collectionsMu.
 func (s *GraphQLSchemaServer) reloadCollection(slug string, c *collection) {
 	if s.operationsManager == nil {
 		return

--- a/router/pkg/mcpserver/collections_test.go
+++ b/router/pkg/mcpserver/collections_test.go
@@ -112,6 +112,28 @@ func TestCollections_RegisterAfterReload(t *testing.T) {
 	assert.ElementsMatch(t, []string{"find_employee"}, listToolNames(t, ts.URL+"/mcp/a"))
 }
 
+func TestCollections_NonCanonicalPaths(t *testing.T) {
+	srv := newCollectionTestServer(t)
+
+	require.NoError(t, srv.RegisterCollection("a", []string{"FindEmployee"}))
+
+	reloadTestServer(t, srv)
+
+	ts := httptest.NewServer(srv.buildHandler())
+	defer ts.Close()
+
+	// Non-canonical paths are cleaned before routing (as the previous
+	// http.ServeMux did via redirect), so clients that naively join base URLs
+	// with a doubled slash keep working.
+	assert.ElementsMatch(t, []string{"find_employee"}, listToolNames(t, ts.URL+"/mcp//a"))
+	assert.ElementsMatch(t, []string{
+		"get_schema",
+		"find_employee",
+		"list_employees",
+		"get_operation_info",
+	}, listToolNames(t, ts.URL+"//mcp"))
+}
+
 func TestCollections_UnknownSlugNotFound(t *testing.T) {
 	srv := newCollectionTestServer(t)
 

--- a/router/pkg/mcpserver/collections_test.go
+++ b/router/pkg/mcpserver/collections_test.go
@@ -1,0 +1,148 @@
+package mcpserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wundergraph/cosmo/router/pkg/cors"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/astparser"
+	"github.com/wundergraph/graphql-go-tools/v2/pkg/asttransform"
+	"go.uber.org/zap"
+)
+
+// newCollectionTestServer creates a schema server with the FindEmployee and
+// ListEmployees operations loaded from a temp directory. Reload is left to the
+// caller so tests can control registration order.
+func newCollectionTestServer(t *testing.T) *GraphQLSchemaServer {
+	t.Helper()
+
+	tempDir := t.TempDir()
+	writeOperationFiles(t, tempDir, map[string]string{
+		"FindEmployee.graphql":  findEmployeeOp,
+		"ListEmployees.graphql": listEmployeesOp,
+	})
+
+	srv, err := NewGraphQLSchemaServer(
+		t.Context(),
+		"http://localhost:4000/graphql",
+		WithLogger(zap.NewNop()),
+		WithOperationsDir(tempDir),
+		WithOmitToolNamePrefix(true),
+		WithCORS(cors.Config{}),
+	)
+	require.NoError(t, err)
+
+	return srv
+}
+
+func reloadTestServer(t *testing.T, srv *GraphQLSchemaServer) {
+	t.Helper()
+
+	schemaDoc, report := astparser.ParseGraphqlDocumentString(testSchema)
+	require.False(t, report.HasErrors())
+	err := asttransform.MergeDefinitionWithBaseSchema(&schemaDoc)
+	require.NoError(t, err)
+
+	err = srv.Reload(&schemaDoc, nil)
+	require.NoError(t, err)
+}
+
+// listToolNames connects an MCP client to the given endpoint and returns the
+// names of the tools it advertises.
+func listToolNames(t *testing.T, endpoint string) []string {
+	t.Helper()
+
+	ctx := t.Context()
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "1.0.0"}, nil)
+	session, err := client.Connect(ctx, &mcp.StreamableClientTransport{
+		Endpoint:             endpoint,
+		DisableStandaloneSSE: true,
+	}, nil)
+	require.NoError(t, err)
+	defer session.Close()
+
+	res, err := session.ListTools(ctx, nil)
+	require.NoError(t, err)
+
+	names := make([]string, 0, len(res.Tools))
+	for _, tool := range res.Tools {
+		names = append(names, tool.Name)
+	}
+	return names
+}
+
+func TestCollections_DisjointToolLists(t *testing.T) {
+	srv := newCollectionTestServer(t)
+
+	require.NoError(t, srv.RegisterCollection("a", []string{"FindEmployee"}))
+	require.NoError(t, srv.RegisterCollection("b", []string{"ListEmployees"}))
+
+	reloadTestServer(t, srv)
+
+	ts := httptest.NewServer(srv.buildHandler())
+	defer ts.Close()
+
+	assert.ElementsMatch(t, []string{"find_employee"}, listToolNames(t, ts.URL+"/mcp/a"))
+	assert.ElementsMatch(t, []string{"list_employees"}, listToolNames(t, ts.URL+"/mcp/b"))
+
+	// The default endpoint is unchanged: all operation tools plus built-ins.
+	assert.ElementsMatch(t, []string{
+		"get_schema",
+		"find_employee",
+		"list_employees",
+		"get_operation_info",
+	}, listToolNames(t, ts.URL+"/mcp"))
+}
+
+func TestCollections_RegisterAfterReload(t *testing.T) {
+	srv := newCollectionTestServer(t)
+
+	reloadTestServer(t, srv)
+
+	require.NoError(t, srv.RegisterCollection("a", []string{"FindEmployee"}))
+
+	ts := httptest.NewServer(srv.buildHandler())
+	defer ts.Close()
+
+	assert.ElementsMatch(t, []string{"find_employee"}, listToolNames(t, ts.URL+"/mcp/a"))
+}
+
+func TestCollections_UnknownSlugNotFound(t *testing.T) {
+	srv := newCollectionTestServer(t)
+
+	require.NoError(t, srv.RegisterCollection("a", []string{"FindEmployee"}))
+
+	reloadTestServer(t, srv)
+
+	ts := httptest.NewServer(srv.buildHandler())
+	defer ts.Close()
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, ts.URL+"/mcp/unknown", strings.NewReader(`{}`))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+func TestCollections_RegistrationErrors(t *testing.T) {
+	srv := newCollectionTestServer(t)
+
+	for _, slug := range []string{"", "Has Spaces", "a/b", "UPPER", "-leading-dash"} {
+		err := srv.RegisterCollection(slug, []string{"FindEmployee"})
+		assert.Error(t, err, "slug %q should be rejected", slug)
+	}
+
+	require.NoError(t, srv.RegisterCollection("valid-slug_1", []string{"FindEmployee"}))
+	err := srv.RegisterCollection("valid-slug_1", []string{"ListEmployees"})
+	assert.ErrorContains(t, err, "already registered")
+}

--- a/router/pkg/mcpserver/server.go
+++ b/router/pkg/mcpserver/server.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	chimiddleware "github.com/go-chi/chi/v5/middleware"
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/iancoleman/strcase"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -503,6 +504,9 @@ func (s *GraphQLSchemaServer) buildHandler() http.Handler {
 
 	httpRouter := chi.NewRouter()
 
+	// Canonicalize request paths
+	httpRouter.Use(chimiddleware.CleanPath)
+
 	// OAuth 2.0 Protected Resource Metadata (RFC 9728) — public discovery endpoint
 	if s.oauthConfig != nil && s.oauthConfig.Enabled && s.oauthConfig.AuthorizationServerURL != "" {
 		httpRouter.Handle("/.well-known/oauth-protected-resource/mcp", middleware(http.HandlerFunc(s.handleProtectedResourceMetadata)))
@@ -674,7 +678,7 @@ func (s *GraphQLSchemaServer) registerTools() error {
 		graphqlOperationNames = append(graphqlOperationNames, op.Name)
 	}
 
-	registered, toolScopes := s.registerOperationTools(s.server, operations, s.registeredTools)
+	registered, toolScopes := s.registerOperationTools(s.server, operations)
 	s.registeredTools = append(s.registeredTools, registered...)
 
 	// Update auth middleware with per-tool scopes (thread-safe)
@@ -710,12 +714,10 @@ func (s *GraphQLSchemaServer) registerTools() error {
 }
 
 // registerOperationTools registers the execute-operation tool for each of the
-// given operations on the target MCP server. alreadyRegistered contains tool
-// names already taken on the target server, used for collision detection when
-// omitToolNamePrefix is enabled. It returns the names of the tools it
-// registered and the per-tool scope requirements of operations that declare
-// any.
-func (s *GraphQLSchemaServer) registerOperationTools(target *mcp.Server, operations []schemaloader.Operation, alreadyRegistered []string) ([]string, map[string][][]string) {
+// given operations on the target MCP server. It returns the names of the
+// tools it registered and the per-tool scope requirements of operations that
+// declare any.
+func (s *GraphQLSchemaServer) registerOperationTools(target *mcp.Server, operations []schemaloader.Operation) ([]string, map[string][][]string) {
 	var registered []string
 
 	// Build per-tool scope map for the auth middleware
@@ -765,7 +767,7 @@ func (s *GraphQLSchemaServer) registerOperationTools(target *mcp.Server, operati
 		toolName := operationToolName
 		if !s.omitToolNamePrefix {
 			toolName = fmt.Sprintf("execute_operation_%s", operationToolName)
-		} else if slices.Contains(alreadyRegistered, operationToolName) || slices.Contains(registered, operationToolName) || slices.Contains(reservedToolNames, operationToolName) {
+		} else if slices.Contains(registered, operationToolName) || slices.Contains(reservedToolNames, operationToolName) {
 			s.logger.Error("Skipping operation due to tool name collision",
 				zap.String("operation", op.Name),
 				zap.String("conflicting_tool", operationToolName),

--- a/router/pkg/mcpserver/server.go
+++ b/router/pkg/mcpserver/server.go
@@ -10,8 +10,10 @@ import (
 	"net/http"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
+	"github.com/go-chi/chi/v5"
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/iancoleman/strcase"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -120,6 +122,8 @@ type GraphQLSchemaServer struct {
 	serverBaseURL             string
 	resourceDocumentation     string
 	authMiddleware            *MCPAuthMiddleware
+	collections               map[string]*collection
+	collectionsMu             sync.RWMutex
 }
 
 type graphqlRequest struct {
@@ -279,20 +283,7 @@ func NewGraphQLSchemaServer(ctx context.Context, routerGraphQLEndpoint string, o
 	}
 
 	// Create the MCP server with all options
-	mcpServer := mcp.NewServer(
-		&mcp.Implementation{
-			Name:    "wundergraph-cosmo-" + strcase.ToKebab(options.GraphName),
-			Version: "0.0.1",
-		},
-		&mcp.ServerOptions{
-			PageSize: 100,
-			// Override default capabilities to disable the "logging" capability
-			// that the SDK advertises by default (for historical reasons).
-			// We don't implement logging/setLevel, so advertising it causes
-			// clients like MCP Inspector to call it and fail.
-			Capabilities: &mcp.ServerCapabilities{},
-		},
-	)
+	mcpServer := newMCPServer(options.GraphName)
 
 	retryClient := retryablehttp.NewClient()
 	retryClient.Logger = nil
@@ -319,9 +310,29 @@ func NewGraphQLSchemaServer(ctx context.Context, routerGraphQLEndpoint string, o
 		serverBaseURL:             options.ServerBaseURL,
 		resourceDocumentation:     options.ResourceDocumentation,
 		authMiddleware:            authMiddleware,
+		collections:               make(map[string]*collection),
 	}
 
 	return gs, nil
+}
+
+// newMCPServer constructs an MCP server with the implementation metadata and
+// options shared by the default endpoint and collections.
+func newMCPServer(name string) *mcp.Server {
+	return mcp.NewServer(
+		&mcp.Implementation{
+			Name:    "wundergraph-cosmo-" + strcase.ToKebab(name),
+			Version: "0.0.1",
+		},
+		&mcp.ServerOptions{
+			PageSize: 100,
+			// Override default capabilities to disable the "logging" capability
+			// that the SDK advertises by default (for historical reasons).
+			// We don't implement logging/setLevel, so advertising it causes
+			// clients like MCP Inspector to call it and fail.
+			Capabilities: &mcp.ServerCapabilities{},
+		},
+	)
 }
 
 // SetHTTPClient allows setting a custom HTTP client (useful for testing)
@@ -436,45 +447,7 @@ func (s *GraphQLSchemaServer) Serve() (*http.Server, error) {
 		IdleTimeout:  60 * time.Second,
 	}
 
-	// Create MCP streamable HTTP handler
-	// The getServer function returns our MCP server instance for each request
-	// Disable the SDK's built-in cross-origin protection (Sec-Fetch-Site check)
-	// because the router already applies its own CORS middleware around the handler.
-	cop := http.NewCrossOriginProtection()
-	cop.AddInsecureBypassPattern("/{path...}")
-
-	streamableHTTPHandler := mcp.NewStreamableHTTPHandler(
-		func(req *http.Request) *mcp.Server {
-			return s.server
-		},
-		&mcp.StreamableHTTPOptions{
-			Stateless:             s.stateless,
-			CrossOriginProtection: cop,
-		},
-	)
-
-	middleware := cors.New(s.corsConfig)
-
-	mux := http.NewServeMux()
-
-	// OAuth 2.0 Protected Resource Metadata (RFC 9728) — public discovery endpoint
-	if s.oauthConfig != nil && s.oauthConfig.Enabled && s.oauthConfig.AuthorizationServerURL != "" {
-		mux.Handle("/.well-known/oauth-protected-resource/mcp", middleware(http.HandlerFunc(s.handleProtectedResourceMetadata)))
-	}
-
-	// Inject request headers into context so tool handlers can forward them
-	// to the GraphQL engine via headersFromContext.
-	mcpHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		r = r.WithContext(requestHeadersFromRequest(r.Context(), r))
-		streamableHTTPHandler.ServeHTTP(w, r)
-	})
-	if s.authMiddleware != nil {
-		mux.Handle("/mcp", middleware(s.authMiddleware.HTTPMiddleware(mcpHandler)))
-	} else {
-		mux.Handle("/mcp", middleware(mcpHandler))
-	}
-
-	httpServer.Handler = mux
+	httpServer.Handler = s.buildHandler()
 
 	logger := []zap.Field{
 		zap.String("listen_addr", s.listenAddr),
@@ -498,6 +471,61 @@ func (s *GraphQLSchemaServer) Serve() (*http.Server, error) {
 	}()
 
 	return httpServer, nil
+}
+
+// buildHandler constructs the HTTP handler serving the MCP endpoint, the
+// per-collection endpoints, and, when OAuth is enabled, the protected
+// resource metadata endpoint.
+func (s *GraphQLSchemaServer) buildHandler() http.Handler {
+	// Create MCP streamable HTTP handler
+	// The getServer function returns the MCP server instance for each request:
+	// the collection's server when the request was routed through the
+	// collection middleware, the default server otherwise.
+	// Disable the SDK's built-in cross-origin protection (Sec-Fetch-Site check)
+	// because the router already applies its own CORS middleware around the handler.
+	cop := http.NewCrossOriginProtection()
+	cop.AddInsecureBypassPattern("/{path...}")
+
+	streamableHTTPHandler := mcp.NewStreamableHTTPHandler(
+		func(req *http.Request) *mcp.Server {
+			if c, ok := collectionFromContext(req.Context()); ok {
+				return c.server
+			}
+			return s.server
+		},
+		&mcp.StreamableHTTPOptions{
+			Stateless:             s.stateless,
+			CrossOriginProtection: cop,
+		},
+	)
+
+	middleware := cors.New(s.corsConfig)
+
+	httpRouter := chi.NewRouter()
+
+	// OAuth 2.0 Protected Resource Metadata (RFC 9728) — public discovery endpoint
+	if s.oauthConfig != nil && s.oauthConfig.Enabled && s.oauthConfig.AuthorizationServerURL != "" {
+		httpRouter.Handle("/.well-known/oauth-protected-resource/mcp", middleware(http.HandlerFunc(s.handleProtectedResourceMetadata)))
+	}
+
+	// Inject request headers into context so tool handlers can forward them
+	// to the GraphQL engine via headersFromContext.
+	mcpHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r = r.WithContext(requestHeadersFromRequest(r.Context(), r))
+		streamableHTTPHandler.ServeHTTP(w, r)
+	})
+
+	wrap := func(h http.Handler) http.Handler {
+		if s.authMiddleware != nil {
+			h = s.authMiddleware.HTTPMiddleware(h)
+		}
+		return middleware(h)
+	}
+
+	httpRouter.Handle("/mcp", wrap(mcpHandler))
+	httpRouter.Handle("/mcp/{collection}", wrap(s.collectionMiddleware(mcpHandler)))
+
+	return httpRouter
 }
 
 // Start loads operations and starts the server
@@ -545,6 +573,8 @@ func (s *GraphQLSchemaServer) Reload(schema *ast.Document, fieldConfigs []*nodev
 	if err := s.registerTools(); err != nil {
 		return fmt.Errorf("failed to register tools: %w", err)
 	}
+
+	s.reloadCollections()
 
 	return nil
 }
@@ -640,6 +670,53 @@ func (s *GraphQLSchemaServer) registerTools() error {
 	operations := s.operationsManager.GetFilteredOperations()
 
 	graphqlOperationNames := make([]string, 0, len(operations))
+	for _, op := range operations {
+		graphqlOperationNames = append(graphqlOperationNames, op.Name)
+	}
+
+	registered, toolScopes := s.registerOperationTools(s.server, operations, s.registeredTools)
+	s.registeredTools = append(s.registeredTools, registered...)
+
+	// Update auth middleware with per-tool scopes (thread-safe)
+	if s.authMiddleware != nil {
+		s.authMiddleware.SetToolScopes(toolScopes)
+	}
+
+	getOperationInfoTool := &mcp.Tool{
+		Name:        "get_operation_info",
+		Description: "Provides instructions on how to execute the GraphQL operation via HTTP and how to integrate it into your application.",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"operationName": map[string]any{
+					"type":        "string",
+					"description": "The exact name of the GraphQL operation to retrieve information for.",
+					"enum":        graphqlOperationNames,
+				},
+			},
+			"required": []string{"operationName"},
+		},
+		Annotations: &mcp.ToolAnnotations{
+			Title:        "Get GraphQL Operation Info",
+			ReadOnlyHint: true,
+		},
+	}
+
+	s.server.AddTool(getOperationInfoTool, s.handleGraphQLOperationInfo())
+
+	s.registeredTools = append(s.registeredTools, "get_operation_info")
+
+	return nil
+}
+
+// registerOperationTools registers the execute-operation tool for each of the
+// given operations on the target MCP server. alreadyRegistered contains tool
+// names already taken on the target server, used for collision detection when
+// omitToolNamePrefix is enabled. It returns the names of the tools it
+// registered and the per-tool scope requirements of operations that declare
+// any.
+func (s *GraphQLSchemaServer) registerOperationTools(target *mcp.Server, operations []schemaloader.Operation, alreadyRegistered []string) ([]string, map[string][][]string) {
+	var registered []string
 
 	// Build per-tool scope map for the auth middleware
 	toolScopes := make(map[string][][]string)
@@ -647,8 +724,6 @@ func (s *GraphQLSchemaServer) registerTools() error {
 	for _, op := range operations {
 		var compiledSchema *jsonschema.Schema
 		var err error
-
-		graphqlOperationNames = append(graphqlOperationNames, op.Name)
 
 		if len(op.JSONSchema) > 0 {
 			// Validate the JSON schema before compiling it
@@ -690,7 +765,7 @@ func (s *GraphQLSchemaServer) registerTools() error {
 		toolName := operationToolName
 		if !s.omitToolNamePrefix {
 			toolName = fmt.Sprintf("execute_operation_%s", operationToolName)
-		} else if slices.Contains(s.registeredTools, operationToolName) || slices.Contains(reservedToolNames, operationToolName) {
+		} else if slices.Contains(alreadyRegistered, operationToolName) || slices.Contains(registered, operationToolName) || slices.Contains(reservedToolNames, operationToolName) {
 			s.logger.Error("Skipping operation due to tool name collision",
 				zap.String("operation", op.Name),
 				zap.String("conflicting_tool", operationToolName),
@@ -723,9 +798,9 @@ func (s *GraphQLSchemaServer) registerTools() error {
 			},
 		}
 
-		s.server.AddTool(tool, s.handleOperation(handler))
+		target.AddTool(tool, s.handleOperation(handler))
 
-		s.registeredTools = append(s.registeredTools, toolName)
+		registered = append(registered, toolName)
 
 		// Record per-tool scope requirements for auth middleware enforcement
 		if len(op.RequiredScopes) > 0 {
@@ -733,36 +808,7 @@ func (s *GraphQLSchemaServer) registerTools() error {
 		}
 	}
 
-	// Update auth middleware with per-tool scopes (thread-safe)
-	if s.authMiddleware != nil {
-		s.authMiddleware.SetToolScopes(toolScopes)
-	}
-
-	getOperationInfoTool := &mcp.Tool{
-		Name:        "get_operation_info",
-		Description: "Provides instructions on how to execute the GraphQL operation via HTTP and how to integrate it into your application.",
-		InputSchema: map[string]any{
-			"type": "object",
-			"properties": map[string]any{
-				"operationName": map[string]any{
-					"type":        "string",
-					"description": "The exact name of the GraphQL operation to retrieve information for.",
-					"enum":        graphqlOperationNames,
-				},
-			},
-			"required": []string{"operationName"},
-		},
-		Annotations: &mcp.ToolAnnotations{
-			Title:        "Get GraphQL Operation Info",
-			ReadOnlyHint: true,
-		},
-	}
-
-	s.server.AddTool(getOperationInfoTool, s.handleGraphQLOperationInfo())
-
-	s.registeredTools = append(s.registeredTools, "get_operation_info")
-
-	return nil
+	return registered, toolScopes
 }
 
 // handleOperation handles a specific operation


### PR DESCRIPTION
## Motivation and Context

Adds named tool collections to the router's MCP server as an internal, Go-API-only capability. A collection is a subset of operation-execution tools served by its own `*mcp.Server` at `/mcp/{collection}`, registered programmatically via `RegisterCollection(slug, operationNames)`. There is no config surface yet and nothing registers collections in production, so wire behavior is unchanged: `/mcp` behaves as before and `/mcp/{anything}` continues to 404.

## Changes

- `Serve()`'s handler construction is extracted into `buildHandler()`, and the `http.ServeMux` is replaced with a go-chi route tree (`/mcp`, `/mcp/{collection}`, and the OAuth well-known endpoint), matching the idiom in `core/graph_server.go`.
- `chimiddleware.CleanPath` preserves the previous ServeMux path canonicalization (e.g. `//mcp` from naive base-URL joining), which chi does not do by default.
- New collection registry (`collections.go`): slug validation (`^[a-z0-9][a-z0-9_-]*$`), duplicate rejection, per-collection `*mcp.Server` built through the shared `newMCPServer`/`registerOperationTools` path. Collections hold only operation-execution tools — `get_schema`, `execute_graphql`, and `get_operation_info` stay on `/mcp`.
- Unknown slugs 404 in middleware before reaching the SDK's streamable handler (whose `getServer`-nil path would return a 400 instead).
- Collections rebuild on every `Reload`; registration works both before and after operations load.
- The operation tool-registration loop is extracted from `registerTools()` into `registerOperationTools(target, operations)`, behavior-preserving, shared by the default server and collections.

## Tests

- New `collections_test.go`: disjoint tool lists per collection via a real MCP client, `/mcp` unchanged (full tool set), unknown slug → 404, invalid/duplicate slug registration errors, register-before-Reload and register-after-Reload orderings, and non-canonical path handling (`//mcp`, `/mcp//a`).
- All existing tests in `router/pkg/mcpserver` and `router-tests/protocol` pass without modification.

## Known follow-ups (intentionally out of scope)

- Collections discard the per-tool scope map; middleware scope enforcement on collection endpoints relies on tool-name overlap with the default server (the GraphQL engine still enforces `@requiresScopes` at execution).
- In stateful session mode (`MCP_SESSION_STATELESS=false`, non-default), the SDK resolves existing sessions before consulting `getServer`, so sessions are not pinned to the endpoint that created them.
- `Reload` swaps `operationsManager`/`schemaCompiler` without holding `collectionsMu`; latent race if `RegisterCollection` is ever called concurrently with a hot reload.
- OAuth protected-resource metadata is only served for `/mcp`, not per-collection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MCP “tool collections” exposed via collection-specific endpoints (e.g., `/mcp/{collection}`), allowing each collection to surface a selected set of operation tools.
  * Collections are created with validation and automatically refresh their advertised tools after schema reloads.
* **Bug Fixes**
  * Unknown collection paths now return a clear 404.
  * Improved handling of non-canonical paths (such as repeated slashes).
* **Tests**
  * Added coverage for disjoint tool lists, post-reload registration, path normalization, unknown-slug 404s, and registration error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->