### PR TITLE
fix(router): preserve APQ query when renewing TTL

### DIFF
--- a/router-tests/operations/automatic_persisted_queries_test.go
+++ b/router-tests/operations/automatic_persisted_queries_test.go
@@ -2,6 +2,8 @@ package integration
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"net/http"
 	"os"
@@ -353,13 +355,20 @@ func TestAutomaticPersistedQueries(t *testing.T) {
 			})
 		})
 
-		t.Run("query renews ttl time", func(t *testing.T) {
+		t.Run("query renewal preserves the stored query", func(t *testing.T) {
 			t.Parallel()
 
-			key := uuid.New().String()
+			const query = `query SkipRenewal($skip: Boolean!) { a: __typename b: __typename @skip(if: $skip) }`
+			sum := sha256.Sum256([]byte(query))
+			sha := hex.EncodeToString(sum[:])
+			extensions := fmt.Sprintf(`{"persistedQuery": {"version": 1, "sha256Hash": %q}}`, sha)
+
+			prefix := uuid.New().String()
+			operationKey := prefix + sha
 			t.Cleanup(func() {
-				del := client.Del(context.Background(), key)
-				require.NoError(t, del.Err())
+				deleted, err := client.Del(context.Background(), operationKey).Result()
+				require.NoError(t, err)
+				require.Equal(t, int64(1), deleted)
 			})
 
 			testenv.Run(t, &testenv.Config{
@@ -380,7 +389,7 @@ func TestAutomaticPersistedQueries(t *testing.T) {
 					},
 					Storage: config.AutomaticPersistedQueriesStorageConfig{
 						ProviderID:   "redis",
-						ObjectPrefix: key,
+						ObjectPrefix: prefix,
 					},
 				},
 			}, func(t *testing.T, xEnv *testenv.Environment) {
@@ -388,27 +397,41 @@ func TestAutomaticPersistedQueries(t *testing.T) {
 				header.Add("graphql-client-name", "my-client")
 
 				res := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
-					Query:      `{__typename}`,
-					Extensions: []byte(`{"persistedQuery": {"version": 1, "sha256Hash": "ecf4edb46db40b5132295c0291d62fb65d6759a9eedfa4d5d612dd5ec54a6b38"}}`),
+					Query:      query,
+					Variables:  []byte(`{"skip":true}`),
+					Extensions: []byte(extensions),
 					Header:     header,
 				})
-				require.Equal(t, `{"data":{"__typename":"Query"}}`, res.Body)
+				require.Equal(t, `{"data":{"a":"Query"}}`, res.Body)
 
-				time.Sleep(3 * time.Second)
+				var ttlBeforeRenewal time.Duration
+				require.Eventually(t, func() bool {
+					ttl, err := client.PTTL(t.Context(), operationKey).Result()
+					ttlBeforeRenewal = ttl
+					return err == nil && ttl > 0 && ttl <= 3*time.Second
+				}, 4*time.Second, 50*time.Millisecond, "APQ entry did not reach the TTL renewal window")
 
 				res2 := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
-					Extensions: []byte(`{"persistedQuery": {"version": 1, "sha256Hash": "ecf4edb46db40b5132295c0291d62fb65d6759a9eedfa4d5d612dd5ec54a6b38"}}`),
+					Variables:  []byte(`{"skip":true}`),
+					Extensions: []byte(extensions),
 					Header:     header,
 				})
-				require.Equal(t, `{"data":{"__typename":"Query"}}`, res2.Body)
+				require.Equal(t, `{"data":{"a":"Query"}}`, res2.Body)
 
-				time.Sleep(3 * time.Second)
+				renewedTTL, err := client.PTTL(t.Context(), operationKey).Result()
+				require.NoError(t, err)
+				require.Greater(t, renewedTTL, ttlBeforeRenewal)
+
+				storedQuery, err := client.Get(t.Context(), operationKey).Result()
+				require.NoError(t, err)
+				require.Equal(t, query, storedQuery)
 
 				res3 := xEnv.MakeGraphQLRequestOK(testenv.GraphQLRequest{
-					Extensions: []byte(`{"persistedQuery": {"version": 1, "sha256Hash": "ecf4edb46db40b5132295c0291d62fb65d6759a9eedfa4d5d612dd5ec54a6b38"}}`),
+					Variables:  []byte(`{"skip":false}`),
+					Extensions: []byte(extensions),
 					Header:     header,
 				})
-				require.Equal(t, `{"data":{"__typename":"Query"}}`, res3.Body)
+				require.Equal(t, `{"data":{"a":"Query","b":"Query"}}`, res3.Body)
 			})
 		})
 

--- a/router-tests/operations/automatic_persisted_queries_test.go
+++ b/router-tests/operations/automatic_persisted_queries_test.go
@@ -355,7 +355,7 @@ func TestAutomaticPersistedQueries(t *testing.T) {
 			})
 		})
 
-		t.Run("query renewal preserves the stored query", func(t *testing.T) {
+		t.Run("renews ttl without changing the stored query after variable-based normalization", func(t *testing.T) {
 			t.Parallel()
 
 			const query = `query SkipRenewal($skip: Boolean!) { a: __typename b: __typename @skip(if: $skip) }`

--- a/router/core/operation_processor.go
+++ b/router/core/operation_processor.go
@@ -456,16 +456,8 @@ func (o *OperationKit) FetchPersistedOperation(ctx context.Context, clientInfo *
 	}
 	if fromCache {
 		if fromCacheHasTTL, _ := o.persistedOperationCacheKeyHasTtl(clientInfo.Name, includeOperationName); fromCacheHasTTL {
-			sha256Hash := o.parsedOperation.GraphQLRequestExtensions.PersistedQuery.Sha256Hash
-			// Reload the raw APQ body because normalization can remove conditional fields.
-			operationBody, apqOperation, loadErr := o.operationProcessor.persistedOperationClient.PersistedOperation(ctx, clientInfo.Name, sha256Hash)
-			if apqOperation && loadErr != nil {
-				return false, false, loadErr
-			}
-			if apqOperation && len(operationBody) > 0 {
-				if err = o.operationProcessor.persistedOperationClient.SaveOperation(ctx, clientInfo.Name, sha256Hash, string(operationBody)); err != nil {
-					return false, false, err
-				}
+			if err := o.renewAPQTTL(ctx, clientInfo.Name); err != nil {
+				return false, false, err
 			}
 		}
 		return true, false, nil
@@ -516,6 +508,23 @@ func (o *OperationKit) FetchPersistedOperation(ctx context.Context, clientInfo *
 	}
 
 	return false, isAPQ, nil
+}
+
+func (o *OperationKit) renewAPQTTL(ctx context.Context, clientName string) error {
+	sha256Hash := o.parsedOperation.GraphQLRequestExtensions.PersistedQuery.Sha256Hash
+	// Reload the raw APQ body because normalization can remove conditional fields.
+	operationBody, isAPQ, err := o.operationProcessor.persistedOperationClient.PersistedOperation(ctx, clientName, sha256Hash)
+	if err != nil {
+		return err
+	}
+	if !isAPQ {
+		return nil
+	}
+	if len(operationBody) == 0 {
+		return nil
+	}
+
+	return o.operationProcessor.persistedOperationClient.SaveOperation(ctx, clientName, sha256Hash, string(operationBody))
 }
 
 const (

--- a/router/core/operation_processor.go
+++ b/router/core/operation_processor.go
@@ -456,9 +456,16 @@ func (o *OperationKit) FetchPersistedOperation(ctx context.Context, clientInfo *
 	}
 	if fromCache {
 		if fromCacheHasTTL, _ := o.persistedOperationCacheKeyHasTtl(clientInfo.Name, includeOperationName); fromCacheHasTTL {
-			// if it is an APQ request, we need to save it again to renew the TTL expiration
-			if err = o.operationProcessor.persistedOperationClient.SaveOperation(ctx, clientInfo.Name, o.parsedOperation.GraphQLRequestExtensions.PersistedQuery.Sha256Hash, o.parsedOperation.NormalizedRepresentation); err != nil {
-				return false, false, err
+			sha256Hash := o.parsedOperation.GraphQLRequestExtensions.PersistedQuery.Sha256Hash
+			// Reload the raw APQ body because normalization can remove conditional fields.
+			operationBody, apqOperation, loadErr := o.operationProcessor.persistedOperationClient.PersistedOperation(ctx, clientInfo.Name, sha256Hash)
+			if apqOperation && loadErr != nil {
+				return false, false, loadErr
+			}
+			if apqOperation && len(operationBody) > 0 {
+				if err = o.operationProcessor.persistedOperationClient.SaveOperation(ctx, clientInfo.Name, sha256Hash, string(operationBody)); err != nil {
+					return false, false, err
+				}
 			}
 		}
 		return true, false, nil


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved persisted-query cache renewal to reliably extend cache lifetime when valid query content is available.
  - Prevented empty persisted-query data from being saved during renewal.
  - Improved error handling when cached query data cannot be retrieved.
  - Ensured persisted queries remain available across renewal intervals.
  - Verified that changing request variables continues to produce the expected directive behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Context

Fixes #3062.

Addresses ROUTER-20 and ENG-9964.

This is a smaller, RGR-structured alternative to #3072. The implementation commit credits the original PR author, @Lawal-create, as a co-author.

## What changed

- Keep the original APQ document in Redis when a cache hit renews its TTL, instead of replacing it with the request-specific normalized document.
- Reproduce the corruption using an APQ document whose `@skip` result changes between requests.
- Keep the TTL-renewal details in a private `OperationKit` helper.

## RGR commits

1. Red: reproduce APQ corruption on TTL renewal.
2. Green: preserve the stored APQ query during renewal.
3. Refactor: extract the TTL-renewal helper from `FetchPersistedOperation`.

## Testing

With Redis available on `localhost:6379`, matching the integration-test environment:

- `go test ./operations -run 'TestAutomaticPersistedQueries/redis_cache/query_renewal_preserves_the_stored_query' -count=1`

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [x] Tests or benchmarks have been added or updated.
- [x] If applicable, I have provided instructions for reviewers for [manually validating my changes](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md#pull-requests-conventions).
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [ ] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.
