### PR TITLE
docs(router): note that WebSocket forwarded payloads become part of t…

### DIFF
--- a/docs-website/router/request-deduplication.mdx
+++ b/docs-website/router/request-deduplication.mdx
@@ -15,8 +15,23 @@ xxhash64(DataSourceID + ":" + requestBody + preComputedHeaderHash)
 ```
 
 - **DataSourceID**: identifies the target subgraph
-- **requestBody**: the complete JSON payload (query + variables)
+- **requestBody**: the complete JSON payload sent to the subgraph — query, variables, and `extensions` when present
 - **preComputedHeaderHash**: xxhash64 of all headers that will be forwarded to this subgraph, as determined by your header forwarding rules
+
+<Warning>
+**WebSocket subscriptions: forwarded data can land in the request body, not just the headers.**
+
+When `websocket.forward_initial_payload` or `websocket.forward_upgrade_headers` is enabled, the router carries that data into the `extensions` field of the subgraph request payload. Because `extensions` is part of `requestBody`, any value that differs per subscriber — an auth token, a session ID — makes every subgraph request unique and prevents deduplication. This happens even when your header forwarding rules exclude those headers, so `preComputedHeaderHash` can be identical across subscribers while deduplication still never fires.
+
+If subscribers you expect to share a fetch are not being deduplicated, compare the full subgraph request bodies, not only the forwarded headers. Both options default to `true`, so this applies unless you have explicitly turned them off:
+
+```yaml
+websocket:
+  forward_initial_payload: false
+  forward_upgrade_headers:
+    enabled: false
+```
+</Warning>
 
 Only `Query` operations are eligible. Mutations and subscriptions are never deduplicated.
 


### PR DESCRIPTION
The Request Deduplication page describes the Layer 1 requestBody component as "the complete JSON payload (query + variables)", which does not mention `extensions`.

`websocket.forward_upgrade_headers` and `websocket.forward_initial_payload ` both default to true and carry data into the extensions field of the subgraph request payload. Since extensions is part of requestBody, per-subscriber values there make every subgraph request hash uniquely and prevent deduplication — even when header forwarding rules exclude those headers and preComputedHeaderHash is identical across subscribers. That combination is hard to diagnose, since the headers look correct.

## Changes

- Widen the `requestBody` bullet to include `extensions`
- Add a `<Warning>` callout under Layer 1 covering the WebSocket case and how to rule it out when debugging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that request deduplication keys include the `extensions` field when present.
  - Added a warning explaining how forwarded WebSocket subscriber data can make requests unique and prevent deduplication.
  - Included configuration guidance for disabling initial payload and upgrade header forwarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->