### PR TITLE
feat(router): pubsub event hooks — OnBroadcastEvents + adapter middleware (draft/RFC)

### DIFF
--- a/router/core/factoryresolver.go
+++ b/router/core/factoryresolver.go
@@ -528,6 +528,11 @@ func (l *Loader) Load(engineConfig *nodev1.EngineConfiguration, subgraphs []*nod
 		onReceiveEventsFns[i] = NewPubSubOnReceiveEventsHook(fn)
 	}
 
+	onBroadcastEventsFns := make([]pubsub_datasource.OnBroadcastEventsFn, len(l.subscriptionHooks.onBroadcastEvents.handlers))
+	for i, fn := range l.subscriptionHooks.onBroadcastEvents.handlers {
+		onBroadcastEventsFns[i] = NewPubSubOnBroadcastEventsHook(fn, l.logger)
+	}
+
 	subscriptionOnCreateFns := make([]pubsub_datasource.SubscriptionOnCreateFn, len(l.subscriptionHooks.onCreate.handlers))
 	for i, fn := range l.subscriptionHooks.onCreate.handlers {
 		subscriptionOnCreateFns[i] = NewPubSubSubscriptionOnCreateHook(fn)
@@ -552,6 +557,9 @@ func (l *Loader) Load(engineConfig *nodev1.EngineConfiguration, subgraphs []*nod
 				Handlers:              onReceiveEventsFns,
 				MaxConcurrentHandlers: l.subscriptionHooks.onReceiveEvents.maxConcurrentHandlers,
 				Timeout:               l.subscriptionHooks.onReceiveEvents.timeout,
+			},
+			OnBroadcastEvents: pubsub_datasource.OnBroadcastEventsHooks{
+				Handlers: onBroadcastEventsFns,
 			},
 			SubscriptionOnCreate: pubsub_datasource.SubscriptionOnCreateHooks{
 				Handlers: subscriptionOnCreateFns,

--- a/router/core/factoryresolver.go
+++ b/router/core/factoryresolver.go
@@ -533,6 +533,16 @@ func (l *Loader) Load(engineConfig *nodev1.EngineConfiguration, subgraphs []*nod
 		onBroadcastEventsFns[i] = NewPubSubOnBroadcastEventsHook(fn, l.logger)
 	}
 
+	var adapterMiddleware pubsub_datasource.AdapterMiddlewareFn
+	if wrappers := l.subscriptionHooks.adapterWrappers; len(wrappers) > 0 {
+		adapterMiddleware = func(providerID string, inner pubsub_datasource.Adapter) pubsub_datasource.Adapter {
+			for _, w := range wrappers {
+				inner = w(providerID, inner)
+			}
+			return inner
+		}
+	}
+
 	subscriptionOnCreateFns := make([]pubsub_datasource.SubscriptionOnCreateFn, len(l.subscriptionHooks.onCreate.handlers))
 	for i, fn := range l.subscriptionHooks.onCreate.handlers {
 		subscriptionOnCreateFns[i] = NewPubSubSubscriptionOnCreateHook(fn)
@@ -561,6 +571,7 @@ func (l *Loader) Load(engineConfig *nodev1.EngineConfiguration, subgraphs []*nod
 			OnBroadcastEvents: pubsub_datasource.OnBroadcastEventsHooks{
 				Handlers: onBroadcastEventsFns,
 			},
+			AdapterMiddleware: adapterMiddleware,
 			SubscriptionOnCreate: pubsub_datasource.SubscriptionOnCreateHooks{
 				Handlers: subscriptionOnCreateFns,
 			},

--- a/router/core/router.go
+++ b/router/core/router.go
@@ -769,6 +769,10 @@ func (r *Router) initModules(ctx context.Context) error {
 			r.subscriptionHooks.onReceiveEvents.handlers = append(r.subscriptionHooks.onReceiveEvents.handlers, handler.OnReceiveEvents)
 		}
 
+		if handler, ok := moduleInstance.(StreamBroadcastEventHandler); ok {
+			r.subscriptionHooks.onBroadcastEvents.handlers = append(r.subscriptionHooks.onBroadcastEvents.handlers, handler.OnBroadcastEvents)
+		}
+
 		if handler, ok := moduleInstance.(SubscriptionOnCreateHandler); ok {
 			r.subscriptionHooks.onCreate.handlers = append(r.subscriptionHooks.onCreate.handlers, handler.SubscriptionOnCreate)
 		}

--- a/router/core/router.go
+++ b/router/core/router.go
@@ -773,6 +773,10 @@ func (r *Router) initModules(ctx context.Context) error {
 			r.subscriptionHooks.onBroadcastEvents.handlers = append(r.subscriptionHooks.onBroadcastEvents.handlers, handler.OnBroadcastEvents)
 		}
 
+		if handler, ok := moduleInstance.(PubSubAdapterProvider); ok {
+			r.subscriptionHooks.adapterWrappers = append(r.subscriptionHooks.adapterWrappers, handler.WrapAdapter)
+		}
+
 		if handler, ok := moduleInstance.(SubscriptionOnCreateHandler); ok {
 			r.subscriptionHooks.onCreate.handlers = append(r.subscriptionHooks.onCreate.handlers, handler.SubscriptionOnCreate)
 		}

--- a/router/core/router_config.go
+++ b/router/core/router_config.go
@@ -30,10 +30,11 @@ import (
 )
 
 type subscriptionHooks struct {
-	onCreate        onCreateHooks
-	onStart         onStartHooks
-	onPublishEvents onPublishEventsHooks
-	onReceiveEvents onReceiveEventsHooks
+	onCreate          onCreateHooks
+	onStart           onStartHooks
+	onPublishEvents   onPublishEventsHooks
+	onReceiveEvents   onReceiveEventsHooks
+	onBroadcastEvents onBroadcastEventsHooks
 }
 
 type onCreateHooks struct {
@@ -52,6 +53,10 @@ type onReceiveEventsHooks struct {
 	handlers              []func(ctx StreamReceiveEventHandlerContext, events datasource.StreamEvents) (datasource.StreamEvents, error)
 	maxConcurrentHandlers int
 	timeout               time.Duration
+}
+
+type onBroadcastEventsHooks struct {
+	handlers []func(ctx StreamBroadcastEventHandlerContext, events datasource.StreamEvents) (datasource.StreamEvents, error)
 }
 
 type Config struct {

--- a/router/core/router_config.go
+++ b/router/core/router_config.go
@@ -35,6 +35,7 @@ type subscriptionHooks struct {
 	onPublishEvents   onPublishEventsHooks
 	onReceiveEvents   onReceiveEventsHooks
 	onBroadcastEvents onBroadcastEventsHooks
+	adapterWrappers   []func(providerID string, inner datasource.Adapter) datasource.Adapter
 }
 
 type onCreateHooks struct {

--- a/router/core/subscriptions_modules.go
+++ b/router/core/subscriptions_modules.go
@@ -468,6 +468,14 @@ type StreamBroadcastEventHandler interface {
 	OnBroadcastEvents(ctx StreamBroadcastEventHandlerContext, events datasource.StreamEvents) (datasource.StreamEvents, error)
 }
 
+// PubSubAdapterProvider is implemented by modules that want to wrap the pubsub Adapter for a
+// provider — e.g. to transform events or stage bypass data inside the adapter, so the engine only
+// ever receives already-normalized data. WrapAdapter is called once per subscription Start with the
+// provider ID and the inner adapter; return inner unchanged to opt out.
+type PubSubAdapterProvider interface {
+	WrapAdapter(providerID string, inner datasource.Adapter) datasource.Adapter
+}
+
 type pubSubStreamBroadcastEventHookContext struct {
 	logger                         *zap.Logger
 	subscriptionEventConfiguration datasource.SubscriptionEventConfiguration

--- a/router/core/subscriptions_modules.go
+++ b/router/core/subscriptions_modules.go
@@ -442,6 +442,86 @@ func NewPubSubOnReceiveEventsHook(fn func(ctx StreamReceiveEventHandlerContext, 
 	}
 }
 
+type StreamBroadcastEventHandlerContext interface {
+	// Context is a context for handlers. If it is cancelled, the handler should stop processing.
+	Context() context.Context
+	// Logger is the logger for the handler
+	Logger() *zap.Logger
+	// SubscriptionEventConfiguration the subscription event configuration
+	SubscriptionEventConfiguration() datasource.SubscriptionEventConfiguration
+	// NewEvent creates a new event that can be used in the subscription.
+	//
+	// The data parameter must contain valid JSON bytes representing the raw event payload
+	// from your message broker (Kafka, NATS, etc.). The JSON must have properly quoted
+	// property names and must include the __typename field required by GraphQL.
+	NewEvent(data []byte) datasource.MutableStreamEvent
+}
+
+type StreamBroadcastEventHandler interface {
+	// OnBroadcastEvents is called once whenever a batch of events is received from a provider,
+	// before delivering them to clients. Unlike OnReceiveEvents it is called ONCE per batch (not
+	// once per active subscriber), and it runs on the concurrent broadcast delivery path — it
+	// does not force the serial per-subscriber path. There is therefore no per-subscriber client
+	// request available on the context. The returned events replace the batch for all subscribers.
+	// Use events.All() to iterate through them and event.Clone() to create mutable copies, when needed.
+	// Returning an error drops the batch and logs the error.
+	OnBroadcastEvents(ctx StreamBroadcastEventHandlerContext, events datasource.StreamEvents) (datasource.StreamEvents, error)
+}
+
+type pubSubStreamBroadcastEventHookContext struct {
+	logger                         *zap.Logger
+	subscriptionEventConfiguration datasource.SubscriptionEventConfiguration
+	eventBuilder                   datasource.EventBuilderFn
+	context                        context.Context
+}
+
+func (c *pubSubStreamBroadcastEventHookContext) Context() context.Context {
+	return c.context
+}
+
+func (c *pubSubStreamBroadcastEventHookContext) Logger() *zap.Logger {
+	return c.logger
+}
+
+func (c *pubSubStreamBroadcastEventHookContext) SubscriptionEventConfiguration() datasource.SubscriptionEventConfiguration {
+	return c.subscriptionEventConfiguration
+}
+
+func (c *pubSubStreamBroadcastEventHookContext) NewEvent(data []byte) datasource.MutableStreamEvent {
+	return c.eventBuilder(data)
+}
+
+func NewPubSubOnBroadcastEventsHook(fn func(ctx StreamBroadcastEventHandlerContext, events datasource.StreamEvents) (datasource.StreamEvents, error), baseLogger *zap.Logger) datasource.OnBroadcastEventsFn {
+	if fn == nil {
+		return nil
+	}
+
+	return func(ctx context.Context, subConf datasource.SubscriptionEventConfiguration, eventBuilder datasource.EventBuilderFn, evts []datasource.StreamEvent) ([]datasource.StreamEvent, error) {
+		// The broadcast path has no per-subscriber client request, so we use the router base
+		// logger rather than a request-scoped one.
+		logger := baseLogger
+		if logger != nil {
+			logger = logger.With(zap.String("component", "on_broadcast_events_hook"))
+			if subConf != nil {
+				logger = logger.With(
+					zap.String("provider_id", subConf.ProviderID()),
+					zap.String("provider_type", string(subConf.ProviderType())),
+					zap.String("field_name", subConf.RootFieldName()),
+				)
+			}
+		}
+
+		hookCtx := &pubSubStreamBroadcastEventHookContext{
+			logger:                         logger,
+			subscriptionEventConfiguration: subConf,
+			eventBuilder:                   eventBuilder,
+			context:                        ctx,
+		}
+		newEvts, err := fn(hookCtx, datasource.NewStreamEvents(evts))
+		return newEvts.Unsafe(), err
+	}
+}
+
 // StreamHandlerError writes an error event with Reason to a subscription client and closes the
 // websocket connection with code 1000 (Normal closure).
 // It can returned from methods of the core.SubscriptionOnStartHandler interface.

--- a/router/pkg/pubsub/datasource/hooks.go
+++ b/router/pkg/pubsub/datasource/hooks.go
@@ -19,6 +19,12 @@ type OnReceiveEventsFn func(subscriptionCtx context.Context, updaterCtx context.
 // context. Returned events replace the batch for all subscribers.
 type OnBroadcastEventsFn func(ctx context.Context, subConf SubscriptionEventConfiguration, eventBuilder EventBuilderFn, evts []StreamEvent) ([]StreamEvent, error)
 
+// AdapterMiddlewareFn optionally wraps a pubsub Adapter for the given provider before Subscribe is
+// called, e.g. to transform events or stage bypass data in the adapter (so the engine only ever
+// receives already-normalized data). Return inner unchanged to opt out. Invoked per subscription
+// Start with the provider's ID.
+type AdapterMiddlewareFn func(providerID string, inner Adapter) Adapter
+
 // SubscriptionOnCreateFn is called before the subscription trigger is created.
 // It receives the current subscription config and may return a modified one.
 // Returning a non-nil error aborts the subscription.
@@ -31,6 +37,8 @@ type Hooks struct {
 	OnPublishEvents      OnPublishEventsHooks
 	OnReceiveEvents      OnReceiveEventsHooks
 	OnBroadcastEvents    OnBroadcastEventsHooks
+	// AdapterMiddleware, when set, wraps each provider's Adapter before Subscribe (see AdapterMiddlewareFn).
+	AdapterMiddleware AdapterMiddlewareFn
 }
 
 // SubscriptionOnCreateHooks contains hooks that run before a subscription trigger is created

--- a/router/pkg/pubsub/datasource/hooks.go
+++ b/router/pkg/pubsub/datasource/hooks.go
@@ -13,6 +13,12 @@ type OnPublishEventsFn func(ctx context.Context, pubConf PublishEventConfigurati
 
 type OnReceiveEventsFn func(subscriptionCtx context.Context, updaterCtx context.Context, subConf SubscriptionEventConfiguration, eventBuilder EventBuilderFn, evts []StreamEvent) ([]StreamEvent, error)
 
+// OnBroadcastEventsFn is called once per received batch, before any per-subscriber fan-out.
+// Unlike OnReceiveEventsFn it runs on the broadcast path (not per active subscriber), so it
+// does not force the serial per-subscriber delivery path. It has no per-subscriber request
+// context. Returned events replace the batch for all subscribers.
+type OnBroadcastEventsFn func(ctx context.Context, subConf SubscriptionEventConfiguration, eventBuilder EventBuilderFn, evts []StreamEvent) ([]StreamEvent, error)
+
 // SubscriptionOnCreateFn is called before the subscription trigger is created.
 // It receives the current subscription config and may return a modified one.
 // Returning a non-nil error aborts the subscription.
@@ -24,6 +30,7 @@ type Hooks struct {
 	SubscriptionOnStart  SubscriptionOnStartHooks
 	OnPublishEvents      OnPublishEventsHooks
 	OnReceiveEvents      OnReceiveEventsHooks
+	OnBroadcastEvents    OnBroadcastEventsHooks
 }
 
 // SubscriptionOnCreateHooks contains hooks that run before a subscription trigger is created
@@ -46,4 +53,9 @@ type OnReceiveEventsHooks struct {
 	Handlers              []OnReceiveEventsFn
 	MaxConcurrentHandlers int
 	Timeout               time.Duration
+}
+
+// OnBroadcastEventsHooks contains hooks that run once per received batch on the broadcast path
+type OnBroadcastEventsHooks struct {
+	Handlers []OnBroadcastEventsFn
 }

--- a/router/pkg/pubsub/datasource/subscription_datasource.go
+++ b/router/pkg/pubsub/datasource/subscription_datasource.go
@@ -52,7 +52,14 @@ func (s *PubSubSubscriptionDataSource[C]) Start(ctx *resolve.Context, header htt
 		zap.String("field_name", conf.RootFieldName()),
 	)
 
-	return s.pubSub.Subscribe(ctx.Context(), conf, NewSubscriptionEventUpdater(conf, s.hooks, updater, logger, s.eventBuilder))
+	adapter := s.pubSub
+	if s.hooks.AdapterMiddleware != nil {
+		// Let a module wrap the adapter (e.g. to transform events / stage bypass data before they
+		// reach the engine). Runs on the concurrent path; does not affect broadcast vs per-subscriber.
+		adapter = s.hooks.AdapterMiddleware(conf.ProviderID(), adapter)
+	}
+
+	return adapter.Subscribe(ctx.Context(), conf, NewSubscriptionEventUpdater(conf, s.hooks, updater, logger, s.eventBuilder))
 }
 
 func (s *PubSubSubscriptionDataSource[C]) SubscriptionOnStart(ctx resolve.StartupHookContext, input []byte) (err error) {

--- a/router/pkg/pubsub/datasource/subscription_event_updater.go
+++ b/router/pkg/pubsub/datasource/subscription_event_updater.go
@@ -34,6 +34,21 @@ type subscriptionEventUpdater struct {
 }
 
 func (s *subscriptionEventUpdater) Update(events []StreamEvent) {
+	// Broadcast hooks run once per received batch, before any per-subscriber fan-out.
+	// They transform the batch for all subscribers and, crucially, do not force the serial
+	// per-subscriber path below (that is only triggered by OnReceiveEvents handlers). With
+	// only broadcast hooks registered, delivery stays on the concurrent broadcast path.
+	if len(s.hooks.OnBroadcastEvents.Handlers) > 0 {
+		var err error
+		for i := range s.hooks.OnBroadcastEvents.Handlers {
+			events, err = s.hooks.OnBroadcastEvents.Handlers[i](context.Background(), s.subscriptionEventConfiguration, s.eventBuilder, events)
+			if err != nil {
+				s.logger.Error("on_broadcast_events hook failed, dropping batch", zap.Error(err))
+				return
+			}
+		}
+	}
+
 	if len(s.hooks.OnReceiveEvents.Handlers) == 0 {
 		for _, event := range events {
 			s.eventUpdater.Update(event.GetData())


### PR DESCRIPTION
**Draft / RFC — feedback welcome.** Two small, additive, *independent* seams for pubsub event handling, plus a sketch of a third for discussion. No behaviour change when unused.

### Context
Registering an `OnReceiveEvents` handler flips every trigger from the concurrent **broadcast** path onto the **serial per-subscriber** path (`pkg/pubsub/datasource/subscription_event_updater.go`, `case 1` vs `case 2/3`). That serializes resolution and defeats single-flight dedup. The seams below let a module transform/observe events while staying on the broadcast path.

### 1. `OnBroadcastEvents` — per-batch hook on the broadcast path
A hook called **once per received batch**, before per-subscriber fan-out, at the top of `subscriptionEventUpdater.Update`. Unlike `OnReceiveEvents` it does **not** force the serial path. Module interface `StreamBroadcastEventHandler`; delivered via `Hooks.OnBroadcastEvents`.

*Use when:* the transform is the **same for every subscriber**. `OnReceiveEvents` runs once **per active subscriber** (in `computeSubscriberEvents`), with that subscriber's request/auth context, so it can produce per-viewer output (redaction, per-user shaping). `OnBroadcastEvents` runs **once per batch** with **no per-subscriber context**, and its single output is broadcast to all subscribers of the trigger — so it's cheaper (1 transform vs N) but by construction cannot vary per subscriber. Reach for it for viewer-independent work: normalizing an envelope, injecting `__typename`, reshaping/observing a batch. (This is about the payload *transform* only — per-subscriber `@openfed__subscriptionFilter` routing is unaffected and still applies.)

### 2. `PubSubAdapterProvider` / `Hooks.AdapterMiddleware` — wrap the adapter
Lets a module wrap a provider's `Adapter` before `Subscribe` (applied in `PubSubSubscriptionDataSource.Start`). The module can decorate the updater to transform/stage events **inside the adapter**, so the engine only ever receives already-normalized data. Module interface `PubSubAdapterProvider.WrapAdapter(providerID, inner) Adapter`.
*Use when:* you want transformation/side-effects at the adapter boundary, before events enter the engine.

**These are two separate operations** — either can be used alone; #2 does not depend on #1.

### 3. (Not implemented — for discussion) Fully pluggable event adapters
A registry/option to register custom `ProviderBuilder`s — or fully custom `Adapter`s — for a provider type. Today the kafka/nats/redis builders are hardcoded in `pubsub.BuildProvidersAndDataSources`. This would give modules full control of the consume loop (offsets, batching, custom dedup, or emitting a key-only event to the engine while staging the full payload elsewhere). Larger surface than #1/#2 and intentionally **not** included here — flagged as the natural next step if there's interest.

---
Happy to adjust naming/shape. Branch is based on a recent `main`; opening as draft to gather direction before polishing (tests/docs).