### PR TITLE
fix: reactivate users via SCIM

### DIFF
--- a/controlplane/src/core/controllers/scim.ts
+++ b/controlplane/src/core/controllers/scim.ts
@@ -211,7 +211,7 @@ const plugin: FastifyPluginCallback<ScimControllerOptions> = function Scim(fasti
         id: user.userID,
         emails: [{ value: user.email }],
         userName: user.email,
-        active: keycloakUsers[0].enabled ?? true,
+        active: user.active,
         name: {
           givenName: keycloakUsers[0].firstName || '',
           familyName: keycloakUsers[0].lastName || '',
@@ -241,7 +241,7 @@ const plugin: FastifyPluginCallback<ScimControllerOptions> = function Scim(fasti
           id: member.userID,
           emails: [{ value: member.email }],
           userName: member.email,
-          active: keycloakUsers[0].enabled ?? true,
+          active: member.active,
           name: {
             givenName: keycloakUsers[0].firstName || '',
             familyName: keycloakUsers[0].lastName || '',


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - SCIM user listings now report each user’s organization membership status accurately.
  - User activity is based on the organization record rather than the external identity provider’s enabled status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] If applicable, I have provided instructions for reviewers for [manually validating my changes](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md#pull-requests-conventions).
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

<!--
Please add any additional information or context regarding your changes here.
-->
