### PR TITLE
fix(mcp): preserve GraphQL error details in tool responses

### DIFF
--- a/router/pkg/mcpserver/server.go
+++ b/router/pkg/mcpserver/server.go
@@ -202,9 +202,41 @@ type LLMGuidance struct {
 	ExecutionTips  []string `json:"executionTips"`
 }
 
-// GraphQLError represents an error returned in a GraphQL response
+// GraphQLErrorLocation identifies a position in the GraphQL document.
+type GraphQLErrorLocation struct {
+	Line   int `json:"line"`
+	Column int `json:"column"`
+}
+
+// GraphQLError represents an error returned in a GraphQL response.
 type GraphQLError struct {
-	Message string `json:"message"`
+	Message    string                 `json:"message"`
+	Locations  []GraphQLErrorLocation `json:"locations,omitempty"`
+	Path       []any                  `json:"path,omitempty"`
+	Extensions map[string]any         `json:"extensions,omitempty"`
+}
+
+func formatGraphQLError(graphqlError GraphQLError) string {
+	if len(graphqlError.Locations) == 0 && len(graphqlError.Path) == 0 && len(graphqlError.Extensions) == 0 {
+		return graphqlError.Message
+	}
+
+	details := struct {
+		Locations  []GraphQLErrorLocation `json:"locations,omitempty"`
+		Path       []any                  `json:"path,omitempty"`
+		Extensions map[string]any         `json:"extensions,omitempty"`
+	}{
+		Locations:  graphqlError.Locations,
+		Path:       graphqlError.Path,
+		Extensions: graphqlError.Extensions,
+	}
+
+	detailsJSON, err := json.Marshal(details)
+	if err != nil {
+		return graphqlError.Message
+	}
+
+	return fmt.Sprintf("%s (details: %s)", graphqlError.Message, detailsJSON)
 }
 
 // GraphQLResponse represents a GraphQL response structure
@@ -1033,7 +1065,7 @@ func (s *GraphQLSchemaServer) executeGraphQLQuery(ctx context.Context, query str
 		// Concatenate all error messages
 		var errorMessages []string
 		for _, gqlErr := range graphqlResponse.Errors {
-			errorMessages = append(errorMessages, gqlErr.Message)
+			errorMessages = append(errorMessages, formatGraphQLError(gqlErr))
 		}
 
 		errorMessage := strings.Join(errorMessages, "; ")

--- a/router/pkg/mcpserver/server.go
+++ b/router/pkg/mcpserver/server.go
@@ -216,6 +216,7 @@ type GraphQLError struct {
 	Extensions map[string]any         `json:"extensions,omitempty"`
 }
 
+// formatGraphQLError formats an error message and its optional metadata for an MCP client.
 func formatGraphQLError(graphqlError GraphQLError) string {
 	if len(graphqlError.Locations) == 0 && len(graphqlError.Path) == 0 && len(graphqlError.Extensions) == 0 {
 		return graphqlError.Message
@@ -243,6 +244,30 @@ func formatGraphQLError(graphqlError GraphQLError) string {
 type GraphQLResponse struct {
 	Errors []GraphQLError  `json:"errors"`
 	Data   json.RawMessage `json:"data"`
+}
+
+// decodeGraphQLResponse decodes exactly one response while preserving JSON number precision.
+func decodeGraphQLResponse(body []byte) (*GraphQLResponse, error) {
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.UseNumber()
+
+	var response *GraphQLResponse
+	if err := decoder.Decode(&response); err != nil {
+		return nil, err
+	}
+	if response == nil {
+		return nil, errors.New("GraphQL response must be an object")
+	}
+
+	var trailing json.RawMessage
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return nil, errors.New("GraphQL response must contain exactly one JSON value")
+		}
+		return nil, err
+	}
+
+	return response, nil
 }
 
 // NewGraphQLSchemaServer creates a new GraphQL schema server
@@ -1050,11 +1075,10 @@ func (s *GraphQLSchemaServer) executeGraphQLQuery(ctx context.Context, query str
 
 	// Per the GraphQL-over-HTTP specification the response body of a GraphQL
 	// endpoint must be a JSON object, so a body that cannot be parsed as one
-	// (a proxy error page, an empty body, or a literal JSON null, which leaves
-	// the pointer nil after unmarshaling) is transport-level breakage and is
-	// reported as a tool error.
-	var graphqlResponse *GraphQLResponse
-	if err := json.Unmarshal(body, &graphqlResponse); err != nil || graphqlResponse == nil {
+	// (a proxy error page, an empty body, or a literal JSON null) is
+	// transport-level breakage and is reported as a tool error.
+	graphqlResponse, err := decodeGraphQLResponse(body)
+	if err != nil {
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("Response error: unexpected response from GraphQL endpoint: %s", body)}},
 			IsError: true,

--- a/router/pkg/mcpserver/server_test.go
+++ b/router/pkg/mcpserver/server_test.go
@@ -345,34 +345,53 @@ func TestExecuteGraphQLQueryResultBoundary(t *testing.T) {
 }
 
 func TestExecuteGraphQLQueryPreservesGraphQLErrorDetails(t *testing.T) {
-	responseBody := `{"errors":[{"message":"Input validation error","locations":[{"line":2,"column":7}],"path":["createDataSet",0],"extensions":{"code":"INPUT_VALIDATION","issues":{"dataSetId":["IS_BLANK"]}}}]}`
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(responseBody))
-	}))
-	defer upstream.Close()
+	t.Parallel()
 
-	srv, err := NewGraphQLSchemaServer(
-		t.Context(),
-		upstream.URL,
-		WithLogger(zap.NewNop()),
-		WithOperationsDir(t.TempDir()),
-		WithOutputSchemaEnabled(true),
-	)
-	require.NoError(t, err)
+	testCases := []struct {
+		name         string
+		responseBody string
+		wantText     string
+	}{
+		{
+			name:         "message-only error keeps the existing format",
+			responseBody: `{"errors":[{"message":"boom"}]}`,
+			wantText:     "Response error: boom",
+		},
+		{
+			name:         "error details are preserved",
+			responseBody: `{"errors":[{"message":"Input validation error","locations":[{"line":2,"column":7}],"path":["createDataSet",0],"extensions":{"code":"INPUT_VALIDATION","issues":{"dataSetId":["IS_BLANK"]}}}]}`,
+			wantText:     `Response error: Input validation error (details: {"locations":[{"line":2,"column":7}],"path":["createDataSet",0],"extensions":{"code":"INPUT_VALIDATION","issues":{"dataSetId":["IS_BLANK"]}}})`,
+		},
+	}
 
-	result, err := srv.executeGraphQLQuery(t.Context(), "query { employee { name } }", nil)
-	require.NoError(t, err)
-	require.True(t, result.IsError)
-	require.Nil(t, result.StructuredContent)
-	require.Len(t, result.Content, 1)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(tc.responseBody))
+			}))
+			defer upstream.Close()
 
-	content, ok := result.Content[0].(*mcp.TextContent)
-	require.True(t, ok)
-	assert.Equal(t,
-		`Response error: Input validation error (details: {"locations":[{"line":2,"column":7}],"path":["createDataSet",0],"extensions":{"code":"INPUT_VALIDATION","issues":{"dataSetId":["IS_BLANK"]}}})`,
-		content.Text,
-	)
+			srv, err := NewGraphQLSchemaServer(
+				t.Context(),
+				upstream.URL,
+				WithLogger(zap.NewNop()),
+				WithOperationsDir(t.TempDir()),
+				WithOutputSchemaEnabled(true),
+			)
+			require.NoError(t, err)
+
+			result, err := srv.executeGraphQLQuery(t.Context(), "query { employee { name } }", nil)
+			require.NoError(t, err)
+			require.True(t, result.IsError)
+			require.Nil(t, result.StructuredContent)
+			require.Len(t, result.Content, 1)
+
+			content, ok := result.Content[0].(*mcp.TextContent)
+			require.True(t, ok)
+			assert.Equal(t, tc.wantText, content.Text)
+		})
+	}
 }
 
 // TestExecuteGraphQLQueryStructuredContentDisabled proves that the flag only

--- a/router/pkg/mcpserver/server_test.go
+++ b/router/pkg/mcpserver/server_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/astparser"
@@ -339,6 +340,74 @@ func TestExecuteGraphQLQueryResultBoundary(t *testing.T) {
 			} else {
 				assert.Nil(t, result.StructuredContent)
 			}
+		})
+	}
+}
+
+func TestExecuteGraphQLQueryPreservesGraphQLErrorDetails(t *testing.T) {
+	testCases := []struct {
+		name         string
+		responseBody string
+		wantText     string
+	}{
+		{
+			name:         "message-only error keeps the existing format",
+			responseBody: `{"errors":[{"message":"boom"}]}`,
+			wantText:     "Response error: boom",
+		},
+		{
+			name:         "nested extensions are preserved",
+			responseBody: `{"errors":[{"message":"Input validation error","extensions":{"code":"INPUT_VALIDATION","issues":{"dataSetId":["IS_BLANK"]}}}]}`,
+			wantText:     `Response error: Input validation error (details: {"extensions":{"code":"INPUT_VALIDATION","issues":{"dataSetId":["IS_BLANK"]}}})`,
+		},
+		{
+			name:         "extensions preserve every JSON value type",
+			responseBody: `{"errors":[{"message":"Validation failed","extensions":{"code":"INVALID","retryable":false,"attempts":3,"metadata":null,"rules":[{"field":"name","minimum":1}]}}]}`,
+			wantText:     `Response error: Validation failed (details: {"extensions":{"attempts":3,"code":"INVALID","metadata":null,"retryable":false,"rules":[{"field":"name","minimum":1}]}})`,
+		},
+		{
+			name:         "locations and mixed path elements are preserved",
+			responseBody: `{"errors":[{"message":"Invalid employee","locations":[{"line":2,"column":7}],"path":["employees",0,"name"],"extensions":{"code":"BAD_USER_INPUT"}}]}`,
+			wantText:     `Response error: Invalid employee (details: {"locations":[{"line":2,"column":7}],"path":["employees",0,"name"],"extensions":{"code":"BAD_USER_INPUT"}})`,
+		},
+		{
+			name:         "multiple errors retain their own metadata",
+			responseBody: `{"errors":[{"message":"first"},{"message":"second","path":["employee"],"extensions":{"code":"SECOND"}}]}`,
+			wantText:     `Response error: first; second (details: {"path":["employee"],"extensions":{"code":"SECOND"}})`,
+		},
+		{
+			name:         "partial data is retained with detailed errors",
+			responseBody: `{"data":{"employee":null},"errors":[{"message":"partial failure","path":["employee"],"extensions":{"code":"PARTIAL"}}]}`,
+			wantText:     `Response error with partial success, Error: partial failure (details: {"path":["employee"],"extensions":{"code":"PARTIAL"}}), Data: {"employee":null})`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(tc.responseBody))
+			}))
+			defer upstream.Close()
+
+			srv, err := NewGraphQLSchemaServer(
+				t.Context(),
+				upstream.URL,
+				WithLogger(zap.NewNop()),
+				WithOperationsDir(t.TempDir()),
+				WithOutputSchemaEnabled(true),
+			)
+			require.NoError(t, err)
+
+			result, err := srv.executeGraphQLQuery(t.Context(), "query { employee { name } }", nil)
+			require.NoError(t, err)
+			require.True(t, result.IsError)
+			require.Nil(t, result.StructuredContent)
+			require.Len(t, result.Content, 1)
+
+			content, ok := result.Content[0].(*mcp.TextContent)
+			require.True(t, ok)
+			assert.Equal(t, tc.wantText, content.Text)
 		})
 	}
 }

--- a/router/pkg/mcpserver/server_test.go
+++ b/router/pkg/mcpserver/server_test.go
@@ -311,6 +311,7 @@ func TestExecuteGraphQLQueryResultBoundary(t *testing.T) {
 		{"non-JSON body returns a tool error", `<html>bad gateway</html>`, true, false},
 		{"empty body returns a tool error", ``, true, false},
 		{"null body returns a tool error", `null`, true, false},
+		{"trailing JSON value returns a tool error", `{"data":{}} {}`, true, false},
 	}
 
 	for _, tc := range testCases {
@@ -366,6 +367,11 @@ func TestExecuteGraphQLQueryPreservesGraphQLErrorDetails(t *testing.T) {
 			name:         "multiple errors are separated",
 			responseBody: `{"errors":[{"message":"First error"},{"message":"Second error","path":["createDataSet"],"extensions":{"code":"INVALID"}}]}`,
 			wantText:     `Response error: First error; Second error (details: {"path":["createDataSet"],"extensions":{"code":"INVALID"}})`,
+		},
+		{
+			name:         "large integers preserve precision",
+			responseBody: `{"errors":[{"message":"Invalid identifier","path":["createDataSet",9007199254740993],"extensions":{"requestId":9007199254740993}}]}`,
+			wantText:     `Response error: Invalid identifier (details: {"path":["createDataSet",9007199254740993],"extensions":{"requestId":9007199254740993}})`,
 		},
 	}
 

--- a/router/pkg/mcpserver/server_test.go
+++ b/router/pkg/mcpserver/server_test.go
@@ -362,6 +362,11 @@ func TestExecuteGraphQLQueryPreservesGraphQLErrorDetails(t *testing.T) {
 			responseBody: `{"errors":[{"message":"Input validation error","locations":[{"line":2,"column":7}],"path":["createDataSet",0],"extensions":{"code":"INPUT_VALIDATION","issues":{"dataSetId":["IS_BLANK"]}}}]}`,
 			wantText:     `Response error: Input validation error (details: {"locations":[{"line":2,"column":7}],"path":["createDataSet",0],"extensions":{"code":"INPUT_VALIDATION","issues":{"dataSetId":["IS_BLANK"]}}})`,
 		},
+		{
+			name:         "multiple errors are separated",
+			responseBody: `{"errors":[{"message":"First error"},{"message":"Second error","path":["createDataSet"],"extensions":{"code":"INVALID"}}]}`,
+			wantText:     `Response error: First error; Second error (details: {"path":["createDataSet"],"extensions":{"code":"INVALID"}})`,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/router/pkg/mcpserver/server_test.go
+++ b/router/pkg/mcpserver/server_test.go
@@ -345,71 +345,34 @@ func TestExecuteGraphQLQueryResultBoundary(t *testing.T) {
 }
 
 func TestExecuteGraphQLQueryPreservesGraphQLErrorDetails(t *testing.T) {
-	testCases := []struct {
-		name         string
-		responseBody string
-		wantText     string
-	}{
-		{
-			name:         "message-only error keeps the existing format",
-			responseBody: `{"errors":[{"message":"boom"}]}`,
-			wantText:     "Response error: boom",
-		},
-		{
-			name:         "nested extensions are preserved",
-			responseBody: `{"errors":[{"message":"Input validation error","extensions":{"code":"INPUT_VALIDATION","issues":{"dataSetId":["IS_BLANK"]}}}]}`,
-			wantText:     `Response error: Input validation error (details: {"extensions":{"code":"INPUT_VALIDATION","issues":{"dataSetId":["IS_BLANK"]}}})`,
-		},
-		{
-			name:         "extensions preserve every JSON value type",
-			responseBody: `{"errors":[{"message":"Validation failed","extensions":{"code":"INVALID","retryable":false,"attempts":3,"metadata":null,"rules":[{"field":"name","minimum":1}]}}]}`,
-			wantText:     `Response error: Validation failed (details: {"extensions":{"attempts":3,"code":"INVALID","metadata":null,"retryable":false,"rules":[{"field":"name","minimum":1}]}})`,
-		},
-		{
-			name:         "locations and mixed path elements are preserved",
-			responseBody: `{"errors":[{"message":"Invalid employee","locations":[{"line":2,"column":7}],"path":["employees",0,"name"],"extensions":{"code":"BAD_USER_INPUT"}}]}`,
-			wantText:     `Response error: Invalid employee (details: {"locations":[{"line":2,"column":7}],"path":["employees",0,"name"],"extensions":{"code":"BAD_USER_INPUT"}})`,
-		},
-		{
-			name:         "multiple errors retain their own metadata",
-			responseBody: `{"errors":[{"message":"first"},{"message":"second","path":["employee"],"extensions":{"code":"SECOND"}}]}`,
-			wantText:     `Response error: first; second (details: {"path":["employee"],"extensions":{"code":"SECOND"}})`,
-		},
-		{
-			name:         "partial data is retained with detailed errors",
-			responseBody: `{"data":{"employee":null},"errors":[{"message":"partial failure","path":["employee"],"extensions":{"code":"PARTIAL"}}]}`,
-			wantText:     `Response error with partial success, Error: partial failure (details: {"path":["employee"],"extensions":{"code":"PARTIAL"}}), Data: {"employee":null})`,
-		},
-	}
+	responseBody := `{"errors":[{"message":"Input validation error","locations":[{"line":2,"column":7}],"path":["createDataSet",0],"extensions":{"code":"INPUT_VALIDATION","issues":{"dataSetId":["IS_BLANK"]}}}]}`
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(responseBody))
+	}))
+	defer upstream.Close()
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				_, _ = w.Write([]byte(tc.responseBody))
-			}))
-			defer upstream.Close()
+	srv, err := NewGraphQLSchemaServer(
+		t.Context(),
+		upstream.URL,
+		WithLogger(zap.NewNop()),
+		WithOperationsDir(t.TempDir()),
+		WithOutputSchemaEnabled(true),
+	)
+	require.NoError(t, err)
 
-			srv, err := NewGraphQLSchemaServer(
-				t.Context(),
-				upstream.URL,
-				WithLogger(zap.NewNop()),
-				WithOperationsDir(t.TempDir()),
-				WithOutputSchemaEnabled(true),
-			)
-			require.NoError(t, err)
+	result, err := srv.executeGraphQLQuery(t.Context(), "query { employee { name } }", nil)
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Nil(t, result.StructuredContent)
+	require.Len(t, result.Content, 1)
 
-			result, err := srv.executeGraphQLQuery(t.Context(), "query { employee { name } }", nil)
-			require.NoError(t, err)
-			require.True(t, result.IsError)
-			require.Nil(t, result.StructuredContent)
-			require.Len(t, result.Content, 1)
-
-			content, ok := result.Content[0].(*mcp.TextContent)
-			require.True(t, ok)
-			assert.Equal(t, tc.wantText, content.Text)
-		})
-	}
+	content, ok := result.Content[0].(*mcp.TextContent)
+	require.True(t, ok)
+	assert.Equal(t,
+		`Response error: Input validation error (details: {"locations":[{"line":2,"column":7}],"path":["createDataSet",0],"extensions":{"code":"INPUT_VALIDATION","issues":{"dataSetId":["IS_BLANK"]}}})`,
+		content.Text,
+	)
 }
 
 // TestExecuteGraphQLQueryStructuredContentDisabled proves that the flag only


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * GraphQL responses now preserve precision for large numeric values.
  * Invalid, null, malformed, or trailing-content responses are reported as clear tool errors.
  * GraphQL errors now include richer diagnostic details, such as locations, paths, and extension metadata.
  * Error messages remain concise when no additional details are available.
  * Formatting gracefully falls back to the original message if metadata cannot be encoded.
  * Multiple errors and partial-data responses preserve their full error information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Summary

- preserve GraphQL error locations, paths, and arbitrary extension values in MCP tool responses
- format decoded metadata as compact JSON details for reliable LLM consumption
- keep message-only errors and existing MCP error semantics unchanged

Fixes ENG-9928

## Testing

- go test ./pkg/mcpserver (from router)
- go test ./protocol -run TestMCP (from router-tests)
- git diff --check

## Checklist

- [x] I have followed the coding standards of the project.
- [x] Tests or benchmarks have been added or updated.
- [x] If applicable, I have provided instructions for reviewers for manually validating my changes.
- [ ] Documentation has been updated on https://github.com/wundergraph/docs-website.

## Open Source AI Manifesto

This project follows the principles of the Open Source AI Manifesto.