### PR TITLE
fix(controlplane): reduce memory usage and latency of schema checks

### DIFF
--- a/controlplane/src/core/composition/composeGraphs.pool.ts
+++ b/controlplane/src/core/composition/composeGraphs.pool.ts
@@ -75,6 +75,12 @@ function getComposeGraphsPool() {
       filename,
       ...(options as Options),
       env: {
+        // The worker environment replaces (rather than extends) the parent environment, so operator
+        // supplied Node flags such as `--max-old-space-size` would otherwise not apply to the child
+        // processes. Composition is the most memory intensive part of the controlplane, so make sure
+        // the same heap limits apply to the workers, otherwise they can grow unbounded and get the
+        // whole pod OOM killed even though the main process stays within its own limit.
+        ...(process.env.NODE_OPTIONS ? { NODE_OPTIONS: process.env.NODE_OPTIONS } : {}),
         SENTRY_ENABLED: env.SENTRY_ENABLED ? 'true' : 'false',
         SENTRY_DSN: env.SENTRY_DSN || '',
         SENTRY_SEND_DEFAULT_PII: env.SENTRY_SEND_DEFAULT_PII ? 'true' : 'false',

--- a/controlplane/src/core/constants.ts
+++ b/controlplane/src/core/constants.ts
@@ -64,9 +64,9 @@ export const graphTokenFeatures: FeatureIds[] = ['split-config-loading'];
  * 65535 bind parameters per statement, so a single multi-row insert of a large result set (e.g. the
  * schema changes of a deleted subgraph or the graph pruning issues of a large schema) would otherwise fail.
  */
-export const dbInsertBatchSize = 1000;
+export const DB_INSERT_BATCH_SIZE = 1000;
 
 /**
  * Maximum number of values passed to a single `IN (...)` clause when looking up rows in bulk.
  */
-export const dbInClauseBatchSize = 5000;
+export const DB_IN_CLAUSE_BATCH_SIZE = 5000;

--- a/controlplane/src/core/constants.ts
+++ b/controlplane/src/core/constants.ts
@@ -58,3 +58,15 @@ export const organizationSchema = z.object({
 export const defaultRetentionLimitInDays = 7;
 
 export const graphTokenFeatures: FeatureIds[] = ['split-config-loading'];
+
+/**
+ * Number of rows inserted per statement when bulk inserting. The Postgres wire protocol allows at most
+ * 65535 bind parameters per statement, so a single multi-row insert of a large result set (e.g. the
+ * schema changes of a deleted subgraph or the graph pruning issues of a large schema) would otherwise fail.
+ */
+export const dbInsertBatchSize = 1000;
+
+/**
+ * Maximum number of values passed to a single `IN (...)` clause when looking up rows in bulk.
+ */
+export const dbInClauseBatchSize = 5000;

--- a/controlplane/src/core/repositories/FeatureFlagRepository.ts
+++ b/controlplane/src/core/repositories/FeatureFlagRepository.ts
@@ -1,10 +1,8 @@
-import { Subgraph } from '@wundergraph/composition';
 import { joinLabel, splitLabel } from '@wundergraph/cosmo-shared';
 import { SQL, and, asc, count, desc, eq, inArray, like, or, sql, arrayOverlaps, isNull, isNotNull } from 'drizzle-orm';
 import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import { FastifyBaseLogger } from 'fastify';
 import { validate as isValidUuid } from 'uuid';
-import { parse } from 'graphql';
 import { alias } from 'drizzle-orm/pg-core';
 import * as schema from '../../db/schema.js';
 import {
@@ -45,8 +43,20 @@ export interface FeatureFlagWithFeatureSubgraphs {
   featureSubgraphs: FeatureSubgraphDTO[];
 }
 
+/**
+ * A lightweight reference to a subgraph that takes part in a composition. Only the name (and url) are
+ * consumed when planning compositions; the SDL is parsed inside the composition worker from the
+ * `SubgraphDTO`s, so we deliberately do not carry a parsed `DocumentNode` here. Parsing every subgraph
+ * of every federated graph on the main thread (and retaining the ASTs, including their token streams,
+ * for the whole check) was a major source of heap pressure on large organizations.
+ */
+export interface CompositionSubgraphRef {
+  name: string;
+  url: string;
+}
+
 export interface SubgraphsToCompose {
-  compositionSubgraphs: Subgraph[];
+  compositionSubgraphs: CompositionSubgraphRef[];
   subgraphs: SubgraphDTO[];
   isFeatureFlagComposition: boolean;
   featureFlagName: string;
@@ -1201,7 +1211,7 @@ export class FeatureFlagRepository {
 
   getFeatureFlagRelatedSubgraphsToCompose(
     featureFlagToComposeByFlagId: Map<string, FeatureFlagWithFeatureSubgraphs>,
-    baseCompositionSubgraphs: Array<Subgraph>,
+    baseCompositionSubgraphs: Array<CompositionSubgraphRef>,
     subgraphs: Array<SubgraphDTO>,
     subgraphsToCompose: Array<SubgraphsToCompose>,
     checkedSubgraphName?: string,
@@ -1224,7 +1234,6 @@ export class FeatureFlagRepository {
         compositionSubgraphs.push({
           name: featureGraph.name,
           url: featureGraph.routingUrl,
-          definitions: parse(featureGraph.schemaSDL),
         });
         subgraphDTOs.push(featureGraph);
       }
@@ -1250,7 +1259,7 @@ export class FeatureFlagRepository {
   }: {
     baseSubgraphs: SubgraphDTO[];
     fedGraphLabelMatchers: string[];
-    baseCompositionSubgraphs: Subgraph[];
+    baseCompositionSubgraphs: CompositionSubgraphRef[];
     // When set (base subgraph checks only), skip recomposing feature flags whose feature subgraph
     // overrides this subgraph — the proposed change is swapped out, so those compositions are redundant.
     checkedSubgraphName?: string;
@@ -1395,10 +1404,9 @@ export class FeatureFlagRepository {
       published: true,
     });
 
-    const baseCompositionSubgraphs: Subgraph[] = baseSubgraphDTOs.map((s) => ({
+    const baseCompositionSubgraphs: CompositionSubgraphRef[] = baseSubgraphDTOs.map((s) => ({
       name: s.name,
       url: s.routingUrl,
-      definitions: parse(s.schemaSDL),
     }));
 
     // Clone each flag and apply the proposed change to the checked feature subgraph. An empty proposed

--- a/controlplane/src/core/repositories/SchemaCheckRepository.ts
+++ b/controlplane/src/core/repositories/SchemaCheckRepository.ts
@@ -21,7 +21,6 @@ import { and, eq, ilike, inArray, or, SQL, sql } from 'drizzle-orm';
 import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import { FastifyBaseLogger } from 'fastify';
 import { GraphQLSchema, parse } from 'graphql';
-import { cloneDeep } from 'lodash-es';
 import pLimit from 'p-limit';
 import { NewSchemaChangeOperationUsage, ProposalMatch, SchemaCheckChangeAction } from '../../db/models.js';
 import * as schema from '../../db/schema.js';
@@ -62,7 +61,7 @@ import {
 } from '../util.js';
 import { OrganizationWebhookService } from '../webhooks/OrganizationWebhookService.js';
 import { BlobStorage } from '../blobstorage/index.js';
-import { defaultRetentionLimitInDays } from '../constants.js';
+import { defaultRetentionLimitInDays, dbInsertBatchSize, dbInClauseBatchSize } from '../constants.js';
 import { traced } from '../tracing.js';
 import { FederatedGraphConfig, FederatedGraphRepository } from './FederatedGraphRepository.js';
 import { OrganizationRepository } from './OrganizationRepository.js';
@@ -71,6 +70,11 @@ import { SchemaGraphPruningRepository } from './SchemaGraphPruningRepository.js'
 import { SchemaLintRepository } from './SchemaLintRepository.js';
 import { SubgraphRepository } from './SubgraphRepository.js';
 import { NamespaceRepository } from './NamespaceRepository.js';
+
+// Identifies a (change type, path) pair, e.g. to match detected breaking changes against stored overrides.
+function changeKey(changeType: string | null, path: string | null) {
+  return `${changeType ?? ''}::${path ?? ''}`;
+}
 
 @traced
 export class SchemaCheckRepository {
@@ -150,29 +154,42 @@ export class SchemaCheckRepository {
     return updatedSchemaCheck[0].id;
   }
 
-  public createSchemaCheckChanges(data: {
+  public async createSchemaCheckChanges(data: {
     schemaCheckID: string;
     changes: SchemaDiff[];
     schemaCheckSubgraphId?: string;
     isFedGraphChange?: boolean;
-  }) {
+  }): Promise<SchemaCheckChangeAction[]> {
     if (data.changes.length === 0) {
       return [];
     }
-    return this.db
-      .insert(schemaCheckChangeAction)
-      .values(
-        data.changes.map((change) => ({
-          schemaCheckId: data.schemaCheckID,
-          changeType: change.changeType,
-          changeMessage: change.message,
-          path: change.path,
-          isBreaking: change.isBreaking,
-          schemaCheckSubgraphId: data.schemaCheckSubgraphId,
-          isFedGraphChange: data.isFedGraphChange ?? false,
-        })),
-      )
-      .returning();
+
+    // Insert in batches. A single multi-row insert is limited by the number of bind parameters the
+    // Postgres wire protocol supports (65535), which a subgraph with many thousands of changes (e.g.
+    // a deletion) can easily exceed, and it also keeps the size of a single statement bounded.
+    return await this.db.transaction(async (tx) => {
+      const inserted: SchemaCheckChangeAction[] = [];
+      for (const batch of createBatches(data.changes, dbInsertBatchSize)) {
+        const rows = await tx
+          .insert(schemaCheckChangeAction)
+          .values(
+            batch.map((change) => ({
+              schemaCheckId: data.schemaCheckID,
+              changeType: change.changeType,
+              changeMessage: change.message,
+              path: change.path,
+              isBreaking: change.isBreaking,
+              schemaCheckSubgraphId: data.schemaCheckSubgraphId,
+              isFedGraphChange: data.isFedGraphChange ?? false,
+            })),
+          )
+          .returning();
+        for (const row of rows) {
+          inserted.push(row);
+        }
+      }
+      return inserted;
+    });
   }
 
   public createFederatedGraphSchemaChanges(data: {
@@ -186,29 +203,38 @@ export class SchemaCheckRepository {
     }
 
     return this.db.transaction(async (tx) => {
-      // Insert changes into schemaCheckChangeAction with isFedGraphChange: true
-      const insertedChanges = await tx
-        .insert(schemaCheckChangeAction)
-        .values(
-          data.changes.map((change) => ({
-            schemaCheckId: data.schemaCheckId,
-            changeType: change.changeType,
-            changeMessage: change.message,
-            path: change.path,
-            isBreaking: change.isBreaking,
-            isFedGraphChange: true,
-          })),
-        )
-        .returning();
+      const insertedChanges: SchemaCheckChangeAction[] = [];
 
-      // Create mappings to link changes to the federated graph
-      await tx.insert(schema.schemaCheckFederatedGraphChanges).values(
-        insertedChanges.map((change) => ({
-          schemaCheckFederatedGraphId: data.schemaCheckFederatedGraphId,
-          schemaCheckChangeActionId: change.id,
-          featureFlagId: data.featureFlagId,
-        })),
-      );
+      // Insert in batches to stay well below the Postgres bind parameter limit (see createSchemaCheckChanges).
+      for (const batch of createBatches(data.changes, dbInsertBatchSize)) {
+        // Insert changes into schemaCheckChangeAction with isFedGraphChange: true
+        const rows = await tx
+          .insert(schemaCheckChangeAction)
+          .values(
+            batch.map((change) => ({
+              schemaCheckId: data.schemaCheckId,
+              changeType: change.changeType,
+              changeMessage: change.message,
+              path: change.path,
+              isBreaking: change.isBreaking,
+              isFedGraphChange: true,
+            })),
+          )
+          .returning();
+
+        // Create mappings to link changes to the federated graph
+        await tx.insert(schema.schemaCheckFederatedGraphChanges).values(
+          rows.map((change) => ({
+            schemaCheckFederatedGraphId: data.schemaCheckFederatedGraphId,
+            schemaCheckChangeActionId: change.id,
+            featureFlagId: data.featureFlagId,
+          })),
+        );
+
+        for (const row of rows) {
+          insertedChanges.push(row);
+        }
+      }
 
       return insertedChanges;
     });
@@ -269,28 +295,30 @@ export class SchemaCheckRepository {
     const limit = pLimit(10);
 
     for (const [schemaCheckChangeActionId, operations] of schemaCheckActionOperations.entries()) {
-      values.push(
-        ...operations.map(
-          (op) =>
-            ({
-              schemaCheckChangeActionId,
-              name: op.name,
-              type: op.type,
-              hash: op.hash,
-              firstSeenAt: op.firstSeenAt,
-              lastSeenAt: op.lastSeenAt,
-              federatedGraphId,
-              isSafeOverride: op.isSafeOverride,
-            }) as NewSchemaChangeOperationUsage,
-        ),
-      );
+      // Avoid `push(...spread)` here: a popular field can be used by a very large number of
+      // operations and spreading that many arguments into a call throws a RangeError.
+      for (const op of operations) {
+        values.push({
+          schemaCheckChangeActionId,
+          name: op.name,
+          type: op.type,
+          hash: op.hash,
+          firstSeenAt: op.firstSeenAt,
+          lastSeenAt: op.lastSeenAt,
+          federatedGraphId,
+          isSafeOverride: op.isSafeOverride,
+        } as NewSchemaChangeOperationUsage);
+      }
     }
 
     if (values.length === 0) {
       return;
     }
 
-    const arrayOfValues: NewSchemaChangeOperationUsage[][] = createBatches<NewSchemaChangeOperationUsage>(values, 1000);
+    const arrayOfValues: NewSchemaChangeOperationUsage[][] = createBatches<NewSchemaChangeOperationUsage>(
+      values,
+      dbInsertBatchSize,
+    );
     const promises = [];
 
     for (const values of arrayOfValues) {
@@ -300,18 +328,6 @@ export class SchemaCheckRepository {
     await Promise.all(promises);
   }
 
-  private mapChangesFromDriverValue(val: any) {
-    if (typeof val === 'string' && val.length > 0 && val !== '{}') {
-      const pairs = val.slice(2, -2).split('","');
-
-      return pairs.map((pair) => {
-        const [changeType, path] = pair.slice(1, -1).split(',');
-        return { changeType, path };
-      });
-    }
-    return [];
-  }
-
   public async checkClientTrafficAgainstOverrides(data: {
     changes: { id: string; changeType: string | null; path: string | null }[];
     inspectorResultsByChangeId: Map<string, InspectorOperationResult[]>;
@@ -319,84 +335,112 @@ export class SchemaCheckRepository {
   }) {
     let hasUnsafeClientTraffic = false;
 
-    const result = cloneDeep(data.inspectorResultsByChangeId);
+    type ChangeAction = (typeof data.changes)[number];
 
-    const changeActionsByOperationHash: Map<string, typeof data.changes> = new Map();
-
-    for (const [schemaCheckChangeId, operationResults] of result.entries()) {
+    // The caller's map must not be mutated, so copy the operation results. A shallow copy of every
+    // operation is sufficient since we only flip `isSafeOverride`; the previous deep clone doubled the
+    // memory footprint of what can be a very large result set.
+    const result = new Map<string, InspectorOperationResult[]>();
+    for (const [schemaCheckChangeId, operationResults] of data.inspectorResultsByChangeId) {
+      const copies: InspectorOperationResult[] = [];
       for (const operationResult of operationResults) {
-        const { hash } = operationResult;
-        if (!changeActionsByOperationHash.has(hash)) {
-          changeActionsByOperationHash.set(hash, []);
-        }
+        copies.push({ ...operationResult });
+      }
+      result.set(schemaCheckChangeId, copies);
+    }
 
-        const change = data.changes.find((c) => c.id === schemaCheckChangeId);
-        if (change) {
-          changeActionsByOperationHash.get(hash)?.push(change);
+    const changeById = new Map<string, ChangeAction>();
+    for (const change of data.changes) {
+      changeById.set(change.id, change);
+    }
+
+    // For every operation hash, collect the changes that affect it together with the copied operation
+    // so we can flag the operation directly instead of searching for it again later.
+    const affectedByOperationHash = new Map<string, { change: ChangeAction; op: InspectorOperationResult }[]>();
+    for (const [schemaCheckChangeId, operationResults] of result) {
+      const change = changeById.get(schemaCheckChangeId);
+      if (!change) {
+        continue;
+      }
+      for (const op of operationResults) {
+        let affected = affectedByOperationHash.get(op.hash);
+        if (!affected) {
+          affected = [];
+          affectedByOperationHash.set(op.hash, affected);
         }
+        affected.push({ change, op });
       }
     }
 
-    for (const [hash, changes] of changeActionsByOperationHash) {
-      const incomingChanges = `array[${changes.map((c) => `('${c.changeType}'::schema_change_type, '${c.path}'::text)`)}]`;
-      const storedChanges = `array_agg(distinct (${schema.operationChangeOverrides.changeType.name}, ${schema.operationChangeOverrides.path.name}))`;
+    if (affectedByOperationHash.size === 0) {
+      return { hasUnsafeClientTraffic, result };
+    }
 
-      // Incoming changes are new breaking changes detected in the current check run
-      // Stored changes are a list of changes that have been marked as safe (override) by the user
-      // Here except tells us the incoming changes that are not safe and an intersection tells us the incoming changes that are safe
-      const res = await this.db
+    // Load the overrides for all affected operations with a few bulk queries instead of two queries per
+    // operation hash. Operations are identified by hash, so a breaking change to a popular field on a
+    // busy graph can easily be used by tens of thousands of distinct operations, which previously
+    // meant tens of thousands of sequential round trips to the database and check requests timing out.
+    const storedChangesByHash = new Map<string, Set<string>>();
+    const ignoreAllHashes = new Set<string>();
+
+    for (const hashes of createBatches([...affectedByOperationHash.keys()], dbInClauseBatchSize)) {
+      const overrides = await this.db
         .select({
-          unsafeChanges: sql
-            .raw(`array(select unnest(${incomingChanges}) except select unnest(${storedChanges}))`)
-            .mapWith({
-              mapFromDriverValue: this.mapChangesFromDriverValue,
-            }),
-          safeChanges: sql
-            .raw(`array(select unnest(${incomingChanges}) intersect select unnest(${storedChanges}))`)
-            .mapWith({
-              mapFromDriverValue: this.mapChangesFromDriverValue,
-            }),
+          hash: schema.operationChangeOverrides.hash,
+          changeType: schema.operationChangeOverrides.changeType,
+          path: schema.operationChangeOverrides.path,
         })
         .from(schema.operationChangeOverrides)
         .where(
           and(
-            eq(schema.operationChangeOverrides.hash, hash),
             eq(schema.operationChangeOverrides.namespaceId, data.namespaceId),
+            inArray(schema.operationChangeOverrides.hash, hashes),
           ),
-        )
-        .groupBy(schema.operationChangeOverrides.hash);
+        );
 
-      const ignoreAll = await this.db.query.operationIgnoreAllOverrides.findFirst({
-        where: and(
-          eq(schema.operationIgnoreAllOverrides.hash, hash),
-          eq(schema.operationIgnoreAllOverrides.namespaceId, data.namespaceId),
-        ),
-      });
+      for (const override of overrides) {
+        let storedChanges = storedChangesByHash.get(override.hash);
+        if (!storedChanges) {
+          storedChanges = new Set<string>();
+          storedChangesByHash.set(override.hash, storedChanges);
+        }
+        storedChanges.add(changeKey(override.changeType, override.path));
+      }
 
-      if (res.length === 0 && !ignoreAll) {
+      const ignoreAllOverrides = await this.db
+        .select({ hash: schema.operationIgnoreAllOverrides.hash })
+        .from(schema.operationIgnoreAllOverrides)
+        .where(
+          and(
+            eq(schema.operationIgnoreAllOverrides.namespaceId, data.namespaceId),
+            inArray(schema.operationIgnoreAllOverrides.hash, hashes),
+          ),
+        );
+
+      for (const ignoreAllOverride of ignoreAllOverrides) {
+        ignoreAllHashes.add(ignoreAllOverride.hash);
+      }
+    }
+
+    for (const [hash, affected] of affectedByOperationHash) {
+      const ignoreAll = ignoreAllHashes.has(hash);
+      // Stored changes are the changes that have been marked as safe (override) by the user for this operation
+      const storedChanges = storedChangesByHash.get(hash);
+
+      if (!storedChanges && !ignoreAll) {
         // If no safe overrides are found, then mark traffic as unsafe
         hasUnsafeClientTraffic = true;
         continue;
       }
 
-      const safeChanges = ignoreAll ? changes : res[0].safeChanges;
-
-      for (const safeChange of safeChanges) {
-        const change = changes.find((c) => c.changeType === safeChange.changeType && c.path === safeChange.path);
-        if (!change) {
-          continue;
+      // Incoming changes are the new breaking changes detected in the current check run. A change is safe
+      // for this operation if all changes are ignored or if it has explicitly been marked as safe.
+      for (const { change, op } of affected) {
+        if (ignoreAll || storedChanges?.has(changeKey(change.changeType, change.path))) {
+          op.isSafeOverride = true;
+        } else {
+          hasUnsafeClientTraffic = true;
         }
-
-        const op = result.get(change.id)?.find((c) => c.hash === hash);
-        if (!op) {
-          continue;
-        }
-
-        op.isSafeOverride = true;
-      }
-
-      if (!ignoreAll && res[0].unsafeChanges.length > 0) {
-        hasUnsafeClientTraffic = true;
       }
     }
 
@@ -1387,7 +1431,9 @@ export class SchemaCheckRepository {
 
           // Collect inspected operations for later aggregation
           for (const resultElement of fedOverrideCheck.result.values()) {
-            inspectedOperations.push(...resultElement);
+            for (const op of resultElement) {
+              inspectedOperations.push(op);
+            }
           }
         }
       }
@@ -1429,7 +1475,9 @@ export class SchemaCheckRepository {
 
         // Collect all inspected operations for later aggregation
         for (const resultElement of overrideCheck.result.values()) {
-          inspectedOperations.push(...resultElement);
+          for (const op of resultElement) {
+            inspectedOperations.push(op);
+          }
         }
       }
     }

--- a/controlplane/src/core/repositories/SchemaCheckRepository.ts
+++ b/controlplane/src/core/repositories/SchemaCheckRepository.ts
@@ -21,7 +21,6 @@ import { and, eq, ilike, inArray, or, SQL, sql } from 'drizzle-orm';
 import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import { FastifyBaseLogger } from 'fastify';
 import { GraphQLSchema, parse } from 'graphql';
-import pLimit from 'p-limit';
 import { NewSchemaChangeOperationUsage, ProposalMatch, SchemaCheckChangeAction } from '../../db/models.js';
 import * as schema from '../../db/schema.js';
 import {
@@ -294,7 +293,6 @@ export class SchemaCheckRepository {
     federatedGraphId: string,
   ) {
     const values: NewSchemaChangeOperationUsage[] = [];
-    const limit = pLimit(10);
 
     for (const [schemaCheckChangeActionId, operations] of schemaCheckActionOperations.entries()) {
       // Avoid `push(...spread)` here: a popular field can be used by a very large number of
@@ -317,17 +315,13 @@ export class SchemaCheckRepository {
       return;
     }
 
-    const arrayOfValues: NewSchemaChangeOperationUsage[][] = createBatches<NewSchemaChangeOperationUsage>(
-      values,
-      DB_INSERT_BATCH_SIZE,
-    );
-    const promises = [];
-
-    for (const values of arrayOfValues) {
-      promises.push(limit(() => this.db.insert(schemaCheckChangeActionOperationUsage).values(values).execute()));
-    }
-
-    await Promise.all(promises);
+    // Insert in batches to stay below the Postgres bind parameter limit, but within a single transaction so a
+    // failing batch does not leave a schema check with partially stored operation usage.
+    await this.db.transaction(async (tx) => {
+      for (const batch of createBatches<NewSchemaChangeOperationUsage>(values, DB_INSERT_BATCH_SIZE)) {
+        await tx.insert(schemaCheckChangeActionOperationUsage).values(batch).execute();
+      }
+    });
   }
 
   public async checkClientTrafficAgainstOverrides(data: {

--- a/controlplane/src/core/repositories/SchemaCheckRepository.ts
+++ b/controlplane/src/core/repositories/SchemaCheckRepository.ts
@@ -61,7 +61,7 @@ import {
 } from '../util.js';
 import { OrganizationWebhookService } from '../webhooks/OrganizationWebhookService.js';
 import { BlobStorage } from '../blobstorage/index.js';
-import { defaultRetentionLimitInDays, dbInsertBatchSize, dbInClauseBatchSize } from '../constants.js';
+import { defaultRetentionLimitInDays, DB_INSERT_BATCH_SIZE, DB_IN_CLAUSE_BATCH_SIZE } from '../constants.js';
 import { traced } from '../tracing.js';
 import { FederatedGraphConfig, FederatedGraphRepository } from './FederatedGraphRepository.js';
 import { OrganizationRepository } from './OrganizationRepository.js';
@@ -71,8 +71,10 @@ import { SchemaLintRepository } from './SchemaLintRepository.js';
 import { SubgraphRepository } from './SubgraphRepository.js';
 import { NamespaceRepository } from './NamespaceRepository.js';
 
-// Identifies a (change type, path) pair, e.g. to match detected breaking changes against stored overrides.
-function changeKey(changeType: string | null, path: string | null) {
+/**
+ * Identifies a (change type, path) pair, e.g. to match detected breaking changes against stored overrides.
+ */
+function changeKey(changeType: string | null, path: string | null): string {
   return `${changeType ?? ''}::${path ?? ''}`;
 }
 
@@ -169,7 +171,7 @@ export class SchemaCheckRepository {
     // a deletion) can easily exceed, and it also keeps the size of a single statement bounded.
     return await this.db.transaction(async (tx) => {
       const inserted: SchemaCheckChangeAction[] = [];
-      for (const batch of createBatches(data.changes, dbInsertBatchSize)) {
+      for (const batch of createBatches(data.changes, DB_INSERT_BATCH_SIZE)) {
         const rows = await tx
           .insert(schemaCheckChangeAction)
           .values(
@@ -206,7 +208,7 @@ export class SchemaCheckRepository {
       const insertedChanges: SchemaCheckChangeAction[] = [];
 
       // Insert in batches to stay well below the Postgres bind parameter limit (see createSchemaCheckChanges).
-      for (const batch of createBatches(data.changes, dbInsertBatchSize)) {
+      for (const batch of createBatches(data.changes, DB_INSERT_BATCH_SIZE)) {
         // Insert changes into schemaCheckChangeAction with isFedGraphChange: true
         const rows = await tx
           .insert(schemaCheckChangeAction)
@@ -317,7 +319,7 @@ export class SchemaCheckRepository {
 
     const arrayOfValues: NewSchemaChangeOperationUsage[][] = createBatches<NewSchemaChangeOperationUsage>(
       values,
-      dbInsertBatchSize,
+      DB_INSERT_BATCH_SIZE,
     );
     const promises = [];
 
@@ -383,7 +385,7 @@ export class SchemaCheckRepository {
     const storedChangesByHash = new Map<string, Set<string>>();
     const ignoreAllHashes = new Set<string>();
 
-    for (const hashes of createBatches([...affectedByOperationHash.keys()], dbInClauseBatchSize)) {
+    for (const hashes of createBatches([...affectedByOperationHash.keys()], DB_IN_CLAUSE_BATCH_SIZE)) {
       const overrides = await this.db
         .select({
           hash: schema.operationChangeOverrides.hash,

--- a/controlplane/src/core/repositories/SchemaGraphPruningRepository.ts
+++ b/controlplane/src/core/repositories/SchemaGraphPruningRepository.ts
@@ -18,7 +18,7 @@ import {
 } from '../../types/index.js';
 import { ClickHouseClient } from '../clickhouse/index.js';
 import { GetDiffBetweenGraphsSuccess } from '../composition/schemaCheck.js';
-import { dbInsertBatchSize } from '../constants.js';
+import { DB_INSERT_BATCH_SIZE } from '../constants.js';
 import SchemaGraphPruner from '../services/SchemaGraphPruner.js';
 import { traced } from '../tracing.js';
 import { createBatches } from '../util.js';
@@ -98,7 +98,7 @@ export class SchemaGraphPruningRepository {
     // One issue is produced per (field, federated graph) pair, so large subgraphs in many federated graphs
     // produce a lot of rows. Insert in batches to stay below the Postgres bind parameter limit (65535).
     await this.db.transaction(async (tx) => {
-      for (const batch of createBatches(graphPruningIssues, dbInsertBatchSize)) {
+      for (const batch of createBatches(graphPruningIssues, DB_INSERT_BATCH_SIZE)) {
         await tx.insert(schemaCheckGraphPruningAction).values(
           batch.map((l) => {
             return {

--- a/controlplane/src/core/repositories/SchemaGraphPruningRepository.ts
+++ b/controlplane/src/core/repositories/SchemaGraphPruningRepository.ts
@@ -18,8 +18,10 @@ import {
 } from '../../types/index.js';
 import { ClickHouseClient } from '../clickhouse/index.js';
 import { GetDiffBetweenGraphsSuccess } from '../composition/schemaCheck.js';
+import { dbInsertBatchSize } from '../constants.js';
 import SchemaGraphPruner from '../services/SchemaGraphPruner.js';
 import { traced } from '../tracing.js';
+import { createBatches } from '../util.js';
 import { UsageRepository } from './analytics/UsageRepository.js';
 import { FederatedGraphRepository } from './FederatedGraphRepository.js';
 import { SubgraphRepository } from './SubgraphRepository.js';
@@ -89,22 +91,30 @@ export class SchemaGraphPruningRepository {
     graphPruningIssues: GraphPruningIssueResult[];
     schemaCheckSubgraphId: string;
   }) {
-    if (graphPruningIssues.length > 0) {
-      await this.db.insert(schemaCheckGraphPruningAction).values(
-        graphPruningIssues.map((l) => {
-          return {
-            graphPruningRuleType: l.graphPruningRuleType,
-            schemaCheckId,
-            fieldPath: l.fieldPath,
-            message: l.message,
-            location: l.issueLocation,
-            isError: l.severity === LintSeverity.error,
-            federatedGraphId: l.federatedGraphId,
-            schemaCheckSubgraphId,
-          };
-        }),
-      );
+    if (graphPruningIssues.length === 0) {
+      return;
     }
+
+    // One issue is produced per (field, federated graph) pair, so large subgraphs in many federated graphs
+    // produce a lot of rows. Insert in batches to stay below the Postgres bind parameter limit (65535).
+    await this.db.transaction(async (tx) => {
+      for (const batch of createBatches(graphPruningIssues, dbInsertBatchSize)) {
+        await tx.insert(schemaCheckGraphPruningAction).values(
+          batch.map((l) => {
+            return {
+              graphPruningRuleType: l.graphPruningRuleType,
+              schemaCheckId,
+              fieldPath: l.fieldPath,
+              message: l.message,
+              location: l.issueLocation,
+              isError: l.severity === LintSeverity.error,
+              federatedGraphId: l.federatedGraphId,
+              schemaCheckSubgraphId,
+            };
+          }),
+        );
+      }
+    });
   }
 
   public async getSchemaCheckGraphPruningIsssues({

--- a/controlplane/src/core/repositories/SchemaLintRepository.ts
+++ b/controlplane/src/core/repositories/SchemaLintRepository.ts
@@ -4,7 +4,7 @@ import { LintConfig, LintSeverity } from '@wundergraph/cosmo-connect/dist/platfo
 import * as schema from '../../db/schema.js';
 import { namespaceLintCheckConfig, schemaCheckLintAction, schemaCheckSubgraphs } from '../../db/schema.js';
 import { SchemaLintDTO, LintSeverityLevel, LintIssueResult, LintRule, SchemaLintIssues } from '../../types/index.js';
-import { dbInsertBatchSize } from '../constants.js';
+import { DB_INSERT_BATCH_SIZE } from '../constants.js';
 import SchemaLinter from '../services/SchemaLinter.js';
 import { traced } from '../tracing.js';
 import { createBatches } from '../util.js';
@@ -69,7 +69,7 @@ export class SchemaLintRepository {
 
     // Insert in batches to stay below the Postgres bind parameter limit (65535) for large schemas.
     await this.db.transaction(async (tx) => {
-      for (const batch of createBatches(lintIssues, dbInsertBatchSize)) {
+      for (const batch of createBatches(lintIssues, DB_INSERT_BATCH_SIZE)) {
         await tx.insert(schemaCheckLintAction).values(
           batch.map((l) => {
             return {

--- a/controlplane/src/core/repositories/SchemaLintRepository.ts
+++ b/controlplane/src/core/repositories/SchemaLintRepository.ts
@@ -4,8 +4,10 @@ import { LintConfig, LintSeverity } from '@wundergraph/cosmo-connect/dist/platfo
 import * as schema from '../../db/schema.js';
 import { namespaceLintCheckConfig, schemaCheckLintAction, schemaCheckSubgraphs } from '../../db/schema.js';
 import { SchemaLintDTO, LintSeverityLevel, LintIssueResult, LintRule, SchemaLintIssues } from '../../types/index.js';
+import { dbInsertBatchSize } from '../constants.js';
 import SchemaLinter from '../services/SchemaLinter.js';
 import { traced } from '../tracing.js';
+import { createBatches } from '../util.js';
 
 @traced
 export class SchemaLintRepository {
@@ -61,20 +63,27 @@ export class SchemaLintRepository {
     lintIssues: LintIssueResult[];
     schemaCheckSubgraphId: string;
   }) {
-    if (lintIssues.length > 0) {
-      await this.db.insert(schemaCheckLintAction).values(
-        lintIssues.map((l) => {
-          return {
-            lintRuleType: l.lintRuleType || null,
-            schemaCheckId,
-            message: l.message,
-            location: l.issueLocation,
-            isError: l.severity === LintSeverity.error,
-            schemaCheckSubgraphId,
-          };
-        }),
-      );
+    if (lintIssues.length === 0) {
+      return;
     }
+
+    // Insert in batches to stay below the Postgres bind parameter limit (65535) for large schemas.
+    await this.db.transaction(async (tx) => {
+      for (const batch of createBatches(lintIssues, dbInsertBatchSize)) {
+        await tx.insert(schemaCheckLintAction).values(
+          batch.map((l) => {
+            return {
+              lintRuleType: l.lintRuleType || null,
+              schemaCheckId,
+              message: l.message,
+              location: l.issueLocation,
+              isError: l.severity === LintSeverity.error,
+              schemaCheckSubgraphId,
+            };
+          }),
+        );
+      }
+    });
   }
 
   public deleteExistingSchemaCheckLintIssues({

--- a/controlplane/src/core/repositories/SubgraphRepository.ts
+++ b/controlplane/src/core/repositories/SubgraphRepository.ts
@@ -13,7 +13,7 @@ import { and, arrayOverlaps, asc, count, desc, eq, gt, inArray, like, lt, notInA
 import { validate as isValidUuid } from 'uuid';
 import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import { FastifyBaseLogger } from 'fastify';
-import { GraphQLSchema, parse } from 'graphql';
+import { GraphQLSchema } from 'graphql';
 import { CompositionOptions } from '@wundergraph/composition';
 import { DBSubgraphType, SchemaCheckChangeAction, WebsocketSubprotocol } from '../../db/models.js';
 import * as schema from '../../db/schema.js';
@@ -2651,7 +2651,6 @@ export class SubgraphRepository {
         const baseCompositionSubgraphs = composableBaseSubgraphs.map((s) => ({
           name: s.name,
           url: s.routingUrl,
-          definitions: parse(s.schemaSDL),
         }));
 
         const plan = await featureFlagRepo.getSubgraphsToCompose({
@@ -2846,7 +2845,9 @@ export class SubgraphRepository {
 
           // Collect inspected operations
           for (const resultElement of subgraphOverrideCheck.result.values()) {
-            inspectedOperations.push(...resultElement);
+            for (const op of resultElement) {
+              inspectedOperations.push(op);
+            }
           }
         }
       }
@@ -2874,7 +2875,9 @@ export class SubgraphRepository {
 
           // Collect inspected operations
           for (const resultElement of fedGraphOverrideCheck.result.values()) {
-            inspectedOperations.push(...resultElement);
+            for (const op of resultElement) {
+              inspectedOperations.push(op);
+            }
           }
         }
       }

--- a/controlplane/src/core/services/CompositionService.ts
+++ b/controlplane/src/core/services/CompositionService.ts
@@ -11,7 +11,6 @@ import { DeploymentError } from '@wundergraph/cosmo-connect/dist/platform/v1/pla
 import { and, eq, inArray } from 'drizzle-orm';
 import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import { FastifyBaseLogger } from 'fastify';
-import { parse } from 'graphql';
 import pLimit from 'p-limit';
 import {
   CompositionOptions,
@@ -235,7 +234,6 @@ export class CompositionService {
       const baseCompositionSubgraphs = subgraphs.map((s) => ({
         name: s.name,
         url: s.routingUrl,
-        definitions: parse(s.schemaSDL),
       }));
 
       const subgraphsToCompose = featureFlagRepo.getFeatureFlagRelatedSubgraphsToCompose(
@@ -576,7 +574,6 @@ export class CompositionService {
           const baseCompositionSubgraphs = subgraphs.map((s) => ({
             name: s.name,
             url: s.routingUrl,
-            definitions: parse(s.schemaSDL),
           }));
 
           const subgraphsToCompose = featureFlagRepo.getFeatureFlagRelatedSubgraphsToCompose(
@@ -1007,7 +1004,6 @@ export class CompositionService {
       const baseCompositionSubgraphs = subgraphs.map((s) => ({
         name: s.name,
         url: s.routingUrl,
-        definitions: parse(s.schemaSDL),
       }));
 
       // Collects the base graph and applicable feature flag-related graphs

--- a/controlplane/src/core/services/SchemaGraphPruner.test.ts
+++ b/controlplane/src/core/services/SchemaGraphPruner.test.ts
@@ -1,0 +1,169 @@
+import { buildSchema } from 'graphql';
+import { LintSeverity } from '@wundergraph/cosmo-connect/dist/platform/v1/platform_pb';
+import { describe, expect, test, vi } from 'vitest';
+import { FederatedGraphDTO } from '../../types/index.js';
+import { SchemaDiff } from '../composition/schemaCheck.js';
+import SchemaGraphPruner from './SchemaGraphPruner.js';
+
+// The pruner only touches `getSubgraphFieldsInGracePeriod` on the subgraph repository and
+// `getUnusedFields` / `getUsedFields` on the usage repository, so both can be stubbed and the
+// field bookkeeping exercised without the Postgres/ClickHouse test harness.
+const schema = buildSchema(/* GraphQL */ `
+  type Query {
+    employees: [Employee!]!
+    employee(id: ID!): Employee
+    products: [Product!]!
+  }
+
+  type Employee {
+    id: ID!
+    name: String!
+    nickname: String @deprecated(reason: "Use name instead")
+  }
+
+  type Product {
+    upc: String!
+    price: Int!
+  }
+`);
+
+const federatedGraphs = [
+  { id: 'fg-1', name: 'graph-one' },
+  { id: 'fg-2', name: 'graph-two' },
+] as unknown as FederatedGraphDTO[];
+
+const fieldDiff = (path: string): SchemaDiff => ({
+  changeType: 'FIELD_ADDED',
+  message: `Field '${path}' was added`,
+  path,
+  isBreaking: false,
+  meta: {} as SchemaDiff['meta'],
+});
+
+describe('SchemaGraphPruner', () => {
+  test('reports unused fields per federated graph, excluding grace period and newly added fields', async () => {
+    const getUnusedFields = vi.fn(
+      ({ federatedGraphId, fields }: { federatedGraphId: string; fields: { name: string; typeName: string }[] }) => {
+        // graph-one has traffic on everything but Employee.name, graph-two has no traffic at all
+        if (federatedGraphId === 'fg-1') {
+          return Promise.resolve(fields.filter((f) => f.typeName === 'Employee' && f.name === 'name'));
+        }
+        return Promise.resolve(fields.map((f) => ({ name: f.name, typeName: f.typeName })));
+      },
+    );
+    const subgraphRepo = {
+      getSubgraphFieldsInGracePeriod: vi.fn().mockResolvedValue([{ path: 'Product.price' }]),
+    };
+    const pruner = new SchemaGraphPruner({} as any, subgraphRepo as any, { getUnusedFields } as any, schema);
+
+    const issues = await pruner.fetchUnusedFields({
+      subgraphId: 'sg-1',
+      namespaceId: 'ns-1',
+      organizationId: 'org-1',
+      federatedGraphs,
+      rangeInDays: 7,
+      addedFields: [fieldDiff('Query.products')],
+      severityLevel: 'error',
+    });
+
+    // Fields in grace period and fields added by this check are never sent to ClickHouse
+    const checkedPaths = getUnusedFields.mock.calls[0][0].fields.map(
+      (f: { typeName: string; name: string }) => `${f.typeName}.${f.name}`,
+    );
+    expect(checkedPaths).not.toContain('Product.price');
+    expect(checkedPaths).not.toContain('Query.products');
+    expect(checkedPaths).toContain('Employee.name');
+    expect(getUnusedFields).toHaveBeenCalledTimes(2);
+
+    const byGraph = (id: string) => issues.filter((i) => i.federatedGraphId === id).map((i) => i.fieldPath);
+    expect(byGraph('fg-1')).toEqual(['Employee.name']);
+    // Order follows the schema field order, not the order ClickHouse returned the rows in
+    expect(byGraph('fg-2')).toEqual([
+      'Query.employees',
+      'Query.employee',
+      'Employee.id',
+      'Employee.name',
+      'Employee.nickname',
+      'Product.upc',
+    ]);
+    expect(issues.every((i) => i.graphPruningRuleType === 'UNUSED_FIELDS' && i.severity === LintSeverity.error)).toBe(
+      true,
+    );
+  });
+
+  test('reports deprecated fields with their usage state', async () => {
+    const getUsedFields = vi.fn(({ federatedGraphId }: { federatedGraphId: string }) =>
+      Promise.resolve(federatedGraphId === 'fg-1' ? [{ name: 'nickname', typeName: 'Employee' }] : []),
+    );
+    const subgraphRepo = {
+      getSubgraphFieldsInGracePeriod: vi.fn().mockResolvedValue([]),
+    };
+    const pruner = new SchemaGraphPruner({} as any, subgraphRepo as any, { getUsedFields } as any, schema);
+
+    const issues = await pruner.fetchDeprecatedFields({
+      subgraphId: 'sg-1',
+      namespaceId: 'ns-1',
+      organizationId: 'org-1',
+      federatedGraphs,
+      rangeInDays: 7,
+      severityLevel: 'warn',
+      addedDeprecatedFields: [],
+    });
+
+    expect(issues).toHaveLength(2);
+    expect(issues.find((i) => i.federatedGraphId === 'fg-1')?.message).toContain('still in use');
+    expect(issues.find((i) => i.federatedGraphId === 'fg-2')?.message).toContain('no longer in use');
+    expect(issues.every((i) => i.fieldPath === 'Employee.nickname' && i.severity === LintSeverity.warn)).toBe(true);
+  });
+
+  test('skips deprecated field checks when all deprecated fields are excluded', async () => {
+    const getUsedFields = vi.fn();
+    const subgraphRepo = {
+      getSubgraphFieldsInGracePeriod: vi.fn().mockResolvedValue([{ path: 'Employee.nickname' }]),
+    };
+    const pruner = new SchemaGraphPruner({} as any, subgraphRepo as any, { getUsedFields } as any, schema);
+
+    const issues = await pruner.fetchDeprecatedFields({
+      subgraphId: 'sg-1',
+      namespaceId: 'ns-1',
+      organizationId: 'org-1',
+      federatedGraphs,
+      rangeInDays: 7,
+      severityLevel: 'warn',
+      addedDeprecatedFields: [],
+    });
+
+    expect(issues).toEqual([]);
+    expect(getUsedFields).not.toHaveBeenCalled();
+  });
+
+  test('flags fields removed without prior deprecation for every federated graph', () => {
+    const pruner = new SchemaGraphPruner({} as any, {} as any, {} as any, schema);
+
+    const issues = pruner.fetchNonDeprecatedDeletedFields({
+      federatedGraphs,
+      severityLevel: 'error',
+      removedFields: [
+        { ...fieldDiff('Employee.nickname'), changeType: 'FIELD_REMOVED' },
+        { ...fieldDiff('Employee.name'), changeType: 'FIELD_REMOVED' },
+      ],
+      oldSchema: /* GraphQL */ `
+        type Query {
+          employees: [Employee!]!
+        }
+
+        type Employee {
+          id: ID!
+          name: String!
+          nickname: String @deprecated(reason: "Use name instead")
+        }
+      `,
+    });
+
+    // `nickname` was deprecated before removal and is fine; `name` was not
+    expect(issues.map((i) => [i.federatedGraphId, i.fieldPath])).toEqual([
+      ['fg-1', 'Employee.name'],
+      ['fg-2', 'Employee.name'],
+    ]);
+  });
+});

--- a/controlplane/src/core/services/SchemaGraphPruner.test.ts
+++ b/controlplane/src/core/services/SchemaGraphPruner.test.ts
@@ -3,7 +3,19 @@ import { LintSeverity } from '@wundergraph/cosmo-connect/dist/platform/v1/platfo
 import { describe, expect, test, vi } from 'vitest';
 import { FederatedGraphDTO } from '../../types/index.js';
 import { SchemaDiff } from '../composition/schemaCheck.js';
+import type { UsageRepository } from '../repositories/analytics/UsageRepository.js';
+import type { FederatedGraphRepository } from '../repositories/FederatedGraphRepository.js';
+import type { SubgraphRepository } from '../repositories/SubgraphRepository.js';
 import SchemaGraphPruner from './SchemaGraphPruner.js';
+
+// The federated graph repository is never touched by the methods under test.
+const federatedGraphRepo = {} as FederatedGraphRepository;
+
+// Only the methods the pruner calls are stubbed; the casts widen the partial doubles to the repository types.
+const asSubgraphRepo = (stub: Pick<SubgraphRepository, 'getSubgraphFieldsInGracePeriod'>): SubgraphRepository =>
+  stub as SubgraphRepository;
+const asUsageRepo = (stub: Partial<Pick<UsageRepository, 'getUnusedFields' | 'getUsedFields'>>): UsageRepository =>
+  stub as UsageRepository;
 
 // The pruner only touches `getSubgraphFieldsInGracePeriod` on the subgraph repository and
 // `getUnusedFields` / `getUsedFields` on the usage repository, so both can be stubbed and the
@@ -54,7 +66,12 @@ describe('SchemaGraphPruner', () => {
     const subgraphRepo = {
       getSubgraphFieldsInGracePeriod: vi.fn().mockResolvedValue([{ path: 'Product.price' }]),
     };
-    const pruner = new SchemaGraphPruner({} as any, subgraphRepo as any, { getUnusedFields } as any, schema);
+    const pruner = new SchemaGraphPruner(
+      federatedGraphRepo,
+      asSubgraphRepo(subgraphRepo),
+      asUsageRepo({ getUnusedFields }),
+      schema,
+    );
 
     const issues = await pruner.fetchUnusedFields({
       subgraphId: 'sg-1',
@@ -98,7 +115,12 @@ describe('SchemaGraphPruner', () => {
     const subgraphRepo = {
       getSubgraphFieldsInGracePeriod: vi.fn().mockResolvedValue([]),
     };
-    const pruner = new SchemaGraphPruner({} as any, subgraphRepo as any, { getUsedFields } as any, schema);
+    const pruner = new SchemaGraphPruner(
+      federatedGraphRepo,
+      asSubgraphRepo(subgraphRepo),
+      asUsageRepo({ getUsedFields }),
+      schema,
+    );
 
     const issues = await pruner.fetchDeprecatedFields({
       subgraphId: 'sg-1',
@@ -121,7 +143,12 @@ describe('SchemaGraphPruner', () => {
     const subgraphRepo = {
       getSubgraphFieldsInGracePeriod: vi.fn().mockResolvedValue([{ path: 'Employee.nickname' }]),
     };
-    const pruner = new SchemaGraphPruner({} as any, subgraphRepo as any, { getUsedFields } as any, schema);
+    const pruner = new SchemaGraphPruner(
+      federatedGraphRepo,
+      asSubgraphRepo(subgraphRepo),
+      asUsageRepo({ getUsedFields }),
+      schema,
+    );
 
     const issues = await pruner.fetchDeprecatedFields({
       subgraphId: 'sg-1',
@@ -138,7 +165,12 @@ describe('SchemaGraphPruner', () => {
   });
 
   test('flags fields removed without prior deprecation for every federated graph', () => {
-    const pruner = new SchemaGraphPruner({} as any, {} as any, {} as any, schema);
+    const pruner = new SchemaGraphPruner(
+      federatedGraphRepo,
+      asSubgraphRepo({} as SubgraphRepository),
+      asUsageRepo({}),
+      schema,
+    );
 
     const issues = pruner.fetchNonDeprecatedDeletedFields({
       federatedGraphs,

--- a/controlplane/src/core/services/SchemaGraphPruner.ts
+++ b/controlplane/src/core/services/SchemaGraphPruner.ts
@@ -19,12 +19,18 @@ import { buildSchema } from '../composition/composition.js';
 import { getFederatedGraphRouterCompatibilityVersion } from '../util.js';
 import { traced } from '../tracing.js';
 
-// Identifies a field by its parent type and name, matching the (TypeName, FieldName) pairs returned by ClickHouse.
-function fieldKey(typeName: string, name: string) {
+/**
+ * Identifies a field by its parent type and name, matching the (TypeName, FieldName) pairs returned by ClickHouse.
+ */
+function fieldKey(typeName: string, name: string): string {
   return `${typeName}.${name}`;
 }
 
-function appendAll<T>(target: T[], items: T[]) {
+/**
+ * Appends all items to the target array without spreading them into a single `push` call,
+ * which throws a RangeError for very large arrays.
+ */
+function appendAll<T>(target: T[], items: T[]): void {
   for (const item of items) {
     target.push(item);
   }

--- a/controlplane/src/core/services/SchemaGraphPruner.ts
+++ b/controlplane/src/core/services/SchemaGraphPruner.ts
@@ -19,6 +19,17 @@ import { buildSchema } from '../composition/composition.js';
 import { getFederatedGraphRouterCompatibilityVersion } from '../util.js';
 import { traced } from '../tracing.js';
 
+// Identifies a field by its parent type and name, matching the (TypeName, FieldName) pairs returned by ClickHouse.
+function fieldKey(typeName: string, name: string) {
+  return `${typeName}.${name}`;
+}
+
+function appendAll<T>(target: T[], items: T[]) {
+  for (const item of items) {
+    target.push(item);
+  }
+}
+
 @traced
 export default class SchemaGraphPruner {
   constructor(
@@ -98,9 +109,16 @@ export default class SchemaGraphPruner {
     const fieldsInGracePeriod = await this.subgraphRepo.getSubgraphFieldsInGracePeriod({ subgraphId, namespaceId });
 
     // filtering out the fields that are in grace period and the fields that were added in the proposed schema
-    const fieldsToBeChecked = allFields.filter((field) => {
-      return !fieldsInGracePeriod.some((f) => f.path === field.path) && !addedFields.some((f) => f.path === field.path);
-    });
+    const excludedFieldPaths = new Set<string>();
+    for (const field of fieldsInGracePeriod) {
+      if (field.path !== null) {
+        excludedFieldPaths.add(field.path);
+      }
+    }
+    for (const field of addedFields) {
+      excludedFieldPaths.add(field.path);
+    }
+    const fieldsToBeChecked = allFields.filter((field) => !excludedFieldPaths.has(field.path));
 
     const graphPruningIssues: GraphPruningIssueResult[] = [];
     const input = [];
@@ -127,9 +145,13 @@ export default class SchemaGraphPruner {
 
     for (const r of result) {
       const { federatedGraphId, federatedGraphName, unusedFieldsWithTypeNames } = r;
-      const unusedFields = allFields.filter((field) =>
-        unusedFieldsWithTypeNames.some((f) => f.name === field.name && f.typeName === field.typeName),
-      );
+      // Index the unused fields returned by ClickHouse so the lookup below is linear in the number of fields
+      // rather than quadratic, which matters for subgraphs with thousands of (mostly unused) fields.
+      const unusedFieldKeys = new Set<string>();
+      for (const f of unusedFieldsWithTypeNames) {
+        unusedFieldKeys.add(fieldKey(f.typeName, f.name));
+      }
+      const unusedFields = allFields.filter((field) => unusedFieldKeys.has(fieldKey(field.typeName, field.name)));
       for (const field of unusedFields) {
         graphPruningIssues.push({
           graphPruningRuleType: 'UNUSED_FIELDS',
@@ -178,12 +200,16 @@ export default class SchemaGraphPruner {
     });
 
     // filtering out the deprecated fields that are in grace period and the deprecated fields that were added in the proposed schema
-    const deprecatedFieldsToBeChecked = allDeprecatedFields.filter((field) => {
-      return (
-        !deprecatedFieldsInGracePeriod.some((f) => f.path === field.path) &&
-        !addedDeprecatedFields.some((f) => f.path === field.path)
-      );
-    });
+    const excludedFieldPaths = new Set<string>();
+    for (const field of deprecatedFieldsInGracePeriod) {
+      if (field.path !== null) {
+        excludedFieldPaths.add(field.path);
+      }
+    }
+    for (const field of addedDeprecatedFields) {
+      excludedFieldPaths.add(field.path);
+    }
+    const deprecatedFieldsToBeChecked = allDeprecatedFields.filter((field) => !excludedFieldPaths.has(field.path));
 
     if (deprecatedFieldsToBeChecked.length === 0) {
       return [];
@@ -215,10 +241,13 @@ export default class SchemaGraphPruner {
     for (const r of result) {
       const { federatedGraphId, federatedGraphName, usedDeprecatedFieldsWithTypeNames } = r;
 
+      const usedFieldKeys = new Set<string>();
+      for (const f of usedDeprecatedFieldsWithTypeNames) {
+        usedFieldKeys.add(fieldKey(f.typeName, f.name));
+      }
+
       for (const field of deprecatedFieldsToBeChecked) {
-        const isUsed = usedDeprecatedFieldsWithTypeNames.some(
-          (f) => f.name === field.name && f.typeName === field.typeName,
-        );
+        const isUsed = usedFieldKeys.has(fieldKey(field.typeName, field.name));
         graphPruningIssues.push({
           graphPruningRuleType: 'DEPRECATED_FIELDS',
           severity: severityLevel === 'error' ? LintSeverity.error : LintSeverity.warn,
@@ -277,12 +306,16 @@ export default class SchemaGraphPruner {
     }
 
     const allDeprecatedFields = this.getAllFields({ schema: oldGraphQLSchema, onlyDeprecated: true });
+    const deprecatedFieldPaths = new Set<string>();
+    for (const field of allDeprecatedFields) {
+      deprecatedFieldPaths.add(field.path);
+    }
     const nonDeprecatedDeletedFields: SchemaDiff[] = [];
     const graphPruningIssues: GraphPruningIssueResult[] = [];
 
     for (const removedField of removedFields) {
       // getting all the fields that were removed without being deprecated first
-      if (!allDeprecatedFields.some((field) => field.path === removedField.path)) {
+      if (!deprecatedFieldPaths.has(removedField.path)) {
         nonDeprecatedDeletedFields.push(removedField);
       }
     }
@@ -350,11 +383,9 @@ export default class SchemaGraphPruner {
             severityLevel: severity,
           });
 
-          if (severity === 'error') {
-            graphPruneErrors.push(...unusedFields);
-          } else {
-            graphPruneWarnings.push(...unusedFields);
-          }
+          // Avoid `push(...spread)`: one issue is produced per field and federated graph, and spreading a
+          // very large array into a call throws a RangeError.
+          appendAll(severity === 'error' ? graphPruneErrors : graphPruneWarnings, unusedFields);
 
           break;
         }
@@ -369,11 +400,9 @@ export default class SchemaGraphPruner {
             addedDeprecatedFields: updatedFields.filter((field) => field.changeType === 'FIELD_DEPRECATION_ADDED'),
           });
 
-          if (severity === 'error') {
-            graphPruneErrors.push(...deprecatedFields);
-          } else {
-            graphPruneWarnings.push(...deprecatedFields);
-          }
+          // Avoid `push(...spread)`: one issue is produced per field and federated graph, and spreading a
+          // very large array into a call throws a RangeError.
+          appendAll(severity === 'error' ? graphPruneErrors : graphPruneWarnings, deprecatedFields);
 
           break;
         }
@@ -385,11 +414,9 @@ export default class SchemaGraphPruner {
             removedFields,
           });
 
-          if (severity === 'error') {
-            graphPruneErrors.push(...nonDeprecatedDeletedFields);
-          } else {
-            graphPruneWarnings.push(...nonDeprecatedDeletedFields);
-          }
+          // Avoid `push(...spread)`: one issue is produced per field and federated graph, and spreading a
+          // very large array into a call throws a RangeError.
+          appendAll(severity === 'error' ? graphPruneErrors : graphPruneWarnings, nonDeprecatedDeletedFields);
 
           break;
         }

--- a/controlplane/src/core/services/SchemaUsageTrafficInspector.test.ts
+++ b/controlplane/src/core/services/SchemaUsageTrafficInspector.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest';
 import { buildSchema, GraphQLSchema } from 'graphql';
 import { SchemaCheckChangeAction } from '../../db/models.js';
+import type { ClickHouseClient } from '../clickhouse/index.js';
 import { getSchemaDiff, SchemaDiff } from '../composition/schemaCheck.js';
 import {
   InspectorSchemaChange,
@@ -506,13 +507,13 @@ const change = (path: string, changeType: SchemaDiff['changeType'], message = `$
   meta: {} as SchemaDiff['meta'],
 });
 
-const action = (id: string, path: string | null, changeType: string | null) =>
+const action = (id: string, path: string | null, changeType: string | null): SchemaCheckChangeAction =>
   ({ id, path, changeType }) as unknown as SchemaCheckChangeAction;
 
-describe('schemaChangesToInspectorChanges', () => {
-  const inspector = new SchemaUsageTrafficInspector({} as any);
+describe('schemaChangesToInspectorChanges', (): void => {
+  const inspector = new SchemaUsageTrafficInspector({} as ClickHouseClient);
 
-  test('maps every change to the stored action with the same path and change type', () => {
+  test('maps every change to the stored action with the same path and change type', (): void => {
     const changes = [change('Query.a', 'FIELD_REMOVED'), change('Employee', 'TYPE_REMOVED')];
     const actions = [
       // Same path, different change type must not be picked up
@@ -529,7 +530,7 @@ describe('schemaChangesToInspectorChanges', () => {
     ]);
   });
 
-  test('uses the first matching action when duplicates are stored', () => {
+  test('uses the first matching action when duplicates are stored', (): void => {
     const changes = [change('Query.a', 'FIELD_REMOVED')];
     const actions = [action('first', 'Query.a', 'FIELD_REMOVED'), action('second', 'Query.a', 'FIELD_REMOVED')];
 
@@ -538,14 +539,14 @@ describe('schemaChangesToInspectorChanges', () => {
     ]);
   });
 
-  test('drops changes that cannot be inspected', () => {
+  test('drops changes that cannot be inspected', (): void => {
     const changes = [change('Query', 'TYPE_DESCRIPTION_CHANGED')];
     const actions = [action('1', 'Query', 'TYPE_DESCRIPTION_CHANGED')];
 
     expect(inspector.schemaChangesToInspectorChanges(changes, actions)).toEqual([]);
   });
 
-  test('throws when a change has no stored action', () => {
+  test('throws when a change has no stored action', (): void => {
     const changes = [change('Query.a', 'FIELD_REMOVED', 'Field a was removed')];
 
     expect(() => inspector.schemaChangesToInspectorChanges(changes, [])).toThrow(

--- a/controlplane/src/core/services/SchemaUsageTrafficInspector.test.ts
+++ b/controlplane/src/core/services/SchemaUsageTrafficInspector.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, test } from 'vitest';
 import { buildSchema, GraphQLSchema } from 'graphql';
-import { getSchemaDiff } from '../composition/schemaCheck.js';
-import { InspectorSchemaChange, toInspectorChange } from './SchemaUsageTrafficInspector.js';
+import { SchemaCheckChangeAction } from '../../db/models.js';
+import { getSchemaDiff, SchemaDiff } from '../composition/schemaCheck.js';
+import {
+  InspectorSchemaChange,
+  SchemaUsageTrafficInspector,
+  toInspectorChange,
+} from './SchemaUsageTrafficInspector.js';
 
 describe('Schema Change converter', (ctx) => {
   describe('Arguments', (ctx) => {
@@ -492,3 +497,59 @@ async function getBreakingChanges(a: GraphQLSchema, b: GraphQLSchema): Promise<I
 
   return groups;
 }
+
+const change = (path: string, changeType: SchemaDiff['changeType'], message = `${changeType} ${path}`): SchemaDiff => ({
+  path,
+  changeType,
+  message,
+  isBreaking: true,
+  meta: {} as SchemaDiff['meta'],
+});
+
+const action = (id: string, path: string | null, changeType: string | null) =>
+  ({ id, path, changeType }) as unknown as SchemaCheckChangeAction;
+
+describe('schemaChangesToInspectorChanges', () => {
+  const inspector = new SchemaUsageTrafficInspector({} as any);
+
+  test('maps every change to the stored action with the same path and change type', () => {
+    const changes = [change('Query.a', 'FIELD_REMOVED'), change('Employee', 'TYPE_REMOVED')];
+    const actions = [
+      // Same path, different change type must not be picked up
+      action('other', 'Query.a', 'FIELD_ADDED'),
+      action('1', 'Query.a', 'FIELD_REMOVED'),
+      action('2', 'Employee', 'TYPE_REMOVED'),
+      // Actions without a path can never match a change
+      action('3', null, 'TYPE_REMOVED'),
+    ];
+
+    expect(inspector.schemaChangesToInspectorChanges(changes, actions)).toEqual<InspectorSchemaChange[]>([
+      { schemaChangeId: '1', typeName: 'Query', fieldName: 'a' },
+      { schemaChangeId: '2', typeName: 'Employee' },
+    ]);
+  });
+
+  test('uses the first matching action when duplicates are stored', () => {
+    const changes = [change('Query.a', 'FIELD_REMOVED')];
+    const actions = [action('first', 'Query.a', 'FIELD_REMOVED'), action('second', 'Query.a', 'FIELD_REMOVED')];
+
+    expect(inspector.schemaChangesToInspectorChanges(changes, actions)).toEqual<InspectorSchemaChange[]>([
+      { schemaChangeId: 'first', typeName: 'Query', fieldName: 'a' },
+    ]);
+  });
+
+  test('drops changes that cannot be inspected', () => {
+    const changes = [change('Query', 'TYPE_DESCRIPTION_CHANGED')];
+    const actions = [action('1', 'Query', 'TYPE_DESCRIPTION_CHANGED')];
+
+    expect(inspector.schemaChangesToInspectorChanges(changes, actions)).toEqual([]);
+  });
+
+  test('throws when a change has no stored action', () => {
+    const changes = [change('Query.a', 'FIELD_REMOVED', 'Field a was removed')];
+
+    expect(() => inspector.schemaChangesToInspectorChanges(changes, [])).toThrow(
+      'Could not find schema check action for change Field a was removed',
+    );
+  });
+});

--- a/controlplane/src/core/services/SchemaUsageTrafficInspector.ts
+++ b/controlplane/src/core/services/SchemaUsageTrafficInspector.ts
@@ -296,7 +296,11 @@ export class SchemaUsageTrafficInspector {
         const schemaChangeId = ops[0].schemaChangeId;
         const existing = results.get(schemaChangeId);
         if (existing) {
-          existing.push(...ops);
+          // Avoid `push(...ops)`: spreading a very large result set into a call throws a
+          // "Maximum call stack size exceeded" RangeError.
+          for (const op of ops) {
+            existing.push(op);
+          }
         } else {
           results.set(schemaChangeId, ops);
         }
@@ -315,19 +319,34 @@ export class SchemaUsageTrafficInspector {
     schemaChanges: SchemaDiff[],
     schemaCheckActions: SchemaCheckChangeAction[],
   ): InspectorSchemaChange[] {
-    const operations = schemaChanges
-      .map((change) => {
-        // find the schema check action that matches the change
-        const schemaCheckAction = schemaCheckActions.find(
-          (action) => action.path === change.path && action.changeType === change.changeType,
-        );
-        // there must be a schema check action for every change otherwise it is a bug
-        if (!schemaCheckAction) {
-          throw new Error(`Could not find schema check action for change ${change.message}`);
-        }
-        return toInspectorChange(change, schemaCheckAction.id);
-      })
-      .filter((change) => change !== null) as InspectorSchemaChange[];
+    // Index the stored actions by (path, changeType) once instead of scanning the list for every
+    // change, which is quadratic and gets very slow when a subgraph with thousands of fields is
+    // removed or heavily modified. The first action wins, matching the previous `find` semantics.
+    const actionIdByKey = new Map<string, string>();
+    for (const action of schemaCheckActions) {
+      // A change always has a path and change type, so actions without them can never match.
+      if (action.path === null || action.changeType === null) {
+        continue;
+      }
+      const key = `${action.path} ${action.changeType}`;
+      if (!actionIdByKey.has(key)) {
+        actionIdByKey.set(key, action.id);
+      }
+    }
+
+    const operations: InspectorSchemaChange[] = [];
+    for (const change of schemaChanges) {
+      // find the schema check action that matches the change
+      const schemaCheckActionId = actionIdByKey.get(`${change.path} ${change.changeType}`);
+      // there must be a schema check action for every change otherwise it is a bug
+      if (!schemaCheckActionId) {
+        throw new Error(`Could not find schema check action for change ${change.message}`);
+      }
+      const inspectorChange = toInspectorChange(change, schemaCheckActionId);
+      if (inspectorChange !== null) {
+        operations.push(inspectorChange);
+      }
+    }
 
     return operations;
   }


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved processing of large schema checks, lint results, graph-pruning issues, and database operations through batching.
  * Reduced memory and processing overhead during schema analysis and traffic inspection.
  * Preserved configured Node.js runtime options for composition workers.

* **Reliability**
  * Improved schema-change matching and validation during traffic inspection.
  * Added safeguards for large database operations and empty result sets.

* **Tests**
  * Expanded coverage for schema graph pruning and schema usage traffic inspection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Motivation

Schema check requests for some organizations are timing out, and controlplane pods are getting OOM killed even though the Node heap of the main process is capped at roughly 50% of the pod memory limit. Investigating the check path did not turn up unbounded recursion, but it did turn up several sources of unbounded memory growth and quadratic work, mostly in composition planning and the field usage checks (client traffic inspection and graph pruning).

## Changes

- **Stop parsing every subgraph SDL on the main thread.** The composition plan (`SubgraphsToCompose.compositionSubgraphs`) carried a parsed `DocumentNode` per subgraph, but nothing ever read it: consumers only use the subgraph name, and the composition worker re-parses the SDL from the `SubgraphDTO`s. In the check path all those ASTs (including their token streams) were retained for the whole check across all federated graphs. The type is now a lightweight `{ name, url }` reference and the `parse` calls in the check and publish paths are gone.
- **Forward `NODE_OPTIONS` to composition workers.** The worker pool replaces the child process environment with only Sentry variables, so `--max-old-space-size` set via `NODE_OPTIONS` never applied to the composition child processes. They now inherit the operator's heap limit.
- **Bulk-load client traffic overrides.** `checkClientTrafficAgainstOverrides` ran two sequential Postgres queries per distinct operation hash and deep-cloned the whole inspector result. It now uses batched `IN` lookups on `operation_change_overrides` and `operation_ignore_all_overrides`, a shallow copy, and indexed lookups. Semantics (safe/unsafe determination and `isSafeOverride` flagging) are unchanged.
- **Batch large inserts.** Schema changes, federated graph schema changes, lint issues and graph pruning issues were inserted as a single statement, which exceeds the Postgres bind parameter limit (65535) for large schemas. They are now inserted in batches of `dbInsertBatchSize` rows inside a transaction.
- **Remove quadratic scans and large spreads.** `Set`/`Map` lookups replace nested `find`/`some` in `schemaChangesToInspectorChanges` and the graph pruner's grace-period / unused-field filtering. `push(...array)` on potentially huge arrays (which throws `RangeError: Maximum call stack size exceeded`) is replaced with loops.

## Tests

- Added `SchemaGraphPruner.test.ts` covering unused, deprecated and removed-without-deprecation field handling with stubbed repositories.
- Added `schemaChangesToInspectorChanges` cases to `SchemaUsageTrafficInspector.test.ts`.
- `tsc`, eslint and prettier pass for the controlplane. The infra-free unit tests pass locally; the integration suite (Postgres/ClickHouse/Keycloak) could not be run in the authoring environment, so CI coverage of the override check and batched inserts should be watched.

## Notes for operators

- `COMPOSITION_MAX_THREADS` defaults to the host's CPU count. Each worker is a full Node process that now honors `NODE_OPTIONS`, so total pod memory is roughly the main heap plus workers times worker heap; setting it explicitly in Helm is recommended.
- Not addressed here: the unused-field ClickHouse query inlines every field as a tuple and will exceed ClickHouse's default `max_query_size` for schemas above roughly 7000 fields.

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [x] Tests or benchmarks have been added or updated.
- [x] If applicable, I have provided instructions for reviewers for [manually validating my changes](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md#pull-requests-conventions).
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L1icN7sgpLfUfUEZk2pkP6

---
_Generated by [Claude Code](https://claude.ai/code/session_01L1icN7sgpLfUfUEZk2pkP6)_