### PR TITLE
docs(security): add response time expectations to security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,10 @@
 # Security Policy
 
 If you have a security issue to report, please contact us at [security@wundergraph.com](mailto:security@wundergraph.com).
+
+## Response Times
+
+We take security reports seriously and aim to respond promptly:
+
+- **Acknowledgement:** We aim to acknowledge receipt of your report within 72 hours.
+- **Triage & Detailed Response:** We aim to triage the issue and provide a more detailed response within 5 business days of our acknowledgement.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,4 +7,4 @@ If you have a security issue to report, please contact us at [security@wundergra
 We take security reports seriously and aim to respond promptly:
 
 - **Acknowledgement:** We aim to acknowledge receipt of your report within 72 hours.
-- **Triage & Detailed Response:** We aim to triage the issue and provide a more detailed response within 5 business days of our acknowledgement.
+- **Triage & Detailed Response:** We aim to triage the issue and provide a more detailed response within 5 business days of the report being made.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,5 +6,5 @@ If you have a security issue to report, please contact us at [security@wundergra
 
 We take security reports seriously and aim to respond promptly:
 
-- **Acknowledgement:** We aim to acknowledge receipt of your report within 72 hours.
+- **Acknowledgement:** We aim to acknowledge receipt of your report within 48 hours.
 - **Triage & Detailed Response:** We aim to triage the issue and provide a more detailed response within 5 business days of the report being made.


### PR DESCRIPTION
## Description

This PR enhances the SECURITY.md file by adding clear response time expectations for security vulnerability reports. The update provides transparency about how quickly the team will acknowledge and triage security issues.

## Changes

- Added a new "Response Times" section to SECURITY.md
- Documented acknowledgement target: 48 hours
- Documented triage and detailed response target: 5 business days

## Motivation

This change improves the security reporting process by setting clear expectations for reporters about response timelines, which is a best practice for responsible disclosure policies.

## Test Plan

N/A - Documentation only change

## Checklist

- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md)
- [x] Documentation has been updated

https://claude.ai/code/session_01DTzT6WtB6tJveULdUgGYyT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added response-time expectations for security reports, including acknowledgement within 48 hours and a detailed triage response within five business days.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->