### PR TITLE
feat(router): Add `wait_for_hook` for Cosmo Streams

### DIFF
--- a/docs-website/router/configuration.mdx
+++ b/docs-website/router/configuration.mdx
@@ -2012,6 +2012,7 @@ Configuration for Cosmo Streams handlers. Learn more about [Custom Modules for C
 | :------------------- | :------------------------------------------------- | :--------------------- | :------------------------------------------------------------------------------------- | :-            |
 |                      | handlers.on_receive_events.handler_timeout         | <Icon icon="square" /> | The maximum time to wait for all OnReceiveEvents handlers to complete per event-batch. | 5s            |
 |                      | handlers.on_receive_events.max_concurrent_handlers | <Icon icon="square" /> | The maximum number of concurrent OnReceiveEvents handlers per trigger.                 | 100           |
+|                      | handlers.on_receive_events.wait_for_hooks          | <Icon icon="square" /> | If true, all OnReceiveEvents handlers for all subscribers run and complete for one event before the router moves on to the next event, so subscribers receive events atomically and in order. If false, handlers for each subscriber run concurrently and independently (subject to `max_concurrent_handlers` and `handler_timeout`), which may deliver events out of order when handlers are slow or time out. | true           |
 
 ## Router Engine Configuration
 

--- a/router-tests/go.mod
+++ b/router-tests/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/wundergraph/cosmo/router v0.0.0-20260710155145-803a4bc06d92
 	github.com/wundergraph/cosmo/router-plugin v0.0.0-20250808194725-de123ba1c65e
 	github.com/wundergraph/cosmo/speedtrap v0.0.0-00010101000000-000000000000
-	github.com/wundergraph/graphql-go-tools/v2 v2.13.1-0.20260718102134-5353e8c91f35
+	github.com/wundergraph/graphql-go-tools/v2 v2.13.1-0.20260718154907-6b3e4a8ada12
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/sdk/metric v1.44.0

--- a/router-tests/go.mod
+++ b/router-tests/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/wundergraph/cosmo/router v0.0.0-20260710155145-803a4bc06d92
 	github.com/wundergraph/cosmo/router-plugin v0.0.0-20250808194725-de123ba1c65e
 	github.com/wundergraph/cosmo/speedtrap v0.0.0-00010101000000-000000000000
-	github.com/wundergraph/graphql-go-tools/v2 v2.13.0
+	github.com/wundergraph/graphql-go-tools/v2 v2.13.1-0.20260718102134-5353e8c91f35
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/sdk/metric v1.44.0

--- a/router-tests/go.sum
+++ b/router-tests/go.sum
@@ -386,8 +386,8 @@ github.com/wundergraph/astjson v1.1.0 h1:xORDosrZ87zQFJwNGe/HIHXqzpdHOFmqWgykCLV
 github.com/wundergraph/astjson v1.1.0/go.mod h1:h12D/dxxnedtLzsKyBLK7/Oe4TAoGpRVC9nDpDrZSWw=
 github.com/wundergraph/go-arena v1.3.0 h1:n0ng5a1vbd8YGq1u3rMr0vPU5f6AZ1BXIiUhL1UIok8=
 github.com/wundergraph/go-arena v1.3.0/go.mod h1:ROOysEHWJjLQ8FSfNxZCziagb7Qw2nXY3/vgKRh7eWw=
-github.com/wundergraph/graphql-go-tools/v2 v2.13.1-0.20260718102134-5353e8c91f35 h1:yLg1dYwCSQ7MhghlD+76mbd+QuqNLf3ihQAayeWmVl0=
-github.com/wundergraph/graphql-go-tools/v2 v2.13.1-0.20260718102134-5353e8c91f35/go.mod h1:zREIKLmpjfNcGSubndaW/913r0Y8XbbYOXQeZFkwHdo=
+github.com/wundergraph/graphql-go-tools/v2 v2.13.1-0.20260718154907-6b3e4a8ada12 h1:tYBJ5YSTnAGAjlkJsChKeV0GHohtAgqpcrUcOrYTXgk=
+github.com/wundergraph/graphql-go-tools/v2 v2.13.1-0.20260718154907-6b3e4a8ada12/go.mod h1:zREIKLmpjfNcGSubndaW/913r0Y8XbbYOXQeZFkwHdo=
 github.com/xrash/smetrics v0.0.0-20250705151800-55b8f293f342 h1:FnBeRrxr7OU4VvAzt5X7s6266i6cSVkkFPS0TuXWbIg=
 github.com/xrash/smetrics v0.0.0-20250705151800-55b8f293f342/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=

--- a/router-tests/go.sum
+++ b/router-tests/go.sum
@@ -386,8 +386,8 @@ github.com/wundergraph/astjson v1.1.0 h1:xORDosrZ87zQFJwNGe/HIHXqzpdHOFmqWgykCLV
 github.com/wundergraph/astjson v1.1.0/go.mod h1:h12D/dxxnedtLzsKyBLK7/Oe4TAoGpRVC9nDpDrZSWw=
 github.com/wundergraph/go-arena v1.3.0 h1:n0ng5a1vbd8YGq1u3rMr0vPU5f6AZ1BXIiUhL1UIok8=
 github.com/wundergraph/go-arena v1.3.0/go.mod h1:ROOysEHWJjLQ8FSfNxZCziagb7Qw2nXY3/vgKRh7eWw=
-github.com/wundergraph/graphql-go-tools/v2 v2.13.0 h1:HfTwkaCgWxTeXiLPQDXI6aNTdO8AJ8Snz4mbuP5c0MM=
-github.com/wundergraph/graphql-go-tools/v2 v2.13.0/go.mod h1:zREIKLmpjfNcGSubndaW/913r0Y8XbbYOXQeZFkwHdo=
+github.com/wundergraph/graphql-go-tools/v2 v2.13.1-0.20260718102134-5353e8c91f35 h1:yLg1dYwCSQ7MhghlD+76mbd+QuqNLf3ihQAayeWmVl0=
+github.com/wundergraph/graphql-go-tools/v2 v2.13.1-0.20260718102134-5353e8c91f35/go.mod h1:zREIKLmpjfNcGSubndaW/913r0Y8XbbYOXQeZFkwHdo=
 github.com/xrash/smetrics v0.0.0-20250705151800-55b8f293f342 h1:FnBeRrxr7OU4VvAzt5X7s6266i6cSVkkFPS0TuXWbIg=
 github.com/xrash/smetrics v0.0.0-20250705151800-55b8f293f342/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=

--- a/router/core/factoryresolver.go
+++ b/router/core/factoryresolver.go
@@ -552,6 +552,7 @@ func (l *Loader) Load(engineConfig *nodev1.EngineConfiguration, subgraphs []*nod
 				Handlers:              onReceiveEventsFns,
 				MaxConcurrentHandlers: l.subscriptionHooks.onReceiveEvents.maxConcurrentHandlers,
 				Timeout:               l.subscriptionHooks.onReceiveEvents.timeout,
+				WaitForHooks:          l.subscriptionHooks.onReceiveEvents.waitForHooks,
 			},
 			SubscriptionOnCreate: pubsub_datasource.SubscriptionOnCreateHooks{
 				Handlers: subscriptionOnCreateFns,

--- a/router/core/router.go
+++ b/router/core/router.go
@@ -2618,6 +2618,7 @@ func WithStreamsHandlerConfiguration(cfg config.StreamsHandlerConfiguration) Opt
 	return func(r *Router) {
 		r.subscriptionHooks.onReceiveEvents.maxConcurrentHandlers = cfg.OnReceiveEvents.MaxConcurrentHandlers
 		r.subscriptionHooks.onReceiveEvents.timeout = cfg.OnReceiveEvents.HandlerTimeout
+		r.subscriptionHooks.onReceiveEvents.waitForHooks = cfg.OnReceiveEvents.WaitForHooks
 	}
 }
 

--- a/router/core/router_config.go
+++ b/router/core/router_config.go
@@ -52,6 +52,7 @@ type onReceiveEventsHooks struct {
 	handlers              []func(ctx StreamReceiveEventHandlerContext, events datasource.StreamEvents) (datasource.StreamEvents, error)
 	maxConcurrentHandlers int
 	timeout               time.Duration
+	waitForHooks          bool
 }
 
 type Config struct {

--- a/router/go.mod
+++ b/router/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/tidwall/gjson v1.18.0
 	github.com/tidwall/sjson v1.2.5
 	github.com/twmb/franz-go v1.16.1
-	github.com/wundergraph/graphql-go-tools/v2 v2.13.0
+	github.com/wundergraph/graphql-go-tools/v2 v2.13.1-0.20260718102134-5353e8c91f35
 	// Do not upgrade, it renames attributes we rely on
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0
 	go.opentelemetry.io/contrib/propagators/b3 v1.44.0

--- a/router/go.mod
+++ b/router/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/tidwall/gjson v1.18.0
 	github.com/tidwall/sjson v1.2.5
 	github.com/twmb/franz-go v1.16.1
-	github.com/wundergraph/graphql-go-tools/v2 v2.13.1-0.20260718102134-5353e8c91f35
+	github.com/wundergraph/graphql-go-tools/v2 v2.13.1-0.20260718154907-6b3e4a8ada12
 	// Do not upgrade, it renames attributes we rely on
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0
 	go.opentelemetry.io/contrib/propagators/b3 v1.44.0

--- a/router/go.sum
+++ b/router/go.sum
@@ -334,8 +334,8 @@ github.com/wundergraph/astjson v1.1.0 h1:xORDosrZ87zQFJwNGe/HIHXqzpdHOFmqWgykCLV
 github.com/wundergraph/astjson v1.1.0/go.mod h1:h12D/dxxnedtLzsKyBLK7/Oe4TAoGpRVC9nDpDrZSWw=
 github.com/wundergraph/go-arena v1.3.0 h1:n0ng5a1vbd8YGq1u3rMr0vPU5f6AZ1BXIiUhL1UIok8=
 github.com/wundergraph/go-arena v1.3.0/go.mod h1:ROOysEHWJjLQ8FSfNxZCziagb7Qw2nXY3/vgKRh7eWw=
-github.com/wundergraph/graphql-go-tools/v2 v2.13.0 h1:HfTwkaCgWxTeXiLPQDXI6aNTdO8AJ8Snz4mbuP5c0MM=
-github.com/wundergraph/graphql-go-tools/v2 v2.13.0/go.mod h1:zREIKLmpjfNcGSubndaW/913r0Y8XbbYOXQeZFkwHdo=
+github.com/wundergraph/graphql-go-tools/v2 v2.13.1-0.20260718102134-5353e8c91f35 h1:yLg1dYwCSQ7MhghlD+76mbd+QuqNLf3ihQAayeWmVl0=
+github.com/wundergraph/graphql-go-tools/v2 v2.13.1-0.20260718102134-5353e8c91f35/go.mod h1:zREIKLmpjfNcGSubndaW/913r0Y8XbbYOXQeZFkwHdo=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=

--- a/router/go.sum
+++ b/router/go.sum
@@ -334,8 +334,8 @@ github.com/wundergraph/astjson v1.1.0 h1:xORDosrZ87zQFJwNGe/HIHXqzpdHOFmqWgykCLV
 github.com/wundergraph/astjson v1.1.0/go.mod h1:h12D/dxxnedtLzsKyBLK7/Oe4TAoGpRVC9nDpDrZSWw=
 github.com/wundergraph/go-arena v1.3.0 h1:n0ng5a1vbd8YGq1u3rMr0vPU5f6AZ1BXIiUhL1UIok8=
 github.com/wundergraph/go-arena v1.3.0/go.mod h1:ROOysEHWJjLQ8FSfNxZCziagb7Qw2nXY3/vgKRh7eWw=
-github.com/wundergraph/graphql-go-tools/v2 v2.13.1-0.20260718102134-5353e8c91f35 h1:yLg1dYwCSQ7MhghlD+76mbd+QuqNLf3ihQAayeWmVl0=
-github.com/wundergraph/graphql-go-tools/v2 v2.13.1-0.20260718102134-5353e8c91f35/go.mod h1:zREIKLmpjfNcGSubndaW/913r0Y8XbbYOXQeZFkwHdo=
+github.com/wundergraph/graphql-go-tools/v2 v2.13.1-0.20260718154907-6b3e4a8ada12 h1:tYBJ5YSTnAGAjlkJsChKeV0GHohtAgqpcrUcOrYTXgk=
+github.com/wundergraph/graphql-go-tools/v2 v2.13.1-0.20260718154907-6b3e4a8ada12/go.mod h1:zREIKLmpjfNcGSubndaW/913r0Y8XbbYOXQeZFkwHdo=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=

--- a/router/pkg/config/config.go
+++ b/router/pkg/config/config.go
@@ -874,6 +874,7 @@ type StreamsHandlerConfiguration struct {
 type OnReceiveEventsConfiguration struct {
 	MaxConcurrentHandlers int           `yaml:"max_concurrent_handlers" envDefault:"100"`
 	HandlerTimeout        time.Duration `yaml:"handler_timeout" envDefault:"5s"`
+	WaitForHooks          bool          `yaml:"wait_for_hooks" envDefault:"false"`
 }
 
 type Cluster struct {

--- a/router/pkg/config/config.schema.json
+++ b/router/pkg/config/config.schema.json
@@ -3287,6 +3287,11 @@
                   "type": "string",
                   "description": "The amount of time that OnReceiveEvents handlers can run in total for a single batch of events. Specify as a duration string (e.g., '5s', '1m', '500ms').",
                   "default": "5s"
+                },
+                "wait_for_hooks": {
+                  "type": "boolean",
+                  "description": "If true, all OnReceiveEvents handlers for all subscribers are run and awaited for one event before moving on to the next event, guaranteeing atomic, ordered updates per event across subscribers. If false, handlers for each subscriber run concurrently and independently, which may deliver events out of order under handler timeouts.",
+                  "default": true
                 }
               }
             }

--- a/router/pkg/config/testdata/config_defaults.json
+++ b/router/pkg/config/testdata/config_defaults.json
@@ -405,7 +405,8 @@
     "Handlers": {
       "OnReceiveEvents": {
         "MaxConcurrentHandlers": 100,
-        "HandlerTimeout": 5000000000
+        "HandlerTimeout": 5000000000,
+        "WaitForHooks": true
       }
     }
   },

--- a/router/pkg/config/testdata/config_full.json
+++ b/router/pkg/config/testdata/config_full.json
@@ -831,7 +831,8 @@
     "Handlers": {
       "OnReceiveEvents": {
         "MaxConcurrentHandlers": 100,
-        "HandlerTimeout": 5000000000
+        "HandlerTimeout": 5000000000,
+        "WaitForHooks": true
       }
     }
   },

--- a/router/pkg/pubsub/datasource/hooks.go
+++ b/router/pkg/pubsub/datasource/hooks.go
@@ -46,4 +46,5 @@ type OnReceiveEventsHooks struct {
 	Handlers              []OnReceiveEventsFn
 	MaxConcurrentHandlers int
 	Timeout               time.Duration
+	WaitForHooks          bool
 }

--- a/router/pkg/pubsub/datasource/subscription_event_updater.go
+++ b/router/pkg/pubsub/datasource/subscription_event_updater.go
@@ -57,7 +57,7 @@ func (s *subscriptionEventUpdater) computeSubscriberEvents(events []StreamEvent)
 			}
 		}
 		if err != nil {
-			// TODO: decide whether to CloseSubscription here or swallow the error
+			s.eventUpdater.CloseSubscription(subID)
 			continue
 		}
 

--- a/router/pkg/pubsub/datasource/subscription_event_updater.go
+++ b/router/pkg/pubsub/datasource/subscription_event_updater.go
@@ -85,7 +85,10 @@ func (s *subscriptionEventUpdater) buildUpdateRounds(outputs map[resolve.Subscri
 		subData := make(map[resolve.SubscriptionIdentifier][]byte, len(outputs))
 		for subID, subEvents := range outputs {
 			if r < len(subEvents) {
-				subData[subID] = subEvents[r].GetData()
+				event := subEvents[r]
+				if event != nil {
+					subData[subID] = event.GetData()
+				}
 			}
 		}
 		rounds[r] = subData

--- a/router/pkg/pubsub/datasource/subscription_event_updater.go
+++ b/router/pkg/pubsub/datasource/subscription_event_updater.go
@@ -31,44 +31,75 @@ type subscriptionEventUpdater struct {
 	eventBuilder                   EventBuilderFn
 	semaphore                      *semaphore.Weighted
 	timeout                        time.Duration
-	atomicUpdate                   bool
+	waitForCompute                 bool
 }
 
-func (s *subscriptionEventUpdater) updateAtomically(events []StreamEvent) {
+func (s *subscriptionEventUpdater) computeSubscriberEvents(events []StreamEvent) map[resolve.SubscriptionIdentifier][]StreamEvent {
 	subscriptions := s.eventUpdater.Subscriptions()
+	hooks := s.hooks.OnReceiveEvents.Handlers
 
-	for _, event := range events {
-		subData := make(map[resolve.SubscriptionIdentifier][]byte, len(subscriptions))
+	outputs := make(map[resolve.SubscriptionIdentifier][]StreamEvent, len(subscriptions))
 
-		for subCtx, subId := range subscriptions {
-			var (
-				hooks     = s.hooks.OnReceiveEvents.Handlers
-				err       error
-				subEvents = []StreamEvent{event}
-			)
-
-			for i := range s.hooks.OnReceiveEvents.Handlers {
-				// TODO: replace context.Background() with something proper
-				// TODO: check if this mutates global events variable
-				// TODO: This executes the hook once for each event --> maybe better: execute hook once for all events and rekey the map from sub to event
-				subEvents, err = hooks[i](subCtx, context.Background(), s.subscriptionEventConfiguration, s.eventBuilder, subEvents)
-				if err != nil {
-					// TODO: check wether to ignore or to fail and most likely don't swallow err
-					continue
-				}
-			}
-
-			if len(subEvents) == 0 {
-				// hook decided that this sub shall not get the event
-				continue
-			}
-
-			subData[subId] = subEvents[0].GetData() // TODO: ensure subEvents len is 1 but we probably can't know this as the hook could invent events
+	for subCtx, subID := range subscriptions {
+		// Give this subscriber its own copy of the source events so in-place
+		// mutations by a hook stay isolated to this chain.
+		subEvents := make([]StreamEvent, len(events))
+		for i, event := range events {
+			subEvents[i] = event.Clone()
 		}
 
-		// at this point we have all modified event data for every subscriber of this event
-		// call the new update method
-		s.eventUpdater.BlockUpdate(subData)
+		var err error
+		for i := range hooks {
+			// TODO: replace context.Background() with something proper
+			subEvents, err = hooks[i](subCtx, context.Background(), s.subscriptionEventConfiguration, s.eventBuilder, subEvents)
+			if err != nil {
+				break
+			}
+		}
+		if err != nil {
+			// TODO: decide whether to CloseSubscription here or swallow the error
+			continue
+		}
+
+		if len(subEvents) == 0 {
+			// hook decided that this subscriber shall not receive any event
+			continue
+		}
+
+		outputs[subID] = subEvents
+	}
+
+	return outputs
+}
+
+func (s *subscriptionEventUpdater) buildUpdateRounds(outputs map[resolve.SubscriptionIdentifier][]StreamEvent) []map[resolve.SubscriptionIdentifier][]byte {
+	maxLen := 0
+	for _, subEvents := range outputs {
+		if len(subEvents) > maxLen {
+			maxLen = len(subEvents)
+		}
+	}
+
+	rounds := make([]map[resolve.SubscriptionIdentifier][]byte, maxLen)
+	for r := range rounds {
+		subData := make(map[resolve.SubscriptionIdentifier][]byte, len(outputs))
+		for subID, subEvents := range outputs {
+			if r < len(subEvents) {
+				subData[subID] = subEvents[r].GetData()
+			}
+		}
+		rounds[r] = subData
+	}
+
+	return rounds
+}
+
+func (s *subscriptionEventUpdater) updateInBulks(events []StreamEvent) {
+	eventOutputs := s.computeSubscriberEvents(events)
+	updateRounds := s.buildUpdateRounds(eventOutputs)
+
+	for _, round := range updateRounds {
+		s.eventUpdater.BlockUpdate(round)
 	}
 }
 
@@ -83,8 +114,8 @@ func (s *subscriptionEventUpdater) Update(events []StreamEvent) {
 
 	// case 2: has hook, atomic update
 	// we need to go through each event and update all subscribers, then move to the next event
-	if s.atomicUpdate {
-		s.updateAtomically(events)
+	if s.waitForCompute {
+		s.updateInBulks(events)
 		return
 	}
 
@@ -208,6 +239,6 @@ func NewSubscriptionEventUpdater(
 		eventBuilder:                   eventBuilder,
 		semaphore:                      semaphore.NewWeighted(int64(limit)),
 		timeout:                        timeout,
-		atomicUpdate:                   true, // TODO: make configurable
+		waitForCompute:                 true, // TODO: make configurable
 	}
 }

--- a/router/pkg/pubsub/datasource/subscription_event_updater.go
+++ b/router/pkg/pubsub/datasource/subscription_event_updater.go
@@ -31,9 +31,49 @@ type subscriptionEventUpdater struct {
 	eventBuilder                   EventBuilderFn
 	semaphore                      *semaphore.Weighted
 	timeout                        time.Duration
+	atomicUpdate                   bool
+}
+
+func (s *subscriptionEventUpdater) updateAtomically(events []StreamEvent) {
+	subscriptions := s.eventUpdater.Subscriptions()
+
+	for _, event := range events {
+		subData := make(map[resolve.SubscriptionIdentifier][]byte, len(subscriptions))
+
+		for subCtx, subId := range subscriptions {
+			var (
+				hooks     = s.hooks.OnReceiveEvents.Handlers
+				err       error
+				subEvents = []StreamEvent{event}
+			)
+
+			for i := range s.hooks.OnReceiveEvents.Handlers {
+				// TODO: replace context.Background() with something proper
+				// TODO: check if this mutates global events variable
+				// TODO: This executes the hook once for each event --> maybe better: execute hook once for all events and rekey the map from sub to event
+				subEvents, err = hooks[i](subCtx, context.Background(), s.subscriptionEventConfiguration, s.eventBuilder, subEvents)
+				if err != nil {
+					// TODO: check wether to ignore or to fail and most likely don't swallow err
+					continue
+				}
+			}
+
+			if len(subEvents) == 0 {
+				// hook decided that this sub shall not get the event
+				continue
+			}
+
+			subData[subId] = subEvents[0].GetData() // TODO: ensure subEvents len is 1 but we probably can't know this as the hook could invent events
+		}
+
+		// at this point we have all modified event data for every subscriber of this event
+		// call the new update method
+		s.eventUpdater.BlockUpdate(subData)
+	}
 }
 
 func (s *subscriptionEventUpdater) Update(events []StreamEvent) {
+	// case 1: no hook, use single update
 	if len(s.hooks.OnReceiveEvents.Handlers) == 0 {
 		for _, event := range events {
 			s.eventUpdater.Update(event.GetData())
@@ -41,6 +81,14 @@ func (s *subscriptionEventUpdater) Update(events []StreamEvent) {
 		return
 	}
 
+	// case 2: has hook, atomic update
+	// we need to go through each event and update all subscribers, then move to the next event
+	if s.atomicUpdate {
+		s.updateAtomically(events)
+		return
+	}
+
+	// case 3: has hook, no atomic update
 	subscriptions := s.eventUpdater.Subscriptions()
 	wg := sync.WaitGroup{}
 	updaterCtx, cancel := context.WithDeadline(context.Background(), time.Now().Add(s.timeout))
@@ -160,5 +208,6 @@ func NewSubscriptionEventUpdater(
 		eventBuilder:                   eventBuilder,
 		semaphore:                      semaphore.NewWeighted(int64(limit)),
 		timeout:                        timeout,
+		atomicUpdate:                   true, // TODO: make configurable
 	}
 }

--- a/router/pkg/pubsub/datasource/subscription_event_updater.go
+++ b/router/pkg/pubsub/datasource/subscription_event_updater.go
@@ -31,7 +31,7 @@ type subscriptionEventUpdater struct {
 	eventBuilder                   EventBuilderFn
 	semaphore                      *semaphore.Weighted
 	timeout                        time.Duration
-	waitForCompute                 bool
+	waitForHooks                   bool
 }
 
 func (s *subscriptionEventUpdater) computeSubscriberEvents(events []StreamEvent) map[resolve.SubscriptionIdentifier][]StreamEvent {
@@ -114,7 +114,7 @@ func (s *subscriptionEventUpdater) Update(events []StreamEvent) {
 
 	// case 2: has hook, atomic update
 	// we need to go through each event and update all subscribers, then move to the next event
-	if s.waitForCompute {
+	if s.waitForHooks {
 		s.updateInBulks(events)
 		return
 	}
@@ -239,6 +239,6 @@ func NewSubscriptionEventUpdater(
 		eventBuilder:                   eventBuilder,
 		semaphore:                      semaphore.NewWeighted(int64(limit)),
 		timeout:                        timeout,
-		waitForCompute:                 true, // TODO: make configurable
+		waitForHooks:                   hooks.OnReceiveEvents.WaitForHooks,
 	}
 }

--- a/router/pkg/pubsub/datasource/subscription_event_updater.go
+++ b/router/pkg/pubsub/datasource/subscription_event_updater.go
@@ -99,7 +99,7 @@ func (s *subscriptionEventUpdater) updateInBulks(events []StreamEvent) {
 	updateRounds := s.buildUpdateRounds(eventOutputs)
 
 	for _, round := range updateRounds {
-		s.eventUpdater.BlockUpdate(round)
+		s.eventUpdater.UpdateBulk(round)
 	}
 }
 


### PR DESCRIPTION
Currently, when using Cosmo Streams with the `OnReceiveEvent` hook the router performs all hook processing for all subscribers on a trigger concurrently. Once any hook instance finished processing a subscriber it immediately asks the engine to perform response resolving and sending the message to clients. This can happen concurrently for any subscriber.

This concurrent calls cause mutex stalls if the router has lots of subscribers. Since the engine does not know when the router wants to update the another subscriber it has to use mutexes synchronize the subscription updater.

We can avoid this by giving the engine a bulk list of what to update, instead of having it to guess when to update what.
In this PR we add a new option called `events.handlers.on_receive_events.wait_for_hooks` to do just that.

If set to `true` the router first processes the `OnReceiveEvent` hook for every subscriber this event is for.
Only after that do we call the engine and handing over a list of all subscribers with their event payload.
The engine can serially work on this, avoiding a lot of mutex work in the process.

The default of this option is `false`. We can think about making it `true`.

This has a bunch of implications:
- The delay between receiving an event from the broker until being ready to sent is bigger, because we first run all hook instances (depends on how long hooks take)
- The delay between the first and the last subscriber update is much smaller (usually this is more important)
- Regarding that latency measured with a passiv hook (pass all incoming events) is identical to using no hook at all
- In-Flight request deduplication is much more likely to happen because of two reasons
  - high differences in hook execution time do not play a role, we wait for all them before the engine
  - The engine can resolve subscriptions faster than subgraphs can respond --> dedup hit

Note: None of the hook processing is async for now. It's one goroutine doing it all. It's debateble wether spawning lots of small routines and having the runtime do the housekeeping is more efficient than simply letting it run synchronously.

Corresponding engine PR: https://github.com/wundergraph/graphql-go-tools/pull/1603

## Todos

This might grow.

- [ ] Implement timeout for hooks
- [ ] Update cosmo-docs
- [ ] Add unit / integration tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `wait_for_hooks` option for subscription receive-event handlers.
  * Default is **enabled**, so handlers finish for all subscribers before the next event is processed (atomic, ordered behavior per event).
  * When disabled, handlers may run concurrently per subscriber, which can allow faster throughput but may result in out-of-order updates under slow/timeouts.
  * Updated configuration defaults, schema, and documentation to reflect the new option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] If applicable, I have provided instructions for reviewers for [manually validating my changes](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md#pull-requests-conventions).
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

<!--
Please add any additional information or context regarding your changes here.
-->
