### PR TITLE
chore(router): assert Cosmo Streams provider adapters don't leak goroutines

### DIFF
--- a/router-tests/events/kafka_events_test.go
+++ b/router-tests/events/kafka_events_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hasura/go-graphql-client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 
 	"github.com/wundergraph/cosmo/router-tests/events"
 	"github.com/wundergraph/cosmo/router-tests/testenv"
@@ -1470,66 +1469,5 @@ func TestKafkaEvents(t *testing.T) {
 				require.NoError(t, err)
 			}, "unable to close client before timeout")
 		})
-	})
-}
-
-func TestKafkaAdapterLeaks(t *testing.T) {
-	// Subscribe and unsubscribe 10 times sequentially, then verify no goroutines have leaked.
-	// A goroutine snapshot is taking after starting the testenv but before the first subscribe.
-	// After the last unsubscribe this snapshot is used to diff the goroutines,
-	// ensuring we only fail if new, still active goroutines have been created meantime.
-
-	cfg := testenv.Config{
-		RouterConfigJSONTemplate: testenv.ConfigWithEdfsKafkaJSONTemplate,
-		EnableKafka:              true,
-	}
-
-	type query struct {
-		EmployeeUpdatedMyKafka struct {
-			ID      float64 `graphql:"id"`
-			Details struct {
-				Forename string `graphql:"forename"`
-				Surname  string `graphql:"surname"`
-			} `graphql:"details"`
-		} `graphql:"employeeUpdatedMyKafka(employeeID: 1)"`
-	}
-
-	noopHandler := func(_ []byte, _ error) error {
-		return nil
-	}
-
-	testenv.Run(t, &cfg, func(t *testing.T, xEnv *testenv.Environment) {
-		ignore := []goleak.Option{
-			goleak.IgnoreCurrent(),
-			// The hasura test client itself leaks sometimes, we have to ignore it.
-			goleak.IgnoreAnyFunction("github.com/hasura/go-graphql-client.(*SubscriptionContext).run"),
-		}
-
-		for range 10 {
-			client := graphql.NewSubscriptionClient(xEnv.GraphQLWebSocketSubscriptionURL())
-
-			subID, err := client.Subscribe(new(query), nil, noopHandler)
-			require.NoError(t, err)
-
-			clientRunCh := make(chan error, 1)
-			go func() {
-				clientRunCh <- client.Run()
-			}()
-			xEnv.WaitForSubscriptionCount(1, EventWaitTimeout)
-
-			err = client.Unsubscribe(subID)
-			require.NoError(t, err)
-			xEnv.WaitForSubscriptionCount(0, EventWaitTimeout)
-
-			err = client.Close()
-			require.NoError(t, err)
-			testenv.AwaitChannelWithT(t, EventWaitTimeout, clientRunCh, func(t *testing.T, err error) {
-				require.NoError(t, err)
-			})
-		}
-
-		require.EventuallyWithT(t, func(t *assert.CollectT) {
-			assert.NoError(t, goleak.Find(ignore...))
-		}, EventWaitTimeout, time.Millisecond*100, "adapter leaked goroutines")
 	})
 }

--- a/router-tests/events/kafka_events_test.go
+++ b/router-tests/events/kafka_events_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hasura/go-graphql-client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
 
 	"github.com/wundergraph/cosmo/router-tests/events"
 	"github.com/wundergraph/cosmo/router-tests/testenv"
@@ -72,7 +73,6 @@ func overrideKafkaTopicsForField(t *testing.T, routerConfig *nodev1.RouterConfig
 
 func TestKafkaEvents(t *testing.T) {
 	t.Parallel()
-	// All tests are running in sequence because they are using the same kafka topic
 
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
@@ -1470,5 +1470,66 @@ func TestKafkaEvents(t *testing.T) {
 				require.NoError(t, err)
 			}, "unable to close client before timeout")
 		})
+	})
+}
+
+func TestKafkaAdapterLeaks(t *testing.T) {
+	// Subscribe and unsubscribe 10 times sequentially, then verify no goroutines have leaked.
+	// A goroutine snapshot is taking after starting the testenv but before the first subscribe.
+	// After the last unsubscribe this snapshot is used to diff the goroutines,
+	// ensuring we only fail if new, still active goroutines have been created meantime.
+
+	cfg := testenv.Config{
+		RouterConfigJSONTemplate: testenv.ConfigWithEdfsKafkaJSONTemplate,
+		EnableKafka:              true,
+	}
+
+	type query struct {
+		EmployeeUpdatedMyKafka struct {
+			ID      float64 `graphql:"id"`
+			Details struct {
+				Forename string `graphql:"forename"`
+				Surname  string `graphql:"surname"`
+			} `graphql:"details"`
+		} `graphql:"employeeUpdatedMyKafka(employeeID: 1)"`
+	}
+
+	noopHandler := func(_ []byte, _ error) error {
+		return nil
+	}
+
+	testenv.Run(t, &cfg, func(t *testing.T, xEnv *testenv.Environment) {
+		ignore := []goleak.Option{
+			goleak.IgnoreCurrent(),
+			// The hasura test client itself leaks sometimes, we have to ignore it.
+			goleak.IgnoreAnyFunction("github.com/hasura/go-graphql-client.(*SubscriptionContext).run"),
+		}
+
+		for range 10 {
+			client := graphql.NewSubscriptionClient(xEnv.GraphQLWebSocketSubscriptionURL())
+
+			subID, err := client.Subscribe(new(query), nil, noopHandler)
+			require.NoError(t, err)
+
+			clientRunCh := make(chan error, 1)
+			go func() {
+				clientRunCh <- client.Run()
+			}()
+			xEnv.WaitForSubscriptionCount(1, EventWaitTimeout)
+
+			err = client.Unsubscribe(subID)
+			require.NoError(t, err)
+			xEnv.WaitForSubscriptionCount(0, EventWaitTimeout)
+
+			err = client.Close()
+			require.NoError(t, err)
+			testenv.AwaitChannelWithT(t, EventWaitTimeout, clientRunCh, func(t *testing.T, err error) {
+				require.NoError(t, err)
+			})
+		}
+
+		require.EventuallyWithT(t, func(t *assert.CollectT) {
+			assert.NoError(t, goleak.Find(ignore...))
+		}, EventWaitTimeout, time.Millisecond*100, "adapter leaked goroutines")
 	})
 }

--- a/router-tests/events/leak_test.go
+++ b/router-tests/events/leak_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestAdapterLeaksGoroutines(t *testing.T) {
 	// Subscribe and unsubscribe 10 times sequentially, then verify no goroutines have leaked.
-	// A goroutine snapshot is taking after starting the testenv but before the first subscribe.
+	// A goroutine snapshot is taken after starting the testenv but before the first subscribe.
 	// After the last unsubscribe this snapshot is used to diff the goroutines,
 	// ensuring we only fail if new, still active goroutines have been created meantime.
 

--- a/router-tests/events/leak_test.go
+++ b/router-tests/events/leak_test.go
@@ -1,0 +1,117 @@
+package events_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hasura/go-graphql-client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wundergraph/cosmo/router-tests/testenv"
+	"go.uber.org/goleak"
+)
+
+func TestAdapterLeaksGoroutines(t *testing.T) {
+	// Subscribe and unsubscribe 10 times sequentially, then verify no goroutines have leaked.
+	// A goroutine snapshot is taking after starting the testenv but before the first subscribe.
+	// After the last unsubscribe this snapshot is used to diff the goroutines,
+	// ensuring we only fail if new, still active goroutines have been created meantime.
+
+	t.Run("Kafka", func(t *testing.T) {
+		cfg := testenv.Config{
+			RouterConfigJSONTemplate: testenv.ConfigWithEdfsKafkaJSONTemplate,
+			EnableKafka:              true,
+		}
+
+		var query struct {
+			EmployeeUpdatedMyKafka struct {
+				ID      float64 `graphql:"id"`
+				Details struct {
+					Forename string `graphql:"forename"`
+					Surname  string `graphql:"surname"`
+				} `graphql:"details"`
+			} `graphql:"employeeUpdatedMyKafka(employeeID: 1)"`
+		}
+
+		testenv.Run(t, &cfg, leakTestHandler(query))
+	})
+
+	t.Run("Redis", func(t *testing.T) {
+		cfg := testenv.Config{
+			RouterConfigJSONTemplate: testenv.ConfigWithEdfsRedisJSONTemplate,
+			EnableRedis:              true,
+		}
+
+		var query struct {
+			EmployeeUpdatedMyRedis struct {
+				ID      float64 `graphql:"id"`
+				Details struct {
+					Forename string `graphql:"forename"`
+					Surname  string `graphql:"surname"`
+				} `graphql:"details"`
+			} `graphql:"employeeUpdatedMyRedis(id: 1)"`
+		}
+
+		testenv.Run(t, &cfg, leakTestHandler(query))
+	})
+
+	t.Run("NATS", func(t *testing.T) {
+		cfg := testenv.Config{
+			RouterConfigJSONTemplate: testenv.ConfigWithEdfsNatsJSONTemplate,
+			EnableNats:               true,
+		}
+
+		var query struct {
+			EmployeeUpdatedMyNats struct {
+				ID      float64 `graphql:"id"`
+				Details struct {
+					Forename string `graphql:"forename"`
+					Surname  string `graphql:"surname"`
+				} `graphql:"details"`
+			} `graphql:"employeeUpdatedMyNats(id: 1)"`
+		}
+
+		testenv.Run(t, &cfg, leakTestHandler(query))
+	})
+}
+
+func leakTestHandler(query any) testenv.Handler {
+	noopHandler := func(_ []byte, _ error) error {
+		return nil
+	}
+
+	return func(t *testing.T, xEnv *testenv.Environment) {
+		ignore := []goleak.Option{
+			goleak.IgnoreCurrent(),
+			// The hasura test client itself leaks sometimes, we have to ignore it.
+			goleak.IgnoreAnyFunction("github.com/hasura/go-graphql-client.(*SubscriptionContext).run"),
+		}
+
+		for range 10 {
+			client := graphql.NewSubscriptionClient(xEnv.GraphQLWebSocketSubscriptionURL())
+
+			subID, err := client.Subscribe(query, nil, noopHandler)
+			require.NoError(t, err)
+
+			clientRunCh := make(chan error, 1)
+			go func() {
+				clientRunCh <- client.Run()
+			}()
+			xEnv.WaitForSubscriptionCount(1, EventWaitTimeout)
+
+			err = client.Unsubscribe(subID)
+			require.NoError(t, err)
+			xEnv.WaitForSubscriptionCount(0, EventWaitTimeout)
+
+			err = client.Close()
+			require.NoError(t, err)
+			testenv.AwaitChannelWithT(t, EventWaitTimeout, clientRunCh, func(t *testing.T, err error) {
+				require.NoError(t, err)
+			})
+		}
+
+		require.EventuallyWithT(t, func(t *assert.CollectT) {
+			assert.NoError(t, goleak.Find(ignore...))
+		}, EventWaitTimeout, time.Millisecond*100, "adapter leaked goroutines")
+	}
+}

--- a/router-tests/freeport/freeport.go
+++ b/router-tests/freeport/freeport.go
@@ -23,6 +23,7 @@ import (
 	"net"
 	"os"
 	"runtime"
+	"strconv"
 	"sync"
 	"time"
 )
@@ -414,6 +415,20 @@ func isPortInUse(port int) bool {
 		return true
 	}
 	ln.Close()
+
+	return isPortAccepting(port)
+}
+
+// isPortAccepting reports whether any listener accepts a connection on the port over
+// loopback, including listeners bound to the wildcard address.
+func isPortAccepting(port int) bool {
+	for _, host := range []string{"127.0.0.1", "::1"} {
+		conn, err := net.DialTimeout("tcp", net.JoinHostPort(host, strconv.Itoa(port)), 200*time.Millisecond)
+		if err == nil {
+			conn.Close()
+			return true
+		}
+	}
 	return false
 }
 

--- a/router-tests/freeport/freeport.go
+++ b/router-tests/freeport/freeport.go
@@ -425,7 +425,7 @@ func isPortAccepting(port int) bool {
 	for _, host := range []string{"127.0.0.1", "::1"} {
 		conn, err := net.DialTimeout("tcp", net.JoinHostPort(host, strconv.Itoa(port)), 200*time.Millisecond)
 		if err == nil {
-			conn.Close()
+			_ = conn.Close()
 			return true
 		}
 	}

--- a/router-tests/testenv/testenv.go
+++ b/router-tests/testenv/testenv.go
@@ -2039,12 +2039,13 @@ func (e *Environment) Shutdown() {
 		}
 	}
 
-	// Flush Kafka connection
+	// Flush Kafka connection and close client
 	if e.cfg.EnableKafka && e.KafkaClient != nil {
 		err := e.KafkaClient.Flush(ctx)
 		if err != nil {
 			e.t.Logf("could not flush Kafka connection: %s", err)
 		}
+		e.KafkaClient.Close()
 	}
 
 	if e.routerCmd != nil {

--- a/router-tests/testenv/testenv.go
+++ b/router-tests/testenv/testenv.go
@@ -80,6 +80,10 @@ const (
 	myRedisProviderID     = "my-redis"
 )
 
+// Handler defines what is run inside the test environment.
+// It provided to testenv.Run and executed inside it.
+type Handler func(t *testing.T, xEnv *Environment)
+
 var (
 	//go:embed testdata/config.json
 	ConfigJSONTemplate string
@@ -117,7 +121,7 @@ func init() {
 }
 
 // Run runs the test and fails the test if an error occurs
-func Run(t *testing.T, cfg *Config, f func(t *testing.T, xEnv *Environment)) {
+func Run(t *testing.T, cfg *Config, f Handler) {
 	t.Helper()
 	env, err := CreateTestEnv(t, cfg)
 	if env != nil {

--- a/router-tests/testenv/testenv.go
+++ b/router-tests/testenv/testenv.go
@@ -81,7 +81,7 @@ const (
 )
 
 // Handler defines what is run inside the test environment.
-// It provided to testenv.Run and executed inside it.
+// It is provided to testenv.Run and executed inside it.
 type Handler func(t *testing.T, xEnv *Environment)
 
 var (


### PR DESCRIPTION
Adds integration tests to verify we don't leak any goroutines in our Cosmo Streams adapter logic, when clients (un)subscribe. It would have catched the bug https://github.com/wundergraph/cosmo/pull/3133 has fixed.

Tests deliberately don't run parallel to reliable count goroutines. I used [uber-go/goleak](https://github.com/uber-go/goleak) for that which already is a dependency in the router.

I found a bug in our freeport used port detection while working on this and optimised it, see commit messages for more details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cleanup of Kafka connections during test-environment shutdown.
  - Enhanced port availability checks for both IPv4 and IPv6 loopback connections, including wildcard listeners.

- **Tests**
  - Added coverage to detect goroutine leaks across Kafka, Redis, and NATS subscription workflows.
  - Strengthened repeated subscribe/unsubscribe and client shutdown verification for more reliable event adapter behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] If applicable, I have provided instructions for reviewers for [manually validating my changes](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md#pull-requests-conventions).
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.
