### PR TITLE
fix(studio): read document.referrer inside an effect on onboarding

### DIFF
--- a/studio/src/components/onboarding/step-1.tsx
+++ b/studio/src/components/onboarding/step-1.tsx
@@ -82,8 +82,6 @@ export const Step1 = () => {
   const { toast } = useToast();
   const { setStep, setSkipped, setOnboarding, initialized, setInitialized } = useOnboarding();
   const [pulse, setPulse] = useState<PulseState>({ key: null, tick: 0 });
-  // Referrer can be `wgc` when onboarding is opened via `wgc demo` command
-  const referrer = normalizeReferrer(router.query.referrer || document?.referrer);
 
   function handleLabelClick(key: string) {
     setPulse((p) => ({ key, tick: p.tick + 1 }));
@@ -148,13 +146,16 @@ export const Step1 = () => {
     // fire it again.
     if (initialized) return;
 
+    // Referrer can be `wgc` when onboarding is opened via `wgc demo` command
+    const referrer = normalizeReferrer(router.query.referrer || document.referrer);
+
     captureOnboardingEvent(posthog, {
       name: 'onboarding_started',
       options: {
         entry_source: referrer,
       },
     });
-  }, [initialized, referrer, posthog]);
+  }, [initialized, posthog, router.query.referrer]);
 
   return (
     <OnboardingContainer>


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Analytics**
  * Improved onboarding start tracking to use the latest referral information when the onboarding flow begins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Loading the onboarding wizard directly — a fresh page load or refresh of `/onboarding/1`, rather than a client-side redirect into it — crashed with `ReferenceError: document is not defined`.

The first step read `document.referrer` during render. The optional chaining on it never helped: the identifier itself is undefined while server rendering, so accessing it throws rather than yielding `undefined`.

The value only feeds an analytics property, so it now gets computed inside the effect that consumes it. Effects do not run on the server, so the hazard disappears without an environment guard, and the effect tracks the query parameter instead of a value recomputed on every render.

This code is not new. It was unreachable while the studio blocked every server render behind a loading spinner, and #3127 removed that gate, so page components now render on the server for the first time.

Follow-up worth doing separately: other components may have the same latent problem for the same reason. Anything reading `window`, `document`, or storage during render — rather than inside an effect — was shielded before and is not now.

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [x] If applicable, I have provided instructions for reviewers for [manually validating my changes](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md#pull-requests-conventions).
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

## Manual validation

1. Reach the onboarding wizard with the feature flag enabled.
2. Refresh the browser on `/onboarding/1`, forcing a server render of the page.
3. The step renders instead of throwing `document is not defined`.
4. Confirm the `onboarding_started` event still carries `entry_source`, including the `wgc` referrer when opened via `wgc demo`.

No test added: the assertion needed here is that the module server-renders at all, which the existing jsdom-based setup cannot express without adding a server-rendering harness.
