### PR TITLE
fix(controlplane): avoid re-logging caller-supplied seed API key

### DIFF
--- a/controlplane/src/bin/get-config.ts
+++ b/controlplane/src/bin/get-config.ts
@@ -10,6 +10,7 @@ const getConfig = () => {
     apiUrl: process.env.KC_API_URL || 'http://localhost:8080',
 
     apiKey: process.env.API_KEY || ApiKeyGenerator.generate(),
+    apiKeyWasGenerated: !process.env.API_KEY,
 
     userEmail: process.env.USER_EMAIL || 'foo@wundergraph.com',
     userPassword: process.env.USER_PASSWORD || 'wunder@123',

--- a/controlplane/src/bin/seed.ts
+++ b/controlplane/src/bin/seed.ts
@@ -18,6 +18,7 @@ const {
   clientId,
   apiUrl,
   apiKey,
+  apiKeyWasGenerated,
   userEmail,
   userPassword,
   userFirstName,
@@ -131,7 +132,11 @@ try {
     timeout: 1,
   });
 
-  console.log(`API Key: ${apiKey}`);
+  if (apiKeyWasGenerated) {
+    console.log(`API Key: ${apiKey}`);
+  } else {
+    console.log('API Key: using the value provided via the API_KEY environment variable');
+  }
   console.log('Done');
 
   // eslint-disable-next-line unicorn/no-process-exit


### PR DESCRIPTION
## Description

The seed script's `console.log(`API Key: ${apiKey}`)` unconditionally re-echoes the API key even when the caller supplied it themselves via `API_KEY`. The only shipped invocation paths (`npm` script, `docker-compose.full.yml`, Helm `organization-seed` Job) all do this, so the log line was pure avoidable disclosure in every documented setup. 

Now the key is only logged when it was auto-generated by `ApiKeyGenerator` (`API_KEY` unset), which is the one case where this log is the operator's sole way of learning it.

Fixes #3169