### PR TITLE
fix(protographic): fix proto codegen omitting `ListOfX` wrapper for required fields on nullable list

### DIFF
--- a/protographic/src/required-fields-visitor.ts
+++ b/protographic/src/required-fields-visitor.ts
@@ -27,6 +27,7 @@ import {
 import {
   CompositeMessageDefinition,
   CompositeMessageKind,
+  ProtoFieldType,
   ProtoMessage,
   ProtoMessageField,
   RPCMethod,
@@ -236,7 +237,7 @@ export class RequiredFieldsVisitor {
    * Tracks list wrapper messages produced by getProtoTypeFromGraphQL so the caller
    * can include their definitions in the final proto output.
    */
-  private trackListWrapper(protoType: ReturnType<typeof getProtoTypeFromGraphQL>): void {
+  private trackListWrapper(protoType: ProtoFieldType): void {
     const listWrapper = protoType.listWrapper;
     if (!listWrapper) {
       return;

--- a/protographic/src/required-fields-visitor.ts
+++ b/protographic/src/required-fields-visitor.ts
@@ -42,7 +42,7 @@ import {
   formatKeyElements,
   graphqlArgumentToProtoField,
 } from './naming-conventions.js';
-import { getProtoTypeFromGraphQL } from './proto-utils.js';
+import { createNestedListWrapper, getProtoTypeFromGraphQL, listNameByNestingLevel } from './proto-utils.js';
 import { AbstractSelectionRewriter } from './abstract-selection-rewriter.js';
 
 /**
@@ -117,6 +117,9 @@ export class RequiredFieldsVisitor {
 
   /** Whether any field argument uses a protobuf wrapper type */
   private _usesWrapperTypes = false;
+
+  /** Generated ListOfX wrapper message definitions, keyed by wrapper name */
+  private _nestedListWrappers = new Map<string, string>();
 
   /**
    * Creates a new RequiredFieldsVisitor.
@@ -218,6 +221,35 @@ export class RequiredFieldsVisitor {
    */
   public get usesWrapperTypes(): boolean {
     return this._usesWrapperTypes;
+  }
+
+  /**
+   * Returns the ListOfX wrapper message definitions generated while resolving
+   * required field types, keyed by wrapper name.
+   * Used by the caller to include these wrapper messages in the final proto output.
+   */
+  public get nestedListWrappers(): Map<string, string> {
+    return this._nestedListWrappers;
+  }
+
+  /**
+   * Tracks list wrapper messages produced by getProtoTypeFromGraphQL so the caller
+   * can include their definitions in the final proto output.
+   */
+  private trackListWrapper(protoType: ReturnType<typeof getProtoTypeFromGraphQL>): void {
+    const listWrapper = protoType.listWrapper;
+    if (!listWrapper) {
+      return;
+    }
+
+    for (let i = 1; i <= listWrapper.nestingLevel; i++) {
+      const wrapperName = listNameByNestingLevel(i, listWrapper.baseType);
+      if (this._nestedListWrappers.has(wrapperName)) {
+        continue;
+      }
+
+      this._nestedListWrappers.set(wrapperName, createNestedListWrapper(false, i, listWrapper.baseType));
+    }
   }
 
   /**
@@ -367,6 +399,7 @@ export class RequiredFieldsVisitor {
           if (protoType.isWrapper) {
             this._usesWrapperTypes = true;
           }
+          this.trackListWrapper(protoType);
           return {
             fieldName: graphqlArgumentToProtoField(d.name),
             typeName: protoType.typeName,
@@ -403,6 +436,7 @@ export class RequiredFieldsVisitor {
 
     // Get the type name from the required field
     const typeInfo = getProtoTypeFromGraphQL(false, this.requiredField.type);
+    this.trackListWrapper(typeInfo);
 
     this.messageDefinitions.push({
       messageName: resultMessageName,
@@ -450,6 +484,7 @@ export class RequiredFieldsVisitor {
     }
 
     const typeInfo = getProtoTypeFromGraphQL(false, fieldDefinition.type);
+    this.trackListWrapper(typeInfo);
     this.current.fields.push({
       fieldName: protoFieldName,
       typeName: typeInfo.typeName,

--- a/protographic/src/sdl-to-proto-visitor.ts
+++ b/protographic/src/sdl-to-proto-visitor.ts
@@ -1176,6 +1176,15 @@ Example:
         const messageDefinitions = visitor.getMessageDefinitions();
         this.usesWrapperTypes = this.usesWrapperTypes || visitor.usesWrapperTypes;
 
+        for (const [wrapperName, wrapperMessage] of visitor.nestedListWrappers) {
+          if (this.processedTypes.has(wrapperName) || this.nestedListWrappers.has(wrapperName)) {
+            continue;
+          }
+
+          this.nestedListWrappers.set(wrapperName, wrapperMessage);
+          this.processedTypes.add(wrapperName);
+        }
+
         result.rpcMethods.push(...rpcMethods.map((m) => renderRPCMethod(this.includeComments, m).join('\n')));
         result.methodNames.push(...rpcMethods.map((m) => m.name));
         const messageLines = messageDefinitions.flatMap((m) => buildProtoMessage(this.includeComments, m));

--- a/protographic/tests/sdl-to-proto/04-federation.test.ts
+++ b/protographic/tests/sdl-to-proto/04-federation.test.ts
@@ -2665,18 +2665,99 @@ describe('SDL to Proto - Federation and Special Types', () => {
 
       const { proto: protoText } = compileGraphQLToProto(sdl);
 
-      expect(protoText).toContain('ListOfBadge badges');
-      expect(protoText).toContain(
-        [
-          'message ListOfBadge {',
-          '  message List {',
-          '    repeated Badge items = 1;',
-          '  }',
-          '  List list = 1;',
-          '}',
-        ].join('\n'),
-      );
       expectValidProto(protoText);
+      expect(protoText).toMatchInlineSnapshot(`
+        "syntax = "proto3";
+        package service.v1;
+
+        // Service definition for DefaultService
+        service DefaultService {
+          // Lookup User entity by id
+          rpc LookupUserById(LookupUserByIdRequest) returns (LookupUserByIdResponse) {}
+          rpc QueryUser(QueryUserRequest) returns (QueryUserResponse) {}
+          rpc RequireUserBadgesById(RequireUserBadgesByIdRequest) returns (RequireUserBadgesByIdResponse) {}
+        }
+
+        message ListOfBadge {
+          message List {
+            repeated Badge items = 1;
+          }
+          List list = 1;
+        }
+        // Key message for User entity lookup
+        message LookupUserByIdRequestKey {
+          // Key field for User entity lookup.
+          string id = 1;
+        }
+
+        // Request message for User entity lookup.
+        message LookupUserByIdRequest {
+          /*
+           * List of keys to look up User entities.
+           * Order matters - each key maps to one entity in LookupUserByIdResponse.
+           */
+          repeated LookupUserByIdRequestKey keys = 1;
+        }
+
+        // Response message for User entity lookup.
+        message LookupUserByIdResponse {
+          /*
+           * List of User entities in the same order as the keys in LookupUserByIdRequest.
+           * Always return the same number of entities as keys. Use null for entities that cannot be found.
+           * 
+           * Example:
+           *   LookupUserByIdRequest:
+           *     keys:
+           *       - id: 1
+           *       - id: 2
+           *   LookupUserByIdResponse:
+           *     result:
+           *       - id: 1 # User with id 1 found
+           *       - null  # User with id 2 not found
+           */
+          repeated User result = 1;
+        }
+
+        // Request message for user operation.
+        message QueryUserRequest {
+          string id = 1;
+        }
+        // Response message for user operation.
+        message QueryUserResponse {
+          User user = 1;
+        }
+        message RequireUserBadgesByIdRequest {
+          // RequireUserBadgesByIdContext provides the context for the required fields method RequireUserBadgesById.
+          repeated RequireUserBadgesByIdContext context = 1;
+        }
+
+        message RequireUserBadgesByIdContext {
+          LookupUserByIdRequestKey key = 1;
+          RequireUserBadgesByIdFields fields = 2;
+        }
+
+        message RequireUserBadgesByIdResponse {
+          // RequireUserBadgesByIdResult provides the result for the required fields method RequireUserBadgesById.
+          repeated RequireUserBadgesByIdResult result = 1;
+        }
+
+        message RequireUserBadgesByIdResult {
+          ListOfBadge badges = 1;
+        }
+
+        message RequireUserBadgesByIdFields {
+          string name = 1;
+        }
+
+        message User {
+          string id = 1;
+        }
+
+        message Badge {
+          string id = 1;
+          string label = 2;
+        }"
+      `);
     });
 
     test('should define the list wrapper for a required field returning a nullable list of an interface type', () => {
@@ -2712,18 +2793,113 @@ describe('SDL to Proto - Federation and Special Types', () => {
 
       const { proto: protoText } = compileGraphQLToProto(sdl);
 
-      expect(protoText).toContain('ListOfStorageItem recommended_items');
-      expect(protoText).toContain(
-        [
-          'message ListOfStorageItem {',
-          '  message List {',
-          '    repeated StorageItem items = 1;',
-          '  }',
-          '  List list = 1;',
-          '}',
-        ].join('\n'),
-      );
       expectValidProto(protoText);
+      expect(protoText).toMatchInlineSnapshot(`
+        "syntax = "proto3";
+        package service.v1;
+
+        // Service definition for DefaultService
+        service DefaultService {
+          // Lookup Storage entity by id
+          rpc LookupStorageById(LookupStorageByIdRequest) returns (LookupStorageByIdResponse) {}
+          rpc QueryStorage(QueryStorageRequest) returns (QueryStorageResponse) {}
+          rpc RequireStorageRecommendedItemsById(RequireStorageRecommendedItemsByIdRequest) returns (RequireStorageRecommendedItemsByIdResponse) {}
+        }
+
+        message ListOfStorageItem {
+          message List {
+            repeated StorageItem items = 1;
+          }
+          List list = 1;
+        }
+        // Key message for Storage entity lookup
+        message LookupStorageByIdRequestKey {
+          // Key field for Storage entity lookup.
+          string id = 1;
+        }
+
+        // Request message for Storage entity lookup.
+        message LookupStorageByIdRequest {
+          /*
+           * List of keys to look up Storage entities.
+           * Order matters - each key maps to one entity in LookupStorageByIdResponse.
+           */
+          repeated LookupStorageByIdRequestKey keys = 1;
+        }
+
+        // Response message for Storage entity lookup.
+        message LookupStorageByIdResponse {
+          /*
+           * List of Storage entities in the same order as the keys in LookupStorageByIdRequest.
+           * Always return the same number of entities as keys. Use null for entities that cannot be found.
+           * 
+           * Example:
+           *   LookupUserByIdRequest:
+           *     keys:
+           *       - id: 1
+           *       - id: 2
+           *   LookupUserByIdResponse:
+           *     result:
+           *       - id: 1 # User with id 1 found
+           *       - null  # User with id 2 not found
+           */
+          repeated Storage result = 1;
+        }
+
+        // Request message for storage operation.
+        message QueryStorageRequest {
+          string id = 1;
+        }
+        // Response message for storage operation.
+        message QueryStorageResponse {
+          Storage storage = 1;
+        }
+        message RequireStorageRecommendedItemsByIdRequest {
+          // RequireStorageRecommendedItemsByIdContext provides the context for the required fields method RequireStorageRecommendedItemsById.
+          repeated RequireStorageRecommendedItemsByIdContext context = 1;
+        }
+
+        message RequireStorageRecommendedItemsByIdContext {
+          LookupStorageByIdRequestKey key = 1;
+          RequireStorageRecommendedItemsByIdFields fields = 2;
+        }
+
+        message RequireStorageRecommendedItemsByIdResponse {
+          // RequireStorageRecommendedItemsByIdResult provides the result for the required fields method RequireStorageRecommendedItemsById.
+          repeated RequireStorageRecommendedItemsByIdResult result = 1;
+        }
+
+        message RequireStorageRecommendedItemsByIdResult {
+          ListOfStorageItem recommended_items = 1;
+        }
+
+        message RequireStorageRecommendedItemsByIdFields {
+          string name = 1;
+        }
+
+        message Storage {
+          string id = 1;
+        }
+
+        message StorageItem {
+          oneof instance {
+          PalletItem pallet_item = 1;
+          ContainerItem container_item = 2;
+          }
+        }
+
+        message PalletItem {
+          string id = 1;
+          string name = 2;
+          int32 pallet_count = 3;
+        }
+
+        message ContainerItem {
+          string id = 1;
+          string name = 2;
+          string container_size = 3;
+        }"
+      `);
     });
 
     test('should define the list wrapper for a required field returning a nullable list of a union type', () => {
@@ -2752,18 +2928,109 @@ describe('SDL to Proto - Federation and Special Types', () => {
 
       const { proto: protoText } = compileGraphQLToProto(sdl);
 
-      expect(protoText).toContain('ListOfStorageOperationResult operation_history');
-      expect(protoText).toContain(
-        [
-          'message ListOfStorageOperationResult {',
-          '  message List {',
-          '    repeated StorageOperationResult items = 1;',
-          '  }',
-          '  List list = 1;',
-          '}',
-        ].join('\n'),
-      );
       expectValidProto(protoText);
+      expect(protoText).toMatchInlineSnapshot(`
+        "syntax = "proto3";
+        package service.v1;
+
+        // Service definition for DefaultService
+        service DefaultService {
+          // Lookup Storage entity by id
+          rpc LookupStorageById(LookupStorageByIdRequest) returns (LookupStorageByIdResponse) {}
+          rpc QueryStorage(QueryStorageRequest) returns (QueryStorageResponse) {}
+          rpc RequireStorageOperationHistoryById(RequireStorageOperationHistoryByIdRequest) returns (RequireStorageOperationHistoryByIdResponse) {}
+        }
+
+        message ListOfStorageOperationResult {
+          message List {
+            repeated StorageOperationResult items = 1;
+          }
+          List list = 1;
+        }
+        // Key message for Storage entity lookup
+        message LookupStorageByIdRequestKey {
+          // Key field for Storage entity lookup.
+          string id = 1;
+        }
+
+        // Request message for Storage entity lookup.
+        message LookupStorageByIdRequest {
+          /*
+           * List of keys to look up Storage entities.
+           * Order matters - each key maps to one entity in LookupStorageByIdResponse.
+           */
+          repeated LookupStorageByIdRequestKey keys = 1;
+        }
+
+        // Response message for Storage entity lookup.
+        message LookupStorageByIdResponse {
+          /*
+           * List of Storage entities in the same order as the keys in LookupStorageByIdRequest.
+           * Always return the same number of entities as keys. Use null for entities that cannot be found.
+           * 
+           * Example:
+           *   LookupUserByIdRequest:
+           *     keys:
+           *       - id: 1
+           *       - id: 2
+           *   LookupUserByIdResponse:
+           *     result:
+           *       - id: 1 # User with id 1 found
+           *       - null  # User with id 2 not found
+           */
+          repeated Storage result = 1;
+        }
+
+        // Request message for storage operation.
+        message QueryStorageRequest {
+          string id = 1;
+        }
+        // Response message for storage operation.
+        message QueryStorageResponse {
+          Storage storage = 1;
+        }
+        message RequireStorageOperationHistoryByIdRequest {
+          // RequireStorageOperationHistoryByIdContext provides the context for the required fields method RequireStorageOperationHistoryById.
+          repeated RequireStorageOperationHistoryByIdContext context = 1;
+        }
+
+        message RequireStorageOperationHistoryByIdContext {
+          LookupStorageByIdRequestKey key = 1;
+          RequireStorageOperationHistoryByIdFields fields = 2;
+        }
+
+        message RequireStorageOperationHistoryByIdResponse {
+          // RequireStorageOperationHistoryByIdResult provides the result for the required fields method RequireStorageOperationHistoryById.
+          repeated RequireStorageOperationHistoryByIdResult result = 1;
+        }
+
+        message RequireStorageOperationHistoryByIdResult {
+          ListOfStorageOperationResult operation_history = 1;
+        }
+
+        message RequireStorageOperationHistoryByIdFields {
+          string name = 1;
+        }
+
+        message Storage {
+          string id = 1;
+        }
+
+        message StorageOperationResult {
+          oneof value {
+          StorageSuccess storage_success = 1;
+          StorageFailure storage_failure = 2;
+          }
+        }
+
+        message StorageSuccess {
+          string message = 1;
+        }
+
+        message StorageFailure {
+          string error_code = 1;
+        }"
+      `);
     });
 
     test('should define the list wrapper for a non-required field returning a nullable list (control)', () => {
@@ -2785,17 +3052,78 @@ describe('SDL to Proto - Federation and Special Types', () => {
 
       const { proto: protoText } = compileGraphQLToProto(sdl);
 
-      expect(protoText).toContain(
-        [
-          'message ListOfBadge {',
-          '  message List {',
-          '    repeated Badge items = 1;',
-          '  }',
-          '  List list = 1;',
-          '}',
-        ].join('\n'),
-      );
       expectValidProto(protoText);
+      expect(protoText).toMatchInlineSnapshot(`
+        "syntax = "proto3";
+        package service.v1;
+
+        // Service definition for DefaultService
+        service DefaultService {
+          // Lookup User entity by id
+          rpc LookupUserById(LookupUserByIdRequest) returns (LookupUserByIdResponse) {}
+          rpc QueryUser(QueryUserRequest) returns (QueryUserResponse) {}
+        }
+
+        // Wrapper message for a list of Badge.
+        message ListOfBadge {
+          message List {
+            repeated Badge items = 1;
+          }
+          List list = 1;
+        }
+        // Key message for User entity lookup
+        message LookupUserByIdRequestKey {
+          // Key field for User entity lookup.
+          string id = 1;
+        }
+
+        // Request message for User entity lookup.
+        message LookupUserByIdRequest {
+          /*
+           * List of keys to look up User entities.
+           * Order matters - each key maps to one entity in LookupUserByIdResponse.
+           */
+          repeated LookupUserByIdRequestKey keys = 1;
+        }
+
+        // Response message for User entity lookup.
+        message LookupUserByIdResponse {
+          /*
+           * List of User entities in the same order as the keys in LookupUserByIdRequest.
+           * Always return the same number of entities as keys. Use null for entities that cannot be found.
+           * 
+           * Example:
+           *   LookupUserByIdRequest:
+           *     keys:
+           *       - id: 1
+           *       - id: 2
+           *   LookupUserByIdResponse:
+           *     result:
+           *       - id: 1 # User with id 1 found
+           *       - null  # User with id 2 not found
+           */
+          repeated User result = 1;
+        }
+
+        // Request message for user operation.
+        message QueryUserRequest {
+          string id = 1;
+        }
+        // Response message for user operation.
+        message QueryUserResponse {
+          User user = 1;
+        }
+
+        message User {
+          string id = 1;
+          ListOfBadge badges = 2;
+        }
+
+        message Badge {
+          string id = 1;
+          string label = 2;
+        }"
+      `);
     });
 
     test('should define the list wrapper for a nullable list field argument on a required field', () => {
@@ -2819,18 +3147,105 @@ describe('SDL to Proto - Federation and Special Types', () => {
 
       const { proto: protoText } = compileGraphQLToProto(sdl);
 
-      expect(protoText).toContain('ListOfString tags');
-      expect(protoText).toContain(
-        [
-          'message ListOfString {',
-          '  message List {',
-          '    repeated string items = 1;',
-          '  }',
-          '  List list = 1;',
-          '}',
-        ].join('\n'),
-      );
       expectValidProto(protoText);
+      expect(protoText).toMatchInlineSnapshot(`
+        "syntax = "proto3";
+        package service.v1;
+
+        // Service definition for DefaultService
+        service DefaultService {
+          // Lookup User entity by id
+          rpc LookupUserById(LookupUserByIdRequest) returns (LookupUserByIdResponse) {}
+          rpc QueryUser(QueryUserRequest) returns (QueryUserResponse) {}
+          rpc RequireUserPostsById(RequireUserPostsByIdRequest) returns (RequireUserPostsByIdResponse) {}
+        }
+
+        message ListOfString {
+          message List {
+            repeated string items = 1;
+          }
+          List list = 1;
+        }
+        // Key message for User entity lookup
+        message LookupUserByIdRequestKey {
+          // Key field for User entity lookup.
+          string id = 1;
+        }
+
+        // Request message for User entity lookup.
+        message LookupUserByIdRequest {
+          /*
+           * List of keys to look up User entities.
+           * Order matters - each key maps to one entity in LookupUserByIdResponse.
+           */
+          repeated LookupUserByIdRequestKey keys = 1;
+        }
+
+        // Response message for User entity lookup.
+        message LookupUserByIdResponse {
+          /*
+           * List of User entities in the same order as the keys in LookupUserByIdRequest.
+           * Always return the same number of entities as keys. Use null for entities that cannot be found.
+           * 
+           * Example:
+           *   LookupUserByIdRequest:
+           *     keys:
+           *       - id: 1
+           *       - id: 2
+           *   LookupUserByIdResponse:
+           *     result:
+           *       - id: 1 # User with id 1 found
+           *       - null  # User with id 2 not found
+           */
+          repeated User result = 1;
+        }
+
+        // Request message for user operation.
+        message QueryUserRequest {
+          string id = 1;
+        }
+        // Response message for user operation.
+        message QueryUserResponse {
+          User user = 1;
+        }
+        message RequireUserPostsByIdRequest {
+          // RequireUserPostsByIdContext provides the context for the required fields method RequireUserPostsById.
+          repeated RequireUserPostsByIdContext context = 1;
+          // RequireUserPostsByIdArgs provides the field arguments for the required field with method RequireUserPostsById.
+          RequireUserPostsByIdArgs field_args = 2;
+        }
+
+        message RequireUserPostsByIdContext {
+          LookupUserByIdRequestKey key = 1;
+          RequireUserPostsByIdFields fields = 2;
+        }
+
+        message RequireUserPostsByIdArgs {
+          ListOfString tags = 1;
+        }
+
+        message RequireUserPostsByIdResponse {
+          // RequireUserPostsByIdResult provides the result for the required fields method RequireUserPostsById.
+          repeated RequireUserPostsByIdResult result = 1;
+        }
+
+        message RequireUserPostsByIdResult {
+          repeated Post posts = 1;
+        }
+
+        message RequireUserPostsByIdFields {
+          string name = 1;
+        }
+
+        message User {
+          string id = 1;
+        }
+
+        message Post {
+          string id = 1;
+          string title = 2;
+        }"
+      `);
     });
 
     test('should define the list wrapper for a nullable list field inside the @requires selection set', () => {
@@ -2849,18 +3264,94 @@ describe('SDL to Proto - Federation and Special Types', () => {
 
       const { proto: protoText } = compileGraphQLToProto(sdl);
 
-      expect(protoText).toContain('ListOfString tags');
-      expect(protoText).toContain(
-        [
-          'message ListOfString {',
-          '  message List {',
-          '    repeated string items = 1;',
-          '  }',
-          '  List list = 1;',
-          '}',
-        ].join('\n'),
-      );
       expectValidProto(protoText);
+      expect(protoText).toMatchInlineSnapshot(`
+        "syntax = "proto3";
+        package service.v1;
+
+        // Service definition for DefaultService
+        service DefaultService {
+          // Lookup User entity by id
+          rpc LookupUserById(LookupUserByIdRequest) returns (LookupUserByIdResponse) {}
+          rpc QueryUser(QueryUserRequest) returns (QueryUserResponse) {}
+          rpc RequireUserGreetingById(RequireUserGreetingByIdRequest) returns (RequireUserGreetingByIdResponse) {}
+        }
+
+        message ListOfString {
+          message List {
+            repeated string items = 1;
+          }
+          List list = 1;
+        }
+        // Key message for User entity lookup
+        message LookupUserByIdRequestKey {
+          // Key field for User entity lookup.
+          string id = 1;
+        }
+
+        // Request message for User entity lookup.
+        message LookupUserByIdRequest {
+          /*
+           * List of keys to look up User entities.
+           * Order matters - each key maps to one entity in LookupUserByIdResponse.
+           */
+          repeated LookupUserByIdRequestKey keys = 1;
+        }
+
+        // Response message for User entity lookup.
+        message LookupUserByIdResponse {
+          /*
+           * List of User entities in the same order as the keys in LookupUserByIdRequest.
+           * Always return the same number of entities as keys. Use null for entities that cannot be found.
+           * 
+           * Example:
+           *   LookupUserByIdRequest:
+           *     keys:
+           *       - id: 1
+           *       - id: 2
+           *   LookupUserByIdResponse:
+           *     result:
+           *       - id: 1 # User with id 1 found
+           *       - null  # User with id 2 not found
+           */
+          repeated User result = 1;
+        }
+
+        // Request message for user operation.
+        message QueryUserRequest {
+          string id = 1;
+        }
+        // Response message for user operation.
+        message QueryUserResponse {
+          User user = 1;
+        }
+        message RequireUserGreetingByIdRequest {
+          // RequireUserGreetingByIdContext provides the context for the required fields method RequireUserGreetingById.
+          repeated RequireUserGreetingByIdContext context = 1;
+        }
+
+        message RequireUserGreetingByIdContext {
+          LookupUserByIdRequestKey key = 1;
+          RequireUserGreetingByIdFields fields = 2;
+        }
+
+        message RequireUserGreetingByIdResponse {
+          // RequireUserGreetingByIdResult provides the result for the required fields method RequireUserGreetingById.
+          repeated RequireUserGreetingByIdResult result = 1;
+        }
+
+        message RequireUserGreetingByIdResult {
+          string greeting = 1;
+        }
+
+        message RequireUserGreetingByIdFields {
+          ListOfString tags = 1;
+        }
+
+        message User {
+          string id = 1;
+        }"
+      `);
     });
   });
 });

--- a/protographic/tests/sdl-to-proto/04-federation.test.ts
+++ b/protographic/tests/sdl-to-proto/04-federation.test.ts
@@ -2666,8 +2666,18 @@ describe('SDL to Proto - Federation and Special Types', () => {
       const { proto: protoText } = compileGraphQLToProto(sdl);
 
       expect(protoText).toContain('ListOfBadge badges');
-      // Fails today: the field references ListOfBadge but no `message ListOfBadge` is emitted.
-      expect(protoText).toContain('message ListOfBadge {');
+      expect(protoText).toContain(
+        [
+          'message ListOfBadge {',
+          '  message List {',
+          '    repeated Badge items = 1;',
+          '  }',
+          '  List list = 1;',
+          '}'
+        ].join(
+          '\n',
+        ),
+      );
       expectValidProto(protoText);
     });
 
@@ -2705,8 +2715,16 @@ describe('SDL to Proto - Federation and Special Types', () => {
       const { proto: protoText } = compileGraphQLToProto(sdl);
 
       expect(protoText).toContain('ListOfStorageItem recommended_items');
-      // Fails today: the field references ListOfStorageItem but no wrapper message is emitted.
-      expect(protoText).toContain('message ListOfStorageItem {');
+      expect(protoText).toContain(
+        [
+          'message ListOfStorageItem {',
+          '  message List {',
+          '    repeated StorageItem items = 1;',
+          '  }',
+          '  List list = 1;',
+          '}',
+        ].join('\n'),
+      );
       expectValidProto(protoText);
     });
 
@@ -2737,8 +2755,16 @@ describe('SDL to Proto - Federation and Special Types', () => {
       const { proto: protoText } = compileGraphQLToProto(sdl);
 
       expect(protoText).toContain('ListOfStorageOperationResult operation_history');
-      // Fails today: the field references ListOfStorageOperationResult but no wrapper message is emitted.
-      expect(protoText).toContain('message ListOfStorageOperationResult {');
+      expect(protoText).toContain(
+        [
+          'message ListOfStorageOperationResult {',
+          '  message List {',
+          '    repeated StorageOperationResult items = 1;',
+          '  }',
+          '  List list = 1;',
+          '}',
+        ].join('\n'),
+      );
       expectValidProto(protoText);
     });
 
@@ -2761,8 +2787,11 @@ describe('SDL to Proto - Federation and Special Types', () => {
 
       const { proto: protoText } = compileGraphQLToProto(sdl);
 
-      // Passes today: the regular SDL path registers the wrapper correctly.
-      expect(protoText).toContain('message ListOfBadge {');
+      expect(protoText).toContain(
+        ['message ListOfBadge {', '  message List {', '    repeated Badge items = 1;', '  }', '  List list = 1;', '}'].join(
+          '\n',
+        ),
+      );
       expectValidProto(protoText);
     });
   });

--- a/protographic/tests/sdl-to-proto/04-federation.test.ts
+++ b/protographic/tests/sdl-to-proto/04-federation.test.ts
@@ -2797,5 +2797,74 @@ describe('SDL to Proto - Federation and Special Types', () => {
       );
       expectValidProto(protoText);
     });
+
+    test('should define the list wrapper for a nullable list field argument on a required field', () => {
+      const sdl = `
+      type User @key(fields: "id") {
+        id: ID!
+        name: String! @external
+
+        posts(tags: [String]): [Post!]! @requires(fields: "name")
+      }
+
+      type Post {
+        id: ID!
+        title: String!
+      }
+
+      type Query {
+        user(id: ID!): User
+      }
+    `;
+
+      const { proto: protoText } = compileGraphQLToProto(sdl);
+
+      expect(protoText).toContain('ListOfString tags');
+      expect(protoText).toContain(
+        [
+          'message ListOfString {',
+          '  message List {',
+          '    repeated string items = 1;',
+          '  }',
+          '  List list = 1;',
+          '}',
+        ].join('\n'),
+      );
+      expectValidProto(protoText);
+    });
+
+    test('should define the list wrapper for a nullable list field inside the @requires selection set', () => {
+      const sdl = `
+      type Address {
+        street: String!
+        zipCodes: [String]
+      }
+
+      type User @key(fields: "id") {
+        id: ID!
+        address: Address! @external
+        greeting: String! @requires(fields: "address { zipCodes }")
+      }
+
+      type Query {
+        user(id: ID!): User
+      }
+    `;
+
+      const { proto: protoText } = compileGraphQLToProto(sdl);
+
+      expect(protoText).toContain('ListOfString zip_codes');
+      expect(protoText).toContain(
+        [
+          'message ListOfString {',
+          '  message List {',
+          '    repeated string items = 1;',
+          '  }',
+          '  List list = 1;',
+          '}',
+        ].join('\n'),
+      );
+      expectValidProto(protoText);
+    });
   });
 });

--- a/protographic/tests/sdl-to-proto/04-federation.test.ts
+++ b/protographic/tests/sdl-to-proto/04-federation.test.ts
@@ -2834,10 +2834,6 @@ describe('SDL to Proto - Federation and Special Types', () => {
     });
 
     test('should define the list wrapper for a nullable list field inside the @requires selection set', () => {
-      // `tags` is a scalar @external field selected directly (not nested through an
-      // object type), so it is excluded from User's own message (which only carries
-      // "id") and the ListOfString wrapper can only be registered via the required
-      // field's selection-set traversal, not any other code path.
       const sdl = `
       type User @key(fields: "id") {
         id: ID!

--- a/protographic/tests/sdl-to-proto/04-federation.test.ts
+++ b/protographic/tests/sdl-to-proto/04-federation.test.ts
@@ -2673,10 +2673,8 @@ describe('SDL to Proto - Federation and Special Types', () => {
           '    repeated Badge items = 1;',
           '  }',
           '  List list = 1;',
-          '}'
-        ].join(
-          '\n',
-        ),
+          '}',
+        ].join('\n'),
       );
       expectValidProto(protoText);
     });
@@ -2788,9 +2786,14 @@ describe('SDL to Proto - Federation and Special Types', () => {
       const { proto: protoText } = compileGraphQLToProto(sdl);
 
       expect(protoText).toContain(
-        ['message ListOfBadge {', '  message List {', '    repeated Badge items = 1;', '  }', '  List list = 1;', '}'].join(
-          '\n',
-        ),
+        [
+          'message ListOfBadge {',
+          '  message List {',
+          '    repeated Badge items = 1;',
+          '  }',
+          '  List list = 1;',
+          '}',
+        ].join('\n'),
       );
       expectValidProto(protoText);
     });

--- a/protographic/tests/sdl-to-proto/04-federation.test.ts
+++ b/protographic/tests/sdl-to-proto/04-federation.test.ts
@@ -2834,16 +2834,16 @@ describe('SDL to Proto - Federation and Special Types', () => {
     });
 
     test('should define the list wrapper for a nullable list field inside the @requires selection set', () => {
+      // `tags` is a scalar @external field selected directly (not nested through an
+      // object type), so it is excluded from User's own message (which only carries
+      // "id") and the ListOfString wrapper can only be registered via the required
+      // field's selection-set traversal, not any other code path.
       const sdl = `
-      type Address {
-        street: String!
-        zipCodes: [String]
-      }
-
       type User @key(fields: "id") {
         id: ID!
-        address: Address! @external
-        greeting: String! @requires(fields: "address { zipCodes }")
+        tags: [String] @external
+
+        greeting: String! @requires(fields: "tags")
       }
 
       type Query {
@@ -2853,7 +2853,7 @@ describe('SDL to Proto - Federation and Special Types', () => {
 
       const { proto: protoText } = compileGraphQLToProto(sdl);
 
-      expect(protoText).toContain('ListOfString zip_codes');
+      expect(protoText).toContain('ListOfString tags');
       expect(protoText).toContain(
         [
           'message ListOfString {',

--- a/protographic/tests/sdl-to-proto/04-federation.test.ts
+++ b/protographic/tests/sdl-to-proto/04-federation.test.ts
@@ -2637,4 +2637,133 @@ describe('SDL to Proto - Federation and Special Types', () => {
       expect(protoText).not.toContain('typename');
     });
   });
+
+  describe('Required fields returning nullable lists', () => {
+    // A nullable list is modelled with a ListOfX wrapper message so that null can be
+    // distinguished from an empty list. The @requires response path emits the reference
+    // to that wrapper but never registers its definition, so the generated proto does
+    // not resolve. This only goes unnoticed when some other field in the schema happens
+    // to register the same wrapper (e.g. ListOfString via an external [String!] field).
+    test('should define the list wrapper for a required field returning a nullable list of an object type', () => {
+      const sdl = `
+      type User @key(fields: "id") {
+        id: ID!
+        name: String! @external
+
+        badges: [Badge!] @requires(fields: "name")
+      }
+
+      type Badge {
+        id: ID!
+        label: String!
+      }
+
+      type Query {
+        user(id: ID!): User
+      }
+    `;
+
+      const { proto: protoText } = compileGraphQLToProto(sdl);
+
+      expect(protoText).toContain('ListOfBadge badges');
+      // Fails today: the field references ListOfBadge but no `message ListOfBadge` is emitted.
+      expect(protoText).toContain('message ListOfBadge {');
+      expectValidProto(protoText);
+    });
+
+    test('should define the list wrapper for a required field returning a nullable list of an interface type', () => {
+      const sdl = `
+      type Storage @key(fields: "id") {
+        id: ID!
+        name: String! @external
+
+        recommendedItems: [StorageItem!] @requires(fields: "name")
+      }
+
+      interface StorageItem {
+        id: ID!
+        name: String!
+      }
+
+      type PalletItem implements StorageItem {
+        id: ID!
+        name: String!
+        palletCount: Int!
+      }
+
+      type ContainerItem implements StorageItem {
+        id: ID!
+        name: String!
+        containerSize: String!
+      }
+
+      type Query {
+        storage(id: ID!): Storage
+      }
+    `;
+
+      const { proto: protoText } = compileGraphQLToProto(sdl);
+
+      expect(protoText).toContain('ListOfStorageItem recommended_items');
+      // Fails today: the field references ListOfStorageItem but no wrapper message is emitted.
+      expect(protoText).toContain('message ListOfStorageItem {');
+      expectValidProto(protoText);
+    });
+
+    test('should define the list wrapper for a required field returning a nullable list of a union type', () => {
+      const sdl = `
+      type Storage @key(fields: "id") {
+        id: ID!
+        name: String! @external
+
+        operationHistory: [StorageOperationResult!] @requires(fields: "name")
+      }
+
+      union StorageOperationResult = StorageSuccess | StorageFailure
+
+      type StorageSuccess {
+        message: String!
+      }
+
+      type StorageFailure {
+        errorCode: String!
+      }
+
+      type Query {
+        storage(id: ID!): Storage
+      }
+    `;
+
+      const { proto: protoText } = compileGraphQLToProto(sdl);
+
+      expect(protoText).toContain('ListOfStorageOperationResult operation_history');
+      // Fails today: the field references ListOfStorageOperationResult but no wrapper message is emitted.
+      expect(protoText).toContain('message ListOfStorageOperationResult {');
+      expectValidProto(protoText);
+    });
+
+    test('should define the list wrapper for a non-required field returning a nullable list (control)', () => {
+      const sdl = `
+      type User @key(fields: "id") {
+        id: ID!
+        badges: [Badge!]
+      }
+
+      type Badge {
+        id: ID!
+        label: String!
+      }
+
+      type Query {
+        user(id: ID!): User
+      }
+    `;
+
+      const { proto: protoText } = compileGraphQLToProto(sdl);
+
+      // Passes today: the regular SDL path registers the wrapper correctly.
+      expect(protoText).toContain('message ListOfBadge {');
+      expectValidProto(protoText);
+    });
+  });
 });


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed protobuf generation for required GraphQL fields involving nullable list return types by correctly capturing and emitting the corresponding `ListOfX` wrapper messages in the final output.
  * Prevents duplicate processing of wrapper messages when collecting required-field RPC methods.
* **Tests**
  * Expanded required-fields coverage for nullable lists (object, interface, and union) with full inline snapshots validating the complete generated proto output and wrapper structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [x] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [x] Tests or benchmarks have been added or updated.
- [x] If applicable, I have provided instructions for reviewers for [manually validating my changes](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md#pull-requests-conventions).
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

<!--
Please add any additional information or context regarding your changes here.
-->
