### PR TITLE
feat: allow to run query plan with new planner options

### DIFF
--- a/docs-website/router/query-plan/batch-generate-query-plans.mdx
+++ b/docs-website/router/query-plan/batch-generate-query-plans.mdx
@@ -106,6 +106,23 @@ If you want the command to exit with an error if at least one query fails to be 
 
 By default the query plan format is text based, but you can view the json version by using `-print-format json`
 
+### Engine execution settings
+
+Some engine settings change the shape of the generated plans. To reproduce the plans of a router
+running with those settings, enable them on the command as well:
+
+* `-enable-multi-fetch` matches `engine.enable_multi_fetch`, merging entity fetches to the same subgraph that execute in the same wave into a single batched request.
+* `-enable-schedule-fetches` matches `engine.enable_schedule_fetches`, replacing the wave-based fetch organizers with the dependency-aware fetch scheduler.
+
+```bash
+./router query-plan \
+  -execution-config execution-config.json \
+  -operations ./operations \
+  -plans ./plans \
+  -enable-multi-fetch \
+  -enable-schedule-fetches
+```
+
 ## Other options
 
 You can see all the options available launching the command without any arguments:
@@ -114,6 +131,10 @@ You can see all the options available launching the command without any argument
 ./router query-plan
   -concurrency int
         how many query plan run concurrently
+  -enable-multi-fetch
+        plan as if engine.enable_multi_fetch is enabled, merging entity fetches to the same subgraph in the same wave
+  -enable-schedule-fetches
+        plan as if engine.enable_schedule_fetches is enabled, using the dependency-aware fetch scheduler
   -execution-config string
         required, execution config file location
   -fail-fast

--- a/router/cmd/plan_generator.go
+++ b/router/cmd/plan_generator.go
@@ -51,6 +51,8 @@ func PlanGenerator(args []string) {
 		return fmt.Errorf("must be one of: text, json (got %q)", s)
 	})
 	f.UintVar(&cfg.MaxDataSourceCollectorsConcurrency, "max-collectors", 0, "max number of concurrent data source collectors, if unset or 0, no limit will be enforced")
+	f.BoolVar(&cfg.EnableMultiFetch, "enable-multi-fetch", false, "plan as if engine.enable_multi_fetch is enabled, merging entity fetches to the same subgraph in the same wave")
+	f.BoolVar(&cfg.EnableScheduleFetches, "enable-schedule-fetches", false, "plan as if engine.enable_schedule_fetches is enabled, using the dependency-aware fetch scheduler")
 
 	if err := f.Parse(args[1:]); err != nil {
 		f.PrintDefaults()

--- a/router/core/plan_generator.go
+++ b/router/core/plan_generator.go
@@ -39,16 +39,26 @@ func (e *PlannerOperationValidationError) Error() string {
 }
 
 type PlanGenerator struct {
-	planConfiguration *plan.Configuration
-	clientDefinition  *ast.Document
-	definition        *ast.Document
+	planConfiguration    *plan.Configuration
+	clientDefinition     *ast.Document
+	definition           *ast.Document
+	postprocessorOptions []postprocess.ProcessorOption
+}
+
+type PlanGeneratorOptions struct {
+	// MaxDataSourceCollectorsConcurrency limits the number of concurrent data source
+	// collectors during planning. Zero means no limit.
+	MaxDataSourceCollectorsConcurrency uint
+	EnableMultiFetch                   bool
+	EnableScheduleFetches              bool
 }
 
 type Planner struct {
-	planner            *plan.Planner
-	definition         *ast.Document
-	clientDefinition   *ast.Document
-	operationValidator *astvalidation.OperationValidator
+	planner              *plan.Planner
+	definition           *ast.Document
+	clientDefinition     *ast.Document
+	operationValidator   *astvalidation.OperationValidator
+	postprocessorOptions []postprocess.ProcessorOption
 }
 
 type OperationTimes struct {
@@ -79,16 +89,17 @@ const (
 	PlanOutputFormatJSON  PlanOutputFormat = "json"
 )
 
-func NewPlanner(planConfiguration *plan.Configuration, definition *ast.Document, clientDefinition *ast.Document) (*Planner, error) {
+func NewPlanner(planConfiguration *plan.Configuration, definition *ast.Document, clientDefinition *ast.Document, postprocessorOptions ...postprocess.ProcessorOption) (*Planner, error) {
 	planner, err := plan.NewPlanner(*planConfiguration)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create planner: %w", err)
 	}
 
 	return &Planner{
-		planner:          planner,
-		definition:       definition,
-		clientDefinition: clientDefinition,
+		planner:              planner,
+		definition:           definition,
+		clientDefinition:     clientDefinition,
+		postprocessorOptions: postprocessorOptions,
 	}, nil
 }
 
@@ -289,7 +300,7 @@ func (pl *Planner) PlanPreparedOperation(operation *ast.Document) (planNode *Pla
 		return nil, opTimes, errors.New(report.Error())
 	}
 
-	post := postprocess.NewProcessor()
+	post := postprocess.NewProcessor(pl.postprocessorOptions...)
 	post.Process(preparedPlan)
 	// measure postprocessing time as part of planning time
 	opTimes.PlanTime = time.Since(start)
@@ -329,7 +340,7 @@ func (pl *Planner) parseOperation(operationFilePath string) (*ast.Document, erro
 	return &doc, nil
 }
 
-func NewPlanGenerator(configFilePath string, logger *zap.Logger, maxDataSourceCollectorsConcurrency uint) (*PlanGenerator, error) {
+func NewPlanGenerator(configFilePath string, logger *zap.Logger, opts PlanGeneratorOptions) (*PlanGenerator, error) {
 	pg := &PlanGenerator{}
 	routerConfig, err := pg.buildRouterConfig(configFilePath)
 	if err != nil {
@@ -339,7 +350,7 @@ func NewPlanGenerator(configFilePath string, logger *zap.Logger, maxDataSourceCo
 	if err := pg.loadConfiguration(
 		routerConfig,
 		logger,
-		maxDataSourceCollectorsConcurrency,
+		opts,
 	); err != nil {
 		return nil, err
 	}
@@ -347,9 +358,9 @@ func NewPlanGenerator(configFilePath string, logger *zap.Logger, maxDataSourceCo
 	return pg, nil
 }
 
-func NewPlanGeneratorFromConfig(config *nodev1.RouterConfig, logger *zap.Logger, maxDataSourceCollectorsConcurrency uint) (*PlanGenerator, error) {
+func NewPlanGeneratorFromConfig(config *nodev1.RouterConfig, logger *zap.Logger, opts PlanGeneratorOptions) (*PlanGenerator, error) {
 	pg := &PlanGenerator{}
-	if err := pg.loadConfiguration(config, logger, maxDataSourceCollectorsConcurrency); err != nil {
+	if err := pg.loadConfiguration(config, logger, opts); err != nil {
 		return nil, err
 	}
 
@@ -357,7 +368,7 @@ func NewPlanGeneratorFromConfig(config *nodev1.RouterConfig, logger *zap.Logger,
 }
 
 func (pg *PlanGenerator) GetPlanner() (*Planner, error) {
-	return NewPlanner(pg.planConfiguration, pg.definition, pg.clientDefinition)
+	return NewPlanner(pg.planConfiguration, pg.definition, pg.clientDefinition, pg.postprocessorOptions...)
 }
 
 func (pg *PlanGenerator) buildRouterConfig(configFilePath string) (*nodev1.RouterConfig, error) {
@@ -369,9 +380,19 @@ func (pg *PlanGenerator) buildRouterConfig(configFilePath string) (*nodev1.Route
 	return routerConfig, nil
 }
 
-func (pg *PlanGenerator) loadConfiguration(routerConfig *nodev1.RouterConfig, logger *zap.Logger, maxDataSourceCollectorsConcurrency uint) error {
+func (pg *PlanGenerator) loadConfiguration(routerConfig *nodev1.RouterConfig, logger *zap.Logger, opts PlanGeneratorOptions) error {
 	routerEngineConfig := RouterEngineConfiguration{
 		StreamMetricStore: metric.NewNoopStreamMetricStore(),
+	}
+	// EnableMultiFetch has to be known at planning time, the planner records the subgraph
+	// operation artifacts the postprocessor's multi-fetch merge stage consumes.
+	routerEngineConfig.Execution.EnableMultiFetch = opts.EnableMultiFetch
+
+	if opts.EnableMultiFetch {
+		pg.postprocessorOptions = append(pg.postprocessorOptions, postprocess.EnableMultiFetch())
+	}
+	if opts.EnableScheduleFetches {
+		pg.postprocessorOptions = append(pg.postprocessorOptions, postprocess.EnableScheduleFetches())
 	}
 	natSources := map[string]*nats.ProviderAdapter{}
 	kafkaSources := map[string]*kafka.ProviderAdapter{}
@@ -433,7 +454,7 @@ func (pg *PlanGenerator) loadConfiguration(routerConfig *nodev1.RouterConfig, lo
 		DatasourceVisitor:             false,
 	}
 
-	planConfig.MaxDataSourceCollectorsConcurrency = maxDataSourceCollectorsConcurrency
+	planConfig.MaxDataSourceCollectorsConcurrency = opts.MaxDataSourceCollectorsConcurrency
 
 	if logger != nil {
 		planConfig.Logger = log.NewZapLogger(logger, log.DebugLevel)

--- a/router/internal/planningbenchmark/benchmark_test.go
+++ b/router/internal/planningbenchmark/benchmark_test.go
@@ -30,7 +30,7 @@ func TestPlanning(t *testing.T) {
 
 	logger := zap.NewNop()
 
-	pg, err := core.NewPlanGenerator(cfg.ExecutionConfigPath, logger, 0)
+	pg, err := core.NewPlanGenerator(cfg.ExecutionConfigPath, logger, core.PlanGeneratorOptions{})
 	require.NoError(t, err)
 
 	pl, err := pg.GetPlanner()
@@ -58,7 +58,7 @@ func BenchmarkPlanning(b *testing.B) {
 
 	logger := zap.NewNop()
 
-	pg, err := core.NewPlanGenerator(cfg.ExecutionConfigPath, logger, 0)
+	pg, err := core.NewPlanGenerator(cfg.ExecutionConfigPath, logger, core.PlanGeneratorOptions{})
 	require.NoError(b, err)
 
 	pl, err := pg.GetPlanner()

--- a/router/pkg/plan_generator/plan_generator.go
+++ b/router/pkg/plan_generator/plan_generator.go
@@ -34,6 +34,10 @@ type QueryPlanConfig struct {
 	LogLevel                           string
 	Logger                             *zap.Logger
 	MaxDataSourceCollectorsConcurrency uint
+	// EnableMultiFetch mirrors the engine.enable_multi_fetch router setting.
+	EnableMultiFetch bool
+	// EnableScheduleFetches mirrors the engine.enable_schedule_fetches router setting.
+	EnableScheduleFetches bool
 }
 
 type QueryPlanResults struct {
@@ -112,7 +116,11 @@ func PlanGenerator(ctx context.Context, cfg QueryPlanConfig) error {
 	ctxError, cancelError := context.WithCancelCause(ctx)
 	defer cancelError(nil)
 
-	pg, err := core.NewPlanGenerator(executionConfigPath, cfg.Logger, cfg.MaxDataSourceCollectorsConcurrency)
+	pg, err := core.NewPlanGenerator(executionConfigPath, cfg.Logger, core.PlanGeneratorOptions{
+		MaxDataSourceCollectorsConcurrency: cfg.MaxDataSourceCollectorsConcurrency,
+		EnableMultiFetch:                   cfg.EnableMultiFetch,
+		EnableScheduleFetches:              cfg.EnableScheduleFetches,
+	})
 	if err != nil {
 		return fmt.Errorf("failed to create plan generator: %w", err)
 	}


### PR DESCRIPTION
<!--
Important: Before developing new features, please open an issue to discuss your ideas with the maintainers. This ensures project alignment and helps avoid unnecessary work for you.

Thank you for your contribution! Please provide a detailed description below and ensure you've met all the requirements.

Contributors Guide: https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md

Squashed commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to facilitate changelog generation.

Please ensure your PR title follows the Conventional Commits specification, using the appropriate type (e.g., feat, fix, docs) and scope.

Examples of good PR titles:

- 💥feat!: change implementation in an non-backward compatible way
- ✨feat(auth): add support for OAuth2 login
- 🐞fix(router): add support for custom metrics
- 📚docs(README): update installation instructions
- 🧹chore(deps): bump dependencies to latest versions
-->

Add enable-multi-fetch and enable-schedule-fetches to query plan command.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added options to merge compatible data fetches during query-plan generation.
  - Added dependency-aware scheduling for data fetches.
  - Exposed both settings through the query-plan generation CLI and configuration.

- **Documentation**
  - Documented the new execution settings, including command examples and CLI option references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] If applicable, I have provided instructions for reviewers for [manually validating my changes](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md#pull-requests-conventions).
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

<!--
Please add any additional information or context regarding your changes here.
-->
