### PR TITLE
fix: specify serviceAccountName on all the controlplane jobs

### DIFF
--- a/helm/cosmo/charts/controlplane/templates/activate-organization.yaml
+++ b/helm/cosmo/charts/controlplane/templates/activate-organization.yaml
@@ -4,7 +4,7 @@ kind: Job
 metadata:
   # We truncate the organization id to keep within 52 characters for the name. We add the full id in the annotations.
   name: "{{ include "controlplane.fullname" . }}-activate-org-{{ trunc 8 .Values.jobs.activateOrganization.id }}"
-  labels: 
+  labels:
     {{- include "controlplane.job.labels" (dict "additionalLabels" .Values.jobs.activateOrganization.additionalLabels "context" .) | nindent 4 }}
   annotations:
     organization-id: {{ .Values.jobs.activateOrganization.id }}
@@ -31,6 +31,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "controlplane.serviceAccountName" . }}
       containers:
         - name: activate-organization
           securityContext:

--- a/helm/cosmo/charts/controlplane/templates/cleanup-old-data-cronjob.yaml
+++ b/helm/cosmo/charts/controlplane/templates/cleanup-old-data-cronjob.yaml
@@ -25,6 +25,7 @@ spec:
           imagePullSecrets:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          serviceAccountName: {{ include "controlplane.serviceAccountName" . }}
           containers:
             - name: cleanup-old-data
               securityContext:

--- a/helm/cosmo/charts/controlplane/templates/clickhouse-migration.yaml
+++ b/helm/cosmo/charts/controlplane/templates/clickhouse-migration.yaml
@@ -35,6 +35,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "controlplane.serviceAccountName" . }}
       containers:
         - name: seed
           securityContext:

--- a/helm/cosmo/charts/controlplane/templates/database-migration.yaml
+++ b/helm/cosmo/charts/controlplane/templates/database-migration.yaml
@@ -30,6 +30,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "controlplane.serviceAccountName" . }}
       containers:
         - name: seed
           securityContext:

--- a/helm/cosmo/charts/controlplane/templates/deactivate-organization.yaml
+++ b/helm/cosmo/charts/controlplane/templates/deactivate-organization.yaml
@@ -31,6 +31,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "controlplane.serviceAccountName" . }}
       containers:
         - name: deactivate-organization
           securityContext:

--- a/helm/cosmo/charts/controlplane/templates/delete-inactive-orgs.yaml
+++ b/helm/cosmo/charts/controlplane/templates/delete-inactive-orgs.yaml
@@ -25,6 +25,7 @@ spec:
           imagePullSecrets:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          serviceAccountName: {{ include "controlplane.serviceAccountName" . }}
           containers:
             - name: delete-inactive-orgs
               securityContext:

--- a/helm/cosmo/charts/controlplane/templates/delete-user.yaml
+++ b/helm/cosmo/charts/controlplane/templates/delete-user.yaml
@@ -30,6 +30,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "controlplane.serviceAccountName" . }}
       containers:
         - name: delete-user
           securityContext:

--- a/helm/cosmo/charts/controlplane/templates/organization-seed.yaml
+++ b/helm/cosmo/charts/controlplane/templates/organization-seed.yaml
@@ -29,6 +29,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "controlplane.serviceAccountName" . }}
       containers:
         - name: seed
           securityContext:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Control-plane background jobs and scheduled tasks now consistently run under the chart-configured service account.
  * Organization activation, deactivation, seeding, cleanup, migration, and user-management operations receive the appropriate workload identity.
  * Improved deployment consistency and compatibility with environments requiring explicit service-account assignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] If applicable, I have provided instructions for reviewers for [manually validating my changes](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md#pull-requests-conventions).
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

When using the helm-charts to deploy cosmo in our environment, I noticed that the serviceAccountName was not used on the jobs. That made me run into various permission errors, so I figured to add this to the various job templates. I hope it's ok I did not create an issue upfront, I will do so for the rest of the fixes / issues I will try to contribute.