### PR TITLE
feat: add support for initContainers in the controlplane job

### DIFF
--- a/helm/cosmo/charts/controlplane/templates/activate-organization.yaml
+++ b/helm/cosmo/charts/controlplane/templates/activate-organization.yaml
@@ -4,7 +4,7 @@ kind: Job
 metadata:
   # We truncate the organization id to keep within 52 characters for the name. We add the full id in the annotations.
   name: "{{ include "controlplane.fullname" . }}-activate-org-{{ trunc 8 .Values.jobs.activateOrganization.id }}"
-  labels: 
+  labels:
     {{- include "controlplane.job.labels" (dict "additionalLabels" .Values.jobs.activateOrganization.additionalLabels "context" .) | nindent 4 }}
   annotations:
     organization-id: {{ .Values.jobs.activateOrganization.id }}
@@ -31,6 +31,8 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      initContainers:
+        {{- tpl (.Values.jobs.activateOrganization.initContainers | toYaml) . | nindent 8 }}
       containers:
         - name: activate-organization
           securityContext:

--- a/helm/cosmo/charts/controlplane/templates/cleanup-old-data-cronjob.yaml
+++ b/helm/cosmo/charts/controlplane/templates/cleanup-old-data-cronjob.yaml
@@ -25,6 +25,8 @@ spec:
           imagePullSecrets:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          initContainers:
+            {{- tpl (.Values.jobs.cleanupOldData.initContainers | toYaml) . | nindent 12 }}
           containers:
             - name: cleanup-old-data
               securityContext:

--- a/helm/cosmo/charts/controlplane/templates/clickhouse-migration.yaml
+++ b/helm/cosmo/charts/controlplane/templates/clickhouse-migration.yaml
@@ -35,6 +35,8 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      initContainers:
+        {{- tpl (.Values.jobs.clickhouseMigration.initContainers | toYaml) . | nindent 8 }}
       containers:
         - name: seed
           securityContext:

--- a/helm/cosmo/charts/controlplane/templates/database-migration.yaml
+++ b/helm/cosmo/charts/controlplane/templates/database-migration.yaml
@@ -30,6 +30,8 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      initContainers:
+        {{- tpl (.Values.jobs.databaseMigration.initContainers | toYaml) . | nindent 8 }}
       containers:
         - name: seed
           securityContext:

--- a/helm/cosmo/charts/controlplane/templates/deactivate-organization.yaml
+++ b/helm/cosmo/charts/controlplane/templates/deactivate-organization.yaml
@@ -31,6 +31,8 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      initContainers:
+        {{- tpl (.Values.jobs.deactivateOrganization.initContainers | toYaml) . | nindent 8 }}
       containers:
         - name: deactivate-organization
           securityContext:

--- a/helm/cosmo/charts/controlplane/templates/delete-inactive-orgs.yaml
+++ b/helm/cosmo/charts/controlplane/templates/delete-inactive-orgs.yaml
@@ -25,6 +25,8 @@ spec:
           imagePullSecrets:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          initContainers:
+            {{- tpl (.Values.jobs.deleteInactiveOrgs.initContainers | toYaml) . | nindent 12 }}
           containers:
             - name: delete-inactive-orgs
               securityContext:

--- a/helm/cosmo/charts/controlplane/templates/delete-user.yaml
+++ b/helm/cosmo/charts/controlplane/templates/delete-user.yaml
@@ -30,6 +30,8 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      initContainers:
+        {{- tpl (.Values.jobs.deleteUser.initContainers | toYaml) . | nindent 8 }}
       containers:
         - name: delete-user
           securityContext:

--- a/helm/cosmo/charts/controlplane/templates/organization-seed.yaml
+++ b/helm/cosmo/charts/controlplane/templates/organization-seed.yaml
@@ -29,6 +29,8 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      initContainers:
+        {{- tpl (.Values.jobs.seedOrganization.initContainers | toYaml) . | nindent 8 }}
       containers:
         - name: seed
           securityContext:

--- a/helm/cosmo/charts/controlplane/values.yaml
+++ b/helm/cosmo/charts/controlplane/values.yaml
@@ -273,6 +273,12 @@ jobs:
     id: '123'
     # -- The reason for deactivation
     reason: ''
+    # -- InitContainers for this job
+    #initContainers:
+    #  - name: init-postgresql
+    #    image: busybox:1.28
+    #    imagePullPolicy: "IfNotPresent"
+    #    command: ['sh', '-c', 'until nslookup {{ include "postgresql.fullname" . }}; do echo waiting for postgresql; sleep 2; done;']
   # -- Used to activate an organization and remove the scheduled deletion
   activateOrganization:
     # -- Adds additional labels to the job
@@ -283,6 +289,12 @@ jobs:
     slug: 'foo'
     # -- The unique identifier of the organization
     id: '123'
+    # -- InitContainers for this job
+    #initContainers:
+    #  - name: init-postgresql
+    #    image: busybox:1.28
+    #    imagePullPolicy: "IfNotPresent"
+    #    command: ['sh', '-c', 'until nslookup {{ include "postgresql.fullname" . }}; do echo waiting for postgresql; sleep 2; done;']
   # -- Used to delete the user
   deleteUser:
     # -- Adds additional labels to the job
@@ -293,15 +305,39 @@ jobs:
     id: '123'
     # -- The email of the user
     email: 'foo@wundergraph.com'
+    # -- InitContainers for this job
+    #initContainers:
+    #  - name: init-postgresql
+    #    image: busybox:1.28
+    #    imagePullPolicy: "IfNotPresent"
+    #    command: ['sh', '-c', 'until nslookup {{ include "postgresql.fullname" . }}; do echo waiting for postgresql; sleep 2; done;']
   clickhouseMigration:
     # -- Adds additional labels to the clickhouse migration job (see: .Values.global.otelcollector)
     additionalLabels: {}
+    # -- InitContainers for this job
+    #initContainers:
+    #  - name: init-postgresql
+    #    image: busybox:1.28
+    #    imagePullPolicy: "IfNotPresent"
+    #    command: ['sh', '-c', 'until nslookup {{ include "postgresql.fullname" . }}; do echo waiting for postgresql; sleep 2; done;']
   databaseMigration:
     # -- Adds additional labels to the database-migration job
     additionalLabels: {}
+    # -- InitContainers for this job
+    #initContainers:
+    #  - name: init-postgresql
+    #    image: busybox:1.28
+    #    imagePullPolicy: "IfNotPresent"
+    #    command: ['sh', '-c', 'until nslookup {{ include "postgresql.fullname" . }}; do echo waiting for postgresql; sleep 2; done;']
   seedOrganization:
     # -- Adds additional labels to the job (see: .Values.global.seed)
     additionalLabels: {}
+    # -- InitContainers for this job
+    #initContainers:
+    #  - name: init-postgresql
+    #    image: busybox:1.28
+    #    imagePullPolicy: "IfNotPresent"
+    #    command: ['sh', '-c', 'until nslookup {{ include "postgresql.fullname" . }}; do echo waiting for postgresql; sleep 2; done;']
   # -- Scheduled CronJob to delete data (schema checks, audit logs, etc.) older than 90 days
   cleanupOldData:
     # -- Enables the cleanup CronJob
@@ -310,6 +346,12 @@ jobs:
     additionalLabels: {}
     # -- Cron schedule (default: 1st of every month at 2AM UTC)
     schedule: '0 2 1 * *'
+    # -- InitContainers for this job
+    #initContainers:
+    #  - name: init-postgresql
+    #    image: busybox:1.28
+    #    imagePullPolicy: "IfNotPresent"
+    #    command: ['sh', '-c', 'until nslookup {{ include "postgresql.fullname" . }}; do echo waiting for postgresql; sleep 2; done;']
   deleteInactiveOrgs:
     # -- Enables the job to be run
     enabled: true
@@ -317,3 +359,9 @@ jobs:
     schedule: '0 0 1 * *'
     # -- Adds additional labels to the job (see: .Values.global.seed)
     additionalLabels: {}
+    # -- InitContainers for this job
+    #initContainers:
+    #  - name: init-postgresql
+    #    image: busybox:1.28
+    #    imagePullPolicy: "IfNotPresent"
+    #    command: ['sh', '-c', 'until nslookup {{ include "postgresql.fullname" . }}; do echo waiting for postgresql; sleep 2; done;']


### PR DESCRIPTION
Solves https://github.com/wundergraph/cosmo/issues/3179

<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable initialization containers for control-plane jobs and scheduled tasks.
  * Initialization steps can now run before activation, migration, cleanup, deletion, and organization-management operations.
  * Added configuration examples for waiting on PostgreSQL availability before jobs start.

* **Documentation**
  * Included commented configuration guidance for enabling initialization containers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] If applicable, I have provided instructions for reviewers for [manually validating my changes](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md#pull-requests-conventions).
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.