### PR TITLE
fix(router): trace remote operation latency

### DIFF
--- a/router-tests/telemetry/telemetry_helpers_test.go
+++ b/router-tests/telemetry/telemetry_helpers_test.go
@@ -5,8 +5,27 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/wundergraph/cosmo/router/pkg/otel"
 	"go.opentelemetry.io/otel/attribute"
 )
+
+func withoutHTTPClientTimingAttributes(attributes []attribute.KeyValue) []attribute.KeyValue {
+	filtered := make([]attribute.KeyValue, 0, len(attributes))
+	for _, attr := range attributes {
+		switch attr.Key {
+		case otel.WgClientConnectionAcquireDuration,
+			otel.WgClientDNSLookupDuration,
+			otel.WgClientTCPConnectDuration,
+			otel.WgClientTLSHandshakeDuration,
+			otel.WgClientTimeToFirstRequestByte,
+			otel.WgClientTimeToFirstByte:
+			continue
+		default:
+			filtered = append(filtered, attr)
+		}
+	}
+	return filtered
+}
 
 func asssertAttributesEqual(t *testing.T, attributes attribute.Set, expectedAttributes ...attribute.KeyValue) {
 	t.Helper()

--- a/router-tests/telemetry/telemetry_test.go
+++ b/router-tests/telemetry/telemetry_test.go
@@ -3965,7 +3965,7 @@ func TestFlakyTelemetry(t *testing.T) {
 
 			rs = attribute.NewSet(sn[6].Attributes()...)
 
-			require.Len(t, sn[6].Attributes(), 14)
+			require.Len(t, withoutHTTPClientTimingAttributes(sn[6].Attributes()), 14)
 			asssertAttributesEqual(t, rs,
 				otel.WgSubgraphID.String("0"),
 				otel.WgSubgraphName.String("employees"),
@@ -4743,7 +4743,7 @@ func TestFlakyTelemetry(t *testing.T) {
 
 			// Span attributes
 
-			require.Len(t, sn[6].Attributes(), 14)
+			require.Len(t, withoutHTTPClientTimingAttributes(sn[6].Attributes()), 14)
 			asssertAttributesEqual(t, attribute.NewSet(sn[6].Attributes()...),
 				otel.WgSubgraphID.String("0"),
 				otel.WgSubgraphName.String("employees"),
@@ -5218,7 +5218,7 @@ func TestFlakyTelemetry(t *testing.T) {
 
 			// Span attributes
 
-			require.Len(t, sn[6].Attributes(), 14)
+			require.Len(t, withoutHTTPClientTimingAttributes(sn[6].Attributes()), 14)
 			asssertAttributesEqual(t, attribute.NewSet(sn[6].Attributes()...),
 				otel.WgSubgraphID.String("0"),
 				otel.WgSubgraphName.String("employees"),
@@ -7280,7 +7280,7 @@ func TestFlakyTelemetry(t *testing.T) {
 			)
 
 			require.Equal(t, "Engine - Fetch", sn[6].Name())
-			require.Len(t, sn[6].Attributes(), 15)
+			require.Len(t, withoutHTTPClientTimingAttributes(sn[6].Attributes()), 15)
 			asssertAttributesEqual(t, attribute.NewSet(sn[6].Attributes()...),
 				otel.WgRouterConfigVersion.String(xEnv.RouterConfigVersionMyFF()),
 				otel.WgFeatureFlag.String("myff"),
@@ -7896,13 +7896,15 @@ func TestFlakyTelemetry(t *testing.T) {
 
 			require.Equal(t, "Engine - Fetch", sn[6].Name())
 			require.Equal(t, trace.SpanKindInternal, sn[6].SpanKind())
-			require.Lenf(t, sn[6].Attributes(), 14, "expected 14 attributes, got %d", len(sn[8].Attributes()))
+			employeesAttributes := withoutHTTPClientTimingAttributes(sn[6].Attributes())
+			require.Lenf(t, employeesAttributes, 14, "expected 14 attributes, got %d", len(employeesAttributes))
 			require.Equal(t, sdktrace.Status{Code: codes.Unset}, sn[6].Status())
 
 			require.Equal(t, "Engine - Fetch", sn[8].Name())
 			require.Equal(t, trace.SpanKindInternal, sn[8].SpanKind())
 			require.Equal(t, codes.Error, sn[8].Status().Code)
-			require.Lenf(t, sn[8].Attributes(), 15, "expected 15 attributes, got %d", len(sn[8].Attributes()))
+			productsAttributes := withoutHTTPClientTimingAttributes(sn[8].Attributes())
+			require.Lenf(t, productsAttributes, 15, "expected 15 attributes, got %d", len(productsAttributes))
 			require.Contains(t, sn[8].Status().Description, "connect: connection refused\nFailed to fetch from Subgraph 'products' at Path: 'employees'.")
 
 			events := sn[8].Events()
@@ -7948,9 +7950,10 @@ func TestFlakyTelemetry(t *testing.T) {
 			require.Equal(t, trace.SpanKindInternal, sn[6].SpanKind())
 			require.Equal(t, sdktrace.Status{Code: codes.Unset}, sn[6].Status())
 
-			require.Lenf(t, sn[6].Attributes(), 14, "expected 14 attributes, got %d", len(sn[6].Attributes()))
+			employeesAttributes := withoutHTTPClientTimingAttributes(sn[6].Attributes())
+			require.Lenf(t, employeesAttributes, 14, "expected 14 attributes, got %d", len(employeesAttributes))
 
-			given := attribute.NewSet(sn[6].Attributes()...)
+			given := attribute.NewSet(employeesAttributes...)
 			want := attribute.NewSet([]attribute.KeyValue{
 				semconv.HTTPStatusCode(200),
 				otel.WgClientName.String("unknown"),
@@ -7974,9 +7977,10 @@ func TestFlakyTelemetry(t *testing.T) {
 			require.Equal(t, "Engine - Fetch", sn[8].Name())
 			require.Equal(t, trace.SpanKindInternal, sn[8].SpanKind())
 
-			require.Lenf(t, sn[8].Attributes(), 15, "expected 15 attributes, got %d", len(sn[8].Attributes()))
+			productsAttributes := withoutHTTPClientTimingAttributes(sn[8].Attributes())
+			require.Lenf(t, productsAttributes, 15, "expected 15 attributes, got %d", len(productsAttributes))
 
-			given = attribute.NewSet(sn[8].Attributes()...)
+			given = attribute.NewSet(productsAttributes...)
 			want = attribute.NewSet([]attribute.KeyValue{
 				otel.WgSubgraphName.String("products"),
 				otel.WgSubgraphID.String("3"),
@@ -9786,7 +9790,7 @@ func TestFlakyTelemetry(t *testing.T) {
 
 				require.Equal(t, "Engine - Fetch", sn[6].Name())
 				require.Len(t, sn[6].Resource().Attributes(), 9)
-				require.Len(t, sn[6].Attributes(), 14)
+				require.Len(t, withoutHTTPClientTimingAttributes(sn[6].Attributes()), 14)
 
 				// GraphQL handler
 				require.Equal(t, "Operation - Execute", sn[7].Name())

--- a/router/core/graph_server.go
+++ b/router/core/graph_server.go
@@ -1487,7 +1487,7 @@ func (s *graphServer) buildGraphMux(
 		return nil, fmt.Errorf("failed to setup plugin host: %w", err)
 	}
 
-	enableTraceClient := s.connectionMetrics != nil || exprManager.VisitorManager.IsSubgraphTraceUsedInExpressions()
+	enableTraceClient := s.traceConfig.Enabled || s.connectionMetrics != nil || exprManager.VisitorManager.IsSubgraphTraceUsedInExpressions()
 
 	var baseConnMetricStore rmetric.ConnectionMetricStore = &rmetric.NoopConnectionMetricStore{}
 	if s.connectionMetrics != nil {

--- a/router/internal/traceclient/traceclient.go
+++ b/router/internal/traceclient/traceclient.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/wundergraph/cosmo/router/pkg/metric"
 	rotel "github.com/wundergraph/cosmo/router/pkg/otel"
+	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
 type AcquiredConnection struct {
@@ -211,7 +212,7 @@ func (t *TraceInjectingRoundTripper) RoundTrip(req *http.Request) (*http.Respons
 	return trip, err
 }
 
-func (t *TraceInjectingRoundTripper) processConnectionMetrics(ctx context.Context, req *http.Request, trace *ClientTrace) {
+func (t *TraceInjectingRoundTripper) processConnectionMetrics(ctx context.Context, req *http.Request, clientTrace *ClientTrace) {
 	var subgraph string
 	subgraphCtxVal := ctx.Value(rcontext.CurrentSubgraphContextKey{})
 	if subgraphCtxVal != nil {
@@ -225,7 +226,7 @@ func (t *TraceInjectingRoundTripper) processConnectionMetrics(ctx context.Contex
 		subgraph = activeSubgraphName
 	}
 
-	if trace == nil {
+	if clientTrace == nil {
 		return
 	}
 
@@ -235,7 +236,8 @@ func (t *TraceInjectingRoundTripper) processConnectionMetrics(ctx context.Contex
 		return
 	}
 
-	connectionGet, connectionAcquired, durations := trace.snapshot()
+	connectionGet, connectionAcquired, durations := clientTrace.snapshot()
+	span := oteltrace.SpanFromContext(ctx)
 
 	// The transport can fail before it ever asks the pool for a connection,
 	// in which case no phase was observed and there is nothing to record.
@@ -254,6 +256,7 @@ func (t *TraceInjectingRoundTripper) processConnectionMetrics(ctx context.Contex
 	if connectionAcquired != nil {
 		if duration := connectionAcquired.Time.Sub(connectionGet.Time); duration >= 0 {
 			results.ConnectionAcquireDuration = duration
+			span.SetAttributes(rotel.WgClientConnectionAcquireDuration.Float64(msFromDuration(duration)))
 			t.connectionMetricStore.MeasureConnectionAcquireDuration(
 				ctx,
 				msFromDuration(duration),
@@ -264,6 +267,7 @@ func (t *TraceInjectingRoundTripper) processConnectionMetrics(ctx context.Contex
 
 	if dur := durations.DNSLookup; dur > 0 {
 		results.DNSLookupDuration = dur
+		span.SetAttributes(rotel.WgClientDNSLookupDuration.Float64(msFromDuration(dur)))
 		t.connectionMetricStore.MeasureDNSLookupDuration(
 			ctx,
 			msFromDuration(dur),
@@ -272,6 +276,7 @@ func (t *TraceInjectingRoundTripper) processConnectionMetrics(ctx context.Contex
 	}
 	if dur := durations.TCPConnect; dur > 0 {
 		results.TCPConnectDuration = dur
+		span.SetAttributes(rotel.WgClientTCPConnectDuration.Float64(msFromDuration(dur)))
 		t.connectionMetricStore.MeasureTCPConnectDuration(
 			ctx,
 			msFromDuration(dur),
@@ -280,6 +285,7 @@ func (t *TraceInjectingRoundTripper) processConnectionMetrics(ctx context.Contex
 	}
 	if dur := durations.TLSHandshake; dur > 0 {
 		results.TLSHandshakeDuration = dur
+		span.SetAttributes(rotel.WgClientTLSHandshakeDuration.Float64(msFromDuration(dur)))
 		t.connectionMetricStore.MeasureTLSHandshakeDuration(
 			ctx,
 			msFromDuration(dur),
@@ -289,6 +295,7 @@ func (t *TraceInjectingRoundTripper) processConnectionMetrics(ctx context.Contex
 
 	if dur := durations.TimeToFirstRequestByte; dur > 0 {
 		results.TimeToFirstRequestByte = dur
+		span.SetAttributes(rotel.WgClientTimeToFirstRequestByte.Float64(msFromDuration(dur)))
 		t.connectionMetricStore.MeasureTimeToFirstRequestByte(
 			ctx,
 			msFromDuration(dur),
@@ -298,6 +305,7 @@ func (t *TraceInjectingRoundTripper) processConnectionMetrics(ctx context.Contex
 
 	if dur := durations.TimeToFirstByte; dur > 0 {
 		results.TimeToFirstByte = dur
+		span.SetAttributes(rotel.WgClientTimeToFirstByte.Float64(msFromDuration(dur)))
 		t.connectionMetricStore.MeasureTimeToFirstByte(
 			ctx,
 			msFromDuration(dur),

--- a/router/internal/traceclient/traceclient_test.go
+++ b/router/internal/traceclient/traceclient_test.go
@@ -15,6 +15,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 
 	"github.com/wundergraph/cosmo/router/internal/expr"
 	"github.com/wundergraph/cosmo/router/pkg/metric"
@@ -132,6 +134,48 @@ func roundTripThroughHooks(t *testing.T, withContainer bool, fire func(ct *httpt
 }
 
 func TestTraceInjectingRoundTripper(t *testing.T) {
+	t.Run("adds connection phase timings to the active span", func(t *testing.T) {
+		exporter := tracetest.NewInMemoryExporter()
+		provider := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+		ctx, span := provider.Tracer("test").Start(WithClientTraceResults(context.Background()), "fetch")
+		now := time.Now()
+		clientTrace := &ClientTrace{
+			ConnectionGet:      &GetConnection{Time: now, HostPort: "subgraph.local:443"},
+			ConnectionAcquired: &AcquiredConnection{Time: now.Add(time.Millisecond)},
+			durations: phaseDurations{
+				DNSLookup:              2 * time.Millisecond,
+				TCPConnect:             3 * time.Millisecond,
+				TLSHandshake:           4 * time.Millisecond,
+				TimeToFirstRequestByte: 5 * time.Millisecond,
+				TimeToFirstByte:        6 * time.Millisecond,
+			},
+		}
+		request, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://subgraph.local/graphql", http.NoBody)
+		require.NoError(t, err)
+		rt := NewTraceInjectingRoundTripper(http.DefaultTransport, &metric.NoopConnectionMetricStore{}, func(context.Context, *http.Request) (*expr.Context, string) {
+			return &expr.Context{}, "service"
+		})
+
+		rt.processConnectionMetrics(ctx, request, clientTrace)
+		span.End()
+
+		spans := exporter.GetSpans()
+		require.Len(t, spans, 1)
+		attributes := attribute.NewSet(spans[0].Attributes...)
+		for key, expected := range map[attribute.Key]float64{
+			"wg.http.client.connection.acquire_duration_ms": 1,
+			"wg.http.client.dns_lookup_duration_ms":         2,
+			"wg.http.client.tcp_connect_duration_ms":        3,
+			"wg.http.client.tls_handshake_duration_ms":      4,
+			"wg.http.client.time_to_first_request_byte_ms":  5,
+			"wg.http.client.time_to_first_byte_ms":          6,
+		} {
+			value, ok := attributes.Value(key)
+			require.True(t, ok, key)
+			require.Equal(t, expected, value.AsFloat64(), key)
+		}
+	})
+
 	t.Run("records a metric for every observed connection phase", func(t *testing.T) {
 		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			_, _ = w.Write([]byte("ok"))

--- a/router/pkg/otel/attributes.go
+++ b/router/pkg/otel/attributes.go
@@ -55,7 +55,13 @@ const (
 	// HTTPRequestUploadFileCount is the number of files uploaded in a request (Not specified in the OpenTelemetry specification)
 	HTTPRequestUploadFileCount = attribute.Key("http.request.upload.file_count")
 
-	WgClientReusedConnection = attribute.Key("wg.http.client.reused_connection")
+	WgClientReusedConnection          = attribute.Key("wg.http.client.reused_connection")
+	WgClientConnectionAcquireDuration = attribute.Key("wg.http.client.connection.acquire_duration_ms")
+	WgClientDNSLookupDuration         = attribute.Key("wg.http.client.dns_lookup_duration_ms")
+	WgClientTCPConnectDuration        = attribute.Key("wg.http.client.tcp_connect_duration_ms")
+	WgClientTLSHandshakeDuration      = attribute.Key("wg.http.client.tls_handshake_duration_ms")
+	WgClientTimeToFirstRequestByte    = attribute.Key("wg.http.client.time_to_first_request_byte_ms")
+	WgClientTimeToFirstByte           = attribute.Key("wg.http.client.time_to_first_byte_ms")
 
 	// Prometheus Schema Field Usage Attrs
 

--- a/router/pkg/trace/transport.go
+++ b/router/pkg/trace/transport.go
@@ -27,7 +27,7 @@ func NewTransport(base http.RoundTripper, otelHttpOptions []otelhttp.Option, opt
 		opt(transport)
 	}
 
-	otelHttpOptions = append(otelHttpOptions, otelhttp.WithFilter(CommonRequestFilter))
+	otelHttpOptions = append(otelHttpOptions, otelhttp.WithFilter(clientRequestFilter))
 
 	return otelhttp.NewTransport(
 		transport, otelHttpOptions...,

--- a/router/pkg/trace/transport_test.go
+++ b/router/pkg/trace/transport_test.go
@@ -16,12 +16,42 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/propagation"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/trace"
 )
 
 func TestTransport(t *testing.T) {
+	t.Run("traces websocket upgrades", func(t *testing.T) {
+		traceparents := make(chan string, 1)
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			traceparents <- r.Header.Get("traceparent")
+			w.Header().Set("Connection", "Upgrade")
+			w.Header().Set("Upgrade", "websocket")
+			w.WriteHeader(http.StatusSwitchingProtocols)
+		}))
+		defer server.Close()
+
+		exporter := tracetest.NewInMemoryExporter(t)
+		tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+		client := http.Client{Transport: NewTransport(http.DefaultTransport, []otelhttp.Option{
+			otelhttp.WithTracerProvider(tp),
+			otelhttp.WithPropagators(propagation.TraceContext{}),
+		})}
+		request, err := http.NewRequest(http.MethodGet, server.URL, nil)
+		require.NoError(t, err)
+		request.Header.Set("Upgrade", "websocket")
+
+		response, err := client.Do(request)
+		require.NoError(t, err)
+		require.NoError(t, response.Body.Close())
+
+		require.NotEmpty(t, <-traceparents)
+		spans := exporter.GetSpans().Snapshots()
+		require.Len(t, spans, 1)
+		require.Equal(t, trace.SpanKindClient, spans[0].SpanKind())
+	})
 
 	t.Run("create a span for every request", func(t *testing.T) {
 		content := []byte("Hello, world!")

--- a/router/pkg/trace/utils.go
+++ b/router/pkg/trace/utils.go
@@ -55,6 +55,16 @@ func CommonRequestFilter(r *http.Request) bool {
 	return true
 }
 
+func clientRequestFilter(r *http.Request) bool {
+	if r.Method != "GET" && r.Method != "POST" {
+		return false
+	}
+	if r.Header.Get("X-WG-DISABLE-TRACING") == "true" {
+		return false
+	}
+	return true
+}
+
 func GetClientHeader(h http.Header, headerNames []string, defaultValue string) string {
 	for _, headerName := range headerNames {
 		value := h.Get(headerName)

--- a/router/pkg/trace/utils_test.go
+++ b/router/pkg/trace/utils_test.go
@@ -79,6 +79,7 @@ func TestCommonRequestFilter(t *testing.T) {
 	r.Header.Set("Upgrade", "websocket")
 	require.NoError(t, err)
 	require.Falsef(t, CommonRequestFilter(r), "ignore websocket upgrades")
+	require.Truef(t, clientRequestFilter(r), "allow outbound websocket upgrades")
 
 	r, err = http.NewRequest("PUT", "http://localhost:8080", nil)
 	require.NoError(t, err)

--- a/router/pkg/trace/utils_test.go
+++ b/router/pkg/trace/utils_test.go
@@ -79,7 +79,6 @@ func TestCommonRequestFilter(t *testing.T) {
 	r.Header.Set("Upgrade", "websocket")
 	require.NoError(t, err)
 	require.Falsef(t, CommonRequestFilter(r), "ignore websocket upgrades")
-	require.Truef(t, clientRequestFilter(r), "allow outbound websocket upgrades")
 
 	r, err = http.NewRequest("PUT", "http://localhost:8080", nil)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

- create client spans and propagate trace context for remote WebSocket operations
- expose HTTP connection-phase timings on the active remote-operation span
- enable the trace client whenever tracing is enabled
- add focused unit coverage for HTTP phase attributes and WebSocket tracing

This is a draft for [ENG-9442](https://linear.app/wundergraph/issue/ENG-9442/investigation-missing-traces-and-metrics) and addresses observability gaps.
## Tests

- `go test ./pkg/trace ./internal/traceclient ./core`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detailed connection timing information to OpenTelemetry traces, including connection acquisition, DNS, TCP, TLS, and time-to-first-byte metrics.
  * Enabled trace clients whenever router tracing is enabled.
  * Added tracing support for WebSocket upgrade requests with trace context propagation.
  * Included response-cache invalidation settings in handler configuration.

* **Bug Fixes**
  * Improved HTTP tracing controls for supported request methods and explicit tracing disablement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->