### PR TITLE
docs(cli): add contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,7 @@
 
 Before contributing to the WunderGraph Cosmo repository, please open an issue to discuss the changes you would like to make. Alternatively, you can also open a discussion in the [WunderGraph Discussions](https://github.com/wundergraph/cosmo/discussions).
 We are open to all kinds of contributions, including bug fixes, new features, and documentation improvements.
+For WunderGraph CLI contributions, read the [CLI Contributing document](https://github.com/wundergraph/cosmo/blob/main/cli/CONTRIBUTING.md).
 
 This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contributions align with its principles.
 

--- a/cli/CONTRIBUTING.md
+++ b/cli/CONTRIBUTING.md
@@ -1,0 +1,64 @@
+# Contributing to the WunderGraph CLI Repository
+
+Before contributing to the WunderGraph CLI repository, please open an issue to discuss your proposed changes and apply the `cli` label. Alternatively, open a thread in [WunderGraph Discussions](https://github.com/wundergraph/cosmo/discussions) and apply the `cli` label.
+
+## Prerequisites
+
+See the [README](./README.md).
+
+## Folder structure
+
+```text
+cli/
+|-- src/
+|   |-- index.ts                 # Executable entry point
+|   |-- commands/
+|   |   |-- index.ts             # Registers all top-level commands
+|   |   `-- <command-group>/
+|   |       |-- index.ts         # Defines and registers a command group
+|   |       |-- commands/        # Subcommand implementations
+|   |       |-- common/          # Code shared within the group, when needed
+|   |       |-- types/           # Group-specific types, when needed
+|   |       `-- utils/           # Group-specific utilities, when needed
+|   |-- core/                    # API client, configuration, telemetry, and other shared services
+|   `-- typedefinitions/         # Type declarations for untyped dependencies
+|-- test/
+|   |-- fixtures/                # Reusable GraphQL test fixtures
+|   |-- testdata/                # Input files used by tests
+|   `-- **/*.test.ts             # Unit and integration tests
+|-- e2e/                         # End-to-end smoke tests
+|-- scripts/                     # Build and maintenance scripts
+```
+
+Most command groups use the same layout: export a Commander command from `src/commands/<command-group>/index.ts`, keep each subcommand in its own file under `commands/`, and place code shared only by that group in a nearby `common/`, `types/`, or `utils/` directory. Cross-command infrastructure belongs in `src/core/`; broadly shared presentation and result-handling helpers belong directly in `src/`.
+
+## Patterns
+
+### 1. Provide machine-readable output for commands
+
+Each command or subcommand should provide a `--json` flag. This makes it easy to combine the WunderGraph CLI with other tools and use it in CI environments. When this flag is used, return error states and messages in JSON format as well.
+
+### 2. Avoid throwing; prefer result objects
+
+When representing an invariant violation or a specific application error, do not use `throw` statements. Instead, have your function return a _result_ object with a `success` property and either `data` or `errors`:
+
+```typescript
+{
+  success: true;
+  data: Record<string, unknown>; // <-- provide actual type
+} |
+{
+  success: false;
+  errors: Array<Error>;
+}
+```
+
+This avoids `try/catch` statements because invalid states can be checked with simple `if` blocks. Using `try/catch` leads to unwieldy code, especially when the blocks are nested.
+
+> [!TIP]
+> A top-level `try/catch` statement intercepts and formats unexpected runtime errors.
+
+To have the application exit with an error, use one of these options:
+
+1. `program.error()`: Sets the exit code to `1` and accepts an error message.
+2. `process.exitCode = 1`: Sets the exit code explicitly for code paths that produce JSON output.

--- a/cli/CONTRIBUTING.md
+++ b/cli/CONTRIBUTING.md
@@ -45,7 +45,7 @@ Command and subcommand implementations should not include `throw` statements. Se
 To have the application exit with an error, use one of these options:
 
 1. `program.error()`: Sets the exit code to `1` and accepts an error message.
-2. `process.exitCode = 1`: Sets the exit code explicitly for code paths that produce JSON output.
+2. `process.exitCode = 1`: Sets the exit code explicitly for code paths that produce JSON output. Always follow it with a `return` statement to stop execution.
 
 > [!TIP]
 > A top-level `try/catch` statement intercepts and formats unexpected runtime errors.

--- a/cli/CONTRIBUTING.md
+++ b/cli/CONTRIBUTING.md
@@ -38,27 +38,32 @@ Most command groups use the same layout: export a Commander command from `src/co
 
 Each command or subcommand should provide a `--json` flag. This makes it easy to combine the WunderGraph CLI with other tools and use it in CI environments. When this flag is used, return error states and messages in JSON format as well.
 
-### 2. Avoid throwing; prefer result objects
+### 2. Avoid throwing; set proper exit codes
 
-When representing an invariant violation or a specific application error, do not use `throw` statements. Instead, have your function return a _result_ object with a `success` property and either `data` or `errors`:
-
-```typescript
-{
-  success: true;
-  data: Record<string, unknown>; // <-- provide actual type
-} |
-{
-  success: false;
-  errors: Array<Error>;
-}
-```
-
-This avoids `try/catch` statements because invalid states can be checked with simple `if` blocks. Using `try/catch` leads to unwieldy code, especially when the blocks are nested.
-
-> [!TIP]
-> A top-level `try/catch` statement intercepts and formats unexpected runtime errors.
+Command and subcommand implementations should not include `throw` statements. See [Return result objects in helper functions](#3-return-result-objects-in-helper-functions) for guidance on containing errors and using control flow to model invalid states.
 
 To have the application exit with an error, use one of these options:
 
 1. `program.error()`: Sets the exit code to `1` and accepts an error message.
 2. `process.exitCode = 1`: Sets the exit code explicitly for code paths that produce JSON output.
+
+> [!TIP]
+> A top-level `try/catch` statement intercepts and formats unexpected runtime errors.
+
+### 3. Return result objects in helper functions
+
+Catch unexpected errors within helper functions. RPC helpers that use `client` to fetch backend data are a common example. These functions should return a _result_ object with a `success` property and either `data` or `errors`:
+
+```typescript
+type Result<T> =
+  | {
+      success: true;
+      data: T;
+    }
+  | {
+      success: false;
+      errors: Array<Error>;
+    };
+```
+
+This avoids `try/catch` statements at call sites. Invalid states can be checked with simple `if` statements, avoiding any nested `try/catch` blocks.

--- a/cli/CONTRIBUTING.md
+++ b/cli/CONTRIBUTING.md
@@ -45,7 +45,7 @@ Command and subcommand implementations should not include `throw` statements. Se
 To have the application exit with an error, use one of these options:
 
 1. `program.error()`: Sets the exit code to `1` and accepts an error message.
-2. `process.exitCode = 1`: Sets the exit code explicitly for code paths that produce JSON output. Always follow it with a `return` statement to stop execution.
+2. `process.exitCode = 1`: For `--json` error paths, pass `error.message` into a JSON-safe output object, print it with `console.log(JSON.stringify(output))`, set the exit code, and return immediately. Do not serialize an `Error` instance directly because `JSON.stringify()` converts it to an empty object.
 
 > [!TIP]
 > A top-level `try/catch` statement intercepts and formats unexpected runtime errors.

--- a/cli/README.md
+++ b/cli/README.md
@@ -145,7 +145,7 @@ query {
 
 ## 🔨 Contributing
 
-- **Contribution document**: [https://github.com/wundergraph/cosmo/blob/main/cli/CONTRIBUTING.md](https://github.com/wundergraph/cosmo/blob/main/cli/CONTRIBUTING.md)
+- **Contributing document**: [https://github.com/wundergraph/cosmo/blob/main/cli/CONTRIBUTING.md](https://github.com/wundergraph/cosmo/blob/main/cli/CONTRIBUTING.md)
 
 ---
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -143,6 +143,12 @@ query {
 
 ---
 
+## 🔨 Contributing
+
+- **Contribution document**: [https://github.com/wundergraph/cosmo/blob/main/cli/CONTRIBUTING.md](https://github.com/wundergraph/cosmo/blob/main/cli/CONTRIBUTING.md)
+
+---
+
 ## 🌐 About WunderGraph Cosmo
 
 WunderGraph Cosmo is a comprehensive, open-source platform for managing GraphQL APIs at scale. It offers:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added CLI contribution guidance covering workflow, repository structure, command organization, machine-readable output, exit-code handling, result errors, and runtime error formatting.
  - Added a link to the contribution guidelines in the CLI README.
  - Clarified conventions for producing machine-readable responses and handling errors consistently when contributing CLI changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Document CLI folder structure.
- Add command output and error-handling guidelines.

Resolves COSMO-406

## Testing

Not run (documentation only).

## Checklist

- [x] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [ ] Tests or benchmarks have been added or updated.
- [ ] If applicable, I have provided instructions for reviewers for [manually validating my changes](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md#pull-requests-conventions).
- [ ] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website).
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.