### PR TITLE
fix(CI): fix Deploy dispatching only one package when several are released together

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -13,7 +13,14 @@ permissions:
 
 concurrency:
   group: Production-Deploy
-  cancel-in-progress: false
+  # A single lerna publish emits one release event per package, so several runs
+  # enter this group at once. Every run computes the same full payload, but
+  # cosmo-cloud opens a deployment PR per dispatch, so duplicate dispatches
+  # are harmful. cancel-in-progress cancels any older run still in flight when a
+  # newer one starts, which collapses the overlapping burst to a single dispatch
+  # (It is not a hard guarantee: a run that finishes and dispatches before
+  # the next release event arrives can still cause a second PR.)
+  cancel-in-progress: true
 
 env:
   CI: true
@@ -23,40 +30,56 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # lerna publishes a separate GitHub release per package, so this workflow
-    # fires once per released package. Only controlplane and studio are deployed,
-    # so ignore every other package's release. Manual dispatch always runs.
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      startsWith(github.event.release.tag_name, 'controlplane@') ||
-      startsWith(github.event.release.tag_name, 'studio@')
     steps:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-
-      # On a release event, deploy only the package that was just released (its
-      # version comes from the release tag, e.g. "controlplane@0.243.0"). On a
-      # manual dispatch there is no tag, so deploy the current version of both.
+          # Need the release commit's parent so "Read versions" can diff it.
+          fetch-depth: 2
       # Unset versions stay empty and the cosmo-cloud receiver skips them.
       - name: Read versions
         id: versions
         env:
           EVENT_NAME: ${{ github.event_name }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
+          controlplane=""
+          studio=""
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            echo "controlplane=$(node -p "require('./controlplane/package.json').version")" >> "$GITHUB_OUTPUT"
-            echo "studio=$(node -p "require('./studio/package.json').version")" >> "$GITHUB_OUTPUT"
+            # On a manual dispatch there is no release commit, so deploy the current
+            # version of both packages.
+            controlplane="$(node -p "require('./controlplane/package.json').version")"
+            studio="$(node -p "require('./studio/package.json').version")"
           else
-            case "$RELEASE_TAG" in
-              controlplane@*) echo "controlplane=${RELEASE_TAG#controlplane@}" >> "$GITHUB_OUTPUT" ;;
-              studio@*)       echo "studio=${RELEASE_TAG#studio@}" >> "$GITHUB_OUTPUT" ;;
+            # On a release event we must NOT trust the triggering tag: lerna bumps every
+            # published package in a single release commit and emits one release event
+            # per package. All those events reference the same commit, and the
+            # Production-Deploy concurrency group collapses their overlapping runs down
+            # to a single surviving run (GitHub keeps only the newest queued run and
+            # cancels the rest) — which may even be an unrelated package's run. So each
+            # run instead derives the full deploy set from the release commit itself, by
+            # detecting which packages' versions changed in it. This is identical across
+            # every run, so whichever one survives dispatches the complete payload.
+            changed="$(git diff --name-only HEAD~1 HEAD)"
+            case "$changed" in
+              *controlplane/package.json*) controlplane="$(node -p "require('./controlplane/package.json').version")" ;;
+            esac
+            case "$changed" in
+              *studio/package.json*) studio="$(node -p "require('./studio/package.json').version")" ;;
             esac
           fi
+          {
+            echo "controlplane=$controlplane"
+            echo "studio=$studio"
+            if [ -n "$controlplane" ] || [ -n "$studio" ]; then
+              echo "deploy=true"
+            else
+              echo "deploy=false"
+            fi
+          } >> "$GITHUB_OUTPUT"
 
       - name: Authenticate
         id: app-token
+        if: steps.versions.outputs.deploy == 'true'
         uses: actions/create-github-app-token@v3
         with:
           client-id: ${{ secrets.APP_CLIENT_ID }}
@@ -66,6 +89,7 @@ jobs:
           permission-contents: write
 
       - name: Trigger Deployment Repo Dispatch
+        if: steps.versions.outputs.deploy == 'true'
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

Detect release tags on each run instead of reading from GH release event since only the latest release event is allowed to run. This fixes the case where both `controlplane` and `studio` have new releases but only one of them gets to run de deployment  workflow.  
Cancel in-progress runs to avoid multiple repo dispatches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Deployment**
  * Prevented outdated deployment runs from continuing when newer runs start.
  * Improved deployment targeting based on changed packages and their versions.
  * Added support for deploying current package versions during manual runs.
  * Skips unnecessary deployment actions when no deployable package has changed.
  * Deployment authentication and notifications now run only when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [x] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] If applicable, I have provided instructions for reviewers for [manually validating my changes](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md#pull-requests-conventions).
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

<!--
Please add any additional information or context regarding your changes here.
-->
