### PR TITLE
fix(router): avoid subscription clients on subgraphs with no subscriptions

### DIFF
--- a/router/core/factoryresolver.go
+++ b/router/core/factoryresolver.go
@@ -48,7 +48,7 @@ type InstanceData struct {
 }
 
 type FactoryResolver interface {
-	ResolveGraphqlFactory(subgraphName string) (plan.PlannerFactory[graphql_datasource.Configuration], error)
+	ResolveGraphqlFactory(subgraphName string, hasSubscriptions bool) (plan.PlannerFactory[graphql_datasource.Configuration], error)
 	ResolveStaticFactory() (plan.PlannerFactory[staticdatasource.Configuration], error)
 	InstanceData() InstanceData
 }
@@ -167,7 +167,18 @@ func NewDefaultFactoryResolver(
 	}
 }
 
-func (d *DefaultFactoryResolver) ResolveGraphqlFactory(subgraphName string) (plan.PlannerFactory[graphql_datasource.Configuration], error) {
+// hasSubscriptionRootNodes reports whether a data source's root nodes include
+// any Subscription fields.
+func hasSubscriptionRootNodes(rootNodes []*nodev1.TypeField) bool {
+	for _, node := range rootNodes {
+		if node.TypeName == "Subscription" && len(node.FieldNames) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func (d *DefaultFactoryResolver) ResolveGraphqlFactory(subgraphName string, hasSubscriptions bool) (plan.PlannerFactory[graphql_datasource.Configuration], error) {
 	if d.connector != nil {
 		// If the connector is not nil, we try to get the provider for the subgraph.
 		// In case of a provider, we use the gRPC client provider to create the factory.
@@ -183,9 +194,13 @@ func (d *DefaultFactoryResolver) ResolveGraphqlFactory(subgraphName string) (pla
 
 	if d.transportFactory == nil || d.baseTransport == nil {
 		// dummy implementation for plan generator that doesn't make requests
-		subscriptionClient := graphql_datasource.NewGraphQLSubscriptionClient(d.engineCtx,
-			d.subscriptionClientOptions...,
-		)
+		var subscriptionClient graphql_datasource.GraphQLSubscriptionClient
+		if hasSubscriptions {
+			subscriptionClient = graphql_datasource.NewGraphQLSubscriptionClient(d.engineCtx,
+				d.subscriptionClientOptions...,
+			)
+		}
+
 		return graphql_datasource.NewFactory(d.engineCtx, http.DefaultClient, subscriptionClient)
 	}
 
@@ -194,14 +209,17 @@ func (d *DefaultFactoryResolver) ResolveGraphqlFactory(subgraphName string) (pla
 		Transport: d.transportFactory.RoundTripper(d.baseTransport),
 	}
 
-	streamingClient := &http.Client{
-		Transport: d.transportFactory.RoundTripper(d.baseTransport),
-	}
+	var subscriptionClient graphql_datasource.GraphQLSubscriptionClient
+	if hasSubscriptions {
+		streamingClient := &http.Client{
+			Transport: d.transportFactory.RoundTripper(d.baseTransport),
+		}
 
-	subscriptionClient := graphql_datasource.NewGraphQLSubscriptionClient(
-		d.engineCtx,
-		append([]graphql_datasource.SubscriptionClientOption{graphql_datasource.WithUpgradeClient(defaultHTTPClient), graphql_datasource.WithStreamingClient(streamingClient)}, d.subscriptionClientOptions...)...,
-	)
+		subscriptionClient = graphql_datasource.NewGraphQLSubscriptionClient(
+			d.engineCtx,
+			append([]graphql_datasource.SubscriptionClientOption{graphql_datasource.WithUpgradeClient(defaultHTTPClient), graphql_datasource.WithStreamingClient(streamingClient)}, d.subscriptionClientOptions...)...,
+		)
+	}
 
 	if subgraphClient, ok := d.subgraphHTTPClients[subgraphName]; ok {
 		// it's intentional that we're not using the subgraphClient for subscriptions
@@ -355,7 +373,7 @@ func (l *Loader) Load(engineConfig *nodev1.EngineConfiguration, subgraphs []*nod
 				return nil, providers, err
 			}
 
-			out, err = plan.NewDataSourceConfiguration[staticdatasource.Configuration](
+			out, err = plan.NewDataSourceConfiguration(
 				in.Id,
 				factory,
 				l.dataSourceMetaData(in),
@@ -483,12 +501,12 @@ func (l *Loader) Load(engineConfig *nodev1.EngineConfiguration, subgraphs []*nod
 
 			dataSourceName := l.subgraphName(subgraphs, in.Id)
 
-			factory, err := l.resolver.ResolveGraphqlFactory(dataSourceName)
+			factory, err := l.resolver.ResolveGraphqlFactory(dataSourceName, hasSubscriptionRootNodes(in.RootNodes))
 			if err != nil {
 				return nil, providers, err
 			}
 
-			out, err = plan.NewDataSourceConfigurationWithName[graphql_datasource.Configuration](
+			out, err = plan.NewDataSourceConfigurationWithName(
 				in.Id,
 				dataSourceName,
 				factory,


### PR DESCRIPTION
WIP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * GraphQL subscriptions are now enabled only for schemas that define subscription root fields.
  * Prevented subscription clients from being created for data sources that do not support subscriptions.
  * Applied consistent subscription handling across configured and generated data source plans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] If applicable, I have provided instructions for reviewers for [manually validating my changes](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md#pull-requests-conventions).
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

<!--
Please add any additional information or context regarding your changes here.
-->
