### PR TITLE
feat: add a custom module to log the rejected queries with the error

### DIFF
--- a/router-tests/modules/log-operations-with-validation-errors/module.go
+++ b/router-tests/modules/log-operations-with-validation-errors/module.go
@@ -1,0 +1,79 @@
+// Package log_operations_with_validation_errors provides a custom module that
+// logs a warning for every operation the router rejects with validation errors,
+// so that previously working but spec-invalid operations can be collected
+// (e.g. after upgrading to a router that validates operations before variable
+// extraction, see Pylon issue #3351).
+//
+// The module is disabled by default. It only logs when it is explicitly
+// enabled through the router configuration:
+//
+//	modules:
+//	  logOperationsWithValidationErrors:
+//	    enabled: true
+package log_operations_with_validation_errors
+
+import (
+	"errors"
+	"net/http"
+
+	"go.uber.org/zap"
+
+	"github.com/wundergraph/cosmo/router/core"
+)
+
+const ModuleID = "logOperationsWithValidationErrors"
+
+type LogOperationsWithValidationErrors struct {
+	// Enabled activates the warning logs. It is decoded from the module's
+	// section of the router configuration and defaults to false.
+	Enabled bool `mapstructure:"enabled"`
+}
+
+// RouterOnRequest wraps the pre-handler, which is where operations are parsed
+// and validated. A RouterMiddlewareHandler would not work here: it is mounted
+// after the pre-handler, and the pre-handler aborts the chain when it rejects
+// an operation, so the middleware would never observe the rejection.
+func (m *LogOperationsWithValidationErrors) RouterOnRequest(ctx core.RequestContext, next http.Handler) {
+	next.ServeHTTP(ctx.ResponseWriter(), ctx.Request())
+
+	if !m.Enabled {
+		return
+	}
+
+	// Operations rejected as invalid GraphQL documents (schema validation, but
+	// also parsing and normalization failures) carry a core.ReportError. Other
+	// request errors (authentication, variable values, execution, ...) don't
+	// and are not logged here.
+	var reportErr core.ReportError
+	if !errors.As(ctx.Error(), &reportErr) {
+		return
+	}
+
+	externalErrors := reportErr.Report().ExternalErrors
+	if len(externalErrors) == 0 {
+		return
+	}
+
+	validationErrors := make([]string, len(externalErrors))
+	for i, externalError := range externalErrors {
+		validationErrors[i] = externalError.Message
+	}
+
+	ctx.Logger().Warn("Operation rejected with validation errors",
+		zap.String("operation_name", ctx.Operation().Name()),
+		zap.Strings("validation_errors", validationErrors),
+	)
+}
+
+func (m *LogOperationsWithValidationErrors) Module() core.ModuleInfo {
+	return core.ModuleInfo{
+		ID:       ModuleID,
+		Priority: 1,
+		New: func() core.Module {
+			return &LogOperationsWithValidationErrors{}
+		},
+	}
+}
+
+// Interface guard
+var _ core.RouterOnRequestHandler = (*LogOperationsWithValidationErrors)(nil)

--- a/router-tests/modules/log_operations_with_validation_errors_test.go
+++ b/router-tests/modules/log_operations_with_validation_errors_test.go
@@ -1,0 +1,133 @@
+package module_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+
+	logvalidationerrors "github.com/wundergraph/cosmo/router-tests/modules/log-operations-with-validation-errors"
+	"github.com/wundergraph/cosmo/router-tests/testenv"
+	"github.com/wundergraph/cosmo/router/core"
+)
+
+// TestLogOperationsWithValidationErrorsModule verifies the module that logs a
+// warning for every operation rejected with validation errors (Pylon issue
+// #3351: collect the operations that stopped working after the router started
+// validating operations before variable extraction).
+func TestLogOperationsWithValidationErrorsModule(t *testing.T) {
+	t.Parallel()
+
+	const (
+		logMessage = "Operation rejected with validation errors"
+
+		// The Pylon #3351 shape on the demo schema: a variable declared as
+		// [String!]! used in a position expecting [EnumType!]!, see
+		// operations/string_variables_for_enums_test.go.
+		invalidQuery    = `query Bad($programs: [String!]!) { rootFieldWithListOfEnumArg(arg: $programs) }`
+		validationError = `Variable "$programs" of type "[String!]!" used in position expecting type "[EnumType!]!".`
+
+		validQuery = `query Good($programs: [EnumType!]!) { rootFieldWithListOfEnumArg(arg: $programs) }`
+	)
+
+	variables := json.RawMessage(`{"programs":["A","B"]}`)
+
+	// requireValidationError asserts the response body carries exactly one
+	// error with the given message.
+	requireValidationError := func(t *testing.T, body, wantMessage string) {
+		t.Helper()
+
+		var resp struct {
+			Errors []struct {
+				Message string `json:"message"`
+			} `json:"errors"`
+		}
+		require.NoErrorf(t, json.Unmarshal([]byte(body), &resp), "invalid JSON body: %s", body)
+		require.Lenf(t, resp.Errors, 1, "expected exactly one error, got body: %s", body)
+		require.Equal(t, wantMessage, resp.Errors[0].Message)
+	}
+
+	t.Run("disabled by default: rejects the operation without logging", func(t *testing.T) {
+		t.Parallel()
+
+		testenv.Run(t, &testenv.Config{
+			RouterOptions: []core.Option{
+				core.WithCustomModules(&logvalidationerrors.LogOperationsWithValidationErrors{}),
+			},
+			LogObservation: testenv.LogObservationConfig{
+				Enabled:  true,
+				LogLevel: zapcore.WarnLevel,
+			},
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+				Query:     invalidQuery,
+				Variables: variables,
+			})
+			requireValidationError(t, res.Body, validationError)
+
+			assert.Empty(t, xEnv.Observer().FilterMessage(logMessage).All())
+		})
+	})
+
+	t.Run("enabled via router config: logs operation name and validation error", func(t *testing.T) {
+		t.Parallel()
+
+		testenv.Run(t, &testenv.Config{
+			RouterOptions: []core.Option{
+				core.WithCustomModules(&logvalidationerrors.LogOperationsWithValidationErrors{}),
+				core.WithModulesConfig(map[string]any{
+					logvalidationerrors.ModuleID: map[string]any{
+						"enabled": true,
+					},
+				}),
+			},
+			LogObservation: testenv.LogObservationConfig{
+				Enabled:  true,
+				LogLevel: zapcore.WarnLevel,
+			},
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+				Query:     invalidQuery,
+				Variables: variables,
+			})
+			requireValidationError(t, res.Body, validationError)
+
+			logs := xEnv.Observer().FilterMessage(logMessage).All()
+			require.Len(t, logs, 1)
+			require.Equal(t, zapcore.WarnLevel, logs[0].Level)
+
+			fields := logs[0].ContextMap()
+			assert.Equal(t, "Bad", fields["operation_name"])
+			assert.Equal(t, []any{validationError}, fields["validation_errors"])
+		})
+	})
+
+	t.Run("enabled via router config: valid operations are not logged", func(t *testing.T) {
+		t.Parallel()
+
+		testenv.Run(t, &testenv.Config{
+			RouterOptions: []core.Option{
+				core.WithCustomModules(&logvalidationerrors.LogOperationsWithValidationErrors{}),
+				core.WithModulesConfig(map[string]any{
+					logvalidationerrors.ModuleID: map[string]any{
+						"enabled": true,
+					},
+				}),
+			},
+			LogObservation: testenv.LogObservationConfig{
+				Enabled:  true,
+				LogLevel: zapcore.WarnLevel,
+			},
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
+				Query:     validQuery,
+				Variables: variables,
+			})
+			assert.Equal(t, `{"data":{"rootFieldWithListOfEnumArg":["A","B"]}}`, res.Body)
+
+			assert.Empty(t, xEnv.Observer().FilterMessage(logMessage).All())
+		})
+	})
+}


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional router module that logs warnings when operations are rejected due to validation errors.
  * Warning logs include the operation name and validation error details.
  * The module is disabled by default and can be enabled through router configuration.

* **Bug Fixes**
  * Added coverage to ensure valid operations are not logged and invalid operations are reported correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] If applicable, I have provided instructions for reviewers for [manually validating my changes](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md#pull-requests-conventions).
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

<!--
Please add any additional information or context regarding your changes here.
-->
