### PR TITLE
[POC] feat(router): serve MCP resources and skills for user-provided context

### DIFF
--- a/docs-website/router/configuration.mdx
+++ b/docs-website/router/configuration.mdx
@@ -341,6 +341,7 @@ The Model Context Protocol (MCP) server allows AI models to discover and interac
 | MCP_ENABLE_ARBITRARY_OPERATIONS | mcp.enable_arbitrary_operations | <Icon icon="square" /> | Whether to allow arbitrary GraphQL operations to be executed. <Warning>   Security risk: Should only be enabled in secure, internal environments. </Warning> | false          |
 | MCP_EXPOSE_SCHEMA               | mcp.expose_schema               | <Icon icon="square" /> | Whether to expose the full GraphQL schema. <Warning>   Security risk: Should only be enabled in secure, internal environments. </Warning>                    | false          |
 | MCP_OMIT_TOOL_NAME_PREFIX       | mcp.omit_tool_name_prefix       | <Icon icon="square" /> | When enabled, MCP tool names generated from GraphQL operations omit the `execute_operation_` prefix.                                                         | false          |
+| MCP_RESOURCES_ENABLED           | mcp.resources.enabled           | <Icon icon="square" /> | Serves markdown context documents and Agent Skills from the operations directory as MCP resources. See [Context Documents and Skills](/router/mcp#context-documents-and-skills). | false          |
 
 Example YAML config:
 

--- a/docs-website/router/mcp.mdx
+++ b/docs-website/router/mcp.mdx
@@ -181,6 +181,86 @@ The MCP server exposes two kinds of tools to AI models:
 
 See the [Tools](/router/mcp/tools) page for the built-in tool reference and how to create your own.
 
+## Context Documents and Skills
+
+The MCP server can also serve markdown documentation and Agent Skills alongside your operation tools. Use this to give AI models domain knowledge, or to teach them how to combine several of your tools into one workflow.
+
+Enable the feature with `mcp.resources.enabled: true` (env `MCP_RESOURCES_ENABLED`). It is off by default. See [Configuration](/router/mcp/configuration#context-resources) for the full option reference.
+
+### Context Documents
+
+Place a `.md` or `.markdown` file anywhere in your operations directory. Each loose file becomes an MCP resource at `context:///<path-relative-to-operations-dir>`. Add optional `title` and `description` frontmatter to set the resource metadata:
+
+```markdown
+---
+title: 'Refund Policy'
+description: 'How to process customer refunds.'
+---
+
+Refunds over $500 require manager approval.
+```
+
+If the frontmatter is malformed, the router logs a warning and still serves the document, without metadata.
+
+### Skills
+
+A directory that contains a `SKILL.md` file is an Agent Skill, defined by the [Agent Skills specification](https://agentskills.io/specification). Skills are the recommended way to teach an AI model how to use several of your tools together for one workflow.
+
+`SKILL.md` requires two frontmatter fields:
+
+- `name`: must match the directory name.
+- `description`: a short summary of the skill.
+
+```markdown
+---
+name: trip-planning
+description: Plan a multi-day trip using the weather and calendar tools.
+---
+
+1. Call `get_alerts` for the destination.
+2. Call `get_forecast` for the travel dates.
+3. Check the calendar for conflicts before booking.
+```
+
+An invalid skill (missing or mismatched frontmatter) is logged as an error, and none of its files are served.
+
+Every file inside a valid skill directory is served under `skill://<skill-path>/<file-path>`, where `<skill-path>` is the directory's path relative to the operations root. A skill at the operations root has no prefix. `.graphql` files inside a skill directory are never registered as tools; use them as examples for the skill instead.
+
+### Example Directory
+
+```
+operations/
+├── GetForecast.graphql          # tool (unchanged)
+├── notes.md                     # resource: context:///notes.md
+└── weather/
+    ├── GetAlerts.graphql        # tool (unchanged)
+    ├── usage.md                 # resource: context:///weather/usage.md
+    └── trip-planning/           # skill "trip-planning"
+        ├── SKILL.md             # resource: skill://weather/trip-planning/SKILL.md
+        └── examples.md          # resource: skill://weather/trip-planning/examples.md
+```
+
+### Discovery
+
+MCP resources are application-driven: a client is not required to call `resources/list` or read `SKILL.md` on its own. Two mechanisms help AI models find your context documents and skills instead:
+
+- **Server instructions.** When `mcp.resources.enabled` is `true`, the router appends a fixed paragraph to your server instructions that points AI models at the `get_context` tool. Add your own guidance with [`mcp.server.discover.instructions`](/router/mcp/configuration#server-discovery).
+- **The `get_context` tool.** Call it without arguments to list available skills and documents, or with a `uri` to read one of them. See [Get Context Tool](/router/mcp/tools#get-context-tool) for the full reference.
+
+### Limits
+
+- A skill directory allows at most 512 files, including `SKILL.md`, and 16 MiB of total content. A skill that exceeds either limit is skipped, with an error logged.
+- A single served file allows at most 16 MiB. A loose document larger than this is skipped, with a warning logged.
+- The router serves only regular files. It skips symbolic links and special files.
+
+### Hot Reload
+
+Context documents and skills reload together with your operations directory. Reads always return the current file content from disk.
+
+<Warning>
+  Resources and skills are operator-supplied content. The router serves them verbatim and never executes skill files, including anything under a `scripts/` directory. Client applications remain responsible for deciding whether instructions or executable content from a skill are safe to run.
+</Warning>
+
 <Card title="Next: Quickstart" icon="arrow-right" href="/router/mcp/quickstart">
   Ready to get started? Follow the quickstart guide to have MCP running in 5 minutes.
 </Card>

--- a/docs-website/router/mcp.mdx
+++ b/docs-website/router/mcp.mdx
@@ -258,7 +258,7 @@ MCP resources are application-driven: a client is not required to call `resource
 Context documents and skills reload together with your operations directory. Reads always return the current file content from disk.
 
 <Warning>
-  Resources and skills are operator-supplied content. The router serves them verbatim and never executes skill files, including anything under a `scripts/` directory. Client applications remain responsible for deciding whether instructions or executable content from a skill are safe to run.
+  Resources and skills are operator-supplied content. The router serves them verbatim and never executes skill files, including anything under a `scripts/` directory. Client applications remain responsible for deciding whether instructions or executable content from a skill is safe to run.
 </Warning>
 
 <Card title="Next: Quickstart" icon="arrow-right" href="/router/mcp/quickstart">

--- a/docs-website/router/mcp/configuration.mdx
+++ b/docs-website/router/mcp/configuration.mdx
@@ -44,6 +44,7 @@ storage_providers:
 | `expose_schema`               | Enables the `get_schema` built-in tool, exposing the full GraphQL schema to MCP clients.                                                                                                                                                                                     | `false`          |
 | `omit_tool_name_prefix`       | When enabled, MCP tool names omit the `execute_operation_` prefix. For example, `GetUser` becomes `get_user` instead of `execute_operation_get_user`. See [Tools - Omitting the Tool Name Prefix](/router/mcp/tools#omitting-the-tool-name-prefix).                | `false`          |
 | `output_schema.enabled`       | When enabled, operation tools declare an output schema derived from their selection set, and successful tool results additionally carry the response as structured content. A tool whose schema cannot be derived stays registered without an output schema. Increases `tools/list` and result payload sizes. See [Tools - Structured Tool Output](/router/mcp/tools#structured-tool-output). | `false`          |
+| `resources.enabled`           | Serves markdown context documents and Agent Skills from the operations directory as MCP resources, alongside the operation tools. Also registers the `get_context` tool. See [Context Documents and Skills](/router/mcp#context-documents-and-skills).                                                                                                                                    | `false`          |
 
 For OAuth-specific configuration, see [OAuth 2.1 Authorization](/router/mcp/oauth/overview).
 
@@ -69,6 +70,7 @@ All MCP options can also be set via environment variables:
 | `MCP_EXPOSE_SCHEMA`               | `mcp.expose_schema`               |
 | `MCP_OMIT_TOOL_NAME_PREFIX`       | `mcp.omit_tool_name_prefix`       |
 | `MCP_OUTPUT_SCHEMA_ENABLED`       | `mcp.output_schema.enabled`       |
+| `MCP_RESOURCES_ENABLED`           | `mcp.resources.enabled`           |
 
 For OAuth-related environment variables, see [OAuth Configuration Reference](/router/mcp/oauth/configuration#environment-variables).
 
@@ -113,6 +115,23 @@ The server sends the instructions to every MCP client. This covers clients that 
 
 The router advertises protocol version `2026-07-28` by default. In session-based mode (`session.stateless: false`), clients negotiate `2025-11-25` or older.
 
+## Context Resources
+
+Set `resources.enabled: true` to serve markdown context documents and Agent Skills from your operations directory as MCP resources:
+
+```yaml
+mcp:
+  enabled: true
+  resources:
+    enabled: true
+  storage:
+    provider_id: 'mcp'
+```
+
+This flag is off by default. Some operations directories contain stray `.md` files. These files must not become visible to MCP clients without an explicit opt-in.
+
+See [Context Documents and Skills](/router/mcp#context-documents-and-skills) for the full feature reference, including the on-disk format, the `get_context` tool, and file size limits.
+
 ## Session Handling
 
 The MCP server uses the Streamable HTTP transport and maintains per-session state via the `Mcp-Session-Id` header. When deploying multiple Router instances, you need **sticky sessions** to ensure all requests for a session reach the same instance.
@@ -143,6 +162,8 @@ mcp:
   expose_schema: false
   omit_tool_name_prefix: false
   output_schema:
+    enabled: false
+  resources:
     enabled: false
   storage:
     provider_id: 'mcp'

--- a/docs-website/router/mcp/tools.mdx
+++ b/docs-website/router/mcp/tools.mdx
@@ -16,6 +16,7 @@ The MCP server gives AI models a set of tools they can discover and execute. It 
 | `get_operation_info` | Returns instructions for executing the operation behind one of your tools directly via HTTP and integrating it into an application. |
 | `get_schema`         | Returns the full GraphQL schema of the API, helping AI models understand the entire API structure.                                  |
 | `execute_graphql`    | Executes an arbitrary GraphQL query or mutation, letting AI models craft operations beyond the tools you have created.              |
+| `get_context`        | Discovers and reads context documents and skills. Only registered when `resources.enabled` is `true`. See [Get Context Tool](#get-context-tool). |
 
 <Warning>
   `get_schema` and `execute_graphql` are disabled by default because they expose your full API surface to AI models.
@@ -423,6 +424,34 @@ When `output_schema.enabled` is `true`, the result also carries the response as 
   }
 }
 ```
+
+## Get Context Tool
+
+`get_context` discovers and reads context documents and skills. The router registers it only when [`resources.enabled`](/router/mcp/configuration#context-resources) is `true`. See [Context Documents and Skills](/router/mcp#context-documents-and-skills) for the on-disk format.
+
+The tool takes one optional input:
+
+```json
+{ "uri": "skill://weather/trip-planning/SKILL.md" }
+```
+
+**Without a `uri`**, the tool returns an index of every available skill and document, as both text and structured content:
+
+```json
+{
+  "skills": [{ "name": "trip-planning", "description": "Plan a multi-day trip.", "uri": "skill://weather/trip-planning/SKILL.md" }],
+  "documents": [{ "uri": "context:///notes.md", "title": "Notes", "description": "Internal notes." }]
+}
+```
+
+**With a `uri`**, the tool returns the raw content of that resource. Blob resources (for example, images) are not returned this way; the tool returns an error that points the client at `resources/read` instead.
+
+An unknown `uri` returns a tool error naming the failed URI and pointing back at the index.
+
+<Tip>
+  A skill file that references another file by relative path, for example `references/REFERENCE.md`, resolves that
+  path against the skill root. In skill `foo`, this resolves to `skill://foo/references/REFERENCE.md`.
+</Tip>
 
 ## Best Practices
 

--- a/router-tests/protocol/mcp_resources_test.go
+++ b/router-tests/protocol/mcp_resources_test.go
@@ -1,0 +1,149 @@
+package integration
+
+import (
+	"encoding/json"
+	"testing"
+
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wundergraph/cosmo/router-tests/testenv"
+	"github.com/wundergraph/cosmo/router/pkg/config"
+	"github.com/wundergraph/cosmo/router/pkg/mcpserver"
+)
+
+// connectSDKClient connects an official go-sdk MCP client to the test router.
+func connectSDKClient(t *testing.T, xEnv *testenv.Environment) *sdkmcp.ClientSession {
+	t.Helper()
+	client := sdkmcp.NewClient(&sdkmcp.Implementation{Name: "resources-test", Version: "1.0.0"}, nil)
+	session, err := client.Connect(xEnv.Context, &sdkmcp.StreamableClientTransport{
+		Endpoint: xEnv.GetMCPServerAddr(),
+	}, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = session.Close() })
+	return session
+}
+
+func TestMCPResources(t *testing.T) {
+	t.Run("resources are listed and readable", func(t *testing.T) {
+		testenv.Run(t, &testenv.Config{
+			MCPOperationsPath: "testdata/mcp_resources",
+			MCP: config.MCPConfiguration{
+				Enabled:   true,
+				Resources: config.MCPResourcesConfiguration{Enabled: true},
+			},
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			session := connectSDKClient(t, xEnv)
+
+			// Discovery instructions are appended when resources are enabled.
+			assert.Contains(t, session.InitializeResult().Instructions, "get_context")
+
+			listed, err := session.ListResources(xEnv.Context, &sdkmcp.ListResourcesParams{})
+			require.NoError(t, err)
+
+			uris := make([]string, 0, len(listed.Resources))
+			for _, r := range listed.Resources {
+				uris = append(uris, r.URI)
+			}
+			assert.ElementsMatch(t, []string{
+				"context:///usage.md",
+				"skill://trip-planning/SKILL.md",
+				"skill://trip-planning/examples.md",
+				// The skill directory serves every regular file under it as
+				// a resource, including the .graphql fixture that proves
+				// skill-internal operations are excluded from tool
+				// registration (see the "skill graphql files are not
+				// registered as tools" subtest below).
+				"skill://trip-planning/Example.graphql",
+			}, uris)
+
+			read, err := session.ReadResource(xEnv.Context, &sdkmcp.ReadResourceParams{
+				URI: "skill://trip-planning/SKILL.md",
+			})
+			require.NoError(t, err)
+			require.Len(t, read.Contents, 1)
+			assert.Equal(t, "text/markdown", read.Contents[0].MIMEType)
+			assert.Contains(t, read.Contents[0].Text, "name: trip-planning")
+			assert.Contains(t, read.Contents[0].Text, "# Trip planning")
+		})
+	})
+
+	t.Run("skill graphql files are not registered as tools", func(t *testing.T) {
+		testenv.Run(t, &testenv.Config{
+			MCPOperationsPath: "testdata/mcp_resources",
+			MCP: config.MCPConfiguration{
+				Enabled:   true,
+				Resources: config.MCPResourcesConfiguration{Enabled: true},
+			},
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			session := connectSDKClient(t, xEnv)
+
+			tools, err := session.ListTools(xEnv.Context, &sdkmcp.ListToolsParams{})
+			require.NoError(t, err)
+
+			names := make([]string, 0, len(tools.Tools))
+			for _, tool := range tools.Tools {
+				names = append(names, tool.Name)
+			}
+			assert.Contains(t, names, "execute_operation_my_employees")
+			assert.Contains(t, names, "get_context")
+			assert.NotContains(t, names, "execute_operation_skill_example")
+		})
+	})
+
+	t.Run("get_context returns index and content", func(t *testing.T) {
+		testenv.Run(t, &testenv.Config{
+			MCPOperationsPath: "testdata/mcp_resources",
+			MCP: config.MCPConfiguration{
+				Enabled:   true,
+				Resources: config.MCPResourcesConfiguration{Enabled: true},
+			},
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			session := connectSDKClient(t, xEnv)
+
+			indexResult, err := session.CallTool(xEnv.Context, &sdkmcp.CallToolParams{
+				Name:      "get_context",
+				Arguments: map[string]any{},
+			})
+			require.NoError(t, err)
+			require.False(t, indexResult.IsError)
+
+			var index mcpserver.ContextIndex
+			text := indexResult.Content[0].(*sdkmcp.TextContent).Text
+			require.NoError(t, json.Unmarshal([]byte(text), &index))
+			require.Len(t, index.Skills, 1)
+			assert.Equal(t, "trip-planning", index.Skills[0].Name)
+			require.Len(t, index.Documents, 1)
+			assert.Equal(t, "context:///usage.md", index.Documents[0].URI)
+
+			docResult, err := session.CallTool(xEnv.Context, &sdkmcp.CallToolParams{
+				Name:      "get_context",
+				Arguments: map[string]any{"uri": "context:///usage.md"},
+			})
+			require.NoError(t, err)
+			require.False(t, docResult.IsError)
+			assert.Contains(t, docResult.Content[0].(*sdkmcp.TextContent).Text, "# API Usage")
+		})
+	})
+
+	t.Run("disabled by default", func(t *testing.T) {
+		testenv.Run(t, &testenv.Config{
+			MCPOperationsPath: "testdata/mcp_resources",
+			MCP: config.MCPConfiguration{
+				Enabled: true,
+			},
+		}, func(t *testing.T, xEnv *testenv.Environment) {
+			session := connectSDKClient(t, xEnv)
+
+			tools, err := session.ListTools(xEnv.Context, &sdkmcp.ListToolsParams{})
+			require.NoError(t, err)
+			for _, tool := range tools.Tools {
+				assert.NotEqual(t, "get_context", tool.Name)
+			}
+
+			// The initialize result must not advertise the resources capability.
+			caps := session.InitializeResult().Capabilities
+			assert.Nil(t, caps.Resources)
+		})
+	})
+}

--- a/router-tests/protocol/testdata/mcp_resources/MyQuery.graphql
+++ b/router-tests/protocol/testdata/mcp_resources/MyQuery.graphql
@@ -1,0 +1,12 @@
+query MyEmployees($criteria: SearchInput) {
+    findEmployees(criteria: $criteria) {
+        id
+        isAvailable
+        currentMood
+        products
+        details {
+            forename
+            nationality
+        }
+    }
+}

--- a/router-tests/protocol/testdata/mcp_resources/trip-planning/Example.graphql
+++ b/router-tests/protocol/testdata/mcp_resources/trip-planning/Example.graphql
@@ -1,0 +1,1 @@
+query SkillExample { employees { id } }

--- a/router-tests/protocol/testdata/mcp_resources/trip-planning/SKILL.md
+++ b/router-tests/protocol/testdata/mcp_resources/trip-planning/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: trip-planning
+description: Shows how to combine the employee tools for trip planning.
+---
+# Trip planning
+
+1. Call execute_operation_my_employees.
+2. Use the result to plan.

--- a/router-tests/protocol/testdata/mcp_resources/trip-planning/examples.md
+++ b/router-tests/protocol/testdata/mcp_resources/trip-planning/examples.md
@@ -1,0 +1,3 @@
+# Examples
+
+Example workflows live here.

--- a/router-tests/protocol/testdata/mcp_resources/usage.md
+++ b/router-tests/protocol/testdata/mcp_resources/usage.md
@@ -1,0 +1,7 @@
+---
+title: API Usage
+description: How to call this API.
+---
+# API Usage
+
+Call MyEmployees to list employees.

--- a/router/core/router.go
+++ b/router/core/router.go
@@ -1321,6 +1321,7 @@ func (r *Router) startMCPServer(ctx context.Context) error {
 		mcpserver.WithExposeSchema(r.mcp.ExposeSchema),
 		mcpserver.WithOmitToolNamePrefix(r.mcp.OmitToolNamePrefix),
 		mcpserver.WithOutputSchemaEnabled(r.mcp.OutputSchema.Enabled),
+		mcpserver.WithResourcesEnabled(r.mcp.Resources.Enabled),
 		mcpserver.WithStateless(r.mcp.Session.Stateless),
 		mcpserver.WithInstructions(r.mcp.Server.Discover.Instructions),
 		mcpserver.WithServerVersion(cmp.Or(r.mcp.Server.Version, Version)),

--- a/router/pkg/config/config.go
+++ b/router/pkg/config/config.go
@@ -1398,10 +1398,11 @@ type CacheWarmupConfiguration struct {
 }
 
 type MCPConfiguration struct {
-	Enabled                   bool             `yaml:"enabled" envDefault:"false" env:"MCP_ENABLED"`
-	Server                    MCPServer        `yaml:"server,omitempty"`
-	Storage                   MCPStorageConfig `yaml:"storage,omitempty"`
-	Session                   MCPSessionConfig `yaml:"session,omitempty"`
+	Enabled                   bool                       `yaml:"enabled" envDefault:"false" env:"MCP_ENABLED"`
+	Server                    MCPServer                  `yaml:"server,omitempty"`
+	Storage                   MCPStorageConfig           `yaml:"storage,omitempty"`
+	Resources                 MCPResourcesConfiguration  `yaml:"resources,omitempty"`
+	Session                   MCPSessionConfig           `yaml:"session,omitempty"`
 	GraphName                 string           `yaml:"graph_name" envDefault:"mygraph" env:"MCP_GRAPH_NAME"`
 	ExcludeMutations          bool             `yaml:"exclude_mutations" envDefault:"false" env:"MCP_EXCLUDE_MUTATIONS"`
 	EnableArbitraryOperations bool             `yaml:"enable_arbitrary_operations" envDefault:"false" env:"MCP_ENABLE_ARBITRARY_OPERATIONS"`
@@ -1495,6 +1496,14 @@ type MCPSessionConfig struct {
 
 type MCPStorageConfig struct {
 	ProviderID string `yaml:"provider_id,omitempty" env:"MCP_STORAGE_PROVIDER_ID"`
+}
+
+// MCPResourcesConfiguration configures serving of user-provided context
+// documents and Agent Skills from the MCP operations directory as MCP
+// resources. Disabled by default so stray markdown files in existing
+// operations directories are not silently exposed to MCP clients.
+type MCPResourcesConfiguration struct {
+	Enabled bool `yaml:"enabled" envDefault:"false" env:"MCP_RESOURCES_ENABLED"`
 }
 
 type MCPServer struct {

--- a/router/pkg/config/config.go
+++ b/router/pkg/config/config.go
@@ -1398,16 +1398,16 @@ type CacheWarmupConfiguration struct {
 }
 
 type MCPConfiguration struct {
-	Enabled                   bool                       `yaml:"enabled" envDefault:"false" env:"MCP_ENABLED"`
-	Server                    MCPServer                  `yaml:"server,omitempty"`
-	Storage                   MCPStorageConfig           `yaml:"storage,omitempty"`
-	Resources                 MCPResourcesConfiguration  `yaml:"resources,omitempty"`
-	Session                   MCPSessionConfig           `yaml:"session,omitempty"`
-	GraphName                 string           `yaml:"graph_name" envDefault:"mygraph" env:"MCP_GRAPH_NAME"`
-	ExcludeMutations          bool             `yaml:"exclude_mutations" envDefault:"false" env:"MCP_EXCLUDE_MUTATIONS"`
-	EnableArbitraryOperations bool             `yaml:"enable_arbitrary_operations" envDefault:"false" env:"MCP_ENABLE_ARBITRARY_OPERATIONS"`
-	ExposeSchema              bool             `yaml:"expose_schema" envDefault:"false" env:"MCP_EXPOSE_SCHEMA"`
-	RouterURL                 string           `yaml:"router_url,omitempty" env:"MCP_ROUTER_URL"`
+	Enabled                   bool                      `yaml:"enabled" envDefault:"false" env:"MCP_ENABLED"`
+	Server                    MCPServer                 `yaml:"server,omitempty"`
+	Storage                   MCPStorageConfig          `yaml:"storage,omitempty"`
+	Resources                 MCPResourcesConfiguration `yaml:"resources,omitempty"`
+	Session                   MCPSessionConfig          `yaml:"session,omitempty"`
+	GraphName                 string                    `yaml:"graph_name" envDefault:"mygraph" env:"MCP_GRAPH_NAME"`
+	ExcludeMutations          bool                      `yaml:"exclude_mutations" envDefault:"false" env:"MCP_EXCLUDE_MUTATIONS"`
+	EnableArbitraryOperations bool                      `yaml:"enable_arbitrary_operations" envDefault:"false" env:"MCP_ENABLE_ARBITRARY_OPERATIONS"`
+	ExposeSchema              bool                      `yaml:"expose_schema" envDefault:"false" env:"MCP_EXPOSE_SCHEMA"`
+	RouterURL                 string                    `yaml:"router_url,omitempty" env:"MCP_ROUTER_URL"`
 	// OmitToolNamePrefix removes the "execute_operation_" prefix from MCP tool names.
 	// When enabled, GetUser becomes get_user. When disabled (default), GetUser becomes execute_operation_get_user.
 	OmitToolNamePrefix bool                  `yaml:"omit_tool_name_prefix" envDefault:"false" env:"MCP_OMIT_TOOL_NAME_PREFIX"`

--- a/router/pkg/config/config.schema.json
+++ b/router/pkg/config/config.schema.json
@@ -2719,6 +2719,18 @@
           },
           "required": ["provider_id"]
         },
+        "resources": {
+          "type": "object",
+          "description": "Configuration for serving user-provided context documents and Agent Skills as MCP resources. Markdown files in the MCP operations directory are served via resources/list and resources/read. Directories containing a SKILL.md file (Agent Skills format, see https://agentskills.io/specification) are served as skills under skill:// URIs.",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false,
+              "description": "Enable serving context documents and skills as MCP resources. When enabled, a get_context tool is also registered so agents without MCP resource support can read the same content."
+            }
+          }
+        },
         "session": {
           "type": "object",
           "description": "Session configuration for the MCP server. This controls how the MCP server handles client sessions.",

--- a/router/pkg/config/fixtures/full.yaml
+++ b/router/pkg/config/fixtures/full.yaml
@@ -118,6 +118,8 @@ mcp:
       instructions: 'Use the operation tools to interact with the graph.'
   storage:
     provider_id: mcp
+  resources:
+    enabled: true
   output_schema:
     enabled: true
 

--- a/router/pkg/config/testdata/config_defaults.json
+++ b/router/pkg/config/testdata/config_defaults.json
@@ -202,6 +202,9 @@
     "Storage": {
       "ProviderID": ""
     },
+    "Resources": {
+      "Enabled": false
+    },
     "Session": {
       "Stateless": true
     },

--- a/router/pkg/config/testdata/config_full.json
+++ b/router/pkg/config/testdata/config_full.json
@@ -271,6 +271,9 @@
     "Storage": {
       "ProviderID": "mcp"
     },
+    "Resources": {
+      "Enabled": true
+    },
     "Session": {
       "Stateless": true
     },

--- a/router/pkg/mcpserver/context_resources.go
+++ b/router/pkg/mcpserver/context_resources.go
@@ -3,10 +3,18 @@ package mcpserver
 import (
 	"bytes"
 	"fmt"
+	"io/fs"
+	"mime"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
 	"regexp"
+	"strings"
 	"unicode/utf8"
 
 	"github.com/goccy/go-yaml"
+	"go.uber.org/zap"
 )
 
 // skillNameRegex enforces the Agent Skills spec name constraints:
@@ -86,4 +94,265 @@ func validateSkillMetadata(dirName string, fm contextFrontmatter, hasFrontmatter
 		return fmt.Errorf("skill description exceeds %d characters", maxSkillDescriptionLength)
 	}
 	return nil
+}
+
+// contextResource is one file served over MCP resources. skillName is empty
+// for loose context documents.
+type contextResource struct {
+	uri         string
+	name        string
+	title       string
+	description string
+	mimeType    string
+	filePath    string
+	skillName   string
+}
+
+// contextSkill is one valid Agent Skills directory found in the scan.
+type contextSkill struct {
+	name        string
+	description string
+	uri         string
+}
+
+// contextScan is the result of scanning the operations directory for context
+// documents and skills. Client-supplied URIs are only ever looked up as map
+// keys into byURI; the handler reads the filePath recorded at scan time, so
+// path traversal is impossible by construction.
+type contextScan struct {
+	skills    []contextSkill
+	resources []contextResource
+	byURI     map[string]contextResource
+}
+
+func newEmptyContextScan() *contextScan {
+	return &contextScan{byURI: map[string]contextResource{}}
+}
+
+func (c *contextScan) add(r contextResource) {
+	c.resources = append(c.resources, r)
+	c.byURI[r.uri] = r
+}
+
+// contextMIMEType maps a file path to the MIME type served in resource
+// metadata and contents.
+func contextMIMEType(p string) string {
+	switch strings.ToLower(filepath.Ext(p)) {
+	case ".md", ".markdown":
+		return "text/markdown"
+	case ".txt":
+		return "text/plain"
+	case ".json":
+		return "application/json"
+	case ".yaml", ".yml":
+		return "application/yaml"
+	default:
+		if t := mime.TypeByExtension(filepath.Ext(p)); t != "" {
+			return t
+		}
+		return "application/octet-stream"
+	}
+}
+
+const skillFileName = "SKILL.md"
+
+// Size limits adopted from the SEP-2640 draft (512 resources per skill,
+// 16 MiB total skill content). maxServedFileBytes also bounds per-request
+// memory: resources/read loads the whole file.
+const (
+	maxSkillFiles      = 512
+	maxSkillTotalBytes = int64(16 << 20)
+	maxServedFileBytes = int64(16 << 20)
+)
+
+// contextDocumentURI builds context:///<encoded-path> for a loose document.
+// The empty authority (triple slash) keeps the URI RFC 3986 compliant:
+// context://weather/usage.md would make "weather" a host.
+func contextDocumentURI(relSlashPath string) string {
+	u := url.URL{Scheme: "context", Path: "/" + relSlashPath}
+	return u.String()
+}
+
+// skillFileURI builds skill://<skill-path>/<encoded-file-path> (SEP-2640
+// shape). skillPath is the skill directory's slash-separated path relative
+// to the operations root: the final segment is the skill name, preceding
+// segments are an organizational prefix, and the first segment occupies the
+// URI authority position with no special semantics. Each segment is
+// percent-encoded so the authority stays a valid RFC 3986 reg-name.
+func skillFileURI(skillPath, relSlashPath string) string {
+	encode := func(p string) string {
+		segs := strings.Split(p, "/")
+		for i, s := range segs {
+			segs[i] = url.PathEscape(s)
+		}
+		return strings.Join(segs, "/")
+	}
+	return "skill://" + encode(skillPath) + "/" + encode(relSlashPath)
+}
+
+// scanContextResources walks dir in lexical order and collects loose markdown
+// documents and Agent Skills directories to serve as MCP resources. Invalid
+// skills are logged and skipped in full; the scan continues. Only regular
+// files are served; symlinks and special files are ignored.
+func scanContextResources(dir string, logger *zap.Logger) (*contextScan, error) {
+	scan := newEmptyContextScan()
+
+	err := filepath.WalkDir(dir, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			// The operations root is the server's namespace, never a skill;
+			// a stray root SKILL.md is served as a loose document.
+			if p == dir {
+				return nil
+			}
+			if _, statErr := os.Stat(filepath.Join(p, skillFileName)); statErr != nil {
+				return nil // not a skill directory, keep walking
+			}
+			collectSkillDirectory(scan, dir, p, logger)
+			return fs.SkipDir // the skill subtree was fully handled above
+		}
+
+		if !d.Type().IsRegular() {
+			logger.Debug("Skipping irregular file in MCP context scan", zap.String("file", p))
+			return nil
+		}
+
+		// Loose files: only markdown becomes a context document.
+		if ext := strings.ToLower(filepath.Ext(p)); ext != ".md" && ext != ".markdown" {
+			return nil
+		}
+		info, infoErr := d.Info()
+		if infoErr != nil {
+			return infoErr
+		}
+		if info.Size() > maxServedFileBytes {
+			logger.Warn("Skipping oversized context file",
+				zap.String("file", p), zap.Int64("size", info.Size()))
+			return nil
+		}
+
+		rel, relErr := filepath.Rel(dir, p)
+		if relErr != nil {
+			return relErr
+		}
+		relSlash := filepath.ToSlash(rel)
+		res := contextResource{
+			uri:      contextDocumentURI(relSlash),
+			name:     relSlash,
+			mimeType: contextMIMEType(p),
+			filePath: p,
+		}
+		if content, readErr := os.ReadFile(p); readErr == nil {
+			fm, found, fmErr := parseContextFrontmatter(content)
+			switch {
+			case fmErr != nil:
+				logger.Warn("Malformed frontmatter in context document",
+					zap.String("file", p), zap.Error(fmErr))
+			case found:
+				res.title = fm.Title
+				res.description = fm.Description
+			}
+		}
+		scan.add(res)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return scan, nil
+}
+
+// collectSkillDirectory validates the skill rooted at root and, when valid,
+// adds the skill and every regular file inside it to scan. Any violation
+// (bad frontmatter, size limits) invalidates the whole skill: none of its
+// files are served. The skill-path is root's path relative to scanDir
+// (SEP-2640 organizational prefix + name), so same-named skills at
+// different paths never collide.
+func collectSkillDirectory(scan *contextScan, scanDir, root string, logger *zap.Logger) {
+	content, err := os.ReadFile(filepath.Join(root, skillFileName))
+	if err != nil {
+		logger.Error("Skipping invalid MCP skill directory", zap.String("dir", root), zap.Error(err))
+		return
+	}
+	fm, found, fmErr := parseContextFrontmatter(content)
+	if vErr := validateSkillMetadata(filepath.Base(root), fm, found && fmErr == nil); vErr != nil {
+		logger.Error("Skipping invalid MCP skill directory", zap.String("dir", root), zap.Error(vErr))
+		return
+	}
+
+	relRoot, err := filepath.Rel(scanDir, root)
+	if err != nil {
+		logger.Error("Skipping invalid MCP skill directory", zap.String("dir", root), zap.Error(err))
+		return
+	}
+	skillPath := filepath.ToSlash(relRoot)
+
+	var (
+		files      []contextResource
+		totalBytes int64
+	)
+	walkErr := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if !d.Type().IsRegular() {
+			logger.Debug("Skipping irregular file in MCP skill", zap.String("file", p))
+			return nil
+		}
+		info, infoErr := d.Info()
+		if infoErr != nil {
+			return infoErr
+		}
+		totalBytes += info.Size()
+
+		rel, relErr := filepath.Rel(root, p)
+		if relErr != nil {
+			return relErr
+		}
+		relSlash := filepath.ToSlash(rel)
+		res := contextResource{
+			uri:       skillFileURI(skillPath, relSlash),
+			name:      fm.Name + "/" + relSlash,
+			mimeType:  contextMIMEType(p),
+			filePath:  p,
+			skillName: fm.Name,
+		}
+		if relSlash == skillFileName {
+			// The skill entry point carries the skill's identity.
+			res.name = fm.Name
+			res.description = fm.Description
+		} else if path.Base(relSlash) == skillFileName {
+			// SEP-2640 permits nested skills; from this skill's perspective a
+			// nested SKILL.md is ordinary supporting content.
+			logger.Debug("Nested SKILL.md served as supporting content of the enclosing skill",
+				zap.String("file", p), zap.String("skill", fm.Name))
+		}
+		files = append(files, res)
+		return nil
+	})
+	if walkErr != nil {
+		logger.Error("Skipping invalid MCP skill directory", zap.String("dir", root), zap.Error(walkErr))
+		return
+	}
+	if len(files) > maxSkillFiles || totalBytes > maxSkillTotalBytes {
+		logger.Error("Skipping MCP skill exceeding size limits",
+			zap.String("dir", root), zap.String("skill", fm.Name),
+			zap.Int("files", len(files)), zap.Int64("total_bytes", totalBytes))
+		return
+	}
+
+	scan.skills = append(scan.skills, contextSkill{
+		name:        fm.Name,
+		description: fm.Description,
+		uri:         skillFileURI(skillPath, skillFileName),
+	})
+	for _, res := range files {
+		scan.add(res)
+	}
 }

--- a/router/pkg/mcpserver/context_resources.go
+++ b/router/pkg/mcpserver/context_resources.go
@@ -1,0 +1,89 @@
+package mcpserver
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"unicode/utf8"
+
+	"github.com/goccy/go-yaml"
+)
+
+// skillNameRegex enforces the Agent Skills spec name constraints:
+// lowercase alphanumerics and single hyphens, no leading or trailing hyphen.
+// See https://agentskills.io/specification.
+var skillNameRegex = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
+
+const (
+	maxSkillNameLength        = 64
+	maxSkillDescriptionLength = 1024
+)
+
+// contextFrontmatter holds the YAML frontmatter fields used for MCP resource
+// metadata. Skills require Name and Description (Agent Skills spec); loose
+// context documents use Title and Description opportunistically.
+type contextFrontmatter struct {
+	Name        string `yaml:"name"`
+	Title       string `yaml:"title"`
+	Description string `yaml:"description"`
+}
+
+var (
+	frontmatterFence = []byte("---")
+	frontmatterLF    = []byte("\n---")
+)
+
+// parseContextFrontmatter extracts a leading YAML frontmatter block delimited
+// by "---" lines. found reports whether a complete block exists; err is
+// non-nil when a found block fails to parse. Callers treat absent and
+// malformed differently: a skill without valid frontmatter is invalid, a
+// loose document with malformed frontmatter is served without metadata.
+func parseContextFrontmatter(content []byte) (fm contextFrontmatter, found bool, err error) {
+	rest, ok := bytes.CutPrefix(content, frontmatterFence)
+	if !ok {
+		return fm, false, nil
+	}
+	// The opening fence must be its own line.
+	rest = bytes.TrimPrefix(rest, []byte("\r"))
+	rest, ok = bytes.CutPrefix(rest, []byte("\n"))
+	if !ok {
+		return fm, false, nil
+	}
+
+	end := bytes.Index(rest, frontmatterLF)
+	if end < 0 {
+		return fm, false, nil
+	}
+
+	if err := yaml.Unmarshal(rest[:end], &fm); err != nil {
+		return contextFrontmatter{}, true, err
+	}
+	return fm, true, nil
+}
+
+// validateSkillMetadata checks a skill's frontmatter against the Agent Skills
+// spec requirements. dirName is the basename of the skill directory.
+func validateSkillMetadata(dirName string, fm contextFrontmatter, hasFrontmatter bool) error {
+	if !hasFrontmatter {
+		return fmt.Errorf("SKILL.md has no frontmatter block")
+	}
+	if fm.Name == "" {
+		return fmt.Errorf("frontmatter field 'name' is required")
+	}
+	if utf8.RuneCountInString(fm.Name) > maxSkillNameLength {
+		return fmt.Errorf("skill name exceeds %d characters", maxSkillNameLength)
+	}
+	if !skillNameRegex.MatchString(fm.Name) {
+		return fmt.Errorf("skill name %q must be lowercase alphanumerics separated by single hyphens", fm.Name)
+	}
+	if fm.Name != dirName {
+		return fmt.Errorf("skill name %q must match the directory name %q", fm.Name, dirName)
+	}
+	if fm.Description == "" {
+		return fmt.Errorf("frontmatter field 'description' is required")
+	}
+	if utf8.RuneCountInString(fm.Description) > maxSkillDescriptionLength {
+		return fmt.Errorf("skill description exceeds %d characters", maxSkillDescriptionLength)
+	}
+	return nil
+}

--- a/router/pkg/mcpserver/context_resources.go
+++ b/router/pkg/mcpserver/context_resources.go
@@ -290,9 +290,24 @@ func collectSkillDirectory(scan *contextScan, scanDir, root string, logger *zap.
 	}
 	skillPath := filepath.ToSlash(relRoot)
 
+	// The first skill-path segment lands in the URI authority position, where
+	// net/url rejects percent-escapes and other characters that are otherwise
+	// valid path segments (for example a space in a prefix directory name).
+	// go-sdk's Server.AddResource panics on an unparsable URI, so an invalid
+	// skill must be rejected here rather than crashing the router at
+	// registration time. Only the authority segment can be invalid, so
+	// validating the entry URI covers every file URI of this skill.
+	entryURI := skillFileURI(skillPath, skillFileName)
+	if _, uriErr := url.Parse(entryURI); uriErr != nil {
+		logger.Error("Skipping MCP skill with invalid URI",
+			zap.String("dir", root), zap.String("uri", entryURI), zap.Error(uriErr))
+		return
+	}
+
 	var (
-		files      []contextResource
-		totalBytes int64
+		files            []contextResource
+		totalBytes       int64
+		skillMDCollected bool
 	)
 	walkErr := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -327,6 +342,7 @@ func collectSkillDirectory(scan *contextScan, scanDir, root string, logger *zap.
 			// The skill entry point carries the skill's identity.
 			res.name = fm.Name
 			res.description = fm.Description
+			skillMDCollected = true
 		} else if path.Base(relSlash) == skillFileName {
 			// SEP-2640 permits nested skills; from this skill's perspective a
 			// nested SKILL.md is ordinary supporting content.
@@ -346,11 +362,19 @@ func collectSkillDirectory(scan *contextScan, scanDir, root string, logger *zap.
 			zap.Int("files", len(files)), zap.Int64("total_bytes", totalBytes))
 		return
 	}
+	if !skillMDCollected {
+		// os.ReadFile above follows a symlinked SKILL.md during frontmatter
+		// validation, but the walk above only serves regular files, so a
+		// symlinked SKILL.md would otherwise advertise a skill URI with no
+		// backing resource.
+		logger.Error("Skipping MCP skill without a regular SKILL.md file", zap.String("dir", root))
+		return
+	}
 
 	scan.skills = append(scan.skills, contextSkill{
 		name:        fm.Name,
 		description: fm.Description,
-		uri:         skillFileURI(skillPath, skillFileName),
+		uri:         entryURI,
 	})
 	for _, res := range files {
 		scan.add(res)

--- a/router/pkg/mcpserver/context_resources_test.go
+++ b/router/pkg/mcpserver/context_resources_test.go
@@ -1,0 +1,85 @@
+package mcpserver
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseContextFrontmatter(t *testing.T) {
+	t.Run("parses name, title and description", func(t *testing.T) {
+		fm, found, err := parseContextFrontmatter([]byte("---\nname: trip-planning\ntitle: Trip Planning\ndescription: Plan trips.\n---\n# Body\n"))
+		require.True(t, found)
+		require.NoError(t, err)
+		assert.Equal(t, "trip-planning", fm.Name)
+		assert.Equal(t, "Trip Planning", fm.Title)
+		assert.Equal(t, "Plan trips.", fm.Description)
+	})
+
+	t.Run("no frontmatter block", func(t *testing.T) {
+		_, found, err := parseContextFrontmatter([]byte("# Just markdown\n"))
+		assert.False(t, found)
+		assert.NoError(t, err)
+	})
+
+	t.Run("unterminated frontmatter is treated as absent", func(t *testing.T) {
+		_, found, err := parseContextFrontmatter([]byte("---\nname: x\nno closing fence"))
+		assert.False(t, found)
+		assert.NoError(t, err)
+	})
+
+	t.Run("invalid yaml is found but errors", func(t *testing.T) {
+		_, found, err := parseContextFrontmatter([]byte("---\n:{not yaml\n---\nbody"))
+		assert.True(t, found)
+		assert.Error(t, err)
+	})
+
+	t.Run("crlf line endings", func(t *testing.T) {
+		fm, found, err := parseContextFrontmatter([]byte("---\r\nname: crlf-skill\r\ndescription: d\r\n---\r\nbody"))
+		require.True(t, found)
+		require.NoError(t, err)
+		assert.Equal(t, "crlf-skill", fm.Name)
+	})
+
+	t.Run("optional agent skills keys are accepted and ignored", func(t *testing.T) {
+		fm, found, err := parseContextFrontmatter([]byte("---\nname: a\ndescription: d\nlicense: MIT\ncompatibility: Requires nothing\nallowed-tools: Read\nmetadata:\n  author: x\n---\n"))
+		require.True(t, found)
+		require.NoError(t, err)
+		assert.Equal(t, "a", fm.Name)
+	})
+}
+
+func TestValidateSkillMetadata(t *testing.T) {
+	valid := contextFrontmatter{Name: "trip-planning", Description: "Plan trips."}
+
+	t.Run("valid", func(t *testing.T) {
+		assert.NoError(t, validateSkillMetadata("trip-planning", valid, true))
+	})
+
+	t.Run("missing frontmatter", func(t *testing.T) {
+		assert.Error(t, validateSkillMetadata("trip-planning", contextFrontmatter{}, false))
+	})
+
+	t.Run("name does not match directory", func(t *testing.T) {
+		assert.Error(t, validateSkillMetadata("other-dir", valid, true))
+	})
+
+	t.Run("empty description", func(t *testing.T) {
+		fm := contextFrontmatter{Name: "trip-planning"}
+		assert.Error(t, validateSkillMetadata("trip-planning", fm, true))
+	})
+
+	t.Run("description too long", func(t *testing.T) {
+		fm := contextFrontmatter{Name: "trip-planning", Description: strings.Repeat("x", 1025)}
+		assert.Error(t, validateSkillMetadata("trip-planning", fm, true))
+	})
+
+	t.Run("invalid names", func(t *testing.T) {
+		for _, name := range []string{"Trip-Planning", "-trip", "trip-", "trip--planning", "trip_planning", "", strings.Repeat("a", 65)} {
+			fm := contextFrontmatter{Name: name, Description: "d"}
+			assert.Error(t, validateSkillMetadata(name, fm, true), "name %q must be rejected", name)
+		}
+	})
+}

--- a/router/pkg/mcpserver/context_resources_test.go
+++ b/router/pkg/mcpserver/context_resources_test.go
@@ -112,7 +112,6 @@ func TestContextURIBuilders(t *testing.T) {
 	assert.Equal(t, "skill://trip-planning/assets/a%20b.md", skillFileURI("trip-planning", "assets/a b.md"))
 	// Multi-segment skill-path: SEP-2640 organizational prefix, every segment encoded.
 	assert.Equal(t, "skill://acme/billing/refunds/SKILL.md", skillFileURI("acme/billing/refunds", "SKILL.md"))
-	assert.Equal(t, "skill://my%20team/refunds/SKILL.md", skillFileURI("my team/refunds", "SKILL.md"))
 }
 
 func TestScanContextResources(t *testing.T) {
@@ -333,6 +332,38 @@ func TestScanContextResources(t *testing.T) {
 		require.Len(t, scan.skills, 1)
 		assert.Contains(t, scan.byURI, "skill://trip-planning/nested/SKILL.md")
 		assert.Equal(t, 1, logs.FilterMessage("Nested SKILL.md served as supporting content of the enclosing skill").Len())
+	})
+
+	t.Run("skill under an invalid prefix directory is skipped", func(t *testing.T) {
+		core, logs := observer.New(zapcore.DebugLevel)
+		dir := t.TempDir()
+		writeContextFiles(t, dir, map[string]string{
+			"my team/refunds/SKILL.md": "---\nname: refunds\ndescription: Handle refunds.\n---\n# Refunds\n",
+		})
+
+		scan, err := scanContextResources(dir, zap.New(core))
+		require.NoError(t, err)
+		assert.Empty(t, scan.skills)
+		assert.Empty(t, scan.resources)
+		assert.Equal(t, 1, logs.FilterMessage("Skipping MCP skill with invalid URI").Len())
+	})
+
+	t.Run("skill with a symlinked SKILL.md is skipped", func(t *testing.T) {
+		core, logs := observer.New(zapcore.DebugLevel)
+		dir := t.TempDir()
+		outsideDir := t.TempDir()
+		realFile := filepath.Join(outsideDir, "real-skill.md")
+		require.NoError(t, os.WriteFile(realFile, []byte("---\nname: refunds\ndescription: Handle refunds.\n---\n# Refunds\n"), 0o644))
+
+		skillDir := filepath.Join(dir, "refunds")
+		require.NoError(t, os.MkdirAll(skillDir, 0o755))
+		require.NoError(t, os.Symlink(realFile, filepath.Join(skillDir, "SKILL.md")))
+
+		scan, err := scanContextResources(dir, zap.New(core))
+		require.NoError(t, err)
+		assert.Empty(t, scan.skills)
+		assert.Empty(t, scan.resources)
+		assert.Equal(t, 1, logs.FilterMessage("Skipping MCP skill without a regular SKILL.md file").Len())
 	})
 
 	t.Run("missing directory returns error", func(t *testing.T) {

--- a/router/pkg/mcpserver/context_resources_test.go
+++ b/router/pkg/mcpserver/context_resources_test.go
@@ -1,11 +1,17 @@
 package mcpserver
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestParseContextFrontmatter(t *testing.T) {
@@ -82,4 +88,264 @@ func TestValidateSkillMetadata(t *testing.T) {
 			assert.Error(t, validateSkillMetadata(name, fm, true), "name %q must be rejected", name)
 		}
 	})
+}
+
+// writeContextFiles writes files into dir, creating parent directories.
+// Keys are slash-separated relative paths.
+func writeContextFiles(t *testing.T, dir string, files map[string]string) {
+	t.Helper()
+	for rel, content := range files {
+		p := filepath.Join(dir, filepath.FromSlash(rel))
+		require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o755))
+		require.NoError(t, os.WriteFile(p, []byte(content), 0o644))
+	}
+}
+
+const validSkillMD = "---\nname: trip-planning\ndescription: Shows how to combine forecast and alert tools.\n---\n# Trip planning\n"
+
+func TestContextURIBuilders(t *testing.T) {
+	assert.Equal(t, "context:///notes.md", contextDocumentURI("notes.md"))
+	assert.Equal(t, "context:///weather/usage.md", contextDocumentURI("weather/usage.md"))
+	assert.Equal(t, "context:///a%20b/100%25.md", contextDocumentURI("a b/100%.md"))
+	// Single-segment skill-path: no organizational prefix.
+	assert.Equal(t, "skill://trip-planning/SKILL.md", skillFileURI("trip-planning", "SKILL.md"))
+	assert.Equal(t, "skill://trip-planning/assets/a%20b.md", skillFileURI("trip-planning", "assets/a b.md"))
+	// Multi-segment skill-path: SEP-2640 organizational prefix, every segment encoded.
+	assert.Equal(t, "skill://acme/billing/refunds/SKILL.md", skillFileURI("acme/billing/refunds", "SKILL.md"))
+	assert.Equal(t, "skill://my%20team/refunds/SKILL.md", skillFileURI("my team/refunds", "SKILL.md"))
+}
+
+func TestScanContextResources(t *testing.T) {
+	logger := zap.NewNop()
+
+	t.Run("loose markdown becomes context resource", func(t *testing.T) {
+		dir := t.TempDir()
+		writeContextFiles(t, dir, map[string]string{
+			"notes.md":            "---\ntitle: Notes\ndescription: Team notes.\n---\nbody",
+			"weather/usage.md":    "# Usage\n",
+			"GetForecast.graphql": "query GetForecast { __typename }",
+			"data.json":           "{}",
+		})
+
+		scan, err := scanContextResources(dir, logger)
+		require.NoError(t, err)
+		require.Empty(t, scan.skills)
+		require.Len(t, scan.resources, 2)
+
+		notes := scan.byURI["context:///notes.md"]
+		assert.Equal(t, "notes.md", notes.name)
+		assert.Equal(t, "Notes", notes.title)
+		assert.Equal(t, "Team notes.", notes.description)
+		assert.Equal(t, "text/markdown", notes.mimeType)
+		assert.Empty(t, notes.skillName)
+
+		usage := scan.byURI["context:///weather/usage.md"]
+		assert.Equal(t, "weather/usage.md", usage.name)
+		assert.Empty(t, usage.title)
+	})
+
+	t.Run("filenames are percent-encoded in URIs", func(t *testing.T) {
+		dir := t.TempDir()
+		writeContextFiles(t, dir, map[string]string{
+			"my notes.md": "# Notes\n",
+		})
+
+		scan, err := scanContextResources(dir, logger)
+		require.NoError(t, err)
+		require.Len(t, scan.resources, 1)
+		assert.Contains(t, scan.byURI, "context:///my%20notes.md")
+	})
+
+	t.Run("malformed loose frontmatter warns and serves bare", func(t *testing.T) {
+		core, logs := observer.New(zapcore.DebugLevel)
+		dir := t.TempDir()
+		writeContextFiles(t, dir, map[string]string{
+			"broken.md": "---\n:{not yaml\n---\nbody",
+		})
+
+		scan, err := scanContextResources(dir, zap.New(core))
+		require.NoError(t, err)
+		require.Len(t, scan.resources, 1)
+		res := scan.byURI["context:///broken.md"]
+		assert.Empty(t, res.title)
+		assert.Empty(t, res.description)
+		assert.Equal(t, 1, logs.FilterMessage("Malformed frontmatter in context document").Len())
+	})
+
+	t.Run("symlinks and irregular files are skipped", func(t *testing.T) {
+		dir := t.TempDir()
+		writeContextFiles(t, dir, map[string]string{
+			"real.md": "# Real\n",
+		})
+		require.NoError(t, os.Symlink(filepath.Join(dir, "real.md"), filepath.Join(dir, "link.md")))
+
+		scan, err := scanContextResources(dir, logger)
+		require.NoError(t, err)
+		require.Len(t, scan.resources, 1)
+		assert.Contains(t, scan.byURI, "context:///real.md")
+	})
+
+	t.Run("oversized loose file is skipped", func(t *testing.T) {
+		core, logs := observer.New(zapcore.DebugLevel)
+		dir := t.TempDir()
+		big := make([]byte, maxServedFileBytes+1)
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "big.md"), big, 0o644))
+
+		scan, err := scanContextResources(dir, zap.New(core))
+		require.NoError(t, err)
+		assert.Empty(t, scan.resources)
+		assert.Equal(t, 1, logs.FilterMessage("Skipping oversized context file").Len())
+	})
+
+	t.Run("skill directory serves every file under skill scheme with path prefix", func(t *testing.T) {
+		dir := t.TempDir()
+		writeContextFiles(t, dir, map[string]string{
+			"weather/trip-planning/SKILL.md":        validSkillMD,
+			"weather/trip-planning/examples.md":     "# Examples\n",
+			"weather/trip-planning/assets/data.csv": "a,b\n",
+		})
+
+		scan, err := scanContextResources(dir, logger)
+		require.NoError(t, err)
+		require.Len(t, scan.skills, 1)
+		assert.Equal(t, "trip-planning", scan.skills[0].name)
+		assert.Equal(t, "Shows how to combine forecast and alert tools.", scan.skills[0].description)
+		// SEP-2640: the skill-path is the relative directory path; "weather"
+		// is the organizational prefix, the final segment is the name.
+		assert.Equal(t, "skill://weather/trip-planning/SKILL.md", scan.skills[0].uri)
+
+		require.Len(t, scan.resources, 3)
+		skillMD := scan.byURI["skill://weather/trip-planning/SKILL.md"]
+		assert.Equal(t, "trip-planning", skillMD.name)
+		assert.Equal(t, "trip-planning", skillMD.skillName)
+		assert.Equal(t, "Shows how to combine forecast and alert tools.", skillMD.description)
+
+		assert.Contains(t, scan.byURI, "skill://weather/trip-planning/examples.md")
+		assert.Contains(t, scan.byURI, "skill://weather/trip-planning/assets/data.csv")
+	})
+
+	t.Run("skill at operations root has no prefix", func(t *testing.T) {
+		dir := t.TempDir()
+		writeContextFiles(t, dir, map[string]string{
+			"trip-planning/SKILL.md": validSkillMD,
+		})
+
+		scan, err := scanContextResources(dir, logger)
+		require.NoError(t, err)
+		require.Len(t, scan.skills, 1)
+		assert.Equal(t, "skill://trip-planning/SKILL.md", scan.skills[0].uri)
+	})
+
+	t.Run("operations root itself is never a skill", func(t *testing.T) {
+		dir := t.TempDir()
+		writeContextFiles(t, dir, map[string]string{
+			"SKILL.md": validSkillMD,
+			"notes.md": "# notes\n",
+		})
+
+		scan, err := scanContextResources(dir, logger)
+		require.NoError(t, err)
+		assert.Empty(t, scan.skills)
+		// The stray root SKILL.md is just a loose markdown document.
+		assert.Contains(t, scan.byURI, "context:///SKILL.md")
+		assert.Contains(t, scan.byURI, "context:///notes.md")
+	})
+
+	t.Run("invalid skill directory is skipped entirely", func(t *testing.T) {
+		core, logs := observer.New(zapcore.DebugLevel)
+		dir := t.TempDir()
+		writeContextFiles(t, dir, map[string]string{
+			"bad/SKILL.md": "---\nname: mismatch\ndescription: d\n---\n",
+			"bad/notes.md": "# inside invalid skill\n",
+			"good.md":      "# loose doc\n",
+		})
+
+		scan, err := scanContextResources(dir, zap.New(core))
+		require.NoError(t, err)
+		assert.Empty(t, scan.skills)
+		require.Len(t, scan.resources, 1)
+		assert.Contains(t, scan.byURI, "context:///good.md")
+		assert.Equal(t, 1, logs.FilterMessage("Skipping invalid MCP skill directory").Len())
+	})
+
+	t.Run("same-named skills at different paths both serve with distinct URIs", func(t *testing.T) {
+		dir := t.TempDir()
+		writeContextFiles(t, dir, map[string]string{
+			"a/trip-planning/SKILL.md":  validSkillMD,
+			"a/trip-planning/first.md":  "# from a\n",
+			"b/trip-planning/SKILL.md":  validSkillMD,
+			"b/trip-planning/second.md": "# from b\n",
+		})
+
+		scan, err := scanContextResources(dir, logger)
+		require.NoError(t, err)
+		// SEP-2640: name is a label, not an identifier; the path-prefixed URI
+		// is the identity, so no collision handling is needed.
+		require.Len(t, scan.skills, 2)
+		assert.Contains(t, scan.byURI, "skill://a/trip-planning/first.md")
+		assert.Contains(t, scan.byURI, "skill://b/trip-planning/second.md")
+	})
+
+	t.Run("skill exceeding file count limit is invalid", func(t *testing.T) {
+		core, logs := observer.New(zapcore.DebugLevel)
+		dir := t.TempDir()
+		files := map[string]string{"crowded/SKILL.md": "---\nname: crowded\ndescription: d\n---\n"}
+		for i := 0; i < maxSkillFiles; i++ { // SKILL.md + maxSkillFiles exceeds the limit
+			files[fmt.Sprintf("crowded/f%04d.md", i)] = "x"
+		}
+		writeContextFiles(t, dir, files)
+
+		scan, err := scanContextResources(dir, zap.New(core))
+		require.NoError(t, err)
+		assert.Empty(t, scan.skills)
+		assert.Empty(t, scan.resources)
+		assert.Equal(t, 1, logs.FilterMessage("Skipping MCP skill exceeding size limits").Len())
+	})
+
+	t.Run("skill exceeding total byte limit is invalid", func(t *testing.T) {
+		core, logs := observer.New(zapcore.DebugLevel)
+		dir := t.TempDir()
+		writeContextFiles(t, dir, map[string]string{
+			"heavy/SKILL.md": "---\nname: heavy\ndescription: d\n---\n",
+		})
+		big := make([]byte, maxSkillTotalBytes+1)
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "heavy", "big.bin"), big, 0o644))
+
+		scan, err := scanContextResources(dir, zap.New(core))
+		require.NoError(t, err)
+		assert.Empty(t, scan.skills)
+		assert.Empty(t, scan.resources)
+		assert.Equal(t, 1, logs.FilterMessage("Skipping MCP skill exceeding size limits").Len())
+	})
+
+	t.Run("nested SKILL.md is served as supporting content of the enclosing skill", func(t *testing.T) {
+		core, logs := observer.New(zapcore.DebugLevel)
+		dir := t.TempDir()
+		writeContextFiles(t, dir, map[string]string{
+			"trip-planning/SKILL.md":        validSkillMD,
+			"trip-planning/nested/SKILL.md": "---\nname: nested\ndescription: d\n---\n",
+		})
+
+		scan, err := scanContextResources(dir, zap.New(core))
+		require.NoError(t, err)
+		// SEP-2640 permits nested skills; from the enclosing skill's
+		// perspective the nested SKILL.md is ordinary supporting content.
+		require.Len(t, scan.skills, 1)
+		assert.Contains(t, scan.byURI, "skill://trip-planning/nested/SKILL.md")
+		assert.Equal(t, 1, logs.FilterMessage("Nested SKILL.md served as supporting content of the enclosing skill").Len())
+	})
+
+	t.Run("missing directory returns error", func(t *testing.T) {
+		_, err := scanContextResources(filepath.Join(t.TempDir(), "missing"), logger)
+		assert.Error(t, err)
+	})
+}
+
+func TestContextMIMEType(t *testing.T) {
+	assert.Equal(t, "text/markdown", contextMIMEType("a/b.md"))
+	assert.Equal(t, "text/markdown", contextMIMEType("a/B.MD"))
+	assert.Equal(t, "text/plain", contextMIMEType("a.txt"))
+	assert.Equal(t, "application/json", contextMIMEType("a.json"))
+	assert.Equal(t, "application/yaml", contextMIMEType("a.yaml"))
+	assert.Equal(t, "application/octet-stream", contextMIMEType("a.unknownext"))
 }

--- a/router/pkg/mcpserver/server.go
+++ b/router/pkg/mcpserver/server.go
@@ -44,6 +44,7 @@ var reservedToolNames = []string{
 	"get_schema",
 	"execute_graphql",
 	"get_operation_info",
+	"get_context",
 }
 
 // requestHeadersKey is a custom context key for storing request headers.
@@ -189,6 +190,32 @@ type OperationsResponse struct {
 	Usage       string          `json:"usage"`
 	LLMGuidance LLMGuidance     `json:"llmGuidance"`
 	Endpoint    string          `json:"endpoint"`
+}
+
+// ContextSkillEntry describes one Agent Skill in the get_context index.
+type ContextSkillEntry struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	URI         string `json:"uri"`
+}
+
+// ContextDocumentEntry describes one loose context document in the
+// get_context index.
+type ContextDocumentEntry struct {
+	URI         string `json:"uri"`
+	Title       string `json:"title,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+// ContextIndex is the get_context response when no URI is requested.
+type ContextIndex struct {
+	Skills    []ContextSkillEntry    `json:"skills"`
+	Documents []ContextDocumentEntry `json:"documents"`
+}
+
+// GetContextInput is the input of the get_context tool.
+type GetContextInput struct {
+	URI string `json:"uri,omitempty"`
 }
 
 // GraphQLOperationInfoResponse is the response structure for the graphql_operation_info tool.
@@ -861,6 +888,35 @@ func (s *GraphQLSchemaServer) registerTools() error {
 		s.registeredTools = append(s.registeredTools, "execute_graphql")
 	}
 
+	// Register the get_context tool when context resources are enabled. It
+	// mirrors resources/list + resources/read for MCP clients that never
+	// fetch resources on their own.
+	if s.resourcesEnabled {
+		getContextSchema := map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"uri": map[string]any{
+					"type":        "string",
+					"description": "URI of a context document or skill file to read (from the index). Omit to list all available skills and context documents.",
+				},
+			},
+			"additionalProperties": false,
+		}
+
+		tool := &mcp.Tool{
+			Name:        "get_context",
+			Description: "Discover and load domain guidance and skills for using this server's tools. Call without a URI before complex or multi-tool workflows to find relevant instructions. When a relevant skill exists, load its SKILL.md before executing the workflow. When a loaded skill references another file by relative path, resolve it against the skill root and request the resulting skill:// URI.",
+			InputSchema: getContextSchema,
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "Get Context Documents and Skills",
+				ReadOnlyHint: true,
+			},
+		}
+
+		s.server.AddTool(tool, s.handleGetContext())
+		s.registeredTools = append(s.registeredTools, "get_context")
+	}
+
 	// Get operations filtered by the excludeMutations setting
 	operations := s.operationsManager.GetFilteredOperations()
 
@@ -1265,6 +1321,79 @@ func (s *GraphQLSchemaServer) handleGetGraphQLSchema() func(ctx context.Context,
 
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{&mcp.TextContent{Text: schemaStr}},
+		}, nil
+	}
+}
+
+// handleGetContext serves the get_context tool: without a URI it returns the
+// index of skills and context documents, with a URI it returns that
+// resource's raw text content.
+func (s *GraphQLSchemaServer) handleGetContext() func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		var input GetContextInput
+		if len(request.Params.Arguments) > 0 {
+			if err := json.Unmarshal(request.Params.Arguments, &input); err != nil {
+				return nil, fmt.Errorf("invalid input: %w", err)
+			}
+		}
+
+		scan := s.contextScan
+
+		if input.URI == "" {
+			index := ContextIndex{
+				Skills:    []ContextSkillEntry{},
+				Documents: []ContextDocumentEntry{},
+			}
+			for _, sk := range scan.skills {
+				index.Skills = append(index.Skills, ContextSkillEntry{
+					Name:        sk.name,
+					Description: sk.description,
+					URI:         sk.uri,
+				})
+			}
+			for _, res := range scan.resources {
+				if res.skillName != "" {
+					continue
+				}
+				index.Documents = append(index.Documents, ContextDocumentEntry{
+					URI:         res.uri,
+					Title:       res.title,
+					Description: res.description,
+				})
+			}
+			payload, err := json.Marshal(index)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal context index: %w", err)
+			}
+			// Structured content plus a serialized-JSON text fallback, per
+			// current MCP guidance for structured tool results. No output
+			// schema is declared on the tool: the uri form returns raw
+			// document text, so one schema cannot describe both responses.
+			return &mcp.CallToolResult{
+				Content:           []mcp.Content{&mcp.TextContent{Text: string(payload)}},
+				StructuredContent: index,
+			}, nil
+		}
+
+		res, ok := scan.byURI[input.URI]
+		if !ok {
+			return &mcp.CallToolResult{
+				IsError: true,
+				Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("unknown context uri: %s (call get_context without arguments to list valid uris)", input.URI)}},
+			}, nil
+		}
+		content, err := os.ReadFile(res.filePath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read %s: %w", input.URI, err)
+		}
+		if !utf8.Valid(content) {
+			return &mcp.CallToolResult{
+				IsError: true,
+				Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("%s is a binary resource; read it via resources/read", input.URI)}},
+			}, nil
+		}
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: string(content)}},
 		}, nil
 	}
 }

--- a/router/pkg/mcpserver/server.go
+++ b/router/pkg/mcpserver/server.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"slices"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/iancoleman/strcase"
@@ -29,6 +31,12 @@ import (
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/ast"
 	"github.com/wundergraph/graphql-go-tools/v2/pkg/astprinter"
 )
+
+// contextInstructions is appended to the configured server instructions when
+// context resources are enabled, so agents know to discover skills before
+// multi-tool workflows. Instructions reach clients via both server/discover
+// and the legacy initialize response.
+const contextInstructions = "This server may provide skills describing how its tools should be used together. For complex workflows, call get_context to discover relevant skills and load the applicable skill before invoking operation tools."
 
 // reservedToolNames contains tool names that are internally registered by the MCP server
 // and must not be used by operations when omitToolNamePrefix is enabled.
@@ -88,6 +96,9 @@ type Options struct {
 	// adds structured content to successful tool results (MCP structured tool
 	// output). Increases tools/list and result payload sizes.
 	OutputSchemaEnabled bool
+	// ResourcesEnabled serves markdown context documents and Agent Skills from
+	// the operations directory as MCP resources, plus a get_context tool.
+	ResourcesEnabled bool
 	// Stateless determines whether the MCP server should be stateless
 	Stateless bool
 	// CorsConfig is the CORS configuration for the MCP server
@@ -136,6 +147,9 @@ type GraphQLSchemaServer struct {
 	operationsManager         *OperationsManager
 	schemaCompiler            *SchemaCompiler
 	registeredTools           []string
+	resourcesEnabled          bool
+	contextScan               *contextScan
+	registeredResources       []string
 	corsConfig                cors.Config
 	cancel                    context.CancelFunc
 	oauthConfig               *config.MCPOAuthConfiguration
@@ -358,6 +372,14 @@ func NewGraphQLSchemaServer(ctx context.Context, routerGraphQLEndpoint string, o
 			zap.Strings("authorization_servers", options.OAuthConfig.AuthorizationServers()))
 	}
 
+	instructions := options.Instructions
+	if options.ResourcesEnabled {
+		if instructions != "" {
+			instructions += "\n\n"
+		}
+		instructions += contextInstructions
+	}
+
 	// Create the MCP server with all options
 	mcpServer := mcp.NewServer(
 		&mcp.Implementation{
@@ -367,7 +389,7 @@ func NewGraphQLSchemaServer(ctx context.Context, routerGraphQLEndpoint string, o
 			Version:     options.ServerVersion,
 		},
 		&mcp.ServerOptions{
-			Instructions: options.Instructions,
+			Instructions: instructions,
 			PageSize:     100,
 			// ttlMs and cacheScope use the SDK defaults (0 / "public"). They
 			// become configurable under mcp.server.discover once the SDK adds a
@@ -400,6 +422,8 @@ func NewGraphQLSchemaServer(ctx context.Context, routerGraphQLEndpoint string, o
 		exposeSchema:              options.ExposeSchema,
 		omitToolNamePrefix:        options.OmitToolNamePrefix,
 		outputSchemaEnabled:       options.OutputSchemaEnabled,
+		resourcesEnabled:          options.ResourcesEnabled,
+		contextScan:               newEmptyContextScan(),
 		stateless:                 options.Stateless,
 		corsConfig:                options.CorsConfig,
 		cancel:                    cancel,
@@ -513,6 +537,14 @@ func WithOmitToolNamePrefix(omitToolNamePrefix bool) func(*Options) {
 func WithOutputSchemaEnabled(outputSchemaEnabled bool) func(*Options) {
 	return func(o *Options) {
 		o.OutputSchemaEnabled = outputSchemaEnabled
+	}
+}
+
+// WithResourcesEnabled serves markdown context documents and Agent Skills
+// from the operations directory as MCP resources.
+func WithResourcesEnabled(enabled bool) func(*Options) {
+	return func(o *Options) {
+		o.ResourcesEnabled = enabled
 	}
 }
 
@@ -671,6 +703,10 @@ func (s *GraphQLSchemaServer) Reload(schema *ast.Document, fieldConfigs []*nodev
 		return fmt.Errorf("failed to register tools: %w", err)
 	}
 
+	if err := s.registerContextResources(); err != nil {
+		return fmt.Errorf("failed to register context resources: %w", err)
+	}
+
 	return nil
 }
 
@@ -696,6 +732,70 @@ func (s *GraphQLSchemaServer) Stop(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// registerContextResources rescans the operations directory and replaces the
+// registered MCP resources, mirroring the tools flow in Reload. The go-sdk
+// advertises the resources capability and emits list_changed notifications
+// automatically when resources are added or removed.
+func (s *GraphQLSchemaServer) registerContextResources() error {
+	s.server.RemoveResources(s.registeredResources...)
+	s.registeredResources = nil
+	s.contextScan = newEmptyContextScan()
+
+	if !s.resourcesEnabled || s.operationsDir == "" {
+		return nil
+	}
+
+	scan, err := scanContextResources(s.operationsDir, s.logger)
+	if err != nil {
+		return err
+	}
+	s.contextScan = scan
+
+	handler := s.handleReadContextResource()
+	for _, res := range scan.resources {
+		s.server.AddResource(&mcp.Resource{
+			URI:         res.uri,
+			Name:        res.name,
+			Title:       res.title,
+			Description: res.description,
+			MIMEType:    res.mimeType,
+		}, handler)
+		s.registeredResources = append(s.registeredResources, res.uri)
+	}
+
+	s.logger.Debug("Registered MCP context resources",
+		zap.Int("resources", len(scan.resources)),
+		zap.Int("skills", len(scan.skills)))
+
+	return nil
+}
+
+// handleReadContextResource serves resources/read for context documents and
+// skill files. Content is read from disk per request so edits between config
+// reloads are served fresh.
+func (s *GraphQLSchemaServer) handleReadContextResource() mcp.ResourceHandler {
+	return func(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+		res, ok := s.contextScan.byURI[req.Params.URI]
+		if !ok {
+			return nil, fmt.Errorf("unknown resource: %s", req.Params.URI)
+		}
+		content, err := os.ReadFile(res.filePath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read resource %s: %w", req.Params.URI, err)
+		}
+		contents := &mcp.ResourceContents{
+			URI:      res.uri,
+			MIMEType: res.mimeType,
+		}
+		if utf8.Valid(content) {
+			contents.Text = string(content)
+		} else {
+			contents.Blob = content
+		}
+		return &mcp.ReadResourceResult{Contents: []*mcp.ResourceContents{contents}}, nil
+	}
 }
 
 // registerTools registers all tools for the MCP server

--- a/router/pkg/mcpserver/server.go
+++ b/router/pkg/mcpserver/server.go
@@ -765,12 +765,17 @@ func (s *GraphQLSchemaServer) Stop(ctx context.Context) error {
 // registered MCP resources, mirroring the tools flow in Reload. The go-sdk
 // advertises the resources capability and emits list_changed notifications
 // automatically when resources are added or removed.
+//
+// The directory is scanned before anything is removed: a scan error leaves
+// the previously registered resources live instead of leaving the server
+// resource-less, and there is no window where resources are briefly
+// unregistered while the scan runs. This mirrors how Reload leaves old tools
+// registered when operation loading fails.
 func (s *GraphQLSchemaServer) registerContextResources() error {
-	s.server.RemoveResources(s.registeredResources...)
-	s.registeredResources = nil
-	s.contextScan = newEmptyContextScan()
-
 	if !s.resourcesEnabled || s.operationsDir == "" {
+		s.server.RemoveResources(s.registeredResources...)
+		s.registeredResources = nil
+		s.contextScan = newEmptyContextScan()
 		return nil
 	}
 
@@ -778,6 +783,9 @@ func (s *GraphQLSchemaServer) registerContextResources() error {
 	if err != nil {
 		return err
 	}
+
+	s.server.RemoveResources(s.registeredResources...)
+	s.registeredResources = nil
 	s.contextScan = scan
 
 	handler := s.handleReadContextResource()
@@ -799,6 +807,24 @@ func (s *GraphQLSchemaServer) registerContextResources() error {
 	return nil
 }
 
+// checkServableFile validates a context resource file at read time. The scan
+// records file metadata once, but a file can grow or be replaced (for
+// example by a FIFO) between the scan and a request, so both read paths
+// re-check the 16 MiB cap and the regular-file requirement before reading.
+func checkServableFile(filePath string) error {
+	info, err := os.Stat(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to stat resource file: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("resource file is not a regular file")
+	}
+	if info.Size() > maxServedFileBytes {
+		return fmt.Errorf("resource file exceeds the %d byte limit", maxServedFileBytes)
+	}
+	return nil
+}
+
 // handleReadContextResource serves resources/read for context documents and
 // skill files. Content is read from disk per request so edits between config
 // reloads are served fresh.
@@ -807,6 +833,9 @@ func (s *GraphQLSchemaServer) handleReadContextResource() mcp.ResourceHandler {
 		res, ok := s.contextScan.byURI[req.Params.URI]
 		if !ok {
 			return nil, fmt.Errorf("unknown resource: %s", req.Params.URI)
+		}
+		if err := checkServableFile(res.filePath); err != nil {
+			return nil, fmt.Errorf("cannot serve resource %s: %w", req.Params.URI, err)
 		}
 		content, err := os.ReadFile(res.filePath)
 		if err != nil {
@@ -1380,6 +1409,12 @@ func (s *GraphQLSchemaServer) handleGetContext() func(ctx context.Context, reque
 			return &mcp.CallToolResult{
 				IsError: true,
 				Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("unknown context uri: %s (call get_context without arguments to list valid uris)", input.URI)}},
+			}, nil
+		}
+		if err := checkServableFile(res.filePath); err != nil {
+			return &mcp.CallToolResult{
+				IsError: true,
+				Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("cannot serve %s: %s", input.URI, err)}},
 			}, nil
 		}
 		content, err := os.ReadFile(res.filePath)

--- a/router/pkg/mcpserver/server_test.go
+++ b/router/pkg/mcpserver/server_test.go
@@ -187,6 +187,56 @@ func TestReload_ResourcesDisabledRegistersNothing(t *testing.T) {
 
 	require.NoError(t, srv.Reload(&schemaDoc, nil))
 	assert.Empty(t, srv.registeredResources)
+
+	// A disabled server still carries a non-nil, empty scan: handlers that
+	// read s.contextScan must never see a nil map.
+	require.NotNil(t, srv.contextScan)
+	assert.Empty(t, srv.contextScan.skills)
+	assert.Empty(t, srv.contextScan.resources)
+	assert.Empty(t, srv.contextScan.byURI)
+}
+
+// TestReadContextResource_OversizedFileAtReadTimeIsRejected proves both read
+// paths (resources/read and get_context) re-check the 16 MiB cap and the
+// regular-file requirement at request time, not just at scan time: a file
+// that grows after the scan must not be served.
+func TestReadContextResource_OversizedFileAtReadTimeIsRejected(t *testing.T) {
+	tempDir := t.TempDir()
+	writeOperationFiles(t, tempDir, map[string]string{
+		"notes.md": "# Notes\n",
+	})
+
+	schemaDoc, report := astparser.ParseGraphqlDocumentString(testSchema)
+	require.False(t, report.HasErrors())
+	require.NoError(t, asttransform.MergeDefinitionWithBaseSchema(&schemaDoc))
+
+	srv, err := NewGraphQLSchemaServer(
+		t.Context(),
+		"http://localhost:4000/graphql",
+		WithLogger(zap.NewNop()),
+		WithOperationsDir(tempDir),
+		WithResourcesEnabled(true),
+	)
+	require.NoError(t, err)
+	require.NoError(t, srv.Reload(&schemaDoc, nil))
+	require.Contains(t, srv.registeredResources, "context:///notes.md")
+
+	// Grow the file past the limit on disk, after the scan already recorded it.
+	oversized := make([]byte, maxServedFileBytes+1)
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "notes.md"), oversized, 0o644))
+
+	readHandler := srv.handleReadContextResource()
+	_, err = readHandler(t.Context(), &mcp.ReadResourceRequest{
+		Params: &mcp.ReadResourceParams{URI: "context:///notes.md"},
+	})
+	assert.Error(t, err)
+
+	getContextHandler := srv.handleGetContext()
+	result, err := getContextHandler(t.Context(), &mcp.CallToolRequest{
+		Params: &mcp.CallToolParamsRaw{Arguments: json.RawMessage(`{"uri":"context:///notes.md"}`)},
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
 }
 
 func TestReload_ReservedToolNameCollision(t *testing.T) {

--- a/router/pkg/mcpserver/server_test.go
+++ b/router/pkg/mcpserver/server_test.go
@@ -114,6 +114,81 @@ func TestReload_NoToolDuplication(t *testing.T) {
 		"no tool name collision errors should be logged on reload")
 }
 
+func TestReload_RegistersContextResources(t *testing.T) {
+	tempDir := t.TempDir()
+	writeOperationFiles(t, tempDir, map[string]string{
+		"FindEmployee.graphql": findEmployeeOp,
+		"notes.md":             "---\ntitle: Notes\ndescription: Team notes.\n---\n# Notes body\n",
+	})
+	skillDir := filepath.Join(tempDir, "employee-workflows")
+	require.NoError(t, os.MkdirAll(skillDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(skillDir, "SKILL.md"),
+		[]byte("---\nname: employee-workflows\ndescription: How to combine employee tools.\n---\n# Guide\n"), 0o644))
+
+	schemaDoc, report := astparser.ParseGraphqlDocumentString(testSchema)
+	require.False(t, report.HasErrors())
+	require.NoError(t, asttransform.MergeDefinitionWithBaseSchema(&schemaDoc))
+
+	srv, err := NewGraphQLSchemaServer(
+		t.Context(),
+		"http://localhost:4000/graphql",
+		WithLogger(zap.NewNop()),
+		WithOperationsDir(tempDir),
+		WithResourcesEnabled(true),
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, srv.Reload(&schemaDoc, nil))
+
+	assert.ElementsMatch(t, []string{
+		"context:///notes.md",
+		"skill://employee-workflows/SKILL.md",
+	}, srv.registeredResources)
+
+	// Reload again: no duplicates.
+	require.NoError(t, srv.Reload(&schemaDoc, nil))
+	assert.Len(t, srv.registeredResources, 2)
+
+	// Read handler serves file content fresh from disk.
+	handler := srv.handleReadContextResource()
+	result, err := handler(t.Context(), &mcp.ReadResourceRequest{
+		Params: &mcp.ReadResourceParams{URI: "context:///notes.md"},
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Contents, 1)
+	assert.Equal(t, "context:///notes.md", result.Contents[0].URI)
+	assert.Equal(t, "text/markdown", result.Contents[0].MIMEType)
+	assert.Contains(t, result.Contents[0].Text, "# Notes body")
+
+	_, err = handler(t.Context(), &mcp.ReadResourceRequest{
+		Params: &mcp.ReadResourceParams{URI: "context:///missing.md"},
+	})
+	assert.Error(t, err)
+}
+
+func TestReload_ResourcesDisabledRegistersNothing(t *testing.T) {
+	tempDir := t.TempDir()
+	writeOperationFiles(t, tempDir, map[string]string{
+		"FindEmployee.graphql": findEmployeeOp,
+		"notes.md":             "# Notes\n",
+	})
+
+	schemaDoc, report := astparser.ParseGraphqlDocumentString(testSchema)
+	require.False(t, report.HasErrors())
+	require.NoError(t, asttransform.MergeDefinitionWithBaseSchema(&schemaDoc))
+
+	srv, err := NewGraphQLSchemaServer(
+		t.Context(),
+		"http://localhost:4000/graphql",
+		WithLogger(zap.NewNop()),
+		WithOperationsDir(tempDir),
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, srv.Reload(&schemaDoc, nil))
+	assert.Empty(t, srv.registeredResources)
+}
+
 func TestReload_ReservedToolNameCollision(t *testing.T) {
 	core, logs := observer.New(zapcore.DebugLevel)
 	logger := zap.New(core)

--- a/router/pkg/mcpserver/server_test.go
+++ b/router/pkg/mcpserver/server_test.go
@@ -518,3 +518,93 @@ func TestExecuteGraphQLQueryStructuredContentDisabled(t *testing.T) {
 		})
 	}
 }
+
+func TestGetContextTool(t *testing.T) {
+	tempDir := t.TempDir()
+	writeOperationFiles(t, tempDir, map[string]string{
+		"FindEmployee.graphql": findEmployeeOp,
+		"notes.md":             "---\ntitle: Notes\ndescription: Team notes.\n---\n# Notes body\n",
+	})
+	skillDir := filepath.Join(tempDir, "employee-workflows")
+	require.NoError(t, os.MkdirAll(skillDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(skillDir, "SKILL.md"),
+		[]byte("---\nname: employee-workflows\ndescription: How to combine employee tools.\n---\n# Guide\n"), 0o644))
+
+	schemaDoc, report := astparser.ParseGraphqlDocumentString(testSchema)
+	require.False(t, report.HasErrors())
+	require.NoError(t, asttransform.MergeDefinitionWithBaseSchema(&schemaDoc))
+
+	srv, err := NewGraphQLSchemaServer(
+		t.Context(),
+		"http://localhost:4000/graphql",
+		WithLogger(zap.NewNop()),
+		WithOperationsDir(tempDir),
+		WithResourcesEnabled(true),
+	)
+	require.NoError(t, err)
+	require.NoError(t, srv.Reload(&schemaDoc, nil))
+
+	assert.Contains(t, srv.registeredTools, "get_context")
+
+	handler := srv.handleGetContext()
+
+	t.Run("no uri returns index", func(t *testing.T) {
+		result, err := handler(t.Context(), &mcp.CallToolRequest{
+			Params: &mcp.CallToolParamsRaw{Arguments: json.RawMessage(`{}`)},
+		})
+		require.NoError(t, err)
+		text := result.Content[0].(*mcp.TextContent).Text
+
+		var index ContextIndex
+		require.NoError(t, json.Unmarshal([]byte(text), &index))
+		require.Len(t, index.Skills, 1)
+		assert.Equal(t, "employee-workflows", index.Skills[0].Name)
+		assert.Equal(t, "skill://employee-workflows/SKILL.md", index.Skills[0].URI)
+		require.Len(t, index.Documents, 1)
+		assert.Equal(t, "context:///notes.md", index.Documents[0].URI)
+		assert.Equal(t, "Notes", index.Documents[0].Title)
+
+		// The index is also returned as structured content (text is the
+		// backward-compatible fallback).
+		require.NotNil(t, result.StructuredContent)
+	})
+
+	t.Run("uri returns raw content", func(t *testing.T) {
+		result, err := handler(t.Context(), &mcp.CallToolRequest{
+			Params: &mcp.CallToolParamsRaw{Arguments: json.RawMessage(`{"uri":"skill://employee-workflows/SKILL.md"}`)},
+		})
+		require.NoError(t, err)
+		text := result.Content[0].(*mcp.TextContent).Text
+		assert.Contains(t, text, "# Guide")
+	})
+
+	t.Run("unknown uri returns error", func(t *testing.T) {
+		result, err := handler(t.Context(), &mcp.CallToolRequest{
+			Params: &mcp.CallToolParamsRaw{Arguments: json.RawMessage(`{"uri":"context:///nope.md"}`)},
+		})
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+	})
+}
+
+func TestGetContextToolNotRegisteredWhenDisabled(t *testing.T) {
+	tempDir := t.TempDir()
+	writeOperationFiles(t, tempDir, map[string]string{
+		"FindEmployee.graphql": findEmployeeOp,
+	})
+
+	schemaDoc, report := astparser.ParseGraphqlDocumentString(testSchema)
+	require.False(t, report.HasErrors())
+	require.NoError(t, asttransform.MergeDefinitionWithBaseSchema(&schemaDoc))
+
+	srv, err := NewGraphQLSchemaServer(
+		t.Context(),
+		"http://localhost:4000/graphql",
+		WithLogger(zap.NewNop()),
+		WithOperationsDir(tempDir),
+	)
+	require.NoError(t, err)
+	require.NoError(t, srv.Reload(&schemaDoc, nil))
+
+	assert.NotContains(t, srv.registeredTools, "get_context")
+}

--- a/router/pkg/schemaloader/loader.go
+++ b/router/pkg/schemaloader/loader.go
@@ -58,8 +58,16 @@ func (l *OperationLoader) LoadOperationsFromDirectory(dirPath string) ([]Operati
 			return err
 		}
 
-		// Skip directories
+		// Skip skill directories. A subdirectory containing a SKILL.md file
+		// is an MCP Agent Skills directory (served as MCP resources, not
+		// operations); .graphql files inside it are examples, never live
+		// tools. The operations root itself is never a skill.
 		if d.IsDir() {
+			if path != dirPath {
+				if _, err := os.Stat(filepath.Join(path, "SKILL.md")); err == nil {
+					return fs.SkipDir
+				}
+			}
 			return nil
 		}
 

--- a/router/pkg/schemaloader/loader_test.go
+++ b/router/pkg/schemaloader/loader_test.go
@@ -318,3 +318,40 @@ func TestLoadOperationsFromEmptyDirectory(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, operations, 0, "Empty directory should return no operations")
 }
+
+// TestLoadOperationsFromDirectorySkipsSkillDirectories tests that skill directories
+// (directories containing a SKILL.md file) are skipped and not processed for
+// operations.
+func TestLoadOperationsFromDirectorySkipsSkillDirectories(t *testing.T) {
+	dir := t.TempDir()
+
+	writeFile := func(rel, content string) {
+		p := filepath.Join(dir, filepath.FromSlash(rel))
+		require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o755))
+		require.NoError(t, os.WriteFile(p, []byte(content), 0o644))
+	}
+
+	writeFile("TopLevel.graphql", `query TopLevel { hello }`)
+	writeFile("trip-planning/SKILL.md", "---\nname: trip-planning\ndescription: d\n---\n")
+	writeFile("trip-planning/Example.graphql", `query SkillExample { hello }`)
+	writeFile("nested/Inner.graphql", `query Inner { hello }`)
+
+	schemaStr := `
+type Query {
+	hello: String
+}
+`
+	schemaDoc, report := astparser.ParseGraphqlDocumentString(schemaStr)
+	require.False(t, report.HasErrors())
+	require.NoError(t, asttransform.MergeDefinitionWithBaseSchema(&schemaDoc))
+
+	loader := NewOperationLoader(zap.NewNop(), &schemaDoc)
+	ops, err := loader.LoadOperationsFromDirectory(dir)
+	require.NoError(t, err)
+
+	names := make([]string, 0, len(ops))
+	for _, op := range ops {
+		names = append(names, op.Name)
+	}
+	assert.ElementsMatch(t, []string{"TopLevel", "Inner"}, names)
+}


### PR DESCRIPTION
[POC] Proof of concept for ROUTER-565. Do not merge yet.

## Motivation and Context

The router MCP server is tools-only. Agents get operation tools but no domain knowledge and no guidance on how to combine them. This PR serves user-provided context documents and Agent Skills from the existing MCP operations directory as MCP resources.

Design goals:

- Disk format: [Agent Skills](https://agentskills.io/specification). A skill is a directory with a `SKILL.md`.
- Wire format: MCP core Resources only (`resources/list`, `resources/read`, list-changed notifications). No draft SEP-2640 methods. Skill files use the SEP-2640 URI shape (`skill://<path-from-operations-root>/<file>`), so a future `skills/list` layer needs no content migration.
- Model fallback: a `get_context` tool, because MCP resources are application-driven and many clients never fetch them.

## What changed

- New `mcp.resources.enabled` flag (env `MCP_RESOURCES_ENABLED`, default `false`).
- Loose `.md` files in the operations directory serve as resources under `context:///` URIs. Optional `title`/`description` frontmatter feeds resource metadata.
- Directories with a `SKILL.md` serve as skills under `skill://` URIs. Frontmatter `name` (must equal the directory name) and `description` are required. Invalid skills are skipped and logged.
- `.graphql` files inside a skill directory never register as tools. They still serve as resources, so a skill can reference example queries. Researched against public skills archives: bundled `.graphql` files are agent-facing content (fallback queries, schemas, templates, anti-pattern examples), never operations for the serving system.
- `get_context` tool: call without arguments for an index of skills and documents, call with `uri` for content. Index responses carry structured content plus a JSON text fallback.
- Discovery guidance appends to the server instructions when the feature is on.
- Safety: only regular files serve; scan-time and read-time 16 MiB caps; SEP-2640 per-skill limits (512 files, 16 MiB total); skill URIs validate with `url.Parse` before registration; lookup is a closed map, so path traversal is impossible by construction.
- Content hot-reloads on the existing operations `Reload()` path.
- Docs: router MCP pages document the feature, config, tool, and the trust boundary (the router serves skill content verbatim and never executes it).

## Open questions for review

- Colocated content vs a separate storage provider for context files.
- `get_context` index pagination for very large trees.
- Whether the schemaloader skill-directory skip should gate on `mcp.resources.enabled` (currently unconditional; a pre-existing `SKILL.md` in an operations subdirectory changes tool loading on upgrade).
- SEP-2640 `skills/list`/`skills/get` layer lands as a follow-up once the SEP ratifies.

## Checklist

- [x] Tests added: unit (`pkg/mcpserver`, `pkg/schemaloader`, `pkg/config`) and integration (`router-tests/protocol/mcp_resources_test.go`, official go-sdk client).
- [ ] Full `TestMCP` suite re-run in CI with NATS available (one pre-existing NATS-dependent subtest cannot run locally).

Linear: ROUTER-565


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional MCP resources for serving Markdown context documents and Agent Skills from the operations directory.
  * Added the `get_context` tool for discovering and retrieving available resources.
  * Added resource discovery, validation, URI handling, limits, and hot reload support.
  * Added configuration support through `mcp.resources.enabled` and `MCP_RESOURCES_ENABLED`; disabled by default.

* **Bug Fixes**
  * Prevented GraphQL files within Agent Skill directories from being registered as operations.

* **Documentation**
  * Documented resource configuration, discovery, validation, limits, retrieval, and skill behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->