### PR TITLE
fix(studio): load studio when analytics cookies are declined

### DIFF
--- a/studio/src/__tests__/posthog-feature-flag-provider.test.tsx
+++ b/studio/src/__tests__/posthog-feature-flag-provider.test.tsx
@@ -3,10 +3,7 @@ import { act } from 'react';
 import { PostHogProvider } from 'posthog-js/react';
 import type { PostHog } from 'posthog-js';
 import { afterEach, expect, test } from 'vitest';
-import {
-  PostHogFeatureFlagProvider,
-  usePostHogFeatureFlags,
-} from '@/components/posthog-feature-flag-provider';
+import { PostHogFeatureFlagProvider, usePostHogFeatureFlags } from '@/components/posthog-feature-flag-provider';
 
 /**
  * Stub standing in for a PostHog client. The real `useFeatureFlagEnabled` hook

--- a/studio/src/__tests__/posthog-feature-flag-provider.test.tsx
+++ b/studio/src/__tests__/posthog-feature-flag-provider.test.tsx
@@ -1,0 +1,118 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { act } from 'react';
+import { PostHogProvider } from 'posthog-js/react';
+import type { PostHog } from 'posthog-js';
+import { afterEach, expect, test } from 'vitest';
+import {
+  PostHogFeatureFlagProvider,
+  usePostHogFeatureFlags,
+} from '@/components/posthog-feature-flag-provider';
+
+/**
+ * Stub standing in for a PostHog client. The real `useFeatureFlagEnabled` hook
+ * runs against it, so these tests cover the hook's own resolution behaviour
+ * rather than a mock of it.
+ */
+function createClient() {
+  let enabled: boolean | undefined;
+  let hasLoadedFlags = false;
+  const subscribers = new Set<() => void>();
+
+  const client = {
+    isFeatureEnabled: () => enabled,
+    onFeatureFlags: (callback: () => void) => {
+      subscribers.add(callback);
+      return () => subscribers.delete(callback);
+    },
+    featureFlags: {
+      get hasLoadedFlags() {
+        return hasLoadedFlags;
+      },
+    },
+  } as unknown as PostHog;
+
+  // Mirrors PostHog delivering flags: values become readable, then subscribers fire.
+  const resolveFlags = (value: boolean) => {
+    enabled = value;
+    hasLoadedFlags = true;
+    act(() => {
+      subscribers.forEach((callback) => callback());
+    });
+  };
+
+  return { client, resolveFlags };
+}
+
+function FlagState() {
+  const { status, onboarding } = usePostHogFeatureFlags();
+  return (
+    <>
+      <span data-testid="status">{status}</span>
+      <span data-testid="onboarding">{String(onboarding.enabled)}</span>
+    </>
+  );
+}
+
+function renderProvider(client: PostHog, disabled = false) {
+  return render(
+    <PostHogProvider client={client}>
+      <PostHogFeatureFlagProvider disabled={disabled}>
+        <span data-testid="child">studio</span>
+        <FlagState />
+      </PostHogFeatureFlagProvider>
+    </PostHogProvider>,
+  );
+}
+
+afterEach(() => cleanup());
+
+test('that the studio renders while the flag is unresolved', () => {
+  // Regression: an unresolved flag used to block the entire app behind a
+  // loader, which never cleared when PostHog could not deliver flags at all.
+  const { client } = createClient();
+
+  renderProvider(client);
+
+  expect(screen.getByTestId('child')).toBeDefined();
+  expect(screen.getByTestId('status').textContent).toBe('success');
+  expect(screen.getByTestId('onboarding').textContent).toBe('false');
+});
+
+test('that onboarding stays disabled when the flag never resolves', () => {
+  const { client } = createClient();
+
+  renderProvider(client);
+
+  expect(screen.getByTestId('onboarding').textContent).toBe('false');
+});
+
+test('that onboarding is enabled once the flag resolves to true', () => {
+  const { client, resolveFlags } = createClient();
+
+  renderProvider(client);
+  expect(screen.getByTestId('onboarding').textContent).toBe('false');
+
+  resolveFlags(true);
+
+  expect(screen.getByTestId('onboarding').textContent).toBe('true');
+});
+
+test('that onboarding stays disabled once the flag resolves to false', () => {
+  const { client, resolveFlags } = createClient();
+
+  renderProvider(client);
+  resolveFlags(false);
+
+  expect(screen.getByTestId('onboarding').textContent).toBe('false');
+});
+
+test('that onboarding stays disabled without a PostHog key, even if the flag is true', () => {
+  const { client, resolveFlags } = createClient();
+
+  renderProvider(client, true);
+  resolveFlags(true);
+
+  expect(screen.getByTestId('child')).toBeDefined();
+  expect(screen.getByTestId('status').textContent).toBe('disabled');
+  expect(screen.getByTestId('onboarding').textContent).toBe('false');
+});

--- a/studio/src/components/onboarding/onboarding-provider.tsx
+++ b/studio/src/components/onboarding/onboarding-provider.tsx
@@ -78,7 +78,7 @@ export const OnboardingProvider = ({ children }: { children: ReactNode }) => {
   const value = useMemo(
     () => ({
       onboarding,
-      enabled: Boolean(onboardingFlag.enabled && featureFlagStatus === 'success' && onboardingFlag),
+      enabled: featureFlagStatus === 'success' && onboardingFlag.enabled,
       setOnboarding,
       currentStep,
       setStep,

--- a/studio/src/components/posthog-feature-flag-provider.tsx
+++ b/studio/src/components/posthog-feature-flag-provider.tsx
@@ -1,8 +1,7 @@
-import { ReactNode, createContext, useContext, useEffect, useReducer, useMemo } from 'react';
+import { ReactNode, createContext, useContext, useMemo } from 'react';
 import { useFeatureFlagEnabled } from 'posthog-js/react';
-import { Loader } from '@/components/ui/loader';
 
-type PostHogFeatureFlagStatus = 'idle' | 'disabled' | 'pending' | 'success';
+type PostHogFeatureFlagStatus = 'disabled' | 'success';
 
 interface PostHogFeatureFlagState {
   status: PostHogFeatureFlagStatus;
@@ -11,27 +10,8 @@ interface PostHogFeatureFlagState {
   };
 }
 
-type PostHogFeatureFlagAction =
-  | { type: 'LOADING' }
-  | { type: 'LOADED'; onboardingEnabled: boolean }
-  | { type: 'DISABLED' };
-
-function postHogFeatureFlagReducer(
-  _state: PostHogFeatureFlagState,
-  action: PostHogFeatureFlagAction,
-): PostHogFeatureFlagState {
-  switch (action.type) {
-    case 'DISABLED':
-      return { status: 'disabled', onboarding: { enabled: false } };
-    case 'LOADING':
-      return { status: 'pending', onboarding: { enabled: false } };
-    case 'LOADED':
-      return { status: 'success', onboarding: { enabled: action.onboardingEnabled } };
-  }
-}
-
 const initialState: PostHogFeatureFlagState = {
-  status: 'idle',
+  status: 'disabled',
   onboarding: { enabled: false },
 };
 
@@ -40,26 +20,22 @@ export const PostHogFeatureFlagContext = createContext<PostHogFeatureFlagState>(
 export const usePostHogFeatureFlags = () => useContext(PostHogFeatureFlagContext);
 
 export const PostHogFeatureFlagProvider = ({ children, disabled }: { children: ReactNode; disabled: boolean }) => {
-  const onboardingFlag = useFeatureFlagEnabled('cosmo-onboarding-v1');
-  const [state, dispatch] = useReducer(postHogFeatureFlagReducer, initialState);
+  // Flags are a progressive enhancement, never a precondition for rendering the
+  // studio. `useFeatureFlagEnabled` yields `undefined` for as long as flags are
+  // unresolved, which includes states it never recovers from: consent rejected
+  // (PostHog then runs cookieless with persistence disabled, so nothing is
+  // cached between loads), request blocked, or PostHog unreachable. Passing an
+  // explicit default keeps those cases as "onboarding off" instead of a value
+  // the app would have to wait on.
+  const onboardingEnabled = useFeatureFlagEnabled('cosmo-onboarding-v1', false);
 
-  useEffect(() => {
-    if (disabled) {
-      dispatch({ type: 'DISABLED' });
-    } else if (onboardingFlag === undefined) {
-      dispatch({ type: 'LOADING' });
-    } else {
-      dispatch({ type: 'LOADED', onboardingEnabled: onboardingFlag });
-    }
-  }, [onboardingFlag, disabled]);
+  const value = useMemo<PostHogFeatureFlagState>(
+    () => ({
+      status: disabled ? 'disabled' : 'success',
+      onboarding: { enabled: !disabled && onboardingEnabled },
+    }),
+    [disabled, onboardingEnabled],
+  );
 
-  if (state.status !== 'success' && state.status !== 'disabled') {
-    return (
-      <div className="fixed inset-0 flex items-center justify-center bg-background">
-        <Loader />
-      </div>
-    );
-  }
-
-  return <PostHogFeatureFlagContext.Provider value={state}>{children}</PostHogFeatureFlagContext.Provider>;
+  return <PostHogFeatureFlagContext.Provider value={value}>{children}</PostHogFeatureFlagContext.Provider>;
 };

--- a/studio/src/pages/_app.tsx
+++ b/studio/src/pages/_app.tsx
@@ -71,10 +71,15 @@ function MyApp({ Component, pageProps }: AppPropsWithLayout) {
     const applyConsent = () => {
       if (hasAnalyticsConsent(window.Osano?.cm?.getConsent?.())) {
         posthog.opt_in_capturing();
-        posthog.reloadFeatureFlags();
       } else {
         posthog.opt_out_capturing();
       }
+
+      // Both transitions reset PostHog's flag state (opting out additionally
+      // disables persistence, so rejecting users hold no cached flags at all).
+      // Re-request in either direction, otherwise flags stay unresolved for
+      // anyone who declines analytics cookies.
+      posthog.reloadFeatureFlags();
     };
 
     const onOsanoReady = () => {

--- a/studio/vitest.config.mts
+++ b/studio/vitest.config.mts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 
@@ -5,6 +6,11 @@ export default defineConfig({
   plugins: [react()],
   test: {
     environment: 'jsdom',
-    alias: [{ find: /^graphql$/, replacement: 'graphql/index.js' }],
+    alias: [
+      { find: /^graphql$/, replacement: 'graphql/index.js' },
+      // Matches the `@/*` path alias in tsconfig.json, so tests import modules
+      // the same way the application does.
+      { find: /^@\//, replacement: fileURLToPath(new URL('./src/', import.meta.url)) },
+    ],
   },
 });


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Onboarding now activates only when its feature flag resolves successfully and is enabled.
  * PostHog feature flags refresh consistently after both opting in and opting out of consent.
  * Feature-flag provider renders immediately (disabled/success), removing the intermediate loading state.

* **Tests / Tooling**
  * Updated Vitest configuration to support `@/*` path aliases for tests.
  * Minor formatting-only change to the feature-flag provider test imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes [COSMO-372](https://linear.app/wundergraph/issue/COSMO-372/studio-studio-never-loads-when-analytics-cookies-are-declined).

Declining Analytics and Marketing cookies left the studio stuck on a loading spinner forever — telemetry, graphs and the login screen all unreachable.

The studio gated its entire render on the `cosmo-onboarding-v1` PostHog flag, treating an unresolved flag as "still loading". But unresolved also covers states that never recover: consent declined (PostHog then runs cookieless with persistence disabled, so nothing is cached between loads), request blocked, or PostHog unreachable. Any of those locked users out of the whole product.

Two changes:

- The flag now gets an explicit default, so it can never be `undefined`, and children render unconditionally. Onboarding still depends entirely on the flag — only the app render no longer does. An unreadable flag now means the feature is off, not that the product is unusable.
- Flags are re-requested on both consent transitions. Previously only accepting triggered a reload, while opting out resets PostHog's flag state and disables persistence, so declining users were left with nothing to fall back on.

The gate was introduced with the onboarding wizard and was harmless until consent gating made the unresolved state durable. It became reachable in production once the consent banner started bootstrapping correctly.

## Checklist

- [x] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [x] Tests or benchmarks have been added or updated.
- [x] If applicable, I have provided instructions for reviewers for [manually validating my changes](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md#pull-requests-conventions).
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

## Manual validation

1. Open the studio in a browser with no prior cookie decision.
2. Decline Analytics and Marketing cookies in the consent banner.
3. Reload. The studio loads normally instead of hanging on a spinner.
4. Accept cookies with the flag enabled and confirm onboarding still triggers.

New tests cover the provider against a stubbed PostHog client: the studio renders while the flag is unresolved, onboarding stays off when the flag never resolves or resolves false, turns on when it resolves true, and stays off without a PostHog key. Verified they fail against the previous implementation.

Vitest previously had no alias for `@/`, so nothing under `src/` could be imported by that path in tests. Added it to match `tsconfig.json`.
