### PR TITLE
ci: split release versioning from npm publish and retry publishes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,10 +67,30 @@ jobs:
       - name: Revert changes
         run: git reset --hard
 
-      - name: Publish packages & Create Github Releases
+        # Split from publish so a failed publish can be re-run: the combined
+        # `lerna publish` finds its own tags on a second run and publishes nothing.
+      - name: Version, tag & create Github Releases
         run: |
           git config --global user.email "bot@wundergraph.com"
           git config --global user.name "hardworker-bot"
-          pnpm release
+          pnpm release:version
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Publish packages to npm
+        run: |
+          # Retried on intermittent sigstore 409s. `from-package` publishes only
+          # what the registry is missing, so repeating is safe.
+          for attempt in 1 2 3; do
+            if pnpm release:publish; then
+              exit 0
+            fi
+            if [ "$attempt" -lt 3 ]; then
+              echo "::warning::npm publish attempt $attempt failed, retrying in 20s"
+              sleep 20
+            fi
+          done
+          echo "npm publish still failing after 3 attempts" >&2
+          exit 1
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -80,11 +80,15 @@ jobs:
       - name: Publish packages to npm
         run: |
           # Retried on intermittent sigstore 409s. `from-package` publishes only
-          # what the registry is missing, so repeating is safe.
+          # what the registry is missing, so repeating is safe. The reset drops
+          # the temporary gitHead lerna writes into the manifests before
+          # publishing and only cleans up on success; left behind, it fails the
+          # next attempt's working tree check instead.
           for attempt in 1 2 3; do
             if pnpm release:publish; then
               exit 0
             fi
+            git reset --hard
             if [ "$attempt" -lt 3 ]; then
               echo "::warning::npm publish attempt $attempt failed, retrying in 20s"
               sleep 20

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -12,6 +12,7 @@ Release the full monorepo with all packages and services can be done by triggeri
 2. After the release, you can validate the release by:
    1. checking the [GitHub Cosmo Packages](https://github.com/orgs/wundergraph/packages?repo_name=cosmo)
    2. checking the [GitHub Cosmo Releases](https://github.com/wundergraph/cosmo/releases)
+   3. checking that each npm package is published at the released version, e.g. `npm view wgc version`
 
 ### If a release fails halfway
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -20,6 +20,8 @@ Versioning and publishing to npm are separate steps. The version step bumps vers
 
 If the publish step fails — sigstore's transparency log occasionally rejects a provenance write, which aborts the publish for every remaining package — just trigger the workflow again. The version step finds nothing new to version and no-ops, and the publish step publishes only the versions still missing from the registry. It also retries three times on its own before failing the run.
 
+Do this before anything else lands on main. The publish step works from the versions in the tree, so once a later release bumps them the versions that were never published cannot be recovered — their tags and GitHub releases stay, but npm skips straight to the newer version.
+
 ## Release Automation
 
 We use conventional commits to automate the release process. This means that we use the commit message to determine the next version. The commit message must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -18,9 +18,9 @@ Release the full monorepo with all packages and services can be done by triggeri
 
 Versioning and publishing to npm are separate steps. The version step bumps versions, creates the tags and GitHub releases, and (through the `postversion` hooks) kicks off the image builds; the publish step pushes the npm packages.
 
-If the publish step fails — sigstore's transparency log occasionally rejects a provenance write, which aborts the publish for every remaining package — just trigger the workflow again. The version step finds nothing new to version and no-ops, and the publish step publishes only the versions still missing from the registry. It also retries three times on its own before failing the run.
+If the publish step fails (sigstore's transparency log occasionally rejects a provenance write, which aborts the publish for every remaining package), trigger the [Release workflow](https://github.com/wundergraph/cosmo/actions/workflows/release.yaml) again exactly as you started it: "Run workflow" against `main`, or `gh workflow run release.yaml --ref main`. The version step finds nothing new to version and no-ops, and the publish step publishes only the versions still missing from the registry. It also retries three times on its own before failing the run.
 
-Do this before anything else lands on main. The publish step works from the versions in the tree, so once a later release bumps them the versions that were never published cannot be recovered — their tags and GitHub releases stay, but npm skips straight to the newer version.
+Do this before anything else lands on main. The publish step works from the versions in the tree, so once a later release bumps them the versions that were never published cannot be recovered. Their tags and GitHub releases stay, but npm skips straight to the newer version.
 
 ## Release Automation
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -5,13 +5,19 @@
 Release the full monorepo with all packages and services can be done by triggering a single GitHub Action workflow.
 
 1. [Trigger the Release workflow](https://github.com/wundergraph/cosmo/actions/workflows/release.yaml): This will create GitHub releases and tags for all components. For services that are not published to NPM but to GitHub container registry, Lerna will trigger a `postversion` npm hooks that triggers the [Build and Release Image](https://github.com/wundergraph/cosmo/actions/workflows/image-release.yml) workflow. This workflow will build and tag all images:
-    - `latest`: Only when the workflow was triggered on the default branch, the `latest` tag will be created.
-    - `short-sha`: The short SHA of the commit that triggered the release workflow will be tagged e.g `sha-d7f7524`.
-    - `git-tag`: The git tag that was updated by Lerna in the `package.json` will be tagged e.g. `0.4.2`
-    - `buildcache`: This tag will be used by the Docker GitHub Action to cache the build step. This tag will be overwritten on every release.
+   - `latest`: Only when the workflow was triggered on the default branch, the `latest` tag will be created.
+   - `short-sha`: The short SHA of the commit that triggered the release workflow will be tagged e.g `sha-d7f7524`.
+   - `git-tag`: The git tag that was updated by Lerna in the `package.json` will be tagged e.g. `0.4.2`
+   - `buildcache`: This tag will be used by the Docker GitHub Action to cache the build step. This tag will be overwritten on every release.
 2. After the release, you can validate the release by:
-    1. checking the [GitHub Cosmo Packages](https://github.com/orgs/wundergraph/packages?repo_name=cosmo)
-    2. checking the [GitHub Cosmo Releases](https://github.com/wundergraph/cosmo/releases)
+   1. checking the [GitHub Cosmo Packages](https://github.com/orgs/wundergraph/packages?repo_name=cosmo)
+   2. checking the [GitHub Cosmo Releases](https://github.com/wundergraph/cosmo/releases)
+
+### If a release fails halfway
+
+Versioning and publishing to npm are separate steps. The version step bumps versions, creates the tags and GitHub releases, and (through the `postversion` hooks) kicks off the image builds; the publish step pushes the npm packages.
+
+If the publish step fails — sigstore's transparency log occasionally rejects a provenance write, which aborts the publish for every remaining package — just trigger the workflow again. The version step finds nothing new to version and no-ops, and the publish step publishes only the versions still missing from the registry. It also retries three times on its own before failing the run.
 
 ## Release Automation
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "format": "pnpm run -r --parallel format",
     "clean": "rm -rf node_modules **/node_modules dist **/dist gen **/gen .next **/.next tsconfig.tsbuildinfo **/tsconfig.tsbuildinfo .eslintcache **/.eslintcache",
     "release-preview": "lerna publish --ignore-scripts --dry-run",
-    "release": "lerna publish -y",
+    "release:version": "lerna version --yes",
+    "release:publish": "lerna publish from-package --yes",
     "wgc": "DO_NOT_TRACK=1 pnpm -r run --filter './cli' wgc"
   },
   "files": [


### PR DESCRIPTION
Today's release ([run 32997975167](https://github.com/wundergraph/cosmo/actions/runs/32997975167)) published 1 of 5 npm packages. `@wundergraph/playground`'s provenance write landed in sigstore's transparency log, the same signed envelope was then replayed against Rekor, and Rekor — which deduplicates on the entry body — returned a 409 pointing at the entry playground itself had just created. `sigstore@4.1.1` hardcodes `fetchOnConflict: false`, so it threw instead of refetching the existing entry.

One package's failure then took out three more. `runTopologically` rejects on the first failure (`.catch(reject)`, no bail option plumbed through), and the rejection escapes as an unhandled rejection, so Node killed the process — aborting `cosmo-shared` and `protographic` mid-publish and leaving `wgc` never queued. Tags, GitHub releases, image builds and the deploy dispatch had all completed by then, so the release is half out: `wgc@0.130.1`, `@wundergraph/cosmo-shared@0.49.9`, `@wundergraph/playground@0.13.7` and `@wundergraph/protographic@0.24.10` are tagged and released but absent from npm.

The worse part is that there was no way to finish it. `pnpm release` was `lerna publish`, which versions first, so a second run finds the tags it just created, reports no changed packages and publishes nothing.

## What changes

Versioning and publishing become separate steps:

- `release:version` (`lerna version --yes`) — bumps, tags, pushes, creates the GitHub releases, and runs the `postversion` hooks that dispatch the image builds. Keeps the app token and lifecycle scripts, so image releases are unaffected.
- `release:publish` (`lerna publish from-package --yes`) — publishes to npm, retried 3× with a 20s gap.

`from-package` derives its set from the registry (`detectFromPackage` → `getUnpublishedPackages`) and lerna already treats an already-published version as a warning (`is-npm-js-publish-version-conflict.js`), so every attempt narrows the set and repeating is safe. A re-dispatch of the workflow now no-ops the version step — `version-command.js:202` returns `false` from `initialize()`, and `runCommand()` skips `execute()` and exits 0 — and the publish step publishes whatever is still missing. Re-running the workflow becomes the recovery path.

Applied to today's failure: attempt 1 publishes connect and dies on playground; attempt 2 sees four missing versions and publishes them with fresh signing certs.

The `release` script is removed rather than kept alongside — it is the combined command that cannot be re-run, and `release.yaml` was its only caller.

## Verified

- YAML parses, step order intact, both new steps carry the app token; `bash -n` clean on the publish step.
- Retry loop tested by extracting the real step body and stubbing the publish command: succeeds-first-try → 1 attempt / exit 0; fails-twice → 3 attempts / exit 0; always-fails → 3 attempts / exit 1; no trailing sleep.

## Notes

- The dry-run → build → `git reset --hard` dance is left alone. Building after the real version bump would remove the need for it, but `from-package` calls `verifyWorkingTreeClean` and I could not confirm the build leaves no tracked file dirty. Worth a follow-up.
- Prettier reindented eight pre-existing list lines in `docs/releasing.md`; that file was not prettier-clean before, and lint-staged reformats it on any commit that touches it.
- Merging this gives a recovery path for the four packages still missing from npm: a dispatch after merge no-ops the version step and publishes exactly those.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Release Process**
  - Separated versioning, tagging, GitHub Release creation, and npm publishing into distinct steps.
  - Added up to three automatic npm publishing retries with delays and working-tree cleanup after failures.
  - Improved handling and recovery guidance for partially completed releases.

- **Documentation**
  - Expanded release guidance with Docker image tag details.
  - Added post-release validation steps, workflow rerun instructions, and warnings about unrecoverable unpublished versions after later version bumps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->