### PR TITLE
fix: add repeatable to @context

### DIFF
--- a/composition/src/directive-definition-data/directive-definition-data.ts
+++ b/composition/src/directive-definition-data/directive-definition-data.ts
@@ -303,6 +303,7 @@ export const CONTEXT_DEFINITION_DATA = newDirectiveDefinitionData({
       }),
     ],
   ]),
+  isRepeatable: true,
   locations: new Set<DirectiveLocation>([INTERFACE_UPPER, OBJECT_UPPER, UNION_UPPER]),
   name: CONTEXT,
   node: CONTEXT_DEFINITION,

--- a/composition/src/v1/constants/directive-definitions.ts
+++ b/composition/src/v1/constants/directive-definitions.ts
@@ -260,7 +260,7 @@ export const COST_DEFINITION: DirectiveDefinitionNode = {
   repeatable: false,
 };
 
-// directive @context(name: String!) on INTERFACE | OBJECT | UNION
+// directive @context(name: String!) repeatable on INTERFACE | OBJECT | UNION
 export const CONTEXT_DEFINITION: DirectiveDefinitionNode = {
   arguments: [
     {
@@ -272,7 +272,7 @@ export const CONTEXT_DEFINITION: DirectiveDefinitionNode = {
   kind: Kind.DIRECTIVE_DEFINITION,
   locations: stringArrayToNameNodeArray([INTERFACE_UPPER, OBJECT_UPPER, UNION_UPPER]),
   name: stringToNameNode(CONTEXT),
-  repeatable: false,
+  repeatable: true,
 };
 
 /* directive @deprecated(reason: String = "No longer supported") on ARGUMENT_DEFINITION | ENUM_VALUE |

--- a/composition/tests/v1/utils/utils.ts
+++ b/composition/tests/v1/utils/utils.ts
@@ -18,7 +18,7 @@ export const CONNECT_FIELD_RESOLVER_DIRECTIVE = `
 `;
 
 export const CONTEXT_DIRECTIVE = `
-  directive @context(name: String!) on INTERFACE | OBJECT | UNION
+  directive @context(name: String!) repeatable on INTERFACE | OBJECT | UNION
 `;
 
 export const COST_DIRECTIVE = `


### PR DESCRIPTION
## Summary by CodeRabbit

* **New Features**
  * The `@context` directive can now be applied multiple times within the same definition.

## Checklist

- [ ] I have discussed my proposed changes in an issue and have received approogval to proceed.
- [ ] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] If applicable, I have provided instructions for reviewers for [manually validating my changes](<https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md#pull-requests-conventions>).
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](<https://github.com/wundergraph/docs-website>).
- [ ] I have read the [Contributors Guide](<https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md>).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](<https://human-oss.dev>). Please ensure your contribution aligns with its principles.