### PR TITLE
feat: set minimum package age policy to 72h

### DIFF
--- a/.github/workflows/shared-ci.yaml
+++ b/.github/workflows/shared-ci.yaml
@@ -3,10 +3,11 @@ on:
   pull_request:
     paths:
       - 'pnpm-lock.yaml'
-      - ".github/workflows/shared-ci.yaml"
-      - "composition/**/*"
-      - "connect/**/*"
-      - "shared/**/*"
+      - 'pnpm-workspace.yaml'
+      - '.github/workflows/shared-ci.yaml'
+      - 'composition/**/*'
+      - 'connect/**/*'
+      - 'shared/**/*'
 
 concurrency:
   group: ${{github.workflow}}-${{github.head_ref}}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,6 +18,8 @@ packages:
   - protographic
   - playground
 
+minimumReleaseAge: 4320
+
 allowBuilds:
   '@bufbuild/buf': true
   '@sentry-internal/node-cpu-profiler': true


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added a minimum three-day waiting period before newly published packages can be installed.
  - Updated automated checks to monitor changes to workspace configuration files and apply consistent pull-request path filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Summary

Set pnpm `minimumReleaseAge` to 4320 minutes (72 hours) for all workspace installs.

Resolves [COSMO-448](https://linear.app/wundergraph/issue/COSMO-448/set-minimumagepolicy-to-72h).

## Validation

1. Run `pnpm config get minimumReleaseAge`; expect `4320`.
2. Run `pnpm dlx typescript@next --version`; a release younger than 72 hours is skipped. At validation time this resolved `7.1.0-dev.20260908.1`, while disabling the policy resolved `7.1.0-dev.20260911.1`.

## Checklist

- [x] I have discussed my proposed changes in an issue and have received approval to proceed.
- [x] I have followed the coding standards of the project.
- [x] Tests or benchmarks have been added or updated. N/A: config-only change, manually validated above.
- [x] If applicable, I have provided instructions for reviewers for [manually validating my changes](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md#pull-requests-conventions).
- [x] Documentation has been updated on [https://github.com/wundergraph/docs-website](https://github.com/wundergraph/docs-website). N/A: internal dependency policy only.
- [x] I have read the [Contributors Guide](https://github.com/wundergraph/cosmo/blob/main/CONTRIBUTING.md).

## Open Source AI Manifesto

This project follows the principles of the [Open Source AI Manifesto](https://human-oss.dev). Please ensure your contribution aligns with its principles.