### PR TITLE
fix: show the feature flag menu in the studio for split config

### DIFF
--- a/controlplane/src/core/bufservices/feature-flag/getFeatureFlagsInLatestCompositionByFederatedGraph.ts
+++ b/controlplane/src/core/bufservices/feature-flag/getFeatureFlagsInLatestCompositionByFederatedGraph.ts
@@ -67,6 +67,7 @@ export function getFeatureFlagsInLatestCompositionByFederatedGraph(
       // Get feature flag IDs from the latest valid composition
       const ffsInLatestValidComposition = await featureFlagRepo.getFeatureFlagSchemaVersionsByBaseSchemaVersion({
         baseSchemaVersionId: federatedGraph.schemaVersionId,
+        federatedGraphId: federatedGraph.id,
       });
 
       const featureFlags: FeatureFlagDTO[] = [];

--- a/controlplane/src/core/bufservices/federated-graph/getFederatedGraphById.ts
+++ b/controlplane/src/core/bufservices/federated-graph/getFederatedGraphById.ts
@@ -76,6 +76,7 @@ export function getFederatedGraphById(
     if (federatedGraph.schemaVersionId) {
       const ffsInLatestValidComposition = await featureFlagRepo.getFeatureFlagSchemaVersionsByBaseSchemaVersion({
         baseSchemaVersionId: federatedGraph.schemaVersionId,
+        federatedGraphId: federatedGraph.id,
       });
       if (ffsInLatestValidComposition) {
         for (const ff of ffsInLatestValidComposition) {

--- a/controlplane/src/core/bufservices/federated-graph/getFederatedGraphById.ts
+++ b/controlplane/src/core/bufservices/federated-graph/getFederatedGraphById.ts
@@ -81,7 +81,9 @@ export function getFederatedGraphById(
       if (ffsInLatestValidComposition) {
         for (const ff of ffsInLatestValidComposition) {
           const flag = featureFlags.find((f) => f.id === ff.featureFlagId);
-          if (flag) {
+          // A disabled feature flag is no longer served in the latest composition. With split config its
+          // schema version rows are never superseded by a new base composition, so it has to be excluded here.
+          if (flag?.isEnabled) {
             featureFlagsInLatestValidComposition.push(flag);
           }
         }

--- a/controlplane/src/core/bufservices/federated-graph/getFederatedGraphById.ts
+++ b/controlplane/src/core/bufservices/federated-graph/getFederatedGraphById.ts
@@ -81,8 +81,7 @@ export function getFederatedGraphById(
       if (ffsInLatestValidComposition) {
         for (const ff of ffsInLatestValidComposition) {
           const flag = featureFlags.find((f) => f.id === ff.featureFlagId);
-          // A disabled feature flag is no longer served in the latest composition. With split config its
-          // schema version rows are never superseded by a new base composition, so it has to be excluded here.
+          // Split config never supersedes these rows, so a disabled flag would otherwise linger here.
           if (flag?.isEnabled) {
             featureFlagsInLatestValidComposition.push(flag);
           }

--- a/controlplane/src/core/repositories/FeatureFlagRepository.ts
+++ b/controlplane/src/core/repositories/FeatureFlagRepository.ts
@@ -1493,13 +1493,25 @@ export class FeatureFlagRepository {
     return featureFlagCompositions;
   }
 
-  // return all the feature flag schema versions associated with the base schema version
-  // input: base schema version id
+  /**
+   * Returns all the feature flag schema versions associated with the base schema version.
+   *
+   * @param baseSchemaVersionId The base composition the feature flags were composed against.
+   * @param federatedGraphId Used in place of the base composition when split config is enabled.
+   */
   public async getFeatureFlagSchemaVersionsByBaseSchemaVersion({
     baseSchemaVersionId,
+    federatedGraphId,
   }: {
     baseSchemaVersionId: string;
+    federatedGraphId: string;
   }) {
+    const orgRepo = new OrganizationRepository(this.logger, this.db);
+    const splitConfigFeature = await orgRepo.getFeature({
+      organizationId: this.organizationId,
+      featureId: 'split-config-loading',
+    });
+
     // A feature flag can have multiple composed schema versions against the same base schema version
     // (e.g. recomposing the feature flag recomposes it against the unchanged base, so rows accumulate).
     // Deduplicate by feature flag, keeping the latest composed version, so callers get one entry per flag.
@@ -1513,7 +1525,16 @@ export class FeatureFlagRepository {
         schemaVersion,
         eq(schemaVersion.id, federatedGraphsToFeatureFlagSchemaVersions.composedSchemaVersionId),
       )
-      .where(eq(federatedGraphsToFeatureFlagSchemaVersions.baseCompositionSchemaVersionId, baseSchemaVersionId))
+      .where(
+        // When split config is enabled, the feature flag composition will not be tied to the base schema version, so
+        // the flags have to be looked up by federated graph with a null baseCompositionSchemaVersionId instead.
+        splitConfigFeature?.enabled
+          ? and(
+              isNull(federatedGraphsToFeatureFlagSchemaVersions.baseCompositionSchemaVersionId),
+              eq(federatedGraphsToFeatureFlagSchemaVersions.federatedGraphId, federatedGraphId),
+            )
+          : eq(federatedGraphsToFeatureFlagSchemaVersions.baseCompositionSchemaVersionId, baseSchemaVersionId),
+      )
       .orderBy(federatedGraphsToFeatureFlagSchemaVersions.featureFlagId, desc(schemaVersion.createdAt))
       .execute();
 

--- a/controlplane/test/feature-flag/get-feature-flags-in-latest-composition-by-federated-graph.test.ts
+++ b/controlplane/test/feature-flag/get-feature-flags-in-latest-composition-by-federated-graph.test.ts
@@ -112,13 +112,16 @@ describe('GetFeatureFlagsInLatestCompositionByFederatedGraph', () => {
     const recomposeResp2 = await client.recomposeFeatureFlag({ name: flagName, namespace });
     expect(recomposeResp2.response?.code).toBe(EnumStatusCode.OK);
 
+    // With split config the flag compositions are not tied to the base schema version, so they have to be
+    // looked up by federated graph. Each flag still appears exactly once, despite the recompositions.
     const resp = await client.getFeatureFlagsInLatestCompositionByFederatedGraph({
       federatedGraphName,
       namespace,
     });
 
     expect(resp.response?.code).toBe(EnumStatusCode.OK);
-    expect(resp.featureFlags).toHaveLength(0);
+    expect(resp.featureFlags).toHaveLength(1);
+    expect(resp.featureFlags[0].name).toBe(flagName);
 
     // Create a second, enabled feature flag
     const secondFlagName = genID('flag');
@@ -129,7 +132,8 @@ describe('GetFeatureFlagsInLatestCompositionByFederatedGraph', () => {
       namespace,
     });
     expect(withSecondFlag.response?.code).toBe(EnumStatusCode.OK);
-    expect(withSecondFlag.featureFlags).toHaveLength(0);
+    expect(withSecondFlag.featureFlags).toHaveLength(2);
+    expect(withSecondFlag.featureFlags.map((f) => f.name).sort()).toStrictEqual([flagName, secondFlagName].sort());
 
     // Only the base graph composition should show up when excluding feature flag compositions
     let compositionsResp = await client.getCompositions({
@@ -164,6 +168,67 @@ describe('GetFeatureFlagsInLatestCompositionByFederatedGraph', () => {
         expect.objectContaining({ featureFlagName: secondFlagName, isFeatureFlagComposition: true }),
       ]),
     );
+  });
+
+  test('that a disabled feature flag is excluded when split config loading is enabled', async (testContext) => {
+    const { client, server } = await SetupTest({ dbname, enabledFeatures: ['split-config-loading'] });
+    testContext.onTestFinished(() => server.close());
+
+    const namespace = genID('namespace').toLowerCase();
+    const labels = [genUniqueLabel()];
+    const federatedGraphName = genID('fedGraph');
+
+    await createNamespace(client, namespace);
+
+    await createAndPublishSubgraph(
+      client,
+      'users',
+      namespace,
+      fs.readFileSync(join(process.cwd(), 'test/test-data/feature-flags/users.graphql')).toString(),
+      labels,
+      DEFAULT_SUBGRAPH_URL_ONE,
+    );
+
+    await createThenPublishFeatureSubgraph(
+      client,
+      'users-feature',
+      'users',
+      namespace,
+      fs.readFileSync(join(process.cwd(), 'test/test-data/feature-flags/users-feature.graphql')).toString(),
+      labels,
+      'http://localhost:4101',
+    );
+
+    const federatedGraphLabels = labels.map(({ key, value }) => `${key}=${value}`);
+    await createFederatedGraph(client, federatedGraphName, namespace, federatedGraphLabels, DEFAULT_ROUTER_URL);
+
+    const flagName = genID('flag');
+    await createFeatureFlag(client, flagName, labels, ['users-feature'], namespace, true);
+
+    // Pin the enabled state first, otherwise a lookup that finds nothing at all would satisfy the
+    // exclusion assertion below.
+    const whileEnabled = await client.getFeatureFlagsInLatestCompositionByFederatedGraph({
+      federatedGraphName,
+      namespace,
+    });
+
+    expect(whileEnabled.response?.code).toBe(EnumStatusCode.OK);
+    expect(whileEnabled.featureFlags).toHaveLength(1);
+    expect(whileEnabled.featureFlags[0].name).toBe(flagName);
+
+    // Disabling does not recompose, so the flag's schema version rows survive. Only the enabled check keeps
+    // it out of the list, which matters more with split config where the rows are never superseded by a
+    // new base composition.
+    const disableResp = await client.enableFeatureFlag({ name: flagName, namespace, enabled: false });
+    expect(disableResp.response?.code).toBe(EnumStatusCode.OK);
+
+    const afterDisable = await client.getFeatureFlagsInLatestCompositionByFederatedGraph({
+      federatedGraphName,
+      namespace,
+    });
+
+    expect(afterDisable.response?.code).toBe(EnumStatusCode.OK);
+    expect(afterDisable.featureFlags).toHaveLength(0);
   });
 
   test('Should return empty list when no feature flags exist', async (testContext) => {

--- a/controlplane/test/federated-graph/get-federated-graph-by-id.test.ts
+++ b/controlplane/test/federated-graph/get-federated-graph-by-id.test.ts
@@ -145,6 +145,74 @@ describe('GetFederatedGraphById', () => {
     expect(response.featureFlagsInLatestValidComposition[0].name).toBe(flagName);
   });
 
+  test('Should exclude a disabled feature flag when split config loading is enabled', async (testContext) => {
+    const { client, server } = await SetupTest({ dbname, enabledFeatures: ['split-config-loading'] });
+    testContext.onTestFinished(() => server.close());
+
+    const graphName = genID('fedgraph');
+    await createFederatedGraph(client, graphName, DEFAULT_NAMESPACE, ['team=A'], 'http://localhost:8080');
+
+    const subgraphName = genID('subgraph');
+    await createThenPublishSubgraph(
+      client,
+      subgraphName,
+      DEFAULT_NAMESPACE,
+      'type Query { hello: String }',
+      [{ key: 'team', value: 'A' }],
+      'http://localhost:4001',
+    );
+
+    const featureSubgraphName = genID('featureSubgraph');
+    await createThenPublishFeatureSubgraph(
+      client,
+      featureSubgraphName,
+      subgraphName,
+      DEFAULT_NAMESPACE,
+      'type Query { hello: String, goodbye: String }',
+      [{ key: 'team', value: 'A' }],
+      'http://localhost:4002',
+    );
+
+    const flagName = genID('flag');
+    await createFeatureFlag(
+      client,
+      flagName,
+      [{ key: 'team', value: 'A' }],
+      [featureSubgraphName],
+      DEFAULT_NAMESPACE,
+      true,
+    );
+
+    const graphByName = await client.getFederatedGraphByName({
+      name: graphName,
+      namespace: DEFAULT_NAMESPACE,
+    });
+    expect(graphByName.response?.code).toBe(EnumStatusCode.OK);
+
+    // Pin the enabled state first, otherwise a lookup that finds nothing at all would satisfy the
+    // exclusion assertion below.
+    const whileEnabled = await client.getFederatedGraphById({
+      id: graphByName.graph!.id,
+      includeMetrics: false,
+    });
+    expect(whileEnabled.featureFlagsInLatestValidComposition.length).toBe(1);
+
+    const disableResp = await client.enableFeatureFlag({
+      name: flagName,
+      namespace: DEFAULT_NAMESPACE,
+      enabled: false,
+    });
+    expect(disableResp.response?.code).toBe(EnumStatusCode.OK);
+
+    const afterDisable = await client.getFederatedGraphById({
+      id: graphByName.graph!.id,
+      includeMetrics: false,
+    });
+
+    expect(afterDisable.response?.code).toBe(EnumStatusCode.OK);
+    expect(afterDisable.featureFlagsInLatestValidComposition).toHaveLength(0);
+  });
+
   test('Should fail when the graph does not exist', async (testContext) => {
     const { client, server } = await SetupTest({ dbname });
     testContext.onTestFinished(() => server.close());

--- a/controlplane/test/federated-graph/get-federated-graph-by-id.test.ts
+++ b/controlplane/test/federated-graph/get-federated-graph-by-id.test.ts
@@ -7,7 +7,14 @@ import {
   createTestRBACEvaluator,
   genID,
 } from '../../src/core/test-util.js';
-import { createFederatedGraph, createThenPublishSubgraph, DEFAULT_NAMESPACE, SetupTest } from '../test-util.js';
+import {
+  createFeatureFlag,
+  createFederatedGraph,
+  createThenPublishFeatureSubgraph,
+  createThenPublishSubgraph,
+  DEFAULT_NAMESPACE,
+  SetupTest,
+} from '../test-util.js';
 
 let dbname = '';
 
@@ -80,6 +87,62 @@ describe('GetFederatedGraphById', () => {
     // The subgraph should be associated with the graph since the labels match
     expect(response.subgraphs.length).toBe(1);
     expect(response.subgraphs[0].name).toBe(subgraphName);
+  });
+
+  test('Should return the feature flags in the latest valid composition when split config loading is enabled', async (testContext) => {
+    const { client, server } = await SetupTest({ dbname, enabledFeatures: ['split-config-loading'] });
+    testContext.onTestFinished(() => server.close());
+
+    const graphName = genID('fedgraph');
+    await createFederatedGraph(client, graphName, DEFAULT_NAMESPACE, ['team=A'], 'http://localhost:8080');
+
+    const subgraphName = genID('subgraph');
+    await createThenPublishSubgraph(
+      client,
+      subgraphName,
+      DEFAULT_NAMESPACE,
+      'type Query { hello: String }',
+      [{ key: 'team', value: 'A' }],
+      'http://localhost:4001',
+    );
+
+    const featureSubgraphName = genID('featureSubgraph');
+    await createThenPublishFeatureSubgraph(
+      client,
+      featureSubgraphName,
+      subgraphName,
+      DEFAULT_NAMESPACE,
+      'type Query { hello: String, goodbye: String }',
+      [{ key: 'team', value: 'A' }],
+      'http://localhost:4002',
+    );
+
+    const flagName = genID('flag');
+    await createFeatureFlag(
+      client,
+      flagName,
+      [{ key: 'team', value: 'A' }],
+      [featureSubgraphName],
+      DEFAULT_NAMESPACE,
+      true,
+    );
+
+    const graphByName = await client.getFederatedGraphByName({
+      name: graphName,
+      namespace: DEFAULT_NAMESPACE,
+    });
+    expect(graphByName.response?.code).toBe(EnumStatusCode.OK);
+
+    const response = await client.getFederatedGraphById({
+      id: graphByName.graph!.id,
+      includeMetrics: false,
+    });
+
+    expect(response.response?.code).toBe(EnumStatusCode.OK);
+    // With split config the flag composition is not tied to the base schema version, so it has to be
+    // resolved via the federated graph instead.
+    expect(response.featureFlagsInLatestValidComposition.length).toBe(1);
+    expect(response.featureFlagsInLatestValidComposition[0].name).toBe(flagName);
   });
 
   test('Should fail when the graph does not exist', async (testContext) => {


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Feature flags now correctly load for the latest valid federated graph composition when split configuration is enabled.
  * Disabled feature flags are excluded from results, even when older schema records remain.
  * Feature flag retrieval now consistently filters results by federated graph.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

The Feature Flags category was missing from the playground graph menu and from Graph > Schema > SDL for organizations on split config.

`getFeatureFlagSchemaVersionsByBaseSchemaVersion` matched rows only by `baseCompositionSchemaVersionId`, but split config writes flag compositions with a null base. Once the base graph recomposed, nothing pointed at the current base schema version and the lookup came back empty. The singular `getFeatureFlagSchemaVersionByBaseSchemaVersion` already had the split-config branch; this adds the same one to the plural, keyed on the federated graph instead.

## Validating manually

Requires an organization with `split-config-loading` enabled.

1. Create a federated graph, a feature subgraph, and an enabled feature flag.
2. Republish one of the base subgraphs so the graph recomposes. The current base schema version now has no feature flag rows pointing at it, which is the broken state.
3. Open Graph > Schema > SDL, and the playground. The Feature Flags category should list the flag, and selecting it should swap the SDL to the flag's composition.

Before the fix, the category is absent at step 3.

## Checklist

- [x] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [x] Tests or benchmarks have been added or updated.
- [x] If applicable, I have provided instructions for reviewers for [manually validating my changes](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md#pull-requests-conventions).
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.
