### PR TITLE
feat(router): expose prompt-to-query via MCP

### DIFF
--- a/docs-website/router/mcp/oauth/configuration.mdx
+++ b/docs-website/router/mcp/oauth/configuration.mdx
@@ -19,6 +19,7 @@ icon: 'sliders-up'
 | `oauth.scopes.execute_graphql`               | Scopes required to call the `execute_graphql` built-in tool. Additive to `tools_call`. Only relevant when `enable_arbitrary_operations` is `true`.                                                                            | `[]`    |
 | `oauth.scopes.get_operation_info`            | Scopes required to call the `get_operation_info` built-in tool. Additive to `tools_call`.                                                                                                                                     | `[]`    |
 | `oauth.scopes.get_schema`                    | Scopes required to call the `get_schema` built-in tool. Additive to `tools_call`. Only relevant when `expose_schema` is `true`.                                                                                               | `[]`    |
+| `oauth.scopes.generate_query`                | Scopes required to call the `generate_query` built-in tool. Additive to `tools_call`. Only relevant when Prompt to Query is enabled by the graph token.                                                                       | `[]`    |
 | `oauth.jwks`                                 | List of JWKS providers for JWT verification. Supports remote JWKS URLs or symmetric secrets.                                                                                                                                  | `[]`    |
 
 ## JWKS Configuration
@@ -90,6 +91,7 @@ The option `authorization_server_url` is deprecated. Use `authorization_server_u
 | `MCP_OAUTH_AUTHORIZATION_SERVER_URL`             | `mcp.oauth.authorization_server_url` (deprecated) |
 | `MCP_OAUTH_SCOPE_CHALLENGE_INCLUDE_TOKEN_SCOPES` | `mcp.oauth.scope_challenge_include_token_scopes` |
 | `MCP_OAUTH_MAX_SCOPE_COMBINATIONS`               | `mcp.oauth.max_scope_combinations`               |
+| `MCP_OAUTH_SCOPES_GENERATE_QUERY`                 | `mcp.oauth.scopes.generate_query`                 |
 
 ## HTTP Error Responses
 

--- a/docs-website/router/mcp/tools.mdx
+++ b/docs-website/router/mcp/tools.mdx
@@ -16,6 +16,7 @@ The MCP server gives AI models a set of tools they can discover and execute. It 
 | `get_operation_info` | Returns instructions for executing the operation behind one of your tools directly via HTTP and integrating it into an application. |
 | `get_schema`         | Returns the full GraphQL schema of the API, helping AI models understand the entire API structure.                                  |
 | `execute_graphql`    | Executes an arbitrary GraphQL query or mutation, letting AI models craft operations beyond the tools you have created.              |
+| `generate_query`     | Uses Cosmo Cloud Prompt to Query to generate a GraphQL operation from a natural-language prompt.                                    |
 
 <Warning>
   `get_schema` and `execute_graphql` are disabled by default because they expose your full API surface to AI models.
@@ -23,6 +24,35 @@ The MCP server gives AI models a set of tools they can discover and execute. It 
   [`enable_arbitrary_operations: true`](/router/mcp/configuration) respectively, and only when arbitrary access is
   intended. Prefer creating focused tools.
 </Warning>
+
+### Generate a GraphQL Operation with Cosmo Cloud
+
+The `generate_query` tool sends a natural-language prompt and the router's active schema version to Cosmo Cloud Prompt
+to Query. The generated operation is returned to the MCP client but is not executed.
+
+The tool accepts one required field:
+
+```json
+{
+  "prompt": "List the names and email addresses of the five most recently created users"
+}
+```
+
+A successful response contains the GraphQL document and the metadata needed to use it:
+
+```json
+{
+  "description": "Lists the five most recently created users",
+  "document": "query RecentUsers { users(first: 5, orderBy: CREATED_AT_DESC) { name email } }",
+  "operationName": "RecentUsers",
+  "operationType": "query",
+  "variablesSchema": "{\"type\":\"object\"}"
+}
+```
+
+The tool is registered only when Prompt to Query is enabled for the Cosmo Cloud organization and the router's graph
+token contains the `prompt-to-query` feature. Graph tokens issued before the feature was enabled must be rotated and the
+router updated with the new token. Control Plane or entitlement errors are returned as MCP tool errors.
 
 ## Creating Tools
 

--- a/router/core/graph_server.go
+++ b/router/core/graph_server.go
@@ -1611,7 +1611,7 @@ func (s *graphServer) buildGraphMux(
 
 	// We support the MCP only on the base graph. Feature flags are not supported yet.
 	if opts.IsBaseGraph() && s.mcpServer != nil {
-		if mErr := s.mcpServer.Reload(executor.ClientSchema, opts.EngineConfig.FieldConfigurations); mErr != nil {
+		if mErr := s.mcpServer.Reload(executor.ClientSchema, opts.EngineConfig.FieldConfigurations, opts.RouterConfigVersion); mErr != nil {
 			return nil, fmt.Errorf("failed to reload MCP server: %w", mErr)
 		}
 	}

--- a/router/core/router.go
+++ b/router/core/router.go
@@ -1335,6 +1335,9 @@ func (r *Router) startMCPServer(ctx context.Context) error {
 		mcpserver.WithServerTitle(r.mcp.Server.Title),
 		mcpserver.WithServerDescription(r.mcp.Server.Description),
 	}
+	if r.promptToQueryClient != nil {
+		mcpOpts = append(mcpOpts, mcpserver.WithPromptToQueryClient(r.promptToQueryClient))
+	}
 
 	if r.corsOptions != nil {
 		mcpOpts = append(mcpOpts, mcpserver.WithCORS(*r.corsOptions))
@@ -2219,6 +2222,13 @@ func WithConfigPoller(cf configpoller.ConfigPoller) Option {
 func WithSelfRegistration(sr selfregister.SelfRegister) Option {
 	return func(r *Router) {
 		r.selfRegister = sr
+	}
+}
+
+// WithPromptToQueryClient sets the control-plane client used by the MCP generate_query tool.
+func WithPromptToQueryClient(client mcpserver.PromptToQueryClient) Option {
+	return func(r *Router) {
+		r.promptToQueryClient = client
 	}
 }
 

--- a/router/core/router_config.go
+++ b/router/core/router_config.go
@@ -152,6 +152,7 @@ type Config struct {
 	// Poller
 	configPoller                 configpoller.ConfigPoller
 	selfRegister                 selfregister.SelfRegister
+	promptToQueryClient          mcpserver.PromptToQueryClient
 	registrationInfo             *nodev1.RegistrationInfo
 	securityConfiguration        config.SecurityConfiguration
 	customModules                []Module

--- a/router/core/supervisor_instance.go
+++ b/router/core/supervisor_instance.go
@@ -9,6 +9,9 @@ import (
 
 	"github.com/KimMachineGun/automemlimit/memlimit"
 	"github.com/dustin/go-humanize"
+	"github.com/wundergraph/cosmo/router/internal/controlplane"
+	rjwt "github.com/wundergraph/cosmo/router/internal/jwt"
+	"github.com/wundergraph/cosmo/router/internal/prompttoquery"
 	"github.com/wundergraph/cosmo/router/pkg/authentication"
 	"github.com/wundergraph/cosmo/router/pkg/config"
 	"github.com/wundergraph/cosmo/router/pkg/controlplane/selfregister"
@@ -157,6 +160,26 @@ func newRouter(ctx context.Context, params RouterResources, additionalOptions ..
 			return nil, fmt.Errorf("could not create self register: %w", err)
 		}
 		options = append(options, WithSelfRegistration(selfRegister))
+	}
+
+	if cfg.MCP.Enabled && cfg.Graph.Token != "" {
+		claims, err := rjwt.ExtractFederatedGraphTokenClaims(cfg.Graph.Token)
+		if err != nil {
+			return nil, fmt.Errorf("could not inspect graph token features: %w", err)
+		}
+
+		if claims.HasFeature(rjwt.FeaturePromptToQuery) {
+			controlplaneTransport, err := controlplane.NewTransport(cfg.Graph.Token, logger)
+			if err != nil {
+				return nil, fmt.Errorf("could not create controlplane transport: %w", err)
+			}
+
+			promptToQueryClient, err := prompttoquery.New(cfg.ControlplaneURL, controlplaneTransport)
+			if err != nil {
+				return nil, fmt.Errorf("could not create prompt-to-query client: %w", err)
+			}
+			options = append(options, WithPromptToQueryClient(promptToQueryClient))
+		}
 	}
 
 	if opt := optionFromExecutionConfig(&cfg.ExecutionConfig, cfg.RouterConfigPath); opt != nil {

--- a/router/internal/controlplane/transport.go
+++ b/router/internal/controlplane/transport.go
@@ -1,0 +1,58 @@
+package controlplane
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/hashicorp/go-retryablehttp"
+	"go.uber.org/zap"
+)
+
+const (
+	retryWaitMax = 15 * time.Second
+	retryMax     = 3
+)
+
+type bearerAuthTransport struct {
+	token string
+	next  http.RoundTripper
+}
+
+// NewTransport creates an authenticated, retrying transport for control plane requests.
+func NewTransport(token string, logger *zap.Logger) (http.RoundTripper, error) {
+	if token == "" {
+		return nil, fmt.Errorf("graph api token is required for controlplane requests")
+	}
+
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+
+	retryClient := retryablehttp.NewClient()
+	retryClient.RetryWaitMax = retryWaitMax
+	retryClient.RetryMax = retryMax
+	retryClient.Backoff = retryablehttp.DefaultBackoff
+	retryClient.Logger = nil
+	retryClient.RequestLogHook = func(_ retryablehttp.Logger, _ *http.Request, retry int) {
+		if retry > 0 {
+			logger.Info("Retry controlplane request", zap.Int("retry", retry))
+		}
+	}
+
+	return newBearerAuthTransport(token, retryClient.StandardClient().Transport), nil
+}
+
+func newBearerAuthTransport(token string, next http.RoundTripper) http.RoundTripper {
+	return &bearerAuthTransport{
+		token: token,
+		next:  next,
+	}
+}
+
+func (t *bearerAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = req.Clone(req.Context())
+	req.Header.Set("Authorization", "Bearer "+t.token)
+
+	return t.next.RoundTrip(req)
+}

--- a/router/internal/jwt/claims.go
+++ b/router/internal/jwt/claims.go
@@ -12,6 +12,7 @@ const (
 	OrganizationIDClaim       = "organization_id"
 	FeaturesClaim             = "features"
 	FeatureSplitConfigLoading = "split-config-loading"
+	FeaturePromptToQuery      = "prompt-to-query"
 )
 
 type FederatedGraphTokenClaims struct {

--- a/router/internal/prompttoquery/client.go
+++ b/router/internal/prompttoquery/client.go
@@ -1,0 +1,56 @@
+package prompttoquery
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"connectrpc.com/connect"
+	aiv1 "github.com/wundergraph/cosmo/router/gen/proto/wg/cosmo/ai/v1"
+	"github.com/wundergraph/cosmo/router/gen/proto/wg/cosmo/ai/v1/aiv1connect"
+	brotli "go.withmatt.com/connect-brotli"
+)
+
+const clientTimeout = 15 * time.Second
+
+// Client generates GraphQL operations through the control plane.
+type Client struct {
+	aiServiceClient aiv1connect.AIServiceClient
+}
+
+func New(endpoint string, transport http.RoundTripper) (*Client, error) {
+	if endpoint == "" {
+		return nil, fmt.Errorf("controlplane endpoint is required for prompt to query")
+	}
+
+	if transport == nil {
+		return nil, fmt.Errorf("controlplane transport is required for prompt to query")
+	}
+
+	httpClient := &http.Client{
+		Transport: transport,
+		Timeout:   clientTimeout,
+	}
+
+	aiServiceClient := aiv1connect.NewAIServiceClient(httpClient, endpoint,
+		brotli.WithCompression(),
+		connect.WithSendCompression(brotli.Name),
+	)
+
+	return &Client{aiServiceClient: aiServiceClient}, nil
+}
+
+func (c *Client) GenerateQuery(ctx context.Context, schemaVersionID, prompt string) (*aiv1.GenerateQueryResponse, error) {
+	req := connect.NewRequest(&aiv1.GenerateQueryRequest{
+		Version: schemaVersionID,
+		Prompt:  prompt,
+	})
+
+	resp, err := c.aiServiceClient.GenerateQuery(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.Msg, nil
+}

--- a/router/pkg/config/config.go
+++ b/router/pkg/config/config.go
@@ -1483,6 +1483,9 @@ type MCPOAuthScopesConfiguration struct {
 	// GetSchema specifies scopes required to call the get_schema built-in tool.
 	// Additive to tools_call scopes. Only relevant when expose_schema is true.
 	GetSchema []string `yaml:"get_schema,omitempty" env:"GET_SCHEMA"`
+	// GenerateQuery specifies scopes required to call the generate_query built-in tool.
+	// Additive to tools_call scopes. Only relevant when query generation is enabled.
+	GenerateQuery []string `yaml:"generate_query,omitempty" env:"GENERATE_QUERY"`
 }
 
 type MCPSessionConfig struct {

--- a/router/pkg/config/config.schema.json
+++ b/router/pkg/config/config.schema.json
@@ -2832,6 +2832,11 @@
                   "type": "array",
                   "description": "Scopes required to call the get_schema built-in tool. Additive to tools_call scopes. Only relevant when expose_schema is true.",
                   "items": { "type": "string" }
+                },
+                "generate_query": {
+                  "type": "array",
+                  "description": "Scopes required to call the generate_query built-in tool. Additive to tools_call scopes. Only relevant when query generation is enabled.",
+                  "items": { "type": "string" }
                 }
               }
             },

--- a/router/pkg/config/testdata/config_defaults.json
+++ b/router/pkg/config/testdata/config_defaults.json
@@ -222,7 +222,8 @@
         "ToolsCall": null,
         "ExecuteGraphQL": null,
         "GetOperationInfo": null,
-        "GetSchema": null
+        "GetSchema": null,
+        "GenerateQuery": null
       },
       "ScopeChallengeIncludeTokenScopes": false,
       "MaxScopeCombinations": 2048

--- a/router/pkg/config/testdata/config_full.json
+++ b/router/pkg/config/testdata/config_full.json
@@ -291,7 +291,8 @@
         "ToolsCall": null,
         "ExecuteGraphQL": null,
         "GetOperationInfo": null,
-        "GetSchema": null
+        "GetSchema": null,
+        "GenerateQuery": null
       },
       "ScopeChallengeIncludeTokenScopes": false,
       "MaxScopeCombinations": 2048

--- a/router/pkg/mcpserver/auth_middleware.go
+++ b/router/pkg/mcpserver/auth_middleware.go
@@ -91,6 +91,8 @@ func (m *MCPAuthMiddleware) getBuiltinToolScopes(toolName string) []string {
 		return m.scopes.GetOperationInfo
 	case "get_schema":
 		return m.scopes.GetSchema
+	case "generate_query":
+		return m.scopes.GenerateQuery
 	default:
 		return nil
 	}

--- a/router/pkg/mcpserver/auth_middleware_test.go
+++ b/router/pkg/mcpserver/auth_middleware_test.go
@@ -607,6 +607,8 @@ func TestMCPAuthMiddlewareBuiltinToolScopes(t *testing.T) {
 				return authentication.Claims{"sub": "user3", "scope": "mcp:connect mcp:tools:call mcp:graphql:execute"}, nil
 			case "has-ops-read":
 				return authentication.Claims{"sub": "user4", "scope": "mcp:connect mcp:tools:call mcp:ops:read"}, nil
+			case "has-query-generate":
+				return authentication.Claims{"sub": "user5", "scope": "mcp:connect mcp:tools:call mcp:query:generate"}, nil
 			default:
 				return nil, errors.New("invalid token")
 			}
@@ -619,6 +621,7 @@ func TestMCPAuthMiddlewareBuiltinToolScopes(t *testing.T) {
 		ExecuteGraphQL:   []string{"mcp:graphql:execute"},
 		GetOperationInfo: []string{"mcp:ops:read"},
 		GetSchema:        []string{"mcp:schema:read"},
+		GenerateQuery:    []string{"mcp:query:generate"},
 	}
 
 	tests := []struct {
@@ -665,6 +668,19 @@ func TestMCPAuthMiddlewareBuiltinToolScopes(t *testing.T) {
 			name:           "allows get_operation_info when token has required builtin scope",
 			token:          "has-ops-read",
 			body:           `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_operation_info"}}`,
+			wantStatusCode: 200,
+		},
+		{
+			name:           "returns 403 when generate_query lacks required builtin scope",
+			token:          "base-only",
+			body:           `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"generate_query"}}`,
+			wantStatusCode: 403,
+			wantScope:      `scope="mcp:query:generate"`,
+		},
+		{
+			name:           "allows generate_query when token has required builtin scope",
+			token:          "has-query-generate",
+			body:           `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"generate_query"}}`,
 			wantStatusCode: 200,
 		},
 		{

--- a/router/pkg/mcpserver/discover_test.go
+++ b/router/pkg/mcpserver/discover_test.go
@@ -36,7 +36,7 @@ func newTestSession(t *testing.T, opts ...func(*Options)) *mcp.ClientSession {
 		}, opts...)...,
 	)
 	require.NoError(t, err)
-	require.NoError(t, srv.Reload(&schemaDoc, nil))
+	require.NoError(t, srv.Reload(&schemaDoc, nil, "schema-version-test"))
 
 	serverTransport, clientTransport := mcp.NewInMemoryTransports()
 

--- a/router/pkg/mcpserver/server.go
+++ b/router/pkg/mcpserver/server.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
@@ -19,6 +20,8 @@ import (
 	"github.com/santhosh-tekuri/jsonschema/v6"
 	"go.uber.org/zap"
 
+	aiv1 "github.com/wundergraph/cosmo/router/gen/proto/wg/cosmo/ai/v1"
+	"github.com/wundergraph/cosmo/router/gen/proto/wg/cosmo/common"
 	nodev1 "github.com/wundergraph/cosmo/router/gen/proto/wg/cosmo/node/v1"
 	"github.com/wundergraph/cosmo/router/internal/headers"
 	"github.com/wundergraph/cosmo/router/pkg/authentication"
@@ -35,6 +38,7 @@ import (
 var reservedToolNames = []string{
 	"get_schema",
 	"execute_graphql",
+	"generate_query",
 	"get_operation_info",
 }
 
@@ -114,6 +118,14 @@ type Options struct {
 	// ServerDescription is a human-readable description reported in the MCP
 	// serverInfo.
 	ServerDescription string
+	// PromptToQueryClient generates GraphQL operations through the Cosmo control plane.
+	// When nil, the generate_query tool is not exposed.
+	PromptToQueryClient PromptToQueryClient
+}
+
+// PromptToQueryClient generates a GraphQL operation for a schema version.
+type PromptToQueryClient interface {
+	GenerateQuery(ctx context.Context, schemaVersionID, prompt string) (*aiv1.GenerateQueryResponse, error)
 }
 
 // GraphQLSchemaServer represents an MCP server that works with GraphQL schemas and operations
@@ -142,6 +154,9 @@ type GraphQLSchemaServer struct {
 	serverBaseURL             string
 	resourceDocumentation     string
 	authMiddleware            *MCPAuthMiddleware
+	promptToQueryClient       PromptToQueryClient
+	schemaVersionIDMu         sync.RWMutex
+	schemaVersionID           string
 }
 
 type graphqlRequest struct {
@@ -153,6 +168,20 @@ type graphqlRequest struct {
 type ExecuteGraphQLInput struct {
 	Query     string          `json:"query"`
 	Variables json.RawMessage `json:"variables,omitempty"`
+}
+
+// GenerateQueryInput defines the input structure for the generate_query tool.
+type GenerateQueryInput struct {
+	Prompt string `json:"prompt"`
+}
+
+// GeneratedQueryResponse is returned by the generate_query tool.
+type GeneratedQueryResponse struct {
+	Description     string `json:"description,omitempty"`
+	Document        string `json:"document"`
+	OperationName   string `json:"operationName"`
+	OperationType   string `json:"operationType"`
+	VariablesSchema string `json:"variablesSchema,omitempty"`
 }
 
 // operationHandler holds an operation and its compiled JSON schema
@@ -407,6 +436,7 @@ func NewGraphQLSchemaServer(ctx context.Context, routerGraphQLEndpoint string, o
 		serverBaseURL:             options.ServerBaseURL,
 		resourceDocumentation:     options.ResourceDocumentation,
 		authMiddleware:            authMiddleware,
+		promptToQueryClient:       options.PromptToQueryClient,
 	}
 
 	return gs, nil
@@ -443,6 +473,13 @@ func WithServerTitle(title string) func(*Options) {
 func WithServerDescription(description string) func(*Options) {
 	return func(o *Options) {
 		o.ServerDescription = description
+	}
+}
+
+// WithPromptToQueryClient enables the generate_query tool using the provided control-plane client.
+func WithPromptToQueryClient(client PromptToQueryClient) func(*Options) {
+	return func(o *Options) {
+		o.PromptToQueryClient = client
 	}
 }
 
@@ -639,13 +676,14 @@ func (s *GraphQLSchemaServer) Start() error {
 
 // Reload reloads the operations and schema, and computes per-tool scope
 // requirements from @requiresScopes directives in the field configurations.
-func (s *GraphQLSchemaServer) Reload(schema *ast.Document, fieldConfigs []*nodev1.FieldConfiguration) error {
+func (s *GraphQLSchemaServer) Reload(schema *ast.Document, fieldConfigs []*nodev1.FieldConfiguration, schemaVersionID string) error {
 	if s.server == nil {
 		return fmt.Errorf("server is not started")
 	}
 
 	s.schemaCompiler = NewSchemaCompiler(s.logger)
 	s.operationsManager = NewOperationsManager(schema, s.logger, s.excludeMutations)
+	s.setSchemaVersionID(schemaVersionID)
 
 	if s.operationsDir != "" {
 		if err := s.operationsManager.LoadOperationsFromDirectory(s.operationsDir); err != nil {
@@ -759,6 +797,36 @@ func (s *GraphQLSchemaServer) registerTools() error {
 
 		s.server.AddTool(tool, s.handleExecuteGraphQL())
 		s.registeredTools = append(s.registeredTools, "execute_graphql")
+	}
+
+	if s.promptToQueryClient != nil {
+		openWorldHint := true
+		generateQueryTool := &mcp.Tool{
+			Name:        "generate_query",
+			Description: "Generates a GraphQL operation for this API from a natural-language prompt.",
+			InputSchema: map[string]any{
+				"type":        "object",
+				"description": "A natural-language description of the GraphQL operation to generate.",
+				"properties": map[string]any{
+					"prompt": map[string]any{
+						"type":        "string",
+						"minLength":   1,
+						"description": "A natural-language description of the GraphQL operation to generate.",
+					},
+				},
+				"additionalProperties": false,
+				"required":             []string{"prompt"},
+			},
+			Annotations: &mcp.ToolAnnotations{
+				Title:          "Generate GraphQL Operation",
+				ReadOnlyHint:   true,
+				IdempotentHint: true,
+				OpenWorldHint:  &openWorldHint,
+			},
+		}
+
+		s.server.AddTool(generateQueryTool, s.handleGenerateQuery())
+		s.registeredTools = append(s.registeredTools, "generate_query")
 	}
 
 	// Get operations filtered by the excludeMutations setting
@@ -903,6 +971,98 @@ func (s *GraphQLSchemaServer) registerTools() error {
 	s.registeredTools = append(s.registeredTools, "get_operation_info")
 
 	return nil
+}
+
+func (s *GraphQLSchemaServer) setSchemaVersionID(schemaVersionID string) {
+	s.schemaVersionIDMu.Lock()
+	defer s.schemaVersionIDMu.Unlock()
+	s.schemaVersionID = schemaVersionID
+}
+
+func (s *GraphQLSchemaServer) getSchemaVersionID() string {
+	s.schemaVersionIDMu.RLock()
+	defer s.schemaVersionIDMu.RUnlock()
+	return s.schemaVersionID
+}
+
+func toolError(message string) *mcp.CallToolResult {
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: message}},
+		IsError: true,
+	}
+}
+
+func operationTypeString(operationType aiv1.SatisfiedOperationType) string {
+	switch operationType {
+	case aiv1.SatisfiedOperationType_SATISFIED_OPERATION_TYPE_QUERY:
+		return "query"
+	case aiv1.SatisfiedOperationType_SATISFIED_OPERATION_TYPE_MUTATION:
+		return "mutation"
+	case aiv1.SatisfiedOperationType_SATISFIED_OPERATION_TYPE_SUBSCRIPTION:
+		return "subscription"
+	default:
+		return ""
+	}
+}
+
+func (s *GraphQLSchemaServer) handleGenerateQuery() func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		var input GenerateQueryInput
+		if err := json.Unmarshal(request.Params.Arguments, &input); err != nil {
+			return toolError(fmt.Sprintf("Invalid input: %v", err)), nil
+		}
+
+		input.Prompt = strings.TrimSpace(input.Prompt)
+		if input.Prompt == "" {
+			return toolError("Input validation failed: prompt is required"), nil
+		}
+
+		schemaVersionID := s.getSchemaVersionID()
+		if schemaVersionID == "" {
+			return toolError("The active GraphQL schema version is not available"), nil
+		}
+
+		response, err := s.promptToQueryClient.GenerateQuery(ctx, schemaVersionID, input.Prompt)
+		if err != nil {
+			s.logger.Error("failed to generate query through the control plane", zap.Error(err))
+			return toolError("Failed to generate a GraphQL operation through the control plane"), nil
+		}
+		if response == nil || response.GetResponse() == nil {
+			return toolError("The control plane returned an invalid generate-query response"), nil
+		}
+		if response.GetResponse().GetCode() != common.EnumStatusCode_OK {
+			details := response.GetResponse().GetDetails()
+			if details == "" {
+				details = fmt.Sprintf("control plane returned status %s", response.GetResponse().GetCode())
+			}
+			return toolError(details), nil
+		}
+
+		query := response.GetQuery()
+		if query == nil {
+			return toolError("The control plane did not return a generated GraphQL operation"), nil
+		}
+		operationType := operationTypeString(query.GetOperationType())
+		if operationType == "" {
+			return toolError("The control plane returned an invalid GraphQL operation type"), nil
+		}
+
+		result := GeneratedQueryResponse{
+			Description:     query.GetDescription(),
+			Document:        query.GetDocument(),
+			OperationName:   query.GetOperationName(),
+			OperationType:   operationType,
+			VariablesSchema: query.GetVariablesSchema(),
+		}
+		resultJSON, err := json.Marshal(result)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal generated query response: %w", err)
+		}
+
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: string(resultJSON)}},
+		}, nil
+	}
 }
 
 // handleOperation handles a specific operation
@@ -1224,6 +1384,9 @@ func (s *GraphQLSchemaServer) handleProtectedResourceMetadata(w http.ResponseWri
 	}
 	if s.exposeSchema {
 		scopeLists = append(scopeLists, s.oauthConfig.Scopes.GetSchema)
+	}
+	if s.promptToQueryClient != nil {
+		scopeLists = append(scopeLists, s.oauthConfig.Scopes.GenerateQuery)
 	}
 
 	for _, scopeList := range scopeLists {

--- a/router/pkg/mcpserver/server_test.go
+++ b/router/pkg/mcpserver/server_test.go
@@ -1,6 +1,7 @@
 package mcpserver
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -11,12 +12,27 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	aiv1 "github.com/wundergraph/cosmo/router/gen/proto/wg/cosmo/ai/v1"
+	"github.com/wundergraph/cosmo/router/gen/proto/wg/cosmo/common"
+	"github.com/wundergraph/cosmo/router/pkg/config"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/astparser"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/asttransform"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
 )
+
+type fakePromptToQueryClient struct {
+	response        *aiv1.GenerateQueryResponse
+	schemaVersionID string
+	prompt          string
+}
+
+func (f *fakePromptToQueryClient) GenerateQuery(_ context.Context, schemaVersionID, prompt string) (*aiv1.GenerateQueryResponse, error) {
+	f.schemaVersionID = schemaVersionID
+	f.prompt = prompt
+	return f.response, nil
+}
 
 const testSchema = `
 schema {
@@ -94,14 +110,14 @@ func TestReload_NoToolDuplication(t *testing.T) {
 	require.NoError(t, err)
 
 	// First load
-	err = srv.Reload(&schemaDoc, nil)
+	err = srv.Reload(&schemaDoc, nil, "schema-version-test")
 	require.NoError(t, err)
 
 	firstLoadTools := make([]string, len(srv.registeredTools))
 	copy(firstLoadTools, srv.registeredTools)
 
 	// Second load (simulates config reload)
-	err = srv.Reload(&schemaDoc, nil)
+	err = srv.Reload(&schemaDoc, nil, "schema-version-test")
 	require.NoError(t, err)
 
 	// registeredTools should be identical after reload — no duplicates
@@ -140,7 +156,7 @@ func TestReload_ReservedToolNameCollision(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	err = srv.Reload(&schemaDoc, nil)
+	err = srv.Reload(&schemaDoc, nil, "schema-version-test")
 	require.NoError(t, err)
 
 	// The operation "GetOperationInfo" (snake: "get_operation_info") should be skipped
@@ -184,7 +200,7 @@ func TestReload_PrefixModeAvoidsReservedNameCollision(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	err = srv.Reload(&schemaDoc, nil)
+	err = srv.Reload(&schemaDoc, nil, "schema-version-test")
 	require.NoError(t, err)
 
 	// No collisions because the prefix disambiguates from the reserved name
@@ -224,7 +240,7 @@ func TestRegisterTools_OutputSchemaFailureRegistersToolWithoutSchema(t *testing.
 	)
 	require.NoError(t, err)
 
-	err = srv.Reload(&schemaDoc, nil)
+	err = srv.Reload(&schemaDoc, nil, "schema-version-test")
 	require.NoError(t, err)
 	require.Contains(t, srv.registeredTools, "list_employees")
 	require.Equal(t, 0, logs.FilterMessage("failed to build output schema for operation; registering tool without output schema").Len(),
@@ -270,7 +286,7 @@ func TestRegisterTools_NoOutputSchemaBuildWhenDisabled(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	require.NoError(t, srv.Reload(&schemaDoc, nil))
+	require.NoError(t, srv.Reload(&schemaDoc, nil, "schema-version-test"))
 	require.Contains(t, srv.registeredTools, "list_employees")
 
 	// With the flag disabled (default), a broken operation must not produce an
@@ -442,4 +458,82 @@ func TestExecuteGraphQLQueryStructuredContentDisabled(t *testing.T) {
 			assert.Nil(t, result.StructuredContent)
 		})
 	}
+}
+
+func TestGenerateQueryTool(t *testing.T) {
+	schemaDoc, report := astparser.ParseGraphqlDocumentString(testSchema)
+	require.False(t, report.HasErrors())
+	require.NoError(t, asttransform.MergeDefinitionWithBaseSchema(&schemaDoc))
+
+	client := &fakePromptToQueryClient{
+		response: &aiv1.GenerateQueryResponse{
+			Response: &aiv1.Response{Code: common.EnumStatusCode_OK},
+			Query: &aiv1.SatisfiedQuery{
+				Description:     "Lists employees",
+				Document:        "query ListEmployees { employees { id name } }",
+				OperationName:   "ListEmployees",
+				OperationType:   aiv1.SatisfiedOperationType_SATISFIED_OPERATION_TYPE_QUERY,
+				VariablesSchema: `{"type":"object"}`,
+			},
+		},
+	}
+	srv, err := NewGraphQLSchemaServer(
+		t.Context(),
+		"http://localhost:4000/graphql",
+		WithPromptToQueryClient(client),
+		WithOperationsDir(""),
+	)
+	require.NoError(t, err)
+	require.NoError(t, srv.Reload(&schemaDoc, nil, "schema-version-first"))
+	require.Contains(t, srv.registeredTools, "generate_query")
+
+	result, err := srv.handleGenerateQuery()(t.Context(), &mcp.CallToolRequest{
+		Params: &mcp.CallToolParamsRaw{Arguments: json.RawMessage(`{"prompt":"  List all employees  "}`)},
+	})
+
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.Equal(t, "schema-version-first", client.schemaVersionID)
+	require.Equal(t, "List all employees", client.prompt)
+	require.Len(t, result.Content, 1)
+	textContent, ok := result.Content[0].(*mcp.TextContent)
+	require.True(t, ok)
+	require.JSONEq(t, `{
+		"description":"Lists employees",
+		"document":"query ListEmployees { employees { id name } }",
+		"operationName":"ListEmployees",
+		"operationType":"query",
+		"variablesSchema":"{\"type\":\"object\"}"
+	}`, textContent.Text)
+
+	require.NoError(t, srv.Reload(&schemaDoc, nil, "schema-version-second"))
+	_, err = srv.handleGenerateQuery()(t.Context(), &mcp.CallToolRequest{
+		Params: &mcp.CallToolParamsRaw{Arguments: json.RawMessage(`{"prompt":"List employees again"}`)},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "schema-version-second", client.schemaVersionID)
+}
+
+func TestGenerateQueryScopeIncludedInProtectedResourceMetadata(t *testing.T) {
+	srv := &GraphQLSchemaServer{
+		oauthConfig: &config.MCPOAuthConfiguration{
+			AuthorizationServerURL: "https://auth.example.com",
+			Scopes: config.MCPOAuthScopesConfiguration{
+				ToolsCall:     []string{"mcp:tools:call"},
+				GenerateQuery: []string{"mcp:query:generate"},
+			},
+		},
+		promptToQueryClient: &fakePromptToQueryClient{},
+		serverBaseURL:       "https://mcp.example.com",
+		logger:              zap.NewNop(),
+	}
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-protected-resource/mcp", nil)
+	srv.handleProtectedResourceMetadata(recorder, request)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	var metadata ProtectedResourceMetadata
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &metadata))
+	require.Equal(t, []string{"mcp:query:generate", "mcp:tools:call"}, metadata.ScopesSupported)
 }


### PR DESCRIPTION
## Summary

- expose a `generate_query` tool through the router MCP server
- send the active `RouterConfig.version` to the control-plane `GenerateQuery` RPC
- resolve that version to the stored SDL in the control plane, call Yoko `EnsureIndex` on demand, and use its returned opaque index ID
- add OAuth scope support and MCP documentation for the tool

## Stack

- Implements [ROUTER-575](https://linear.app/wundergraph/issue/ROUTER-575/router-mcp-query-generation-support)
- Depends on #3138
- This PR is intentionally based on the head branch of #3138. Once #3138 merges, this PR can be retargeted to `main`.
- Prompt-to-query service behavior remains covered by the base PR; this stack focuses on the router/MCP integration.

## Verification

- `CGO_ENABLED=0 go test ./...` in `router`
- control-plane TypeScript build
