### PR TITLE
fix(router): incorrect alias behavior for required fields

### DIFF
--- a/router-tests/go.mod
+++ b/router-tests/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/wundergraph/cosmo/router v0.0.0-20260710155145-803a4bc06d92
 	github.com/wundergraph/cosmo/router-plugin v0.0.0-20250808194725-de123ba1c65e
 	github.com/wundergraph/cosmo/speedtrap v0.0.0-00010101000000-000000000000
-	github.com/wundergraph/graphql-go-tools/v2 v2.13.2
+	github.com/wundergraph/graphql-go-tools/v2 v2.13.3-0.20260720102200-0cf6a478bea5
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/sdk/metric v1.44.0

--- a/router-tests/go.mod
+++ b/router-tests/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/wundergraph/cosmo/router v0.0.0-20260710155145-803a4bc06d92
 	github.com/wundergraph/cosmo/router-plugin v0.0.0-20250808194725-de123ba1c65e
 	github.com/wundergraph/cosmo/speedtrap v0.0.0-00010101000000-000000000000
-	github.com/wundergraph/graphql-go-tools/v2 v2.13.3-0.20260720102200-0cf6a478bea5
+	github.com/wundergraph/graphql-go-tools/v2 v2.14.1
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/sdk/metric v1.44.0

--- a/router-tests/go.sum
+++ b/router-tests/go.sum
@@ -386,8 +386,8 @@ github.com/wundergraph/astjson v1.1.0 h1:xORDosrZ87zQFJwNGe/HIHXqzpdHOFmqWgykCLV
 github.com/wundergraph/astjson v1.1.0/go.mod h1:h12D/dxxnedtLzsKyBLK7/Oe4TAoGpRVC9nDpDrZSWw=
 github.com/wundergraph/go-arena v1.3.0 h1:n0ng5a1vbd8YGq1u3rMr0vPU5f6AZ1BXIiUhL1UIok8=
 github.com/wundergraph/go-arena v1.3.0/go.mod h1:ROOysEHWJjLQ8FSfNxZCziagb7Qw2nXY3/vgKRh7eWw=
-github.com/wundergraph/graphql-go-tools/v2 v2.13.3-0.20260720102200-0cf6a478bea5 h1:5MM+LkBRti8WeSD+8wm8pNm1H+zMIP0bNEhB82e8oH8=
-github.com/wundergraph/graphql-go-tools/v2 v2.13.3-0.20260720102200-0cf6a478bea5/go.mod h1:zREIKLmpjfNcGSubndaW/913r0Y8XbbYOXQeZFkwHdo=
+github.com/wundergraph/graphql-go-tools/v2 v2.14.1 h1:TecnvTyhskoeiqo6W+1xh7HqAPL/RG5vfbFhezu7RLs=
+github.com/wundergraph/graphql-go-tools/v2 v2.14.1/go.mod h1:zREIKLmpjfNcGSubndaW/913r0Y8XbbYOXQeZFkwHdo=
 github.com/xrash/smetrics v0.0.0-20250705151800-55b8f293f342 h1:FnBeRrxr7OU4VvAzt5X7s6266i6cSVkkFPS0TuXWbIg=
 github.com/xrash/smetrics v0.0.0-20250705151800-55b8f293f342/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=

--- a/router-tests/go.sum
+++ b/router-tests/go.sum
@@ -386,8 +386,8 @@ github.com/wundergraph/astjson v1.1.0 h1:xORDosrZ87zQFJwNGe/HIHXqzpdHOFmqWgykCLV
 github.com/wundergraph/astjson v1.1.0/go.mod h1:h12D/dxxnedtLzsKyBLK7/Oe4TAoGpRVC9nDpDrZSWw=
 github.com/wundergraph/go-arena v1.3.0 h1:n0ng5a1vbd8YGq1u3rMr0vPU5f6AZ1BXIiUhL1UIok8=
 github.com/wundergraph/go-arena v1.3.0/go.mod h1:ROOysEHWJjLQ8FSfNxZCziagb7Qw2nXY3/vgKRh7eWw=
-github.com/wundergraph/graphql-go-tools/v2 v2.13.2 h1:YbK0HRgqoYNrlaFJDxST2+G9zex6okKLtjgDXNeVd48=
-github.com/wundergraph/graphql-go-tools/v2 v2.13.2/go.mod h1:zREIKLmpjfNcGSubndaW/913r0Y8XbbYOXQeZFkwHdo=
+github.com/wundergraph/graphql-go-tools/v2 v2.13.3-0.20260720102200-0cf6a478bea5 h1:5MM+LkBRti8WeSD+8wm8pNm1H+zMIP0bNEhB82e8oH8=
+github.com/wundergraph/graphql-go-tools/v2 v2.13.3-0.20260720102200-0cf6a478bea5/go.mod h1:zREIKLmpjfNcGSubndaW/913r0Y8XbbYOXQeZFkwHdo=
 github.com/xrash/smetrics v0.0.0-20250705151800-55b8f293f342 h1:FnBeRrxr7OU4VvAzt5X7s6266i6cSVkkFPS0TuXWbIg=
 github.com/xrash/smetrics v0.0.0-20250705151800-55b8f293f342/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=

--- a/router-tests/protocol/grpc_subgraph_test.go
+++ b/router-tests/protocol/grpc_subgraph_test.go
@@ -357,6 +357,11 @@ func TestGRPCSubgraph(t *testing.T) {
 				query:    `{ employee(id: 2) { id reviewReport } }`,
 				expected: `{"data":{"employee":{"id":2,"reviewReport":"Rejected: Needs more documentation (code: DOC_001)"}}}`,
 			},
+			{
+				name:     "query employee @requires flat union aliased (approval)",
+				query:    `{ employee(id: 1) { id aliasedReviewReport: reviewReport } }`,
+				expected: `{"data":{"employee":{"id":1,"aliasedReviewReport":"Approved: Excellent work on the API at 2024-01-15"}}}`,
+			},
 			// Pattern 3: Concrete wrapping abstract
 			{
 				name:     "query employee @requires concrete wrapping abstract (technical)",

--- a/router-tests/protocol/grpc_subgraph_test.go
+++ b/router-tests/protocol/grpc_subgraph_test.go
@@ -311,6 +311,11 @@ func TestGRPCSubgraph(t *testing.T) {
 				expected: `{"data":{"employee":{"id":1,"taggedProjectSummary":"expertise: Backend Architecture, project tags: [cloud, migration, priority, devops, ci-cd, infrastructure]"}}}`,
 			},
 			{
+				name:     "query employee @requires field resolved with expertise and aliased",
+				query:    `{ employee(id: 1) { id preAlias: taggedProjectSummary taggedProjectSummary aliasedTaggedProjectSummary: taggedProjectSummary } }`,
+				expected: `{"data":{"employee":{"id":1,"preAlias":"expertise: Backend Architecture, project tags: [cloud, migration, priority, devops, ci-cd, infrastructure]","taggedProjectSummary":"expertise: Backend Architecture, project tags: [cloud, migration, priority, devops, ci-cd, infrastructure]","aliasedTaggedProjectSummary":"expertise: Backend Architecture, project tags: [cloud, migration, priority, devops, ci-cd, infrastructure]"}}}`,
+			},
+			{
 				name:     "query employee @requires field resolved with expertise (employee 2)",
 				query:    `{ employee(id: 2) { id taggedProjectSummary } }`,
 				expected: `{"data":{"employee":{"id":2,"taggedProjectSummary":"expertise: Fullstack Development, project tags: [cloud, migration, priority, microservices, architecture, security, zero-trust]"}}}`,
@@ -396,10 +401,20 @@ func TestGRPCSubgraph(t *testing.T) {
 				query:    `{ employee(id: 2) { id deepWorkItemInfo } }`,
 				expected: `{"data":{"employee":{"id":2,"deepWorkItemInfo":"ManagementHandler: Bob Lead"}}}`,
 			},
+			{
+				name:     "query employee @requires aliased nested abstract through concrete (management deep)",
+				query:    `{ employee(id: 2) { id aliasedDeepWorkItemInfo: deepWorkItemInfo } }`,
+				expected: `{"data":{"employee":{"id":2,"aliasedDeepWorkItemInfo":"ManagementHandler: Bob Lead"}}}`,
+			},
 			// Non-existent employee with composite @requires fields
 			{
 				name:     "query non-existent employee with @requires composite fields returns null",
 				query:    `{ employee(id: 999) { id workItemInfo reviewReport } }`,
+				expected: `{"data":{"employee":null}}`,
+			},
+			{
+				name:     "query non-existent employee with @requires and aliased fields returns null",
+				query:    `{ employee(id: 999) { id workItemInfo reviewReport aliasedReviewReport: reviewReport } }`,
 				expected: `{"data":{"employee":null}}`,
 			},
 		}

--- a/router/go.mod
+++ b/router/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/tidwall/gjson v1.18.0
 	github.com/tidwall/sjson v1.2.5
 	github.com/twmb/franz-go v1.16.1
-	github.com/wundergraph/graphql-go-tools/v2 v2.13.2
+	github.com/wundergraph/graphql-go-tools/v2 v2.13.3-0.20260720102200-0cf6a478bea5
 	// Do not upgrade, it renames attributes we rely on
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0
 	go.opentelemetry.io/contrib/propagators/b3 v1.44.0

--- a/router/go.mod
+++ b/router/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/tidwall/gjson v1.18.0
 	github.com/tidwall/sjson v1.2.5
 	github.com/twmb/franz-go v1.16.1
-	github.com/wundergraph/graphql-go-tools/v2 v2.13.3-0.20260720102200-0cf6a478bea5
+	github.com/wundergraph/graphql-go-tools/v2 v2.14.1
 	// Do not upgrade, it renames attributes we rely on
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0
 	go.opentelemetry.io/contrib/propagators/b3 v1.44.0

--- a/router/go.sum
+++ b/router/go.sum
@@ -334,8 +334,8 @@ github.com/wundergraph/astjson v1.1.0 h1:xORDosrZ87zQFJwNGe/HIHXqzpdHOFmqWgykCLV
 github.com/wundergraph/astjson v1.1.0/go.mod h1:h12D/dxxnedtLzsKyBLK7/Oe4TAoGpRVC9nDpDrZSWw=
 github.com/wundergraph/go-arena v1.3.0 h1:n0ng5a1vbd8YGq1u3rMr0vPU5f6AZ1BXIiUhL1UIok8=
 github.com/wundergraph/go-arena v1.3.0/go.mod h1:ROOysEHWJjLQ8FSfNxZCziagb7Qw2nXY3/vgKRh7eWw=
-github.com/wundergraph/graphql-go-tools/v2 v2.13.3-0.20260720102200-0cf6a478bea5 h1:5MM+LkBRti8WeSD+8wm8pNm1H+zMIP0bNEhB82e8oH8=
-github.com/wundergraph/graphql-go-tools/v2 v2.13.3-0.20260720102200-0cf6a478bea5/go.mod h1:zREIKLmpjfNcGSubndaW/913r0Y8XbbYOXQeZFkwHdo=
+github.com/wundergraph/graphql-go-tools/v2 v2.14.1 h1:TecnvTyhskoeiqo6W+1xh7HqAPL/RG5vfbFhezu7RLs=
+github.com/wundergraph/graphql-go-tools/v2 v2.14.1/go.mod h1:zREIKLmpjfNcGSubndaW/913r0Y8XbbYOXQeZFkwHdo=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=

--- a/router/go.sum
+++ b/router/go.sum
@@ -334,8 +334,8 @@ github.com/wundergraph/astjson v1.1.0 h1:xORDosrZ87zQFJwNGe/HIHXqzpdHOFmqWgykCLV
 github.com/wundergraph/astjson v1.1.0/go.mod h1:h12D/dxxnedtLzsKyBLK7/Oe4TAoGpRVC9nDpDrZSWw=
 github.com/wundergraph/go-arena v1.3.0 h1:n0ng5a1vbd8YGq1u3rMr0vPU5f6AZ1BXIiUhL1UIok8=
 github.com/wundergraph/go-arena v1.3.0/go.mod h1:ROOysEHWJjLQ8FSfNxZCziagb7Qw2nXY3/vgKRh7eWw=
-github.com/wundergraph/graphql-go-tools/v2 v2.13.2 h1:YbK0HRgqoYNrlaFJDxST2+G9zex6okKLtjgDXNeVd48=
-github.com/wundergraph/graphql-go-tools/v2 v2.13.2/go.mod h1:zREIKLmpjfNcGSubndaW/913r0Y8XbbYOXQeZFkwHdo=
+github.com/wundergraph/graphql-go-tools/v2 v2.13.3-0.20260720102200-0cf6a478bea5 h1:5MM+LkBRti8WeSD+8wm8pNm1H+zMIP0bNEhB82e8oH8=
+github.com/wundergraph/graphql-go-tools/v2 v2.13.3-0.20260720102200-0cf6a478bea5/go.mod h1:zREIKLmpjfNcGSubndaW/913r0Y8XbbYOXQeZFkwHdo=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=


### PR DESCRIPTION
Related engine PR: https://github.com/wundergraph/graphql-go-tools/pull/1606

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

- **Bug Fixes**
  - Improved GraphQL `@requires` behavior when requested fields use aliases, including nested/abstract data and composite `@requires` scenarios.
  - Ensured alias-based composite `@requires` queries return `null` when the employee does not exist.
- **Tests**
  - Expanded the GraphQL gRPC subgraph test suite with new alias-based cases to validate `@requires` resolution, nested alias access, and missing-employee behavior.
- **Chores**
  - Updated the GraphQL tooling dependency version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] If applicable, I have provided instructions for reviewers for [manually validating my changes](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md#pull-requests-conventions).
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

<!--
Please add any additional information or context regarding your changes here.
-->
