### PR TITLE
fix: executable directive definitions missing in client schema

### DIFF
--- a/composition/src/v1/federation/federation-factory.ts
+++ b/composition/src/v1/federation/federation-factory.ts
@@ -3243,6 +3243,10 @@ export class FederationFactory {
       }
 
       this.routerDefinitions.push(data.node);
+
+      if (!data.isComposed && data.executableLocations.size > 0) {
+        this.clientDefinitions.push(data.node);
+      }
     }
   }
 

--- a/composition/tests/v1/federation-factory.test.ts
+++ b/composition/tests/v1/federation-factory.test.ts
@@ -908,6 +908,51 @@ describe('FederationFactory tests', () => {
     );
   });
 
+  test('that an executable directive is not persisted in the federated graph if it is not defined in all subgraphs', () => {
+    const a = createSubgraph(
+      'a',
+      `
+      directive @a on FIELD | FIELD_DEFINITION
+
+      type Query {
+        a: ID
+      }
+      `,
+    );
+    const b = createSubgraph(
+      'b',
+      `
+      type Query {
+        a: ID
+      }
+    `,
+    );
+    const { federatedGraphClientSchema, federatedGraphSchema } = federateSubgraphsSuccess(
+      [a, b],
+      ROUTER_COMPATIBILITY_VERSION_ONE,
+    );
+    expect(schemaToSortedNormalizedString(federatedGraphClientSchema)).toBe(
+      normalizeString(
+        SCHEMA_QUERY_DEFINITION +
+          `
+          type Query {
+            a: ID
+          }
+      `,
+      ),
+    );
+    expect(schemaToSortedNormalizedString(federatedGraphSchema)).toBe(
+      normalizeString(
+        SCHEMA_QUERY_DEFINITION +
+          `
+          type Query {
+            a: ID
+          }
+      `,
+      ),
+    );
+  });
+
   test('that all nested entity keys are considered to be shareable', () => {
     const { federatedGraphSchema } = federateSubgraphsSuccess([subgraphM, subgraphN], ROUTER_COMPATIBILITY_VERSION_ONE);
     expect(schemaToSortedNormalizedString(federatedGraphSchema)).toBe(

--- a/composition/tests/v1/federation-factory.test.ts
+++ b/composition/tests/v1/federation-factory.test.ts
@@ -33,6 +33,7 @@ import fs from 'node:fs';
 import path, { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
+  createSubgraph,
   federateSubgraphsFailure,
   federateSubgraphsSuccess,
   normalizeString,
@@ -851,6 +852,57 @@ describe('FederationFactory tests', () => {
         type Query {
           a: ID
         }
+      `,
+      ),
+    );
+  });
+
+  test('that an executable directive is merged and persisted in the federated graph without any type system locations', () => {
+    const a = createSubgraph(
+      'a',
+      `
+      directive @a on FIELD | FIELD_DEFINITION
+
+      type Query {
+        a: ID
+      }
+      `,
+    );
+    const b = createSubgraph(
+      'b',
+      `
+      directive @a on FIELD | FIELD_DEFINITION
+
+      type Query {
+        a: ID
+      }
+    `,
+    );
+    const { federatedGraphClientSchema, federatedGraphSchema } = federateSubgraphsSuccess(
+      [a, b],
+      ROUTER_COMPATIBILITY_VERSION_ONE,
+    );
+    expect(schemaToSortedNormalizedString(federatedGraphClientSchema)).toBe(
+      normalizeString(
+        SCHEMA_QUERY_DEFINITION +
+          `
+          directive @a on FIELD
+
+          type Query {
+            a: ID
+          }
+      `,
+      ),
+    );
+    expect(schemaToSortedNormalizedString(federatedGraphSchema)).toBe(
+      normalizeString(
+        SCHEMA_QUERY_DEFINITION +
+          `
+          directive @a on FIELD
+
+          type Query {
+            a: ID
+          }
       `,
       ),
     );

--- a/composition/tests/v1/federation-factory.test.ts
+++ b/composition/tests/v1/federation-factory.test.ts
@@ -813,6 +813,18 @@ describe('FederationFactory tests', () => {
       `,
       ),
     );
+    expect(schemaToSortedNormalizedString(result.federatedGraphClientSchema)).toBe(
+      normalizeString(
+        SCHEMA_QUERY_DEFINITION +
+          `
+        directive @executableDirective(optionalArgInAll: Float, requiredArgInAll: String!, requiredArgInSome: Int!) on FIELD
+
+        type Query {
+          dummy: String
+        }
+      `,
+      ),
+    );
   });
 
   test('that valid executable directives are merged and persisted in the federated graph #2', () => {
@@ -823,6 +835,19 @@ describe('FederationFactory tests', () => {
           `
         directive @executableDirective on FIELD
         
+        type Query {
+          a: ID
+        }
+      `,
+      ),
+    );
+
+    expect(schemaToSortedNormalizedString(result.federatedGraphClientSchema)).toBe(
+      normalizeString(
+        SCHEMA_QUERY_DEFINITION +
+          `
+        directive @executableDirective on FIELD
+
         type Query {
           a: ID
         }


### PR DESCRIPTION
Executable directives should be part of client schema. This change adds them in. Unit tests are
provided to prove the change.

Run `pnpm --filter composition test` to test the changes. Addresses #3106

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured executable directives are persisted not only in the federated graph schema, but also in the federated client schema when they are present across relevant directive definitions.
* **Tests**
  * Expanded federation-factory tests to verify merged executable directives in both schemas, including coverage for federating multiple subgraphs and scenarios where an executable directive is missing from one subgraph.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [X] I have discussed my proposed changes in an issue and have received approval to proceed.
- [X] I have followed the coding standards of the project.
- [X] Tests or benchmarks have been added or updated.
- [ ] If applicable, I have provided instructions for reviewers for [manually validating my changes](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md#pull-requests-conventions).
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website). (n/a)
- [X] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

<!--
Please add any additional information or context regarding your changes here.
-->
